### PR TITLE
[codex] Strengthen n9 focused source template audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ A local-core subset audit checks that each compact local-core packet is an
 actual subset of its full motif representative and already obstructs by a
 direct quotient replay.
 A focused packet catalog audit checks that the 12 proof-facing focused
-local-lemma packets agree with the template catalog and aggregate
-focused-note crosschecks; this is packet/catalog bookkeeping only.
+local-lemma packets agree with the source template packets, template catalog,
+and aggregate focused-note crosschecks; this is packet/catalog bookkeeping only.
 See [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 
 An incoming `n=10` singleton-slice continuation is now recorded as a

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -694,10 +694,11 @@ full motif representatives and already force the same obstruction status by
 direct quotient replay. It is compact-core bookkeeping only.
 The focused packet catalog audit
 `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
-checks that the 12 focused local-lemma packets, template catalog records, and
-aggregate focused-note crosschecks agree on the same `184` assignments and
-16 families. It is packet/catalog bookkeeping only, not packet soundness,
-local-lemma completeness, frontier coverage, or a proof of `n=9`.
+checks that the 12 focused local-lemma packets, source template packet records,
+template catalog records, and aggregate focused-note crosschecks agree on the
+same `184` assignments and 16 families. It is packet/catalog bookkeeping only,
+not packet soundness, local-lemma completeness, frontier coverage, or a proof
+of `n=9`.
 
 This is a candidate extension of the repo-local finite-case pipeline to `n=9`,
 but it is not yet the source-of-truth strongest result. The raw incoming bundle

--- a/STATE.md
+++ b/STATE.md
@@ -461,10 +461,11 @@ direct quotient replay. It is compact-core bookkeeping only, not local-lemma
 completeness or a proof of `n=9`.
 The focused packet catalog audit
 `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
-checks that the 12 focused local-lemma packets, template catalog records, and
-aggregate focused-note crosschecks agree on the same `184` assignments and
-16 families. It is packet/catalog bookkeeping only, not packet soundness,
-local-lemma completeness, frontier coverage, or a proof of `n=9`.
+checks that the 12 focused local-lemma packets, source template packet records,
+template catalog records, and aggregate focused-note crosschecks agree on the
+same `184` assignments and 16 families. It is packet/catalog bookkeeping only,
+not packet soundness, local-lemma completeness, frontier coverage, or a proof
+of `n=9`.
 
 A 2026-05-05 multi-agent attack adds an independent Gröbner-basis verification
 at n=8 (all 15 incidence-completeness survivors unrealizable by algebra alone)

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -22,8 +22,9 @@ Use this queue when no more specific issue is selected.
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
    than an `n=9` proof. The focused packet catalog audit command
    `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
-   now checks that the focused packet coverage, source catalog records, and
-   aggregate focused-note crosschecks agree before packet soundness review.
+   now checks that the focused packet coverage, source template records,
+   source catalog records, and aggregate focused-note crosschecks agree before
+   packet soundness review.
 2. Use the stored simple replay artifact
    `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` as a
    reviewer-facing input for the aggregate local-template coverage. The replay

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -87,9 +87,10 @@ lemma-candidate crosswalk for proof mining. All of these are review-pending
 diagnostics only, not independent proofs and not status promotions.
 The focused packet catalog audit
 `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
-checks that the 12 focused packet JSON files, the template catalog, and the
-aggregate local-lemma focused-note ledger agree on packet coverage. This is
-bookkeeping only, not packet soundness or an `n=9` proof.
+checks that the 12 focused packet JSON files, the source template packets, the
+template catalog, and the aggregate local-lemma focused-note ledger agree on
+packet coverage. This is bookkeeping only, not packet soundness or an `n=9`
+proof.
 
 The audit command
 `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py` checks the

--- a/docs/n9-vertex-circle-template-lemma-catalog.md
+++ b/docs/n9-vertex-circle-template-lemma-catalog.md
@@ -53,8 +53,8 @@ Run the targeted artifact tests:
 python -m pytest tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
 ```
 
-Cross-check the focused proof-facing packets against this catalog and the
-aggregate local-lemma focused-note ledger:
+Cross-check the focused proof-facing packets against the source template
+packets, this catalog, and the aggregate local-lemma focused-note ledger:
 
 ```bash
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py \
@@ -64,9 +64,9 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py \
 ```
 
 That audit is JSON bookkeeping only. It verifies agreement among checked-in
-packet, catalog, and aggregate scan records; it does not prove packet
-soundness, local-lemma completeness, frontier coverage, `n=9`, or a
-counterexample.
+packet, source-template, catalog, and aggregate scan records; it does not
+prove packet soundness, local-lemma completeness, frontier coverage, `n=9`, or
+a counterexample.
 
 ## Review standard
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -350,8 +350,9 @@ Next steps:
   coverage of stored packets rather than an independent `n=9` proof;
 - use
   `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
-  to cross-check the 12 focused packet JSON files against the template catalog
-  and aggregate focused-note ledger before reviewing packet soundness;
+  to cross-check the 12 focused packet JSON files against the source template
+  packets, template catalog, and aggregate focused-note ledger before reviewing
+  packet soundness;
 - use `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` to
   replay the aggregate local-template coverage from stored packet JSON without
   sharing the main quotient-replay helper;

--- a/scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py
+++ b/scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py
@@ -23,6 +23,12 @@ DEFAULT_TEMPLATE_CATALOG = (
 DEFAULT_LOCAL_LEMMAS = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_local_lemmas.json"
 )
+DEFAULT_TEMPLATE_PACKET_PATHS = {
+    "self_edge": ROOT / "data" / "certificates" / "n9_vertex_circle_self_edge_template_packet.json",
+    "strict_cycle": (
+        ROOT / "data" / "certificates" / "n9_vertex_circle_strict_cycle_template_packet.json"
+    ),
+}
 DEFAULT_PACKET_PATHS = {
     "T01": ROOT / "data" / "certificates" / "n9_vertex_circle_t01_self_edge_lemma_packet.json",
     "T02": ROOT / "data" / "certificates" / "n9_vertex_circle_t02_self_edge_lemma_packet.json",
@@ -45,9 +51,9 @@ CLAIM_SCOPE = (
     "JSON-only cross-artifact audit for the review-pending n=9 vertex-circle "
     "focused local-lemma packets. It checks that T01..T12 packet coverage, "
     "source catalog records, and aggregate focused-note crosschecks agree with "
-    "the template lemma catalog and local-lemma scan. It does not prove packet "
-    "soundness, local-lemma completeness, frontier coverage, n=9, a "
-    "counterexample, or any official/global status update."
+    "the template lemma catalog, source template packets, and local-lemma scan. "
+    "It does not prove packet soundness, local-lemma completeness, frontier "
+    "coverage, n=9, a counterexample, or any official/global status update."
 )
 PROVENANCE = {
     "generator": "scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py",
@@ -62,6 +68,15 @@ EXPECTED_STATUS_COUNTS = {"self_edge": 9, "strict_cycle": 3}
 EXPECTED_STATUS_ASSIGNMENT_COUNTS = {"self_edge": 158, "strict_cycle": 26}
 EXPECTED_FAMILY_COUNT = 16
 EXPECTED_ASSIGNMENT_COUNT = 184
+ALLOWED_SOURCE_TEMPLATE_OMISSIONS = {
+    template_id: {"family_records"} for template_id in EXPECTED_TEMPLATE_IDS
+}
+ALLOWED_SOURCE_TEMPLATE_OMISSIONS["T01"].update(
+    {"orbit_size_sum", "shared_endpoint_counts"}
+)
+EXPECTED_ALLOWED_SOURCE_TEMPLATE_OMISSION_COUNT = sum(
+    len(fields) for fields in ALLOWED_SOURCE_TEMPLATE_OMISSIONS.values()
+)
 
 
 def load_json(path: Path) -> Any:
@@ -74,6 +89,7 @@ def focused_packet_catalog_audit_payload(
     *,
     template_catalog_path: Path = DEFAULT_TEMPLATE_CATALOG,
     local_lemmas_path: Path = DEFAULT_LOCAL_LEMMAS,
+    template_packet_paths: Mapping[str, Path] | None = None,
     packet_paths: Mapping[str, Path] | None = None,
 ) -> dict[str, Any]:
     """Return a JSON-only focused-packet/catalog cross-audit payload."""
@@ -84,13 +100,27 @@ def focused_packet_catalog_audit_payload(
     }
     catalog_path = _resolve(template_catalog_path)
     local_path = _resolve(local_lemmas_path)
+    resolved_template_packets = {
+        kind: _resolve(path)
+        for kind, path in (template_packet_paths or DEFAULT_TEMPLATE_PACKET_PATHS).items()
+    }
     catalog = load_json(catalog_path)
     local_lemmas = load_json(local_path)
+    template_packets = {
+        kind: load_json(path) for kind, path in resolved_template_packets.items()
+    }
     packets = {
         template_id: load_json(path) for template_id, path in resolved_packets.items()
     }
     errors: list[str] = []
-    summary = _audit(catalog, local_lemmas, packets, resolved_packets, errors)
+    summary = _audit(
+        catalog,
+        local_lemmas,
+        template_packets,
+        packets,
+        resolved_packets,
+        errors,
+    )
     return {
         "schema": SCHEMA,
         "status": STATUS,
@@ -114,6 +144,22 @@ def focused_packet_catalog_audit_payload(
                 "status": local_lemmas.get("status") if isinstance(local_lemmas, Mapping) else None,
                 "trust": local_lemmas.get("trust") if isinstance(local_lemmas, Mapping) else None,
             },
+            *[
+                {
+                    "path": display_path(path, ROOT),
+                    "role": f"{kind.replace('_', '-')} template packet",
+                    "schema": template_packets.get(kind, {}).get("schema")
+                    if isinstance(template_packets.get(kind), Mapping)
+                    else None,
+                    "status": template_packets.get(kind, {}).get("status")
+                    if isinstance(template_packets.get(kind), Mapping)
+                    else None,
+                    "trust": template_packets.get(kind, {}).get("trust")
+                    if isinstance(template_packets.get(kind), Mapping)
+                    else None,
+                }
+                for kind, path in sorted(resolved_template_packets.items())
+            ],
         ],
         "packet_artifacts": [
             {
@@ -135,8 +181,9 @@ def focused_packet_catalog_audit_payload(
         "validation_errors": errors,
         "interpretation": (
             "A passed audit says the stored focused packets, template catalog, "
-            "and aggregate local-lemma focused-note crosschecks agree on the "
-            "T01..T12 coverage ledger. This is packet/catalog bookkeeping only."
+            "source template packets, and aggregate local-lemma focused-note "
+            "crosschecks agree on the T01..T12 coverage ledger. This is "
+            "packet/catalog bookkeeping only."
         ),
         "provenance": dict(PROVENANCE),
     }
@@ -182,11 +229,18 @@ def assert_expected_focused_packet_catalog_audit(payload: Mapping[str, Any]) -> 
         "missing_packet_template_count": 0,
         "extra_packet_template_count": 0,
         "source_catalog_mismatch_count": 0,
-        "source_template_mismatch_count": 0,
         "catalog_coverage_mismatch_count": 0,
         "focused_crosscheck_mismatch_count": 0,
+        "source_template_packet_count": 12,
         "duplicate_assignment_id_count": 0,
         "duplicate_family_id_count": 0,
+        "source_template_mismatch_count": 0,
+        "source_template_field_mismatch_count": 0,
+        "source_template_extra_field_count": 0,
+        "source_template_unexpected_missing_field_count": 0,
+        "source_template_allowed_omitted_field_count": (
+            EXPECTED_ALLOWED_SOURCE_TEMPLATE_OMISSION_COUNT
+        ),
     }
     for key, value in expected.items():
         if summary.get(key) != value:
@@ -196,17 +250,23 @@ def assert_expected_focused_packet_catalog_audit(payload: Mapping[str, Any]) -> 
 def _audit(
     catalog: Any,
     local_lemmas: Any,
+    template_packets: Mapping[str, Any],
     packets: Mapping[str, Any],
     packet_paths: Mapping[str, Path],
     errors: list[str],
 ) -> dict[str, Any]:
     catalog_records = _catalog_records(catalog, errors)
     focused_records = _focused_records(local_lemmas, errors)
+    source_template_records = _source_template_records(template_packets, errors)
     packet_records: list[dict[str, Any]] = []
     source_catalog_mismatch_count = 0
-    source_template_mismatch_count = 0
     catalog_coverage_mismatch_count = 0
     focused_crosscheck_mismatch_count = 0
+    source_template_mismatch_count = 0
+    source_template_field_mismatch_count = 0
+    source_template_extra_field_count = 0
+    source_template_unexpected_missing_field_count = 0
+    source_template_allowed_omitted_field_count = 0
     assignment_ids: list[str] = []
     family_ids: list[str] = []
     status_counts: Counter[str] = Counter()
@@ -242,10 +302,30 @@ def _audit(
                 catalog_coverage_mismatch_count += 1
                 errors.append(f"{template_id}: packet coverage does not match catalog")
             source_template = packet.get("source_template_record")
-            template_key = catalog_record.get("template_key")
-            if not isinstance(source_template, Mapping) or source_template.get("template_key") != template_key:
+            template_comparison = _source_template_comparison(
+                template_id,
+                source_template,
+                source_template_records.get(template_id),
+            )
+            record["source_template_stored_field_count"] = template_comparison[
+                "stored_field_count"
+            ]
+            record["source_template_allowed_omitted_fields"] = template_comparison[
+                "allowed_omitted_fields"
+            ]
+            source_template_field_mismatch_count += len(
+                template_comparison["field_mismatches"]
+            )
+            source_template_extra_field_count += len(template_comparison["extra_fields"])
+            source_template_unexpected_missing_field_count += len(
+                template_comparison["unexpected_missing_fields"]
+            )
+            source_template_allowed_omitted_field_count += len(
+                template_comparison["allowed_omitted_fields"]
+            )
+            if not template_comparison["matches"]:
                 source_template_mismatch_count += 1
-                errors.append(f"{template_id}: source_template_record template_key mismatch")
+                errors.extend(template_comparison["errors"])
 
         focused = focused_records.get(template_id)
         if focused is None:
@@ -266,6 +346,7 @@ def _audit(
         "packet_count": len(packet_records),
         "catalog_template_count": len(catalog_records),
         "focused_crosscheck_count": len(focused_records),
+        "source_template_packet_count": len(source_template_records),
         "covered_assignment_count": len(assignment_ids),
         "covered_family_count": len(set(family_ids)),
         "template_ids": [record["template_id"] for record in packet_records],
@@ -275,6 +356,14 @@ def _audit(
         "extra_packet_template_count": len(extra_template_ids),
         "source_catalog_mismatch_count": source_catalog_mismatch_count,
         "source_template_mismatch_count": source_template_mismatch_count,
+        "source_template_field_mismatch_count": source_template_field_mismatch_count,
+        "source_template_extra_field_count": source_template_extra_field_count,
+        "source_template_unexpected_missing_field_count": (
+            source_template_unexpected_missing_field_count
+        ),
+        "source_template_allowed_omitted_field_count": (
+            source_template_allowed_omitted_field_count
+        ),
         "catalog_coverage_mismatch_count": catalog_coverage_mismatch_count,
         "focused_crosscheck_mismatch_count": focused_crosscheck_mismatch_count,
         "duplicate_assignment_id_count": duplicate_assignment_id_count,
@@ -320,6 +409,30 @@ def _focused_records(local_lemmas: Any, errors: list[str]) -> dict[str, Mapping[
         if template_id in records:
             errors.append(f"duplicate focused template id: {template_id}")
         records[template_id] = item
+    return records
+
+
+def _source_template_records(
+    template_packets: Mapping[str, Any],
+    errors: list[str],
+) -> dict[str, Mapping[str, Any]]:
+    records: dict[str, Mapping[str, Any]] = {}
+    for kind, payload in sorted(template_packets.items()):
+        if not isinstance(payload, Mapping):
+            errors.append(f"{kind}: template packet must be an object")
+            continue
+        templates = payload.get("templates")
+        if not isinstance(templates, list):
+            errors.append(f"{kind}: template packet templates must be a list")
+            continue
+        for item in templates:
+            if not isinstance(item, Mapping):
+                errors.append(f"{kind}: template packet records must be objects")
+                continue
+            template_id = str(item.get("template_id"))
+            if template_id in records:
+                errors.append(f"duplicate source template id: {template_id}")
+            records[template_id] = item
     return records
 
 
@@ -371,6 +484,68 @@ def _packet_record(
         "family_orbit_sizes": dict(sorted(family_orbit_sizes.items())),
         "orbit_size_sum": orbit_size_sum,
         "core_size": int(packet.get("core_size", -1)),
+    }
+
+
+def _source_template_comparison(
+    template_id: str,
+    source_template: Any,
+    source_record: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(source_template, Mapping):
+        return {
+            "matches": False,
+            "errors": [f"{template_id}: source_template_record must be an object"],
+            "stored_field_count": 0,
+            "field_mismatches": [],
+            "extra_fields": [],
+            "unexpected_missing_fields": [],
+            "allowed_omitted_fields": [],
+        }
+    if source_record is None:
+        return {
+            "matches": False,
+            "errors": [f"{template_id}: missing source template packet record"],
+            "stored_field_count": len(source_template),
+            "field_mismatches": [],
+            "extra_fields": sorted(set(source_template)),
+            "unexpected_missing_fields": [],
+            "allowed_omitted_fields": [],
+        }
+
+    expected_keys = set(source_record)
+    stored_keys = set(source_template)
+    allowed_omitted = ALLOWED_SOURCE_TEMPLATE_OMISSIONS.get(template_id, set())
+    missing = expected_keys - stored_keys
+    unexpected_missing = sorted(missing - allowed_omitted)
+    allowed_missing = sorted(missing & allowed_omitted)
+    extra_fields = sorted(stored_keys - expected_keys)
+    field_mismatches = sorted(
+        key for key in stored_keys & expected_keys if source_template[key] != source_record[key]
+    )
+    errors = []
+    if field_mismatches:
+        errors.append(
+            f"{template_id}: source_template_record stored field mismatch: "
+            f"{field_mismatches!r}"
+        )
+    if extra_fields:
+        errors.append(
+            f"{template_id}: source_template_record extra fields: {extra_fields!r}"
+        )
+    if unexpected_missing:
+        errors.append(
+            f"{template_id}: source_template_record unexpected missing fields: "
+            f"{unexpected_missing!r}"
+        )
+    return {
+        "matches": not errors,
+        "errors": errors,
+        "stored_field_count": len(source_template),
+        "field_mismatches": field_mismatches,
+        "extra_fields": extra_fields,
+        "unexpected_missing_fields": unexpected_missing,
+        "allowed_omitted_fields": allowed_missing,
     }
 
 

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -537,10 +537,10 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
         claim_scope=(
             "JSON-only cross-artifact audit for the 12 focused n=9 "
-            "local-lemma packets against the template catalog and aggregate "
-            "focused-note crosschecks; not packet soundness, local-lemma "
-            "completeness, frontier coverage, proof of n=9, counterexample, "
-            "or official/global status update."
+            "local-lemma packets against the source template packets, "
+            "template catalog, and aggregate focused-note crosschecks; not "
+            "packet soundness, local-lemma completeness, frontier coverage, "
+            "proof of n=9, counterexample, or official/global status update."
         ),
     ),
     AuditCommand(

--- a/tests/test_n9_vertex_circle_focused_packet_catalog_audit.py
+++ b/tests/test_n9_vertex_circle_focused_packet_catalog_audit.py
@@ -9,6 +9,7 @@ from scripts.check_n9_vertex_circle_focused_packet_catalog_audit import (
     DEFAULT_LOCAL_LEMMAS,
     DEFAULT_PACKET_PATHS,
     DEFAULT_TEMPLATE_CATALOG,
+    DEFAULT_TEMPLATE_PACKET_PATHS,
     assert_expected_focused_packet_catalog_audit,
     focused_packet_catalog_audit_payload,
     load_json,
@@ -38,6 +39,9 @@ def test_focused_packet_catalog_audit_counts_and_scope() -> None:
     assert summary["covered_family_count"] == 16
     assert summary["status_counts"] == {"self_edge": 9, "strict_cycle": 3}
     assert summary["status_assignment_counts"] == {"self_edge": 158, "strict_cycle": 26}
+    assert summary["source_template_packet_count"] == 12
+    assert summary["source_template_mismatch_count"] == 0
+    assert summary["source_template_allowed_omitted_field_count"] == 14
 
 
 def test_focused_packet_catalog_audit_rejects_packet_coverage_drift(
@@ -96,6 +100,52 @@ def test_focused_packet_catalog_audit_rejects_local_lemma_crosscheck_drift(
     assert "T01: aggregate focused crosscheck mismatch" in payload["validation_errors"]
     summary = payload["focused_packet_catalog_audit"]
     assert summary["focused_crosscheck_mismatch_count"] == 1
+
+
+def test_focused_packet_catalog_audit_rejects_source_template_record_drift(
+    tmp_path: Path,
+) -> None:
+    t01_path = tmp_path / "t01_packet.json"
+    t01_packet = load_json(DEFAULT_PACKET_PATHS["T01"])
+    t01_packet["source_template_record"]["strict_edge_count"] = 999
+    _write_json(t01_path, t01_packet)
+    packet_paths = dict(DEFAULT_PACKET_PATHS)
+    packet_paths["T01"] = t01_path
+
+    payload = focused_packet_catalog_audit_payload(packet_paths=packet_paths)
+
+    assert payload["validation_status"] == "failed"
+    assert (
+        "T01: source_template_record stored field mismatch: ['strict_edge_count']"
+        in payload["validation_errors"]
+    )
+    summary = payload["focused_packet_catalog_audit"]
+    assert summary["source_template_mismatch_count"] == 1
+    assert summary["source_template_field_mismatch_count"] == 1
+
+
+def test_focused_packet_catalog_audit_rejects_source_template_packet_drift(
+    tmp_path: Path,
+) -> None:
+    self_edge_path = tmp_path / "self_edge_template_packet.json"
+    self_edge_packet = load_json(DEFAULT_TEMPLATE_PACKET_PATHS["self_edge"])
+    self_edge_packet["templates"][0]["strict_edge_count"] = 999
+    _write_json(self_edge_path, self_edge_packet)
+    template_packet_paths = dict(DEFAULT_TEMPLATE_PACKET_PATHS)
+    template_packet_paths["self_edge"] = self_edge_path
+
+    payload = focused_packet_catalog_audit_payload(
+        template_packet_paths=template_packet_paths,
+    )
+
+    assert payload["validation_status"] == "failed"
+    assert (
+        "T01: source_template_record stored field mismatch: ['strict_edge_count']"
+        in payload["validation_errors"]
+    )
+    summary = payload["focused_packet_catalog_audit"]
+    assert summary["source_template_mismatch_count"] == 1
+    assert summary["source_template_field_mismatch_count"] == 1
 
 
 def test_focused_packet_catalog_audit_cli_json() -> None:


### PR DESCRIPTION
## Summary

- extend the focused packet catalog audit to load the self-edge and strict-cycle source template packet artifacts
- compare each focused packet's embedded `source_template_record` against the corresponding source template packet fields
- record allowed compact omissions explicitly and add drift tests for both focused packets and source template packets
- update audit-runner scope text and docs to include source template packet agreement

## Scope

This remains JSON bookkeeping only. It does not claim packet soundness, local-lemma completeness, frontier coverage, an n=9 proof, a counterexample, or an official/global status update.

## Validation

- `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_focused_packet_catalog_audit.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py tests/test_n9_vertex_circle_focused_packet_catalog_audit.py scripts/run_artifact_audit.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`