### PR TITLE
[codex] Add n9 quotient soundness replay audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ The companion input-data audit checks the stored row0 witness coverage and
 summary arithmetic without rerunning the brancher. A fixed-center-order replay
 checks agreement with the dynamic minimum-remaining-options brancher but still
 does not prove the pruning lemmas. A strict-edge geometry audit checks the
-local proper-interval inequality generator for all candidate selected rows.
+local proper-interval inequality generator for all candidate selected rows. A
+quotient-soundness audit checks selected-distance quotient status agreement on
+the stored local-core and frontier rows.
 See [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 
 An incoming `n=10` singleton-slice continuation is now recorded as a
@@ -452,6 +454,7 @@ python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-e
 python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -639,6 +639,12 @@ The strict-edge geometry audit
 checks that every candidate selected row produces exactly the proper-interval
 strict inequalities used by the checker, with `5,670` total local strict
 edges across 630 candidate rows. This is local rule verification only.
+The quotient-soundness audit
+`scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
+checks that the stored local-core rows and 184 stored frontier assignments get
+the same selected-distance quotient status from the exhaustive checker, the
+reusable replay helper, and a small direct replay. This is implementation
+agreement only.
 
 This is a candidate extension of the repo-local finite-case pipeline to `n=9`,
 but it is not yet the source-of-truth strongest result. The raw incoming bundle

--- a/STATE.md
+++ b/STATE.md
@@ -403,6 +403,11 @@ The strict-edge geometry audit
 `scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
 checks the local proper-interval inequality generator for all 630 candidate
 selected rows, while leaving quotient and coverage review separate.
+The quotient-soundness audit
+`scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
+checks selected-distance quotient status agreement on the stored local-core
+rows, stored full frontier assignments, and stored transformed frontier cores.
+It leaves branch coverage and strict-edge geometry review separate.
 
 A 2026-05-05 multi-agent attack adds an independent Gröbner-basis verification
 at n=8 (all 15 incidence-completeness survivors unrealizable by algebra alone)

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -48,6 +48,10 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
    independently checks the proper-interval strict-edge generator for all
    candidate selected rows.
+   The quotient-soundness replay
+   `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
+   checks selected-distance quotient status agreement on the stored local-core
+   and frontier rows.
 3. Continue the minimal fragile-cover bridge after the stored block-6
    vertex-circle full-extension audit
    `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.
@@ -232,6 +236,11 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`,
    covers the local vertex-circle strict-edge generator only; quotient
    soundness and exhaustive coverage still need separate review.
+   The quotient-soundness command,
+   `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`,
+   covers selected-distance quotient status agreement on stored local-core and
+   frontier rows only; branch coverage and strict-edge geometry remain separate
+   review scopes.
 
 ## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
 

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -134,6 +134,17 @@ selected rows and compares them with the checker strict-edge table. This is a
 local geometry-rule audit only, not selected-distance quotient or exhaustive
 coverage review.
 
+The quotient-soundness audit command checks selected-distance quotient status
+agreement on the stored local-core and frontier rows:
+
+```bash
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+```
+
+It compares the exhaustive checker, the reusable quotient replay helper, and a
+small direct quotient/status replay. This is implementation agreement only, not
+branch coverage, strict-edge geometry, or a completed `n=9` review.
+
 ## Commands
 
 Run the stable checker and assert the expected counts:

--- a/docs/n9-vertex-circle-quotient-soundness-audit.md
+++ b/docs/n9-vertex-circle-quotient-soundness-audit.md
@@ -101,6 +101,22 @@ either obstruction is already a contradiction.
 
 ## One-off Audits
 
+The audit is now replayable:
+
+```bash
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+```
+
+The script compares three status implementations on the stored local-core
+packet and the stored 184 frontier assignments: the repo-native exhaustive
+checker, the reusable quotient replay helper, and a small direct
+quotient/status replay inside the audit command. It also checks the transformed
+core rows stored in the frontier-classification artifact. This is an
+implementation-agreement audit only, not branch coverage or geometry review.
+
+The following transcript snippets are the historical one-off checks that the
+replay command now stabilizes.
+
 The local-core replay bundle was checked directly:
 
 ```text

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -167,6 +167,18 @@ table. It addresses the vertex-circle strict-edge generator only; it does not
 review selected-distance quotient soundness, branch coverage, the crossing
 filters, prove `n=9`, or complete review.
 
+Current quotient-soundness audit:
+
+```bash
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+```
+
+This command checks stored local-core rows, stored full frontier assignments,
+and stored transformed frontier cores against three quotient/status views: the
+exhaustive checker, the reusable quotient replay helper, and a small direct
+quotient/status replay. It does not audit branch coverage, strict-edge
+geometry, prove `n=9`, or complete review.
+
 ## Priority 6 - mine a reusable vertex-circle lemma
 
 Target: `docs/n9-vertex-circle-obstruction-shapes.md` and

--- a/scripts/check_n9_vertex_circle_quotient_soundness.py
+++ b/scripts/check_n9_vertex_circle_quotient_soundness.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Replay the n=9 vertex-circle selected-distance quotient audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97 import n9_vertex_circle_exhaustive as n9  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    SelectedRow,
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+)
+
+DEFAULT_LOCAL_CORE_PACKET = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_local_core_packet.json"
+)
+DEFAULT_FRONTIER_CLASSIFICATION = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_vertex_circle_frontier_motif_classification.json"
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_quotient_soundness.v1"
+STATUS = "REVIEW_PENDING_QUOTIENT_SOUNDNESS_AUDIT"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Selected-distance quotient status audit for the review-pending n=9 "
+    "vertex-circle checker. It compares the repo-native checker, the reusable "
+    "quotient replay helper, and a direct local quotient/status replay on "
+    "stored local-core rows and the 184 stored pre-vertex-circle frontier "
+    "assignments. It does not prove row coverage, brancher coverage, "
+    "strict-edge geometry, n=9, a counterexample, or any official/global "
+    "status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_quotient_soundness.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+        "--check --assert-expected --json"
+    ),
+}
+
+EXPECTED_LOCAL_CORE = {
+    "row_set_count": 16,
+    "selected_row_total": 67,
+    "spoke_pairs_checked": 268,
+    "status_counts": {"self_edge": 13, "strict_cycle": 3},
+    "strict_edge_count_histogram": {27: 5, 36: 6, 45: 2, 54: 3},
+    "replay_self_edge_conflict_records": 43,
+    "replay_cycle_edge_records": 8,
+}
+EXPECTED_FRONTIER_FULL = {
+    "row_set_count": 184,
+    "selected_row_total": 1_656,
+    "spoke_pairs_checked": 6_624,
+    "status_counts": {"self_edge": 158, "strict_cycle": 26},
+    "strict_edge_count_histogram": {81: 184},
+    "replay_self_edge_conflict_records": 2_988,
+    "replay_cycle_edge_records": 56,
+}
+EXPECTED_FRONTIER_CORE = {
+    "row_set_count": 184,
+    "selected_row_total": 802,
+    "spoke_pairs_checked": 3_208,
+    "status_counts": {"self_edge": 158, "strict_cycle": 26},
+    "strict_edge_count_histogram": {27: 46, 36: 64, 45: 36, 54: 38},
+    "replay_self_edge_conflict_records": 670,
+    "replay_cycle_edge_records": 59,
+}
+
+Pair = tuple[int, int]
+
+
+@dataclass(frozen=True)
+class DirectQuotientResult:
+    """Small direct replay result for one selected-row set."""
+
+    selected_row_count: int
+    strict_edge_count: int
+    status: str
+    self_edge_count: int
+    has_strict_cycle: bool
+    row_equality_component_violations: int
+
+
+class UnionFind:
+    """Deterministic union-find over unordered pair labels."""
+
+    def __init__(self, items: Sequence[Pair]) -> None:
+        self.parent = {item: item for item in items}
+
+    def find(self, item: Pair) -> Pair:
+        while self.parent[item] != item:
+            self.parent[item] = self.parent[self.parent[item]]
+            item = self.parent[item]
+        return item
+
+    def union(self, a: Pair, b: Pair) -> None:
+        root_a = self.find(a)
+        root_b = self.find(b)
+        if root_a == root_b:
+            return
+        if root_b < root_a:
+            root_a, root_b = root_b, root_a
+        self.parent[root_b] = root_a
+
+
+def load_json(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def direct_quotient_result(
+    n: int,
+    order: Sequence[int],
+    rows: Sequence[SelectedRow],
+) -> DirectQuotientResult:
+    """Replay quotient equalities and strict edges without using helper status code."""
+
+    order_tuple = tuple(int(label) for label in order)
+    positions = {label: index for index, label in enumerate(order_tuple)}
+    uf = UnionFind(_all_pairs(n))
+    for row in rows:
+        spokes = [_pair(row.center, witness) for witness in row.witnesses]
+        base = spokes[0]
+        for spoke in spokes[1:]:
+            uf.union(base, spoke)
+
+    row_violations = 0
+    for row in rows:
+        roots = {uf.find(_pair(row.center, witness)) for witness in row.witnesses}
+        if len(roots) != 1:
+            row_violations += 1
+
+    edge_roots: list[tuple[Pair, Pair]] = []
+    for row in rows:
+        witnesses = tuple(
+            sorted(
+                row.witnesses,
+                key=lambda witness: (positions[witness] - positions[row.center]) % n,
+            )
+        )
+        for outer_start in range(4):
+            for outer_end in range(outer_start + 1, 4):
+                for inner_start in range(4):
+                    for inner_end in range(inner_start + 1, 4):
+                        if (outer_start, outer_end) == (inner_start, inner_end):
+                            continue
+                        if not _properly_contains(
+                            outer_start,
+                            outer_end,
+                            inner_start,
+                            inner_end,
+                        ):
+                            continue
+                        outer = _pair(witnesses[outer_start], witnesses[outer_end])
+                        inner = _pair(witnesses[inner_start], witnesses[inner_end])
+                        edge_roots.append((uf.find(outer), uf.find(inner)))
+
+    self_edge_count = sum(outer == inner for outer, inner in edge_roots)
+    has_cycle = False if self_edge_count else _has_directed_cycle(edge_roots)
+    if self_edge_count:
+        status = "self_edge"
+    elif has_cycle:
+        status = "strict_cycle"
+    else:
+        status = "ok"
+    return DirectQuotientResult(
+        selected_row_count=len(rows),
+        strict_edge_count=len(edge_roots),
+        status=status,
+        self_edge_count=self_edge_count,
+        has_strict_cycle=has_cycle,
+        row_equality_component_violations=row_violations,
+    )
+
+
+def quotient_soundness_payload(
+    *,
+    local_core_path: Path = DEFAULT_LOCAL_CORE_PACKET,
+    frontier_path: Path = DEFAULT_FRONTIER_CLASSIFICATION,
+) -> dict[str, Any]:
+    """Return a replay audit for n=9 selected-distance quotient soundness."""
+
+    local_core = load_json(local_core_path)
+    frontier = load_json(frontier_path)
+    errors: list[str] = []
+
+    local_core_summary = _audit_named_row_sets(
+        [
+            {
+                "row_set_id": str(certificate["family_id"]),
+                "recorded_status": str(certificate["status"]),
+                "rows": certificate["compact_selected_rows"],
+            }
+            for certificate in local_core["certificates"]
+        ],
+        label="local core packet",
+    )
+    frontier_full_summary = _audit_named_row_sets(
+        [
+            {
+                "row_set_id": str(assignment["assignment_id"]),
+                "recorded_status": str(assignment["status"]),
+                "rows": assignment["selected_rows"],
+            }
+            for assignment in frontier["assignments"]
+        ],
+        label="frontier full assignments",
+    )
+    frontier_core_summary = _audit_named_row_sets(
+        [
+            {
+                "row_set_id": str(assignment["assignment_id"]),
+                "recorded_status": str(assignment["status"]),
+                "rows": assignment["core_selected_rows"],
+            }
+            for assignment in frontier["assignments"]
+        ],
+        label="frontier transformed cores",
+    )
+
+    _check_section(errors, "local_core_packet", local_core_summary, EXPECTED_LOCAL_CORE)
+    _check_section(
+        errors,
+        "frontier_full_assignments",
+        frontier_full_summary,
+        EXPECTED_FRONTIER_FULL,
+    )
+    _check_section(
+        errors,
+        "frontier_core_assignments",
+        frontier_core_summary,
+        EXPECTED_FRONTIER_CORE,
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "local_core_packet": local_core_summary,
+        "frontier_full_assignments": frontier_full_summary,
+        "frontier_core_assignments": frontier_core_summary,
+        "source_artifacts": [
+            _source_metadata(local_core_path, local_core),
+            _source_metadata(frontier_path, frontier),
+        ],
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "interpretation": (
+            "A passed audit says stored n=9 local-core rows and stored "
+            "pre-vertex-circle frontier rows get the same quotient-obstruction "
+            "status from the exhaustive checker, the reusable replay helper, "
+            "and a small direct quotient/status replay. This is quotient "
+            "implementation agreement only."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def assert_expected_quotient_soundness(payload: Mapping[str, Any]) -> None:
+    """Assert the expected quotient-soundness replay audit result."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not prove row coverage",
+        "brancher coverage",
+        "strict-edge geometry",
+        "n=9",
+        "counterexample",
+        "official/global status update",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+    if payload.get("validation_status") != "passed":
+        raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+    _assert_section("local_core_packet", payload, EXPECTED_LOCAL_CORE)
+    _assert_section("frontier_full_assignments", payload, EXPECTED_FRONTIER_FULL)
+    _assert_section("frontier_core_assignments", payload, EXPECTED_FRONTIER_CORE)
+
+
+def _audit_named_row_sets(
+    row_sets: Sequence[Mapping[str, Any]],
+    *,
+    label: str,
+) -> dict[str, Any]:
+    replay_status_counts: Counter[str] = Counter()
+    checker_status_counts: Counter[str] = Counter()
+    direct_status_counts: Counter[str] = Counter()
+    recorded_status_counts: Counter[str] = Counter()
+    strict_edge_histogram: Counter[int] = Counter()
+    selected_row_total = 0
+    spoke_pairs_checked = 0
+    replay_self_edge_conflicts = 0
+    replay_cycle_edges = 0
+    direct_self_edges = 0
+    direct_strict_cycle_count = 0
+    row_equality_component_violations = 0
+    status_mismatches = 0
+    example_mismatches: list[dict[str, Any]] = []
+
+    for row_set in row_sets:
+        row_set_id = str(row_set["row_set_id"])
+        recorded_status = str(row_set["recorded_status"])
+        rows = parse_selected_rows(row_set["rows"])
+        replay = replay_vertex_circle_quotient(n9.N, n9.ORDER, rows)
+        direct = direct_quotient_result(n9.N, n9.ORDER, rows)
+        checker_status = n9.vertex_circle_status(_assignment_from_rows(rows))
+
+        selected_row_total += len(rows)
+        spoke_pairs_checked += len(rows) * n9.ROW_SIZE
+        replay_status_counts[replay.status] += 1
+        checker_status_counts[checker_status] += 1
+        direct_status_counts[direct.status] += 1
+        recorded_status_counts[recorded_status] += 1
+        strict_edge_histogram[replay.strict_edge_count] += 1
+        replay_self_edge_conflicts += len(replay.self_edge_conflicts)
+        replay_cycle_edges += len(replay.cycle_edges)
+        direct_self_edges += direct.self_edge_count
+        if direct.has_strict_cycle:
+            direct_strict_cycle_count += 1
+        row_equality_component_violations += direct.row_equality_component_violations
+
+        statuses = {
+            "recorded": recorded_status,
+            "checker": checker_status,
+            "replay": replay.status,
+            "direct": direct.status,
+        }
+        if len(set(statuses.values())) != 1:
+            status_mismatches += 1
+            if len(example_mismatches) < 5:
+                example_mismatches.append({"row_set_id": row_set_id, "statuses": statuses})
+
+    return {
+        "label": label,
+        "row_set_count": len(row_sets),
+        "selected_row_total": selected_row_total,
+        "spoke_pairs_checked": spoke_pairs_checked,
+        "status_counts": dict(sorted(replay_status_counts.items())),
+        "recorded_status_counts": dict(sorted(recorded_status_counts.items())),
+        "checker_status_counts": dict(sorted(checker_status_counts.items())),
+        "replay_status_counts": dict(sorted(replay_status_counts.items())),
+        "direct_status_counts": dict(sorted(direct_status_counts.items())),
+        "strict_edge_count_histogram": dict(sorted(strict_edge_histogram.items())),
+        "replay_self_edge_conflict_records": replay_self_edge_conflicts,
+        "replay_cycle_edge_records": replay_cycle_edges,
+        "direct_self_edge_records": direct_self_edges,
+        "direct_strict_cycle_row_sets": direct_strict_cycle_count,
+        "row_equality_component_violations": row_equality_component_violations,
+        "status_mismatches": status_mismatches,
+        "example_mismatches": example_mismatches,
+    }
+
+
+def _check_section(
+    errors: list[str],
+    name: str,
+    section: Mapping[str, Any],
+    expected: Mapping[str, Any],
+) -> None:
+    if section.get("status_mismatches") != 0:
+        errors.append(f"{name} status mismatches: {section.get('example_mismatches')!r}")
+    if section.get("row_equality_component_violations") != 0:
+        errors.append(
+            f"{name} row equality component violations: "
+            f"{section.get('row_equality_component_violations')!r}"
+        )
+    for key, value in expected.items():
+        if section.get(key) != value:
+            errors.append(f"{name} {key} mismatch: {section.get(key)!r} != {value!r}")
+    for key in (
+        "recorded_status_counts",
+        "checker_status_counts",
+        "replay_status_counts",
+        "direct_status_counts",
+    ):
+        if section.get(key) != expected["status_counts"]:
+            errors.append(
+                f"{name} {key} mismatch: "
+                f"{section.get(key)!r} != {expected['status_counts']!r}"
+            )
+
+
+def _assert_section(
+    name: str,
+    payload: Mapping[str, Any],
+    expected: Mapping[str, Any],
+) -> None:
+    section = payload.get(name)
+    if not isinstance(section, Mapping):
+        raise AssertionError(f"{name} section missing")
+    errors: list[str] = []
+    _check_section(errors, name, section, expected)
+    if errors:
+        raise AssertionError("; ".join(errors))
+
+
+def _assignment_from_rows(rows: Sequence[SelectedRow]) -> dict[int, int]:
+    return {
+        row.center: n9.mask([int(witness) for witness in row.witnesses])
+        for row in rows
+    }
+
+
+def _source_metadata(path: Path, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": str(path.relative_to(ROOT)).replace("\\", "/"),
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+    }
+
+
+def _all_pairs(n: int) -> list[Pair]:
+    return [(u, v) for u in range(n) for v in range(u + 1, n)]
+
+
+def _pair(a: int, b: int) -> Pair:
+    if a == b:
+        raise ValueError(f"loop pair is not allowed: ({a}, {b})")
+    return (a, b) if a < b else (b, a)
+
+
+def _properly_contains(
+    outer_start: int,
+    outer_end: int,
+    inner_start: int,
+    inner_end: int,
+) -> bool:
+    return (
+        outer_start <= inner_start
+        and inner_end <= outer_end
+        and (outer_start < inner_start or inner_end < outer_end)
+    )
+
+
+def _has_directed_cycle(edges: Sequence[tuple[Pair, Pair]]) -> bool:
+    graph: dict[Pair, list[Pair]] = defaultdict(list)
+    for outer, inner in edges:
+        if outer != inner:
+            graph[outer].append(inner)
+    for source in graph:
+        graph[source].sort()
+
+    color: dict[Pair, int] = {}
+
+    def visit(node: Pair) -> bool:
+        color[node] = 1
+        for target in graph.get(node, []):
+            target_color = color.get(target, 0)
+            if target_color == 1:
+                return True
+            if target_color == 0 and visit(target):
+                return True
+        color[node] = 2
+        return False
+
+    return any(color.get(node, 0) == 0 and visit(node) for node in sorted(graph))
+
+
+def summary_lines(payload: Mapping[str, Any]) -> list[str]:
+    return [
+        f"schema: {payload['schema']}",
+        f"status: {payload['status']}",
+        f"validation: {payload['validation_status']}",
+        "local-core row sets: "
+        f"{payload['local_core_packet']['row_set_count']}",
+        "frontier full row sets: "
+        f"{payload['frontier_full_assignments']['row_set_count']}",
+        "frontier core row sets: "
+        f"{payload['frontier_core_assignments']['row_set_count']}",
+    ]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--local-core-packet", type=Path, default=DEFAULT_LOCAL_CORE_PACKET)
+    parser.add_argument(
+        "--frontier-classification",
+        type=Path,
+        default=DEFAULT_FRONTIER_CLASSIFICATION,
+    )
+    parser.add_argument("--check", action="store_true", help="validate the audit")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    local_core_path = (
+        args.local_core_packet
+        if args.local_core_packet.is_absolute()
+        else ROOT / args.local_core_packet
+    )
+    frontier_path = (
+        args.frontier_classification
+        if args.frontier_classification.is_absolute()
+        else ROOT / args.frontier_classification
+    )
+    payload = quotient_soundness_payload(
+        local_core_path=local_core_path,
+        frontier_path=frontier_path,
+    )
+
+    if args.assert_expected:
+        assert_expected_quotient_soundness(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif payload.get("validation_status") == "passed":
+        print("n=9 vertex-circle quotient soundness audit")
+        for line in summary_lines(payload):
+            print(line)
+        print("OK: n=9 quotient soundness audit checks passed")
+    else:
+        print("FAILED: n=9 quotient soundness audit", file=sys.stderr)
+        for error in payload.get("validation_errors", []):
+            print(f"- {error}", file=sys.stderr)
+
+    if args.check and payload.get("validation_status") != "passed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -275,6 +275,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_quotient_soundness",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_quotient_soundness.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Selected-distance quotient status agreement audit for stored "
+            "n=9 local-core rows and frontier assignments; not row coverage, "
+            "brancher coverage, strict-edge geometry, proof of n=9, "
+            "counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_self_edge_path_join",
         command=(
             "python",

--- a/tests/test_n9_vertex_circle_quotient_soundness.py
+++ b/tests/test_n9_vertex_circle_quotient_soundness.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97 import n9_vertex_circle_exhaustive as n9
+from erdos97.vertex_circle_quotient_replay import parse_selected_rows
+from scripts.check_n9_vertex_circle_quotient_soundness import (
+    EXPECTED_FRONTIER_CORE,
+    EXPECTED_FRONTIER_FULL,
+    EXPECTED_LOCAL_CORE,
+    assert_expected_quotient_soundness,
+    direct_quotient_result,
+    quotient_soundness_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_direct_quotient_result_matches_checker_for_sample_rows() -> None:
+    rows = parse_selected_rows(
+        [
+            [0, 1, 2, 3, 8],
+            [1, 0, 2, 4, 7],
+            [8, 0, 1, 4, 5],
+        ]
+    )
+    direct = direct_quotient_result(n9.N, n9.ORDER, rows)
+
+    assert direct.status == "self_edge"
+    assert direct.selected_row_count == 3
+    assert direct.strict_edge_count == 27
+    assert direct.self_edge_count > 0
+    assert direct.row_equality_component_violations == 0
+
+
+def test_quotient_soundness_expected_counts_and_scope() -> None:
+    payload = quotient_soundness_payload()
+
+    assert_expected_quotient_soundness(payload)
+    assert payload["validation_status"] == "passed"
+    assert payload["local_core_packet"]["row_set_count"] == EXPECTED_LOCAL_CORE["row_set_count"]
+    assert (
+        payload["frontier_full_assignments"]["selected_row_total"]
+        == EXPECTED_FRONTIER_FULL["selected_row_total"]
+    )
+    assert (
+        payload["frontier_core_assignments"]["spoke_pairs_checked"]
+        == EXPECTED_FRONTIER_CORE["spoke_pairs_checked"]
+    )
+    assert "strict-edge geometry" in payload["claim_scope"]
+    assert "counterexample" in payload["claim_scope"]
+    assert "official/global status update" in payload["claim_scope"]
+
+
+def test_quotient_soundness_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_quotient_soundness.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    parsed = json.loads(result.stdout)
+    assert parsed["validation_status"] == "passed"
+    assert parsed["local_core_packet"]["status_counts"] == {
+        "self_edge": 13,
+        "strict_cycle": 3,
+    }
+    assert parsed["frontier_full_assignments"]["strict_edge_count_histogram"] == {
+        "81": 184
+    }

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -210,6 +210,25 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_frontier_motif_classification.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_self_edge_path_join.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_self_edge_path_join.py "
         "--check --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary

- Add a replayable `n=9` selected-distance quotient/status audit for stored local-core rows, stored full frontier assignments, and stored transformed frontier cores.
- Compare the repo-native exhaustive checker, the reusable quotient replay helper, and a small direct quotient/status replay.
- Register the command in the artifact audit runner and document the review-pending, implementation-agreement-only scope.

## Validation

- `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_quotient_soundness.py tests\test_run_artifact_audit.py -q`
- focused `ruff`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`966 passed, 291 deselected`)

## Scope

This is a quotient/status implementation agreement audit only. It does not claim a proof of `n=9`, a counterexample, branch coverage, strict-edge geometry, exhaustive checker review completion, or any official/global status update.