### PR TITLE
Register speculative circulant frontier audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
 python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
+python scripts/check_speculative_circulant_frontier_obstructions.py --check --json
 python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json

--- a/docs/candidate-patterns.md
+++ b/docs/candidate-patterns.md
@@ -52,7 +52,8 @@ The checked cleanup artifact
 one exact abstract-incidence kill and four natural-order diagnostics for this
 group. The C41, C43, C49, and R44 observations below are fixed-natural-order
 only; they do not rule out arbitrary cyclic orders for the same abstract
-selected-witness patterns.
+selected-witness patterns. Its checker is registered in the scheduled/manual
+artifact audit runner (`make audit-artifacts`).
 
 | Rank | Name | n | Formula | Type | Current status |
 |---:|---|---:|---|---|---|

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -179,6 +179,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="speculative_circulant_frontier_obstructions",
+        command=(
+            "python",
+            "scripts/check_speculative_circulant_frontier_obstructions.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Exact cleanup for selected speculative circulant patterns: C45 "
+            "is killed as a fixed abstract selected-witness incidence pattern "
+            "by the two-circle cap, while C41, C43, C49, and R44 are "
+            "fixed-natural-order diagnostics only. No general proof of Erdos "
+            "Problem #97 and no counterexample are claimed."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_review_pending",
         command=("python", "scripts/check_n9_vertex_circle_exhaustive.py", "--assert-expected", "--json"),
         claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -57,6 +57,17 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json"
     )
     assert (
+        "python scripts/check_speculative_circulant_frontier_obstructions.py "
+        "--check --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_speculative_circulant_frontier_obstructions.py "
+        "--check --json"
+    )
+    assert (
         "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected "
         "--check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json"
         in command_texts


### PR DESCRIPTION
## Summary
- register the speculative circulant frontier obstruction checker in the unified artifact audit runner
- add the checker to the README artifact command list
- note in the candidate-patterns doc that this diagnostic is part of `make audit-artifacts`
- assert the audit command and placement in the audit-runner test

## Verification
- `python scripts/check_speculative_circulant_frontier_obstructions.py --check --json`
- `python -m pytest tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/run_artifact_audit.py tests/test_run_artifact_audit.py scripts/check_speculative_circulant_frontier_obstructions.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`