### PR TITLE
Register n9 frontier comparison audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expecte
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json
+python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -687,6 +687,13 @@ treats the 16 stored motif representatives as input and checks their
 representative self-edge equality paths or strict-cycle edge chains after
 recomputing quotient classes and strict interval edges. It is
 stored-certificate bookkeeping only.
+The frontier comparison
+`scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
+checks the stored P18/C19 comparison artifact against the current local-core
+and vertex-circle helpers. It records zero exact n=9 local-core embeddings into
+the recorded P18 and C19 patterns, while preserving the P18 strict-cycle and
+C19 fixed-order pass guardrails. It is comparison diagnostics only, not a
+transfer theorem, counterexample, or proof of `n=9`.
 The local-core subset audit
 `scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
 checks that the compact local-core packet rows are exact subsets of the stored

--- a/STATE.md
+++ b/STATE.md
@@ -453,6 +453,13 @@ treats the stored motif representatives as input and verifies their stored
 self-edge equality paths or strict-cycle edge chains by recomputing quotient
 classes and strict interval edges. It is stored-certificate bookkeeping only,
 not frontier coverage, brancher soundness, or a proof of `n=9`.
+The frontier comparison
+`scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
+checks the stored P18/C19 comparison artifact against the current local-core
+and vertex-circle helpers. It records zero exact n=9 local-core embeddings into
+the recorded P18 and C19 patterns, while preserving the P18 strict-cycle and
+C19 fixed-order pass guardrails. It is comparison diagnostics only, not a
+transfer theorem, counterexample, or proof of `n=9`.
 The local-core subset audit
 `scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
 checks that the compact local-core packet rows are exact subsets of the stored

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -315,6 +315,12 @@ Use this queue when no more specific issue is selected.
    families; frontier coverage, brancher soundness, incidence-filter
    soundness, dihedral orbit bookkeeping, and full n=9 review remain separate
    scopes.
+   The frontier-comparison command,
+   `python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`,
+   covers only the stored P18/C19 comparison against current local-core and
+   vertex-circle helpers; exact-core non-embedding, P18 strict-cycle behavior,
+   and C19 fixed-order pass behavior remain guardrails, not a proof of `n=9`,
+   counterexample, or transfer theorem.
    The local-core subset audit command,
    `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`,
    covers only the compact-core-to-full-representative subset relation and

--- a/docs/n9-vertex-circle-frontier-comparison.md
+++ b/docs/n9-vertex-circle-frontier-comparison.md
@@ -44,13 +44,25 @@ quotient-graph vertex-circle obstruction is not enough by itself.
 
 ## Reproduction
 
-Generate and check the comparison artifact:
+Check the stored comparison artifact:
+
+```bash
+python scripts/compare_n9_vertex_circle_frontier.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Regenerate the comparison artifact:
 
 ```bash
 python scripts/compare_n9_vertex_circle_frontier.py \
   --assert-expected \
   --write
 ```
+
+The check command is also registered in `scripts/run_artifact_audit.py` and
+`metadata/generated_artifacts.yaml` as a review-pending diagnostic artifact.
 
 Run the targeted artifact test:
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -214,6 +214,18 @@ edge chains. It is stored-certificate bookkeeping only, not frontier coverage,
 brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, or
 a proof of `n=9`.
 
+Current frontier comparison:
+
+```bash
+python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json
+```
+
+This command checks the stored P18/C19 comparison artifact against the current
+local-core and vertex-circle helpers. It records zero exact n=9 local-core
+embeddings into the recorded P18 and C19 patterns, preserves the P18
+strict-cycle and C19 fixed-order pass guardrails, and does not prove `n=9`,
+provide a counterexample, or supply a transfer theorem.
+
 Current frontier-assignment audit:
 
 ```bash

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -406,6 +406,31 @@ artifacts:
       - motif classification is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_frontier_comparison
+    path: data/certificates/n9_vertex_circle_frontier_comparison.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/compare_n9_vertex_circle_frontier.py
+    command: python scripts/compare_n9_vertex_circle_frontier.py --assert-expected --write
+    checker: scripts/compare_n9_vertex_circle_frontier.py
+    check_command: python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Review-pending comparison of exact n=9 local-core embeddings with recorded P18/C19 frontier vertex-circle behavior; not a proof of n=9, not a counterexample, not a transfer theorem, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      type: n9_vertex_circle_frontier_comparison_v1
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      scope: Compare exact n=9 local cores with P18 and C19 frontier vertex-circle behavior.
+      n9_local_core_artifact: data/certificates/n9_vertex_circle_local_cores.json
+    forbidden_claims:
+      - n=9 is proved
+      - exact core comparison is a transfer theorem
+      - P18 proves C19
+      - C19_skew is a counterexample
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_self_edge_path_join
     path: data/certificates/n9_vertex_circle_self_edge_path_join.json
     kind: certificate_diagnostic_artifact

