### PR TITLE
Register n10 turn row0 pilot audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ python scripts/check_block6_reversed_block_clean_kalmanson.py --check --assert-e
 python scripts/check_block6_reversed_block_two_stage_closure.py --check --assert-expected --json
 python scripts/check_block6_forward_block_two_orientation_closure.py --check --assert-expected --json
 python scripts/check_block6_oriented_block_reversal_closure.py --check --assert-expected --json
+python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
 python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json

--- a/docs/n10-turn-row0-pilot.md
+++ b/docs/n10-turn-row0-pilot.md
@@ -27,6 +27,9 @@ python scripts/check_n10_turn_row0_pilot.py --assert-expected --write
 python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
 ```
 
+The check command is also registered in the scheduled/manual artifact audit
+runner (`make audit-artifacts`).
+
 ## Result
 
 The row0-index-0 slice has:

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1363,6 +1363,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n10_turn_row0_pilot",
+        command=(
+            "python",
+            "scripts/check_n10_turn_row0_pilot.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Bounded n=10 row0-index-0 turn-frontier pilot; not a proof of "
+            "n=10, not a complete n=10 search, not a counterexample, and "
+            "not a global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -552,6 +552,18 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
     )
     assert (
+        "python scripts/check_n10_turn_row0_pilot.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n10_turn_row0_pilot.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "
+        "--spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125"
+    )
+    assert (
         "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "
         "--spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125"
         in command_texts


### PR DESCRIPTION
## Summary
- register the bounded n=10 row0 turn pilot checker in the unified artifact audit runner
- add the checker to the README artifact command list
- note in the n=10 turn pilot doc that the check is included in `make audit-artifacts`
- assert the audit command and placement before the n=10 singleton draft audits

## Verification
- `python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json` (JSON output suppressed locally)
- `python -m pytest tests/test_n10_turn_row0_pilot.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/run_artifact_audit.py tests/test_run_artifact_audit.py scripts/check_n10_turn_row0_pilot.py src/erdos97/n10_turn_row0_pilot.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`