### PR TITLE
[codex] Add n9 partial-pruning replay audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ with the dynamic minimum-remaining-options brancher but still does not prove
 the pruning lemmas. A strict-edge geometry audit checks the local
 proper-interval inequality generator for all candidate selected rows. A
 quotient-soundness audit checks selected-distance quotient status agreement on
-the stored local-core and frontier rows.
+the stored local-core and frontier rows. A partial-pruning audit checks all
+nonempty selected-row subsets of the stored 184 frontier assignments for
+monotone obstruction persistence and checker/replay status agreement only.
 See [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 
 An incoming `n=10` singleton-slice continuation is now recorded as a
@@ -458,6 +460,7 @@ python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expe
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -650,6 +650,12 @@ checks that the stored local-core rows and 184 stored frontier assignments get
 the same selected-distance quotient status from the exhaustive checker, the
 reusable replay helper, and a small direct replay. This is implementation
 agreement only.
+The partial-pruning audit
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+checks all 94,024 nonempty selected-row subsets of the stored 184 frontier
+assignments. It finds zero checker/replay status mismatches and zero stored
+extension violations for obstructed subsets. This is stored-frontier pruning
+diagnostics only.
 
 This is a candidate extension of the repo-local finite-case pipeline to `n=9`,
 but it is not yet the source-of-truth strongest result. The raw incoming bundle

--- a/STATE.md
+++ b/STATE.md
@@ -413,6 +413,12 @@ The quotient-soundness audit
 checks selected-distance quotient status agreement on the stored local-core
 rows, stored full frontier assignments, and stored transformed frontier cores.
 It leaves branch coverage and strict-edge geometry review separate.
+The partial-pruning audit
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+checks all 94,024 nonempty selected-row subsets of the stored 184 frontier
+assignments for monotone obstruction persistence and checker/replay status
+agreement. It is stored-frontier diagnostics only and leaves frontier coverage,
+brancher soundness, strict-edge geometry, and quotient soundness separate.
 
 A 2026-05-05 multi-agent attack adds an independent Gröbner-basis verification
 at n=8 (all 15 incidence-completeness survivors unrealizable by algebra alone)

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -56,6 +56,11 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
    checks the row-level two-overlap crossing, witness-pair cap, and
    selected-indegree cap tables.
+   The partial-pruning replay
+   `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+   checks all nonempty selected-row subsets of the stored 184 frontier
+   assignments for monotone obstruction persistence and checker/replay status
+   agreement only.
 3. Continue the minimal fragile-cover bridge after the stored block-6
    vertex-circle full-extension audit
    `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -156,6 +156,19 @@ It compares the exhaustive checker, the reusable quotient replay helper, and a
 small direct quotient/status replay. This is implementation agreement only, not
 branch coverage, strict-edge geometry, or a completed `n=9` review.
 
+The partial-pruning audit command checks stored-frontier row subsets:
+
+```bash
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+```
+
+It scans all 94,024 nonempty row subsets from the 184 stored frontier
+assignments, checks that every obstructed subset extends only to a stored full
+assignment that remains obstructed, and compares checker status with the
+reusable quotient replay. This is stored-frontier pruning diagnostics only, not
+frontier coverage, brancher soundness, strict-edge geometry, quotient
+soundness, or a completed `n=9` review.
+
 ## Commands
 
 Run the stable checker and assert the expected counts:

--- a/docs/n9-vertex-circle-partial-pruning-audit.md
+++ b/docs/n9-vertex-circle-partial-pruning-audit.md
@@ -1,6 +1,6 @@
 # n=9 Vertex-circle Partial-pruning Audit
 
-Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+Status: `REVIEW_PENDING_PARTIAL_PRUNING_AUDIT`.
 
 This note audits one narrow pruning question in the repo-native `n=9`
 vertex-circle exhaustive checker: once a partial assignment already has a
@@ -74,7 +74,7 @@ else:
     counts[f"partial_{status}"] += 1
 ```
 
-A one-off static audit reported:
+An earlier one-off static audit reported:
 
 ```text
 vertex_circle_status lines: 192-226
@@ -95,7 +95,44 @@ It does not prove the geometric vertex-circle strict-chord lemma, does not
 audit the pair/crossing/count filters, does not independently replay the 184
 pre-vertex-circle assignments, and does not prove the full `n=9` finite case.
 
+## Stored-frontier Replay
+
+The command
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+turns the monotonicity note into a stored-frontier diagnostic. It scans every
+nonempty subset of selected rows from the 184 stored pre-vertex-circle frontier
+assignments in
+`data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
+
+The replay checks:
+
+- 184 stored assignments;
+- 94,024 nonempty row subsets;
+- 58,606 obstructed subsets;
+- zero checker/replay status mismatches;
+- zero cases where an obstructed subset extends to a stored full assignment
+  that is vertex-circle clean.
+
+The subset status counts are:
+
+```text
+ok:           35418
+self_edge:    24890
+strict_cycle: 33716
+```
+
+This does not prove frontier coverage, brancher soundness, strict-edge
+geometry, selected-distance quotient soundness, `n=9`, a counterexample, or
+any official/global status update. It is a reproducibility check for the
+partial-pruning step on the stored frontier only.
+
 ## Commands
+
+Run the stored-frontier partial-pruning audit:
+
+```bash
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+```
 
 Run the exhaustive checker and the targeted artifact test:
 
@@ -104,4 +141,3 @@ python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
 
 python -m pytest tests/test_n9_vertex_circle_exhaustive.py -q -m "artifact"
 ```
-

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -190,6 +190,18 @@ exhaustive checker, the reusable quotient replay helper, and a small direct
 quotient/status replay. It does not audit branch coverage, strict-edge
 geometry, prove `n=9`, or complete review.
 
+Current partial-pruning audit:
+
+```bash
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+```
+
+This command scans all nonempty selected-row subsets of the 184 stored
+pre-vertex-circle frontier assignments. It checks monotone obstruction
+persistence and checker/replay status agreement on those stored subsets only.
+It does not prove frontier coverage, brancher soundness, strict-edge geometry,
+selected-distance quotient soundness, `n=9`, or complete review.
+
 ## Priority 6 - mine a reusable vertex-circle lemma
 
 Target: `docs/n9-vertex-circle-obstruction-shapes.md` and

--- a/scripts/check_n9_vertex_circle_partial_pruning.py
+++ b/scripts/check_n9_vertex_circle_partial_pruning.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Replay n=9 vertex-circle partial-pruning monotonicity diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97 import n9_vertex_circle_exhaustive as n9  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    parse_selected_rows,
+    replay_vertex_circle_quotient,
+)
+
+DEFAULT_FRONTIER_CLASSIFICATION = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_vertex_circle_frontier_motif_classification.json"
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_partial_pruning.v1"
+STATUS = "REVIEW_PENDING_PARTIAL_PRUNING_AUDIT"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Partial-pruning audit for the review-pending n=9 vertex-circle checker. "
+    "It checks stored frontier assignment subsets for monotone obstruction "
+    "persistence and checker/replay status agreement. It does not prove "
+    "frontier coverage, brancher soundness, strict-edge geometry, "
+    "selected-distance quotient soundness, n=9, a counterexample, or any "
+    "official/global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_partial_pruning.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_partial_pruning.py "
+        "--check --assert-expected --json"
+    ),
+}
+
+EXPECTED_ASSIGNMENT_COUNT = 184
+EXPECTED_SUBSET_COUNT = 94_024
+EXPECTED_SUBSET_STATUS_COUNTS = {
+    "ok": 35_418,
+    "self_edge": 24_890,
+    "strict_cycle": 33_716,
+}
+EXPECTED_OBSTRUCTED_SUBSETS = 58_606
+EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS = {3: 182, 4: 2}
+EXPECTED_PREFIX_TOTAL = 1_656
+EXPECTED_PREFIX_STATUS_COUNTS = {
+    "ok": 570,
+    "self_edge": 758,
+    "strict_cycle": 328,
+}
+
+
+def load_json(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def partial_pruning_payload(
+    *,
+    frontier_path: Path = DEFAULT_FRONTIER_CLASSIFICATION,
+) -> dict[str, Any]:
+    """Return a stored-frontier partial-pruning replay audit."""
+
+    frontier = load_json(frontier_path)
+    errors: list[str] = []
+    summary = _audit_frontier_subsets(frontier)
+    _check_equal(errors, "assignment count", summary["assignment_count"], EXPECTED_ASSIGNMENT_COUNT)
+    _check_equal(errors, "subset count", summary["subset_count"], EXPECTED_SUBSET_COUNT)
+    _check_equal(
+        errors,
+        "subset status counts",
+        summary["subset_status_counts"],
+        EXPECTED_SUBSET_STATUS_COUNTS,
+    )
+    _check_equal(
+        errors,
+        "obstructed subset count",
+        summary["obstructed_subset_count"],
+        EXPECTED_OBSTRUCTED_SUBSETS,
+    )
+    _check_equal(
+        errors,
+        "min obstruction size counts",
+        summary["min_obstruction_size_counts"],
+        EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS,
+    )
+    _check_equal(errors, "prefix total", summary["stored_row_order_prefix_total"], EXPECTED_PREFIX_TOTAL)
+    _check_equal(
+        errors,
+        "prefix status counts",
+        summary["stored_row_order_prefix_status_counts"],
+        EXPECTED_PREFIX_STATUS_COUNTS,
+    )
+    _check_equal(errors, "extension violations", summary["extension_violations"], 0)
+    _check_equal(errors, "checker/replay status mismatches", summary["checker_replay_status_mismatches"], 0)
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n9.N,
+        "row_size": n9.ROW_SIZE,
+        "frontier_subset_audit": summary,
+        "source_artifact": _source_metadata(frontier_path, frontier),
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "interpretation": (
+            "A passed audit says every obstructed nonempty row subset of the "
+            "stored 184 n=9 pre-vertex-circle frontier assignments extends to "
+            "a stored full assignment that remains vertex-circle obstructed, "
+            "and the checker status agrees with the reusable quotient replay "
+            "on every such subset. This is a stored-frontier diagnostic only."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def assert_expected_partial_pruning(payload: Mapping[str, Any]) -> None:
+    """Assert the expected partial-pruning audit result."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not prove frontier coverage",
+        "brancher soundness",
+        "strict-edge geometry",
+        "selected-distance quotient soundness",
+        "n=9",
+        "counterexample",
+        "official/global status update",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+    if payload.get("validation_status") != "passed":
+        raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+    summary = payload.get("frontier_subset_audit")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("frontier_subset_audit missing")
+    expected = {
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "subset_count": EXPECTED_SUBSET_COUNT,
+        "subset_status_counts": EXPECTED_SUBSET_STATUS_COUNTS,
+        "obstructed_subset_count": EXPECTED_OBSTRUCTED_SUBSETS,
+        "min_obstruction_size_counts": EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS,
+        "stored_row_order_prefix_total": EXPECTED_PREFIX_TOTAL,
+        "stored_row_order_prefix_status_counts": EXPECTED_PREFIX_STATUS_COUNTS,
+        "extension_violations": 0,
+        "checker_replay_status_mismatches": 0,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(f"{key} mismatch: {summary.get(key)!r} != {value!r}")
+
+
+def _audit_frontier_subsets(frontier: Mapping[str, Any]) -> dict[str, Any]:
+    assignments = frontier.get("assignments")
+    if not isinstance(assignments, list):
+        raise ValueError("frontier classification artifact must contain assignments")
+
+    subset_status_counts: Counter[str] = Counter()
+    full_status_counts: Counter[str] = Counter()
+    min_obstruction_size_counts: Counter[int] = Counter()
+    prefix_status_counts: Counter[str] = Counter()
+    subset_count = 0
+    obstructed_subset_count = 0
+    extension_violations = 0
+    checker_replay_status_mismatches = 0
+    example_mismatches: list[dict[str, Any]] = []
+
+    for assignment in assignments:
+        if not isinstance(assignment, Mapping):
+            raise ValueError("assignment rows must be objects")
+        assignment_id = str(assignment["assignment_id"])
+        rows = assignment["selected_rows"]
+        if not isinstance(rows, list):
+            raise ValueError(f"{assignment_id} selected_rows must be a list")
+        full_status = _checker_status(rows)
+        full_status_counts[full_status] += 1
+        min_obstruction_size: int | None = None
+
+        for size in range(1, len(rows) + 1):
+            for indices in itertools.combinations(range(len(rows)), size):
+                subset = [rows[index] for index in indices]
+                subset_count += 1
+                checker_status = _checker_status(subset)
+                replay_status = _replay_status(subset)
+                subset_status_counts[checker_status] += 1
+                if checker_status != replay_status:
+                    checker_replay_status_mismatches += 1
+                    if len(example_mismatches) < 5:
+                        example_mismatches.append(
+                            {
+                                "assignment_id": assignment_id,
+                                "indices": list(indices),
+                                "checker_status": checker_status,
+                                "replay_status": replay_status,
+                            }
+                        )
+                if checker_status != "ok":
+                    obstructed_subset_count += 1
+                    if full_status == "ok":
+                        extension_violations += 1
+                    if min_obstruction_size is None:
+                        min_obstruction_size = size
+
+        if min_obstruction_size is not None:
+            min_obstruction_size_counts[min_obstruction_size] += 1
+
+        for prefix_size in range(1, len(rows) + 1):
+            prefix = rows[:prefix_size]
+            prefix_status_counts[_checker_status(prefix)] += 1
+
+    return {
+        "assignment_count": len(assignments),
+        "full_status_counts": dict(sorted(full_status_counts.items())),
+        "subset_count": subset_count,
+        "subset_status_counts": dict(sorted(subset_status_counts.items())),
+        "obstructed_subset_count": obstructed_subset_count,
+        "extension_violations": extension_violations,
+        "checker_replay_status_mismatches": checker_replay_status_mismatches,
+        "example_mismatches": example_mismatches,
+        "min_obstruction_size_counts": dict(sorted(min_obstruction_size_counts.items())),
+        "stored_row_order_prefix_total": sum(prefix_status_counts.values()),
+        "stored_row_order_prefix_status_counts": dict(sorted(prefix_status_counts.items())),
+    }
+
+
+def _checker_status(rows: Sequence[Sequence[int]]) -> str:
+    return n9.vertex_circle_status(_assignment_from_compact_rows(rows))
+
+
+def _replay_status(rows: Sequence[Sequence[int]]) -> str:
+    return replay_vertex_circle_quotient(
+        n9.N,
+        n9.ORDER,
+        parse_selected_rows(rows),
+    ).status
+
+
+def _assignment_from_compact_rows(rows: Sequence[Sequence[int]]) -> dict[int, int]:
+    return {
+        int(row[0]): n9.mask([int(witness) for witness in row[1:]])
+        for row in rows
+    }
+
+
+def _source_metadata(path: Path, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": str(path.relative_to(ROOT)).replace("\\", "/"),
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+    }
+
+
+def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> None:
+    if actual != expected:
+        errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
+
+
+def summary_lines(payload: Mapping[str, Any]) -> list[str]:
+    summary = payload["frontier_subset_audit"]
+    return [
+        f"schema: {payload['schema']}",
+        f"status: {payload['status']}",
+        f"validation: {payload['validation_status']}",
+        f"assignments checked: {summary['assignment_count']}",
+        f"subsets checked: {summary['subset_count']}",
+        f"extension violations: {summary['extension_violations']}",
+        "checker/replay mismatches: "
+        f"{summary['checker_replay_status_mismatches']}",
+    ]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--frontier-classification",
+        type=Path,
+        default=DEFAULT_FRONTIER_CLASSIFICATION,
+    )
+    parser.add_argument("--check", action="store_true", help="validate the audit")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    frontier_path = (
+        args.frontier_classification
+        if args.frontier_classification.is_absolute()
+        else ROOT / args.frontier_classification
+    )
+    payload = partial_pruning_payload(frontier_path=frontier_path)
+
+    if args.assert_expected:
+        assert_expected_partial_pruning(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif payload.get("validation_status") == "passed":
+        print("n=9 vertex-circle partial-pruning audit")
+        for line in summary_lines(payload):
+            print(line)
+        print("OK: n=9 partial-pruning audit checks passed")
+    else:
+        print("FAILED: n=9 partial-pruning audit", file=sys.stderr)
+        for error in payload.get("validation_errors", []):
+            print(f"- {error}", file=sys.stderr)
+
+    if args.check and payload.get("validation_status") != "passed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -307,6 +307,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_partial_pruning",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_partial_pruning.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Stored-frontier subset replay for n=9 vertex-circle partial "
+            "pruning; checks monotone obstruction persistence and "
+            "checker/replay status agreement only, not frontier coverage, "
+            "brancher soundness, strict-edge geometry, proof of n=9, "
+            "counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_self_edge_path_join",
         command=(
             "python",

--- a/tests/test_n9_vertex_circle_partial_pruning.py
+++ b/tests/test_n9_vertex_circle_partial_pruning.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_n9_vertex_circle_partial_pruning import (
+    EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS,
+    EXPECTED_PREFIX_STATUS_COUNTS,
+    EXPECTED_SUBSET_STATUS_COUNTS,
+    assert_expected_partial_pruning,
+    partial_pruning_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_partial_pruning_payload_scope_and_counts() -> None:
+    payload = partial_pruning_payload()
+
+    assert_expected_partial_pruning(payload)
+    assert payload["validation_status"] == "passed"
+    summary = payload["frontier_subset_audit"]
+    assert summary["assignment_count"] == 184
+    assert summary["subset_count"] == 94_024
+    assert summary["subset_status_counts"] == EXPECTED_SUBSET_STATUS_COUNTS
+    assert summary["min_obstruction_size_counts"] == EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS
+    assert summary["stored_row_order_prefix_status_counts"] == EXPECTED_PREFIX_STATUS_COUNTS
+    assert summary["extension_violations"] == 0
+    assert summary["checker_replay_status_mismatches"] == 0
+    assert "stored frontier assignment subsets" in payload["claim_scope"]
+    assert "does not prove frontier coverage" in payload["claim_scope"]
+    assert "counterexample" in payload["claim_scope"]
+
+
+def test_partial_pruning_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_partial_pruning.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    parsed = json.loads(result.stdout)
+    summary = parsed["frontier_subset_audit"]
+    assert parsed["validation_status"] == "passed"
+    assert summary["subset_status_counts"] == {
+        "ok": 35418,
+        "self_edge": 24890,
+        "strict_cycle": 33716,
+    }
+    assert summary["min_obstruction_size_counts"] == {"3": 182, "4": 2}
+    assert summary["extension_violations"] == 0
+    assert summary["checker_replay_status_mismatches"] == 0

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -226,6 +226,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n9_vertex_circle_partial_pruning.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_frontier_motif_classification.py "
         "--check --assert-expected --json"
@@ -235,6 +240,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_partial_pruning.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_partial_pruning.py "
         "--check --assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_self_edge_path_join.py "


### PR DESCRIPTION
## Summary

- Add `scripts/check_n9_vertex_circle_partial_pruning.py`, a stored-frontier diagnostic for the review-pending n=9 vertex-circle checker.
- Replay all 94,024 nonempty selected-row subsets of the 184 stored frontier assignments, checking monotone obstruction persistence and checker/replay status agreement.
- Register the command in the artifact audit runner and document the deliberately narrow scope: no frontier coverage proof, no brancher soundness claim, no n=9 proof, no counterexample, and no official/global status update.

## Validation

- `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_partial_pruning.py -q`
- `python -m pytest tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_partial_pruning.py scripts/run_artifact_audit.py tests/test_n9_vertex_circle_partial_pruning.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (971 passed, 291 deselected)