--- a/scripts/compare_n9_vertex_circle_frontier.py
+++ b/scripts/compare_n9_vertex_circle_frontier.py
@@ -20,6 +20,27 @@ from erdos97.n9_vertex_circle_frontier_comparison import (  # noqa: E402
 from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_frontier_comparison.json"
+DEFAULT_ARTIFACT = DEFAULT_OUT
+
+
+def load_json(path: Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def artifact_check_errors(payload: object, artifact: Path) -> list[str]:
+    try:
+        checked = load_json(artifact)
+    except OSError as exc:
+        return [f"could not load {display_path(artifact, ROOT)}: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"could not parse {display_path(artifact, ROOT)} as JSON: {exc}"]
+
+    if checked != payload:
+        return [
+            f"generated payload differs from {display_path(artifact, ROOT)}",
+        ]
+    return []
 
 
 def main() -> int:
@@ -27,12 +48,28 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="print stable JSON")
     parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
     parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare generated payload with --artifact",
+    )
+    parser.add_argument(
+        "--artifact",
+        default=str(DEFAULT_ARTIFACT),
+        help="artifact path used by --check",
+    )
     parser.add_argument("--assert-expected", action="store_true")
     args = parser.parse_args()
 
     payload = frontier_comparison_summary()
     if args.assert_expected:
         assert_expected_frontier_comparison(payload)
+    check_errors: list[str] = []
+    if args.check:
+        artifact = Path(args.artifact)
+        if not artifact.is_absolute():
+            artifact = ROOT / artifact
+        check_errors = artifact_check_errors(payload, artifact)
     if args.write:
         out = Path(args.out)
         out.parent.mkdir(parents=True, exist_ok=True)
@@ -51,8 +88,15 @@ def main() -> int:
             print(f"{result['pattern']} vertex-circle status: {result['status']}")
         if args.assert_expected:
             print("OK: frontier comparison counts verified")
+        if args.check and not check_errors:
+            print(f"OK: artifact is current at {display_path(artifact, ROOT)}")
         if args.write:
             print(f"wrote {display_path(args.out, ROOT)}")
+    if check_errors:
+        print("FAILED: n=9 vertex-circle frontier comparison check failed", file=sys.stderr)
+        for error in check_errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -387,6 +387,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_frontier_comparison",
+        command=(
+            "python",
+            "scripts/compare_n9_vertex_circle_frontier.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Comparison of exact n=9 local-core embeddings against recorded "
+            "P18/C19 frontier patterns and vertex-circle behavior; not a "
+            "proof of n=9, counterexample, transfer theorem, or "
+            "official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_frontier_assignment_audit",
         command=(
             "python",

--- a/tests/test_n9_vertex_circle_frontier_comparison.py
+++ b/tests/test_n9_vertex_circle_frontier_comparison.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from erdos97.n9_vertex_circle_frontier_comparison import (
     assert_expected_frontier_comparison,
-    frontier_comparison_summary,
+)
+from scripts.compare_n9_vertex_circle_frontier import (
+    artifact_check_errors,
 )
 
 
@@ -33,9 +37,39 @@ def test_n9_vertex_circle_frontier_comparison_artifact_counts() -> None:
     assert pattern_results["C19_skew"]["status"] == "passes_vertex_circle_filter"
 
 
+def test_n9_vertex_circle_frontier_comparison_check_rejects_mismatch(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    tampered = dict(payload)
+    tampered["trust"] = "BROKEN"
+    artifact = tmp_path / "tampered.json"
+    artifact.write_text(json.dumps(tampered), encoding="utf-8")
+
+    errors = artifact_check_errors(payload, artifact)
+
+    assert len(errors) == 1
+    assert "generated payload differs from" in errors[0]
+    assert str(artifact) in errors[0]
+
+
 @pytest.mark.artifact
 @pytest.mark.exhaustive
-def test_n9_vertex_circle_frontier_comparison_artifact_is_current() -> None:
-    checked_in = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+def test_n9_vertex_circle_frontier_comparison_script_check_is_current() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/compare_n9_vertex_circle_frontier.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
-    assert frontier_comparison_summary() == checked_in
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert_expected_frontier_comparison(payload)

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -287,6 +287,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/compare_n9_vertex_circle_frontier.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_frontier_assignment_audit.py "
         "--check --assert-expected --json"
         in command_texts
@@ -317,6 +322,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_motif_obstruction_audit.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/compare_n9_vertex_circle_frontier.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/compare_n9_vertex_circle_frontier.py "
         "--check --assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_frontier_assignment_audit.py "


### PR DESCRIPTION
## Summary
- add `--check`/`--artifact` support to the n=9 P18/C19 frontier comparison script
- register the comparison artifact in the audit runner and generated-artifact manifest
- document the diagnostic-only scope and add tests for check-mode mismatch and audit registration

## Verification
- `python -m pytest tests/test_n9_vertex_circle_frontier_comparison.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/compare_n9_vertex_circle_frontier.py tests/test_n9_vertex_circle_frontier_comparison.py scripts/run_artifact_audit.py tests/test_run_artifact_audit.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`