### PR TITLE
Register n9 turn frontier audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --j
 python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -629,6 +629,12 @@ recomputes the row-0 choices as the 70 lexicographic 4-subsets of labels
 `1..8` and checks the stored witness lists, masks, summary counts, and
 no-overclaiming scope. It does not rerun the brancher or replay the
 vertex-circle certificates.
+The turn-inequality frontier replay
+`scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+checks stored integer dual certificates for the candidate weak turn system on
+all 184 regenerated pair/crossing/count frontier assignments. It records all
+184 weak systems as arithmetically infeasible, but the geometric turn lemma and
+indexing conventions remain review-pending, so this does not promote `n=9`.
 A fixed-center-order replay command,
 `scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
 also closes the vertex-circle-pruned search and reaches the same

--- a/STATE.md
+++ b/STATE.md
@@ -395,6 +395,13 @@ The companion input-data audit
 `scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
 checks the stored row0 witness coverage and summary arithmetic without
 rerunning the brancher. It is a review aid only, not an `n=9` proof.
+The turn-inequality frontier replay
+`scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+checks stored integer dual certificates for the candidate weak turn system on
+all 184 regenerated pair/crossing/count frontier assignments. It is
+review-pending finite-case evidence only: the geometric turn lemma and
+indexing conventions remain the review bottleneck, and this does not promote
+`n=9`.
 A fixed-center-order replay,
 `scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
 checks agreement with the dynamic minimum-remaining-options brancher on the

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -50,6 +50,11 @@ Use this queue when no more specific issue is selected.
    inputs. The T10 paired-square entry audit
    `python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
    remains a diagnostic companion, not a theorem.
+   The turn-inequality frontier replay
+   `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+   checks stored integer dual certificates for all 184 regenerated
+   pair/crossing/count frontier assignments under the candidate weak turn
+   system; the geometric turn lemma and indexing remain review bottlenecks.
    The input-data audit
    `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
    now separately checks the stored row0 witness coverage and summary

--- a/docs/n9-turn-inequality-frontier.md
+++ b/docs/n9-turn-inequality-frontier.md
@@ -29,6 +29,9 @@ python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
 ```
 
+The check command is also registered in `scripts/run_artifact_audit.py` and
+listed in the raw audit command set in `README.md`.
+
 ## Candidate Turn Lemma
 
 Let `tau_i` be exterior turns and set `t_i = 2*tau_i/pi`, so

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -391,6 +391,12 @@ Next steps:
 - use
   `scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
   as a T10/F12 diagnostic companion only, not a theorem;
+- use
+  `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+  to audit the stored integer dual certificates for the candidate weak
+  turn-inequality system on all 184 regenerated n=9 frontier assignments,
+  while keeping the geometric turn lemma and indexing conventions
+  review-pending;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -184,6 +184,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",
     ),
     AuditCommand(
+        ident="n9_turn_inequality_frontier",
+        command=(
+            "python",
+            "scripts/check_n9_turn_inequality_frontier.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Review-pending n=9 turn-inequality frontier replay with stored "
+            "integer dual certificates; not a proof of n=9, counterexample, "
+            "geometric lemma review, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_input_audit",
         command=(
             "python",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -168,6 +168,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_turn_inequality_frontier.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_input_audit.py --check "
         "--assert-expected --json"
         in command_texts
@@ -194,6 +199,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_turn_inequality_frontier.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_turn_inequality_frontier.py --check "
+        "--assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_input_audit.py --check "
         "--assert-expected --json"


### PR DESCRIPTION
## Summary
- register the review-pending n=9 turn-inequality frontier replay in the artifact audit runner
- add the command to the README raw audit list and audit-registration tests
- document the review-pending scope in STATE, RESULTS, backlog, review priorities, and the turn-frontier note

## Verification
- `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_turn_inequality_frontier.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/run_artifact_audit.py tests/test_run_artifact_audit.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`