### PR TITLE
[codex] Isolate n8 residual certificate audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/n8-independent-obstruction.md`](docs/n8-independent-obstruction.md).
 - For the focused class `14` Groebner/strict-interior audit, read
   [`docs/n8-class14-certificate.md`](docs/n8-class14-certificate.md).
+- For the focused residual class `3`, `4`, and `5` certificate audit, read
+  [`docs/n8-residual-certificates.md`](docs/n8-residual-certificates.md).
 - For the review-pending exhaustive `n=9` vertex-circle finite-case checker,
   read [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 - For the derived `n=9` vertex-circle template lemma-candidate catalog, read

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -105,6 +105,11 @@ derives the four real branches, and verifies exact strict-interior failure on
 each branch. This isolates the most delicate survivor-class obstruction for
 review; it is not a new public theorem claim.
 
+A companion residual audit in `docs/n8-residual-certificates.md` isolates
+classes `3`, `4`, and `5`: duplicate vertices, collinearity, and the class `5`
+Groebner-y2 contradiction after the recorded substitutions. It is another
+repo-local review aid, not a status upgrade.
+
 ### Proof-note draft: geometric exclusion of n <= 8
 
 Status: proof-note draft; independent review requested.

--- a/STATE.md
+++ b/STATE.md
@@ -53,6 +53,13 @@ hull vertices and four strict interior labels. This is still repo-local audit
 support pending external review, not a public theorem claim. See
 `docs/n8-class14-certificate.md`.
 
+A companion residual checker,
+`scripts/check_n8_residual_certificates.py --check --json`, isolates the
+class `3`, `4`, and `5` duplicate, collinearity, and Groebner-y2 certificates.
+It verifies the stored substitution chains and ideal equivalence for class `5`
+without importing the full exact survivor checker. This is also repo-local
+audit support pending external review. See `docs/n8-residual-certificates.md`.
+
 For the general bridge problem, minimality now gives a small proved foothold:
 every minimal counterexample admits a partial fragile-cover witness system made
 from exact critical 4-ties. This is necessary structure only; the block-6

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -203,9 +203,11 @@ Use this queue when no more specific issue is selected.
    the focused class `14` replay command,
    `python scripts/check_n8_class14_certificate.py --check --json`, now
    isolates the PB+ED Groebner/strict-interior certificate for that class.
-   The remaining `n=8` audit gap is smaller but still includes independent
-   review of the Groebner-based classes `3`, `4`, and `5`, plus external
-   review of the new class `14` checker.
+   The residual replay command,
+   `python scripts/check_n8_residual_certificates.py --check --json`,
+   isolates the class `3`, `4`, and `5` duplicate, collinearity, and
+   Groebner-y2 certificates. The remaining `n=8` audit gap is now external
+   review of these focused checkers and the underlying artifact assumptions.
 
 ## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -232,6 +232,9 @@ put detailed reconciliation in the canonical synthesis.
   obstructions.
 - [`n8-class14-certificate.md`](n8-class14-certificate.md): focused audit of
   the class `14` Groebner basis and strict-interior obstruction.
+- [`n8-residual-certificates.md`](n8-residual-certificates.md): focused audit
+  of the class `3`, `4`, and `5` duplicate, collinearity, and Groebner
+  certificates.
 - [`n8-geometric-proof.md`](n8-geometric-proof.md): proof-note draft giving a
   compact geometric obstruction for bad convex octagons via isosceles-triangle
   counting and exterior-turn angles.

--- a/docs/n8-exact-survivors.md
+++ b/docs/n8-exact-survivors.md
@@ -198,6 +198,7 @@ pip install -e .[dev]
 python scripts/independent_check_n8_artifacts.py --check --json
 python scripts/independent_n8_obstruction_recheck.py --check --json
 python scripts/check_n8_class14_certificate.py --check --json
+python scripts/check_n8_residual_certificates.py --check --json
 python scripts/analyze_n8_exact_survivors.py --check --json
 python scripts/analyze_n8_exact_survivors.py --check --json --check-compatible-orders-data data/incidence/n8_compatible_orders.json --check-exact-analysis-data certificates/n8_exact_analysis.json
 pytest -q
@@ -232,6 +233,11 @@ larger exact checker. It rebuilds the class `14` perpendicular-bisector plus
 equal-distance system, compares the stored Groebner basis, derives the four
 real branches, and verifies exact strict-interior failure branch by branch.
 
+The `check_n8_residual_certificates.py` entrypoint isolates classes `3`, `4`,
+and `5` from the same larger checker. It verifies the duplicate-vertex,
+collinearity, and class `5` Groebner-y2 certificates from the stored survivor
+rows and exact-analysis data.
+
 The expanded polynomial systems and full compatible cyclic-order lists are stored
 as reproducibility artifacts:
 
@@ -246,7 +252,8 @@ certificates/n8_polynomial_systems.txt
 
 The incidence-completeness gap is closed in this repository by
 `data/incidence/n8_incidence_completeness.json`. The remaining risk is ordinary
-computer-assisted-proof review: independently review the class `3`, `4`, and
-`14` exact certificates and the checker implementations before making an
-external theorem claim. The focused class `14` checker is intended to make that
-review smaller, not to replace external review.
+computer-assisted-proof review: independently review the classes `3`, `4`,
+`5`, and `14` exact certificates and the checker implementations before making
+an external theorem claim. The focused class `14` checker is intended to make
+that review smaller, and the residual checker does the same for classes `3`,
+`4`, and `5`; neither replaces external review.

--- a/docs/n8-residual-certificates.md
+++ b/docs/n8-residual-certificates.md
@@ -1,0 +1,46 @@
+# n=8 Residual Certificate Audit
+
+Status: `REPO_LOCAL_EXACT_OBSTRUCTION_AUDIT_PENDING_EXTERNAL_REVIEW`.
+
+This note isolates the remaining `n=8` survivor-class certificates not covered
+by the SymPy-free independent recheck or the focused class `14` audit. It covers
+classes `3`, `4`, and `5` only. It does not regenerate the `n=8` incidence
+enumeration, does not check class `14`, and does not turn the repo-local
+`n <= 8` finite-case result into a public theorem-style claim.
+
+## What The Checker Verifies
+
+The verifier in `scripts/check_n8_residual_certificates.py` reads the checked-in
+survivor rows from `data/incidence/n8_reconstructed_15_survivors.json` and the
+stored certificate notes from `certificates/n8_exact_analysis.json`.
+
+It then rebuilds the required perpendicular-bisector equations for the three
+classes and verifies the exact substitution chains:
+
+- Class `3`: the first PB stage forces `x3=x2`, `y3=-y2`, and
+  `y2*(2*x2-1)=0`; the nondegenerate branch forces `p_7=p_0`, so the class has
+  duplicate vertices.
+- Class `4`: the shared first PB stage plus the class-specific PB equations
+  force the collinearity determinant for labels `2,3,4`.
+- Class `5`: after the recorded substitutions
+  `x3=x2`, `y3=-y2`, `x6=2*x2-x4`, and `y6=y4`, the recomputed Groebner basis
+  and the stored generating set are checked to define the same ideal, and both
+  contain `y2`, contradicting the nondegenerate gauge branch.
+
+## Reproduction
+
+```bash
+python scripts/check_n8_residual_certificates.py --check --json
+python -m pytest tests/test_n8_residual_certificates.py -q -m artifact
+```
+
+The command is also included in the manual artifact audit command list in
+`scripts/run_artifact_audit.py`.
+
+## Scope Boundary
+
+This is a focused replay of stored exact certificates for three survivor
+classes. It still uses SymPy Groebner reductions and depends on the checked-in
+survivor and certificate artifacts as inputs. The result remains a repo-local
+exact-obstruction audit pending external review; no general proof of Erdos
+Problem #97 and no counterexample are claimed.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -90,12 +90,14 @@ Current focused entrypoint:
 
 ```bash
 python scripts/check_n8_class14_certificate.py --check --json
