### PR TITLE
Register bridge lemma frontier audit

### DIFF
--- a/docs/bridge-lemma-frontier.md
+++ b/docs/bridge-lemma-frontier.md
@@ -30,6 +30,9 @@ Regenerate and compare the checked artifact:
 python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
 ```
 
+This check is also registered in the scheduled/manual artifact audit runner
+(`make audit-artifacts`).
+
 Rewrite the artifact after an intentional generator change:
 
 ```bash

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1141,6 +1141,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bridge_lemma_frontier",
+        command=(
+            "python",
+            "scripts/check_bridge_lemma_frontier.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Finite n=8/n=9 ear-orderability and obstruction cross-tab for "
+            "Bridge Lemma A' proof mining; not a proof of the bridge, not a "
+            "proof of Erdos Problem #97, not a counterexample, and not an "
+            "official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="block6_fragile_vertex_circle_extension",
         command=(
             "python",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -163,6 +163,25 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_bridge_lemma_frontier.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_bridge_lemma_frontier.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_bridge_lemma_frontier.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_block6_fragile_vertex_circle_extension.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_local_core_packet.py --check "
         "--assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary
- register the bridge lemma frontier checker in the unified artifact audit runner
- assert the command and placement in the audit-runner test
- note in the bridge frontier doc that the check is included in `make audit-artifacts`

## Verification
- `python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json`
- `python -m pytest tests/test_run_artifact_audit.py -q`
- `python -m pytest tests/test_bridge_lemma_frontier.py -q -m "artifact and exhaustive"`
- `python -m ruff check scripts/run_artifact_audit.py tests/test_run_artifact_audit.py scripts/check_bridge_lemma_frontier.py src/erdos97/bridge_lemma_frontier.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`