### PR TITLE
[codex] Add n9 strict-edge geometry replay audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ result; independent review is required before any public theorem-style claim.
 The companion input-data audit checks the stored row0 witness coverage and
 summary arithmetic without rerunning the brancher. A fixed-center-order replay
 checks agreement with the dynamic minimum-remaining-options brancher but still
-does not prove the pruning lemmas.
+does not prove the pruning lemmas. A strict-edge geometry audit checks the
+local proper-interval inequality generator for all candidate selected rows.
 See [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 
 An incoming `n=10` singleton-slice continuation is now recorded as a
@@ -447,6 +448,7 @@ python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifac
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -634,6 +634,11 @@ A fixed-center-order replay command,
 also closes the vertex-circle-pruned search and reaches the same
 `184 = 158 + 26` pre-vertex-circle frontier classification as the dynamic
 minimum-remaining-options artifact. This checks branch-order agreement only.
+The strict-edge geometry audit
+`scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
+checks that every candidate selected row produces exactly the proper-interval
+strict inequalities used by the checker, with `5,670` total local strict
+edges across 630 candidate rows. This is local rule verification only.
 
 This is a candidate extension of the repo-local finite-case pipeline to `n=9`,
 but it is not yet the source-of-truth strongest result. The raw incoming bundle

--- a/STATE.md
+++ b/STATE.md
@@ -399,6 +399,10 @@ A fixed-center-order replay,
 `scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
 checks agreement with the dynamic minimum-remaining-options brancher on the
 closed search and 184-frontier classification. It is also a review aid only.
+The strict-edge geometry audit
+`scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
+checks the local proper-interval inequality generator for all 630 candidate
+selected rows, while leaving quotient and coverage review separate.
 
 A 2026-05-05 multi-agent attack adds an independent Gröbner-basis verification
 at n=8 (all 15 incidence-completeness survivors unrealizable by algebra alone)

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -44,6 +44,10 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`
    now reruns the same filters with fixed center order and checks agreement
    with the dynamic minimum-remaining-options artifact.
+   The strict-edge geometry replay
+   `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
+   independently checks the proper-interval strict-edge generator for all
+   candidate selected rows.
 3. Continue the minimal fragile-cover bridge after the stored block-6
    vertex-circle full-extension audit
    `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.
@@ -224,6 +228,10 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
    covers the branch-order checklist item only; the pruning lemmas and
    vertex-circle certificates still need separate review.
+   The strict-edge geometry command,
+   `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`,
+   covers the local vertex-circle strict-edge generator only; quotient
+   soundness and exhaustive coverage still need separate review.
 
 ## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
 

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -122,6 +122,18 @@ It closes the fixed-order vertex-circle-pruned search and reaches the same
 branch-order audit only, not a proof of the filters or a completed `n=9`
 review.
 
+The strict-edge geometry audit command checks the local vertex-circle
+inequality generator:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
+```
+
+It independently enumerates proper interval containments for all 630 candidate
+selected rows and compares them with the checker strict-edge table. This is a
+local geometry-rule audit only, not selected-distance quotient or exhaustive
+coverage review.
+
 ## Commands
 
 Run the stable checker and assert the expected counts:

--- a/docs/n9-vertex-circle-strict-edge-geometry-audit.md
+++ b/docs/n9-vertex-circle-strict-edge-geometry-audit.md
@@ -120,6 +120,19 @@ interval span histogram {'(2, 1)': 2520, '(3, 1)': 1890, '(3, 2)': 1260}
 total strict edges 5670
 ```
 
+The same audit is now replayable:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
+```
+
+The script independently enumerates every proper interval containment for all
+`9 * binom(8,4) = 630` candidate selected rows, compares the resulting strict
+edge table with `src/erdos97/n9_vertex_circle_exhaustive.py`, and checks that
+the quotient replay implementation records the same one-row strict-edge count.
+It preserves the same scope boundary as this note: local strict-edge geometry
+only, not quotient soundness or exhaustive coverage.
+
 This audit checks implementation agreement with the strict-edge lemma. It
 does not audit the later selected-distance quotient graph, self-edge
 criterion, strict-cycle criterion, or exhaustive assignment coverage.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -155,6 +155,18 @@ pre-vertex-circle frontier classification as the dynamic MRO artifact. It does
 not prove the filters, independently replay vertex-circle geometry, prove
 `n=9`, or complete review.
 
+Current strict-edge geometry audit:
+
+```bash
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
+```
+
+This command independently enumerates all proper interval containments for the
+630 candidate selected rows and compares them with the checker strict-edge
+table. It addresses the vertex-circle strict-edge generator only; it does not
+review selected-distance quotient soundness, branch coverage, the crossing
+filters, prove `n=9`, or complete review.
+
 ## Priority 6 - mine a reusable vertex-circle lemma
 
 Target: `docs/n9-vertex-circle-obstruction-shapes.md` and

--- a/scripts/check_n9_vertex_circle_strict_edge_geometry.py
+++ b/scripts/check_n9_vertex_circle_strict_edge_geometry.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Replay the n=9 vertex-circle strict-edge geometry rule."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97 import n9_vertex_circle_exhaustive as n9  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    SelectedRow,
+    pair,
+    replay_vertex_circle_quotient,
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_strict_edge_geometry.v1"
+STATUS = "REVIEW_PENDING_GEOMETRY_RULE_AUDIT"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Strict-edge geometry rule audit for the review-pending n=9 "
+    "vertex-circle checker. It independently enumerates proper interval "
+    "containments for every candidate selected row and compares them to the "
+    "checker strict-edge table. It does not prove row coverage, brancher "
+    "coverage, selected-distance quotient soundness, n=9, a counterexample, "
+    "or any official/global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_strict_edge_geometry.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_strict_edge_geometry.py "
+        "--check --assert-expected --json"
+    ),
+}
+
+EXPECTED_SELECTED_ROWS = 630
+EXPECTED_STRICT_EDGES_PER_ROW = {9: 630}
+EXPECTED_SPAN_HISTOGRAM = {
+    "2->1": 2_520,
+    "3->1": 1_890,
+    "3->2": 1_260,
+}
+EXPECTED_TOTAL_STRICT_EDGES = 5_670
+
+
+def direct_strict_edges(center: int, row_mask: int) -> list[tuple[int, int]]:
+    """Return direct proper-interval strict edges for one selected row."""
+
+    witnesses = sorted(n9.MASK_BITS[row_mask], key=lambda witness: (witness - center) % n9.N)
+    edges: list[tuple[int, int]] = []
+    for outer_start in range(n9.ROW_SIZE):
+        for outer_end in range(outer_start + 1, n9.ROW_SIZE):
+            for inner_start in range(n9.ROW_SIZE):
+                for inner_end in range(inner_start + 1, n9.ROW_SIZE):
+                    if (outer_start, outer_end) == (inner_start, inner_end):
+                        continue
+                    if not _properly_contains(
+                        outer_start,
+                        outer_end,
+                        inner_start,
+                        inner_end,
+                    ):
+                        continue
+                    outer = pair(witnesses[outer_start], witnesses[outer_end])
+                    inner = pair(witnesses[inner_start], witnesses[inner_end])
+                    edges.append((n9.PAIR_INDEX[outer], n9.PAIR_INDEX[inner]))
+    return edges
+
+
+def strict_edge_geometry_payload() -> dict[str, Any]:
+    """Return a replay audit for the n=9 strict-edge geometry table."""
+
+    errors: list[str] = []
+    selected_rows_checked = 0
+    mismatch_count = 0
+    strict_edges_per_row: Counter[int] = Counter()
+    span_histogram: Counter[str] = Counter()
+    quotient_replay_strict_edge_mismatches = 0
+    example_mismatches: list[dict[str, Any]] = []
+
+    for center in range(n9.N):
+        for row_mask in n9.OPTIONS[center]:
+            selected_rows_checked += 1
+            direct = direct_strict_edges(center, row_mask)
+            checker = n9.STRICT_EDGES[(center, row_mask)]
+            if direct != checker:
+                mismatch_count += 1
+                if len(example_mismatches) < 5:
+                    example_mismatches.append(
+                        {
+                            "center": center,
+                            "witnesses": n9.MASK_BITS[row_mask],
+                            "direct": direct,
+                            "checker": checker,
+                        }
+                    )
+            strict_edges_per_row[len(direct)] += 1
+            _add_span_histogram(center, row_mask, span_histogram)
+
+            replay_result = replay_vertex_circle_quotient(
+                n9.N,
+                n9.ORDER,
+                [
+                    SelectedRow(
+                        center=center,
+                        witnesses=tuple(n9.MASK_BITS[row_mask]),
+                    )
+                ],
+            )
+            if replay_result.strict_edge_count != len(direct):
+                quotient_replay_strict_edge_mismatches += 1
+
+    total_strict_edges = sum(length * count for length, count in strict_edges_per_row.items())
+    _check_equal(errors, "selected rows checked", selected_rows_checked, EXPECTED_SELECTED_ROWS)
+    _check_equal(errors, "strict edge mismatches", mismatch_count, 0)
+    _check_equal(
+        errors,
+        "quotient replay strict-edge mismatches",
+        quotient_replay_strict_edge_mismatches,
+        0,
+    )
+    _check_equal(
+        errors,
+        "strict edges per row",
+        dict(sorted(strict_edges_per_row.items())),
+        EXPECTED_STRICT_EDGES_PER_ROW,
+    )
+    _check_equal(
+        errors,
+        "span histogram",
+        dict(sorted(span_histogram.items())),
+        EXPECTED_SPAN_HISTOGRAM,
+    )
+    _check_equal(errors, "total strict edges", total_strict_edges, EXPECTED_TOTAL_STRICT_EDGES)
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "selected_rows_checked": selected_rows_checked,
+        "strict_edge_mismatches": mismatch_count,
+        "quotient_replay_strict_edge_mismatches": quotient_replay_strict_edge_mismatches,
+        "strict_edges_per_row": dict(sorted(strict_edges_per_row.items())),
+        "interval_span_histogram": dict(sorted(span_histogram.items())),
+        "total_strict_edges": total_strict_edges,
+        "example_mismatches": example_mismatches,
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "interpretation": (
+            "A passed audit says the n=9 checker strict-edge table matches a "
+            "direct proper-interval-containment enumeration for every "
+            "candidate row, and the quotient replay implementation records "
+            "the same strict-edge count per one-row payload. It does not "
+            "audit later quotient or exhaustive-search soundness."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def assert_expected_strict_edge_geometry(payload: Mapping[str, Any]) -> None:
+    """Assert the expected strict-edge geometry audit result."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not prove row coverage",
+        "brancher coverage",
+        "selected-distance quotient soundness",
+        "n=9",
+        "counterexample",
+        "official/global status update",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+    if payload.get("validation_status") != "passed":
+        raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+    expected = {
+        "selected_rows_checked": EXPECTED_SELECTED_ROWS,
+        "strict_edge_mismatches": 0,
+        "quotient_replay_strict_edge_mismatches": 0,
+        "strict_edges_per_row": EXPECTED_STRICT_EDGES_PER_ROW,
+        "interval_span_histogram": EXPECTED_SPAN_HISTOGRAM,
+        "total_strict_edges": EXPECTED_TOTAL_STRICT_EDGES,
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            raise AssertionError(f"{key} mismatch: expected {value!r}, got {payload.get(key)!r}")
+
+
+def _properly_contains(
+    outer_start: int,
+    outer_end: int,
+    inner_start: int,
+    inner_end: int,
+) -> bool:
+    return (
+        outer_start <= inner_start
+        and inner_end <= outer_end
+        and (outer_start < inner_start or inner_end < outer_end)
+    )
+
+
+def _add_span_histogram(center: int, row_mask: int, histogram: Counter[str]) -> None:
+    witnesses = sorted(n9.MASK_BITS[row_mask], key=lambda witness: (witness - center) % n9.N)
+    for outer_start in range(n9.ROW_SIZE):
+        for outer_end in range(outer_start + 1, n9.ROW_SIZE):
+            for inner_start in range(n9.ROW_SIZE):
+                for inner_end in range(inner_start + 1, n9.ROW_SIZE):
+                    if (outer_start, outer_end) == (inner_start, inner_end):
+                        continue
+                    if _properly_contains(outer_start, outer_end, inner_start, inner_end):
+                        outer_span = outer_end - outer_start
+                        inner_span = inner_end - inner_start
+                        outer = pair(witnesses[outer_start], witnesses[outer_end])
+                        inner = pair(witnesses[inner_start], witnesses[inner_end])
+                        if outer == inner:
+                            raise AssertionError("proper interval produced equal pairs")
+                        histogram[f"{outer_span}->{inner_span}"] += 1
+
+
+def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> bool:
+    if actual != expected:
+        errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
+        return False
+    return True
+
+
+def summary_lines(payload: Mapping[str, Any]) -> list[str]:
+    return [
+        f"schema: {payload['schema']}",
+        f"status: {payload['status']}",
+        f"validation: {payload['validation_status']}",
+        f"selected rows checked: {payload['selected_rows_checked']}",
+        f"strict-edge mismatches: {payload['strict_edge_mismatches']}",
+        f"total strict edges: {payload['total_strict_edges']}",
+    ]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate the audit")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = strict_edge_geometry_payload()
+
+    if args.assert_expected:
+        assert_expected_strict_edge_geometry(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif payload.get("validation_status") == "passed":
+        print("n=9 vertex-circle strict-edge geometry audit")
+        for line in summary_lines(payload):
+            print(line)
+        print("OK: n=9 strict-edge geometry audit checks passed")
+    else:
+        print("FAILED: n=9 strict-edge geometry audit", file=sys.stderr)
+        for error in payload.get("validation_errors", []):
+            print(f"- {error}", file=sys.stderr)
+
+    if args.check and payload.get("validation_status") != "passed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -216,6 +216,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_strict_edge_geometry",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_strict_edge_geometry.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Strict-edge geometry rule audit for every candidate n=9 "
+            "selected row; not row coverage, brancher coverage, quotient "
+            "soundness, proof of n=9, counterexample, or official/global "
+            "status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_local_core_packet",
         command=(
             "python",

--- a/tests/test_n9_vertex_circle_strict_edge_geometry.py
+++ b/tests/test_n9_vertex_circle_strict_edge_geometry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from scripts.check_n9_vertex_circle_strict_edge_geometry import (
+    EXPECTED_SELECTED_ROWS,
+    EXPECTED_SPAN_HISTOGRAM,
+    EXPECTED_STRICT_EDGES_PER_ROW,
+    EXPECTED_TOTAL_STRICT_EDGES,
+    assert_expected_strict_edge_geometry,
+    direct_strict_edges,
+    strict_edge_geometry_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_direct_strict_edges_match_checker_for_sample_rows() -> None:
+    samples = [
+        (0, n9.OPTIONS[0][0]),
+        (0, n9.OPTIONS[0][-1]),
+        (4, n9.OPTIONS[4][17]),
+        (8, n9.OPTIONS[8][42]),
+    ]
+
+    for center, row_mask in samples:
+        assert direct_strict_edges(center, row_mask) == n9.STRICT_EDGES[(center, row_mask)]
+        assert len(direct_strict_edges(center, row_mask)) == 9
+
+
+def test_strict_edge_geometry_expected_counts_and_scope() -> None:
+    payload = strict_edge_geometry_payload()
+
+    assert_expected_strict_edge_geometry(payload)
+    assert payload["validation_status"] == "passed"
+    assert payload["selected_rows_checked"] == EXPECTED_SELECTED_ROWS
+    assert payload["strict_edges_per_row"] == EXPECTED_STRICT_EDGES_PER_ROW
+    assert payload["interval_span_histogram"] == EXPECTED_SPAN_HISTOGRAM
+    assert payload["total_strict_edges"] == EXPECTED_TOTAL_STRICT_EDGES
+    assert "does not prove row coverage" in payload["claim_scope"]
+    assert "selected-distance quotient soundness" in payload["claim_scope"]
+    assert "counterexample" in payload["claim_scope"]
+
+
+def test_strict_edge_geometry_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_edge_geometry.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    parsed = json.loads(result.stdout)
+    assert parsed["validation_status"] == "passed"
+    assert parsed["selected_rows_checked"] == 630
+    assert parsed["strict_edges_per_row"] == {"9": 630}

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -189,6 +189,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n9_vertex_circle_mro_branching_replay.py --check "
         "--assert-expected --json"
     ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_local_core_packet.py --check "
         "--assert-expected --json"
     )


### PR DESCRIPTION
## Summary

- Add a replayable `n=9` vertex-circle strict-edge geometry audit for all 630 candidate selected rows.
- Compare direct proper-interval containment enumeration with the checker strict-edge table and one-row quotient replay strict-edge counts.
- Register the audit in the artifact audit runner and document its review-pending, local-rule-only scope.

## Validation

- `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_strict_edge_geometry.py tests\test_run_artifact_audit.py -q`
- `python -m ruff check scripts\check_n9_vertex_circle_strict_edge_geometry.py tests\test_n9_vertex_circle_strict_edge_geometry.py scripts\run_artifact_audit.py tests\test_run_artifact_audit.py`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`963 passed, 291 deselected`)

## Scope

This is a review aid for the local strict-edge geometry rule only. It does not claim a proof of `n=9`, a counterexample, selected-distance quotient soundness, full brancher coverage, or any official/global status update.