### PR TITLE
Register n9 mini-replay audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --ass
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
@@ -510,9 +511,13 @@ python scripts/check_n9_vertex_circle_t07_self_edge_lemma_packet.py --check --as
 python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
+python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -40,6 +40,16 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
    connects the compact 16-skeleton proof-mining catalog to the same
    aggregate/simple-replay family accounting.
+   The focused mini-replay commands
+   `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
+   `python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`,
+   `python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`,
+   and
+   `python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json`
+   replay the smallest currently extracted self-edge and strict-cycle packet
+   inputs. The T10 paired-square entry audit
+   `python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
+   remains a diagnostic companion, not a theorem.
    The input-data audit
    `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
    now separately checks the stored row0 witness coverage and summary

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -380,6 +380,17 @@ Next steps:
   `scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
   to compare the 16-entry relation-skeleton catalog with the same
   aggregate/simple-replay local-lemma family accounting;
+- use the focused mini-replay commands
+  `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
+  `scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`,
+  `scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`,
+  and
+  `scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json`
+  as minimal input-data replays for the currently extracted self-edge and
+  strict-cycle packets;
+- use
+  `scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
+  as a T10/F12 diagnostic companion only, not a theorem;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -620,6 +620,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_t01_self_edge_minireplay",
+        command=(
+            "python",
+            "scripts/check_n9_t01_self_edge_minireplay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Minimal input-data replay of the focused T01/F09 self-edge "
+            "local lemma packet; proof-mining scaffolding only, not a proof "
+            "of n=9, counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t02_self_edge_lemma_packet",
         command=(
             "python",
@@ -755,6 +770,36 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_t10_strict_cycle_minireplay",
+        command=(
+            "python",
+            "scripts/check_n9_t10_strict_cycle_minireplay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Minimal input-data replay of the focused T10/F12 strict-cycle "
+            "local lemma packet; proof-mining scaffolding only, not a proof "
+            "of n=9, counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
+        ident="n9_t10_paired_square_entry_audit",
+        command=(
+            "python",
+            "scripts/check_n9_t10_paired_square_entry.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Paired-square entry audit for the focused T10/F12 strict-cycle "
+            "assignments; proof-mining diagnostics only, not a proof of "
+            "n=9, counterexample, or global status update."
+        ),
+    ),
+    AuditCommand(
         ident="relation_skeleton_catalog",
         command=(
             "python",
@@ -801,6 +846,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_t11_strict_cycle_minireplay",
+        command=(
+            "python",
+            "scripts/check_n9_t11_strict_cycle_minireplay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Minimal input-data replay of the focused T11/F07 strict-cycle "
+            "local lemma packet; proof-mining scaffolding only, not a proof "
+            "of n=9, counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t12_strict_cycle_lemma_packet",
         command=(
             "python",
@@ -813,6 +873,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "Focused T12/F16 n=9 strict-cycle local lemma packet; "
             "proof-mining scaffolding only, not a proof of n=9, "
             "counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
+        ident="n9_t12_strict_cycle_minireplay",
+        command=(
+            "python",
+            "scripts/check_n9_t12_strict_cycle_minireplay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Minimal input-data replay of the focused T12/F16 strict-cycle "
+            "local lemma packet; proof-mining scaffolding only, not a proof "
+            "of n=9, counterexample, or independent review completion."
         ),
     ),
     AuditCommand(

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -425,6 +425,18 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_t01_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t01_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts
@@ -440,14 +452,62 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_t10_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
+        "python scripts/check_n9_t10_paired_square_entry.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t10_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_t10_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t10_paired_square_entry.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts
     )
     assert (
+        "python scripts/check_n9_t11_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t11_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts
+    )
+    assert (
+        "python scripts/check_n9_t12_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t12_strict_cycle_minireplay.py "
+        "--check --assert-expected --json"
     )
     assert (
         "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "


### PR DESCRIPTION
## Summary
- add existing T01/T10/T11/T12 mini-replay commands to the artifact audit runner
- add the existing T10 paired-square entry diagnostic to the artifact audit runner
- update the raw audit command list, backlog, review-priority docs, and audit-registration tests

## Verification
- `python -m pytest tests/test_run_artifact_audit.py tests/test_n9_t01_self_edge_minireplay.py tests/test_n9_t10_strict_cycle_minireplay.py tests/test_n9_t11_strict_cycle_minireplay.py tests/test_n9_t12_strict_cycle_minireplay.py tests/test_n9_t10_paired_square_entry.py -q`
- `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`