+python scripts/check_n8_residual_certificates.py --check --json
 ```
 
-This checker rebuilds only the class `14` `PB+ED` system from the checked-in
-survivor rows, compares the stored Groebner basis, derives the four real
-branches, and verifies exact strict-interior failure. It remains a repo-local
-audit pending external review.
+The class `14` checker rebuilds only the class `14` `PB+ED` system from the
+checked-in survivor rows, compares the stored Groebner basis, derives the four
+real branches, and verifies exact strict-interior failure. The residual checker
+does the analogous focused replay for classes `3`, `4`, and `5`. Both remain
+repo-local audits pending external review.
 
 ## Priority 4 - pin literature coverage
 

--- a/scripts/check_n8_residual_certificates.py
+++ b/scripts/check_n8_residual_certificates.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Focused audit for the n=8 classes 3, 4, and 5 certificates.
+
+This complements ``check_n8_class14_certificate.py`` by isolating the remaining
+Groebner/substitution survivor-class certificates from the larger n=8 exact
+checker.  It does not regenerate n=8 incidence completeness, and it does not
+promote the repo-local finite-case result to a public theorem claim.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import check_n8_class14_certificate as base
+
+N = base.N
+TARGET_CLASS_IDS = (3, 4, 5)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_class_rows(root: Path, class_id: int) -> list[list[int]]:
+    survivors = base.json_load(root / "data" / "incidence" / "n8_reconstructed_15_survivors.json")
+    for record in survivors:
+        if int(record.get("id")) == class_id:
+            return record["rows"]
+    raise SystemExit(f"class {class_id} was not found in n8_reconstructed_15_survivors.json")
+
+
+def load_certificate(root: Path, class_id: int) -> dict[str, Any]:
+    exact = base.json_load(root / "certificates" / "n8_exact_analysis.json")
+    key = f"class_{class_id}"
+    try:
+        return exact["contradictions"][key]
+    except KeyError as exc:
+        raise SystemExit(f"{key} certificate missing from n8_exact_analysis.json") from exc
+
+
+def pb_equation_map(rows: list[list[int]]):
+    sp, _symbols, p, _vars_order = base.sympy_context()
+    eqs = {}
+    for (i, j), (a, b) in base.phi_edges(rows):
+        pix, piy = p[i]
+        pjx, pjy = p[j]
+        pax, pay = p[a]
+        pbx, pby = p[b]
+        dot = sp.expand((pix - pjx) * (pax - pbx) + (piy - pjy) * (pay - pby))
+        bis = sp.expand(
+            (pjx - pix) * (pay + pby - 2 * piy)
+            - (pjy - piy) * (pax + pbx - 2 * pix)
+        )
+        eqs[((i, j), (a, b))] = (dot, bis)
+    return eqs
+
+
+def ideal_contains(groebner_basis, expr) -> bool:
+    sp, _symbols, _coords, _vars_order = base.sympy_context()
+    return sp.expand(groebner_basis.reduce(expr)[1]) == 0
+
+
+def first_stage_relations(eq):
+    sp, symbols, _coords, _vars_order = base.sympy_context()
+    x2, y2 = symbols["x2"], symbols["y2"]
+    x3, y3 = symbols["x3"], symbols["y3"]
+    first = [
+        eq[((0, 1), (2, 3))][0],
+        eq[((0, 1), (2, 3))][1],
+        eq[((2, 3), (0, 1))][1],
+    ]
+    basis = sp.groebner(first, x3, y3, x2, y2, order="lex", domain=sp.QQ)
+    relations = [x3 - x2, y3 + y2, y2 * (2 * x2 - 1)]
+    return {
+        "basis_polynomial_count": len(basis.polys),
+        "contains_x3_equals_x2": ideal_contains(basis, relations[0]),
+        "contains_y3_equals_minus_y2": ideal_contains(basis, relations[1]),
+        "contains_y2_times_2x2_minus_1": ideal_contains(basis, relations[2]),
+        "all_expected_relations_hold": all(ideal_contains(basis, rel) for rel in relations),
+    }
+
+
+def check_class3(root: Path) -> dict[str, Any]:
+    sp, symbols, _coords, _vars_order = base.sympy_context()
+    rows = load_class_rows(root, 3)
+    eq = pb_equation_map(rows)
+    x2, y2 = symbols["x2"], symbols["y2"]
+    x3, y3 = symbols["x3"], symbols["y3"]
+    x4, y4 = symbols["x4"], symbols["y4"]
+    x7, y7 = symbols["x7"], symbols["y7"]
+
+    first = first_stage_relations(eq)
+    stage1 = {x2: sp.Rational(1, 2), x3: sp.Rational(1, 2), y3: -y2}
+    second = [
+        sp.expand(poly.subs(stage1))
+        for edge in [((0, 2), (1, 4)), ((1, 4), (0, 2))]
+        for poly in eq[edge]
+    ]
+    second_basis = sp.groebner(second, x4, y4, y2, order="lex", domain=sp.QQ)
+    second_relations = [
+        y4 - y2,
+        x4 + 2 * y2**2 - 1,
+        y2 * (4 * y2**2 - 3),
+    ]
+
+    stage2 = {
+        x2: sp.Rational(1, 2),
+        x3: sp.Rational(1, 2),
+        y3: -y2,
+        x4: -sp.Rational(1, 2),
+        y4: y2,
+    }
+    third = [
+        sp.expand(poly.subs(stage2))
+        for edge in [((0, 7), (3, 4)), ((3, 4), (0, 7))]
+        for poly in eq[edge]
+    ]
+    third.append(y2**2 - sp.Rational(3, 4))
+    third_basis = sp.groebner(third, x7, y7, y2, order="lex", domain=sp.QQ)
+    duplicate_forced = ideal_contains(third_basis, x7) and ideal_contains(third_basis, y7)
+    verified = (
+        first["all_expected_relations_hold"]
+        and all(ideal_contains(second_basis, rel) for rel in second_relations)
+        and duplicate_forced
+    )
+    return {
+        "class_id": 3,
+        "verified": verified,
+        "mechanism": "duplicate_vertex",
+        "row_strings": ["".join(str(value) for value in row) for row in rows],
+        "first_stage": first,
+        "second_stage": {
+            "basis_polynomial_count": len(second_basis.polys),
+            "contains_y4_equals_y2": ideal_contains(second_basis, second_relations[0]),
+            "contains_x4_relation": ideal_contains(second_basis, second_relations[1]),
+            "contains_y2_squared_relation_up_to_y2": ideal_contains(second_basis, second_relations[2]),
+        },
+        "third_stage": {
+            "basis_polynomial_count": len(third_basis.polys),
+            "contains_x7": ideal_contains(third_basis, x7),
+            "contains_y7": ideal_contains(third_basis, y7),
+            "forces_p7_equals_p0": duplicate_forced,
+        },
+    }
+
+
+def check_class4(root: Path) -> dict[str, Any]:
+    sp, symbols, _coords, _vars_order = base.sympy_context()
+    rows = load_class_rows(root, 4)
+    eq = pb_equation_map(rows)
+    x2, y2 = symbols["x2"], symbols["y2"]
+    x3, y3 = symbols["x3"], symbols["y3"]
+    x4, y4 = symbols["x4"], symbols["y4"]
+
+    first = first_stage_relations(eq)
+    stage1 = {x2: sp.Rational(1, 2), x3: sp.Rational(1, 2), y3: -y2}
+    collinearity_equations = [
+        sp.expand(eq[((0, 2), (1, 4))][0].subs(stage1)),
+        sp.expand(eq[((0, 4), (1, 2))][0].subs(stage1)),
+        sp.expand(eq[((0, 4), (1, 2))][1].subs(stage1)),
+    ]
+    basis = sp.groebner(collinearity_equations, x4, y4, y2, order="lex", domain=sp.QQ)
+    coldet_234 = 2 * y2 * (x4 - sp.Rational(1, 2))
+    relations = [2 * x4 - 1, y2**2 - sp.Rational(3, 4), coldet_234]
+    verified = first["all_expected_relations_hold"] and all(
+        ideal_contains(basis, rel) for rel in relations
+    )
+    return {
+        "class_id": 4,
+        "verified": verified,
+        "mechanism": "collinear_vertices",
+        "row_strings": ["".join(str(value) for value in row) for row in rows],
+        "first_stage": first,
+        "collinearity_stage": {
+            "basis_polynomial_count": len(basis.polys),
+            "contains_2x4_minus_1": ideal_contains(basis, relations[0]),
+            "contains_y2_squared_minus_3_over_4": ideal_contains(basis, relations[1]),
+            "contains_collinearity_determinant": ideal_contains(basis, relations[2]),
+            "collinear_labels": [2, 3, 4],
+        },
+    }
+
+
+def check_class5(root: Path) -> dict[str, Any]:
+    sp, symbols, _coords, _vars_order = base.sympy_context()
+    rows = load_class_rows(root, 5)
+    certificate = load_certificate(root, 5)
+    x2, y2 = symbols["x2"], symbols["y2"]
+    subs = {
+        symbols["x3"]: x2,
+        symbols["y3"]: -y2,
+        symbols["x6"]: 2 * x2 - symbols["x4"],
+        symbols["y6"]: symbols["y4"],
+    }
+    eqs = [sp.expand(eq.subs(subs)) for eq in base.pb_equations(rows)]
+    eqs = [eq for eq in eqs if eq != 0]
+    vars_after = [
+        symbols["x2"],
+        symbols["y2"],
+        symbols["x4"],
+        symbols["y4"],
+        symbols["x5"],
+        symbols["y5"],
+        symbols["x7"],
+        symbols["y7"],
+    ]
+    basis = sp.groebner(eqs, *vars_after, order="lex", domain=sp.QQ)
+    artifact_polys = [
+        base.parse_expr(item)
+        for item in certificate.get("groebner_basis_after_substitution", [])
+    ]
+    artifact_basis = sp.groebner(artifact_polys, *vars_after, order="lex", domain=sp.QQ)
+    artifact_polys_reduce_in_computed_ideal = all(
+        sp.expand(basis.reduce(poly)[1]) == 0 for poly in artifact_polys
+    )
+    original_equations_reduce_in_artifact_ideal = all(
+        sp.expand(artifact_basis.reduce(eq)[1]) == 0 for eq in eqs
+    )
+    artifact_generating_set_equivalent = (
+        artifact_polys_reduce_in_computed_ideal
+        and original_equations_reduce_in_artifact_ideal
+    )
+    contains_y2 = any(
+        sp.Poly(poly.as_expr(), *vars_after, domain=sp.QQ).as_expr() == y2
+        for poly in basis.polys
+    )
+    artifact_contains_y2 = any(sp.expand(poly - y2) == 0 for poly in artifact_polys)
+    verified = artifact_generating_set_equivalent and contains_y2 and artifact_contains_y2
+    return {
+        "class_id": 5,
+        "verified": verified,
+        "mechanism": "groebner_contains_y2_after_substitution",
+        "row_strings": ["".join(str(value) for value in row) for row in rows],
+        "substitutions": {
+            "x3": "x2",
+            "y3": "-y2",
+            "x6": "2*x2 - x4",
+            "y6": "y4",
+        },
+        "groebner": {
+            "basis_polynomial_count": len(basis.polys),
+            "artifact_generating_set_polynomial_count": len(artifact_polys),
+            "artifact_polys_reduce_in_computed_ideal": artifact_polys_reduce_in_computed_ideal,
+            "original_equations_reduce_in_artifact_ideal": original_equations_reduce_in_artifact_ideal,
+            "artifact_generating_set_equivalent": artifact_generating_set_equivalent,
+            "contains_y2": contains_y2,
+            "artifact_contains_y2": artifact_contains_y2,
+        },
+    }
+
+
+def check_all(root: Path) -> dict[str, Any]:
+    class3 = check_class3(root)
+    class4 = check_class4(root)
+    class5 = check_class5(root)
+    classes = [class3, class4, class5]
+    verified = all(record["verified"] for record in classes)
+    return {
+        "type": "n8_residual_certificate_audit_v1",
+        "verified": verified,
+        "trust": "REPO_LOCAL_EXACT_OBSTRUCTION_AUDIT_PENDING_EXTERNAL_REVIEW",
+        "claim_scope": (
+            "Focused audit of the checked-in n=8 class 3, 4, and 5 "
+            "substitution/Groebner certificates only. No general proof of "
+            "Erdos Problem #97 and no counterexample are claimed."
+        ),
+        "class_ids": list(TARGET_CLASS_IDS),
+        "classes": classes,
+        "does_not_check": [
+            "n=8 incidence completeness",
+            "class 14 certificate",
+            "external independent review",
+            "general Erdos Problem #97 proof",
+        ],
+        "errors": [
+            f"class {record['class_id']} did not verify"
+            for record in classes
+            if not record["verified"]
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Exit nonzero if verification fails.")
+    parser.add_argument("--json", action="store_true", help="Print full JSON summary.")
+    args = parser.parse_args(argv)
+
+    summary = check_all(repo_root())
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        status = "verified" if summary["verified"] else "FAILED"
+        mechanisms = ", ".join(record["mechanism"] for record in summary["classes"])
+        print(f"n=8 residual certificate audit: {status}")
+        print(f"mechanisms: {mechanisms}")
+    if args.check and not summary["verified"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -72,6 +72,20 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n8_residual_certificate_audit",
+        command=(
+            "python",
+            "scripts/check_n8_residual_certificates.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Focused audit of the n=8 class 3, 4, and 5 duplicate, "
+            "collinearity, and Groebner-y2 certificates; repo-local exact "
+            "obstruction audit pending external review, not a public theorem claim."
+        ),
+    ),
+    AuditCommand(
         ident="round2_certificates",
         command=("python", "scripts/check_round2_certificates.py"),
         claim_scope="Fixed-pattern and fixed-order round-two certificate regression checks only.",

--- a/tests/test_n8_residual_certificates.py
+++ b/tests/test_n8_residual_certificates.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.artifact
+
+
+def run_residual_script(repo: Path) -> dict:
+    script = repo / "scripts" / "check_n8_residual_certificates.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--check", "--json"],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_n8_residual_certificate_audit() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    summary = run_residual_script(repo)
+
+    assert summary["verified"] is True
+    assert summary["class_ids"] == [3, 4, 5]
+
+    by_class = {record["class_id"]: record for record in summary["classes"]}
+    assert by_class[3]["mechanism"] == "duplicate_vertex"
+    assert by_class[3]["first_stage"]["all_expected_relations_hold"] is True
+    assert by_class[3]["third_stage"]["forces_p7_equals_p0"] is True
+
+    assert by_class[4]["mechanism"] == "collinear_vertices"
+    assert by_class[4]["first_stage"]["all_expected_relations_hold"] is True
+    assert by_class[4]["collinearity_stage"]["contains_collinearity_determinant"] is True
+    assert by_class[4]["collinearity_stage"]["collinear_labels"] == [2, 3, 4]
+
+    assert by_class[5]["mechanism"] == "groebner_contains_y2_after_substitution"
+    assert by_class[5]["groebner"]["basis_polynomial_count"] == 8
+    assert by_class[5]["groebner"]["artifact_generating_set_equivalent"] is True
+    assert by_class[5]["groebner"]["contains_y2"] is True
+    assert by_class[5]["groebner"]["artifact_contains_y2"] is True

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -42,6 +42,7 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert "python scripts/check_n8_class14_certificate.py --check --json" in command_texts
+    assert "python scripts/check_n8_residual_certificates.py --check --json" in command_texts
     assert (
         "python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary

- Add `scripts/check_n8_residual_certificates.py`, a focused checker for the remaining `n=8` classes `3`, `4`, and `5` certificates.
- Verify the class `3` duplicate-vertex chain, the class `4` collinearity chain, and the class `5` Groebner-y2 contradiction after the recorded substitutions.
- Register the checker in the manual artifact audit list and document the remaining scope boundary.

## Scope

This is repo-local audit support for stored exact certificates only. It does not regenerate `n=8` incidence completeness, does not replace external review, and does not claim a public theorem, general proof, or counterexample.

## Validation

- `python scripts/check_n8_residual_certificates.py --check --json`
- `python -m pytest tests\test_n8_residual_certificates.py -q -m artifact`
- `python -m pytest tests\test_n8_residual_certificates.py tests\test_run_artifact_audit.py -q`
- `python -m ruff check scripts\check_n8_residual_certificates.py scripts\run_artifact_audit.py tests\test_n8_residual_certificates.py tests\test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`953 passed, 287 deselected`)