### PR TITLE
Add n10 row0 escape self-edge templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/relation-skeleton-catalog.md`](docs/relation-skeleton-catalog.md).
 - For the review-pending `n=10` singleton-slice finite-case draft, read
   [`docs/n10-vertex-circle-singleton-slices.md`](docs/n10-vertex-circle-singleton-slices.md).
+- For the bounded `n=10` row0 turn-frontier pilot and its weak-turn escape
+  self-edge templates, read
+  [`docs/n10-turn-row0-pilot.md`](docs/n10-turn-row0-pilot.md) and
+  [`docs/n10-turn-row0-escape-self-edges.md`](docs/n10-turn-row0-escape-self-edges.md).
 - For a compact human-readable proof-note draft excluding bad convex octagons,
   read [`docs/n8-geometric-proof.md`](docs/n8-geometric-proof.md).
 - For an interactive visualization of that proof idea, open
@@ -575,6 +579,7 @@ python scripts/check_block6_reversed_block_two_stage_closure.py --check --assert
 python scripts/check_block6_forward_block_two_orientation_closure.py --check --assert-expected --json
 python scripts/check_block6_oriented_block_reversal_closure.py --check --assert-expected --json
 python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
+python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json
 python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -780,6 +780,17 @@ certificate format before any public theorem-style use. It is not promoted to
 the source-of-truth strongest result. See
 `docs/n10-vertex-circle-singleton-slices.md`.
 
+The bounded `n=10` row0-index-0 turn pilot in
+`data/certificates/n10_turn_row0_pilot.json` is finite bookkeeping only. It
+records 160 raw assignments in the first row0 slice: 156 have weak-turn Farkas
+certificates, and the four weak-turn SAT escapes are all killed by row0-local
+vertex-circle self-edges. The derived artifact
+`data/certificates/n10_turn_row0_escape_self_edges.json` records those four
+first self-edge templates compactly. This is proof-mining evidence only, not a
+complete n=10 search, not a proof of `n=10`, and not a counterexample. See
+`docs/n10-turn-row0-pilot.md` and
+`docs/n10-turn-row0-escape-self-edges.md`.
+
 The row-circle Ptolemy diagnostic in
 `docs/row-circle-ptolemy-nlp.md` adds the Ptolemy equality forced by each
 selected witness quadruple being concyclic around its center. It numerically

--- a/STATE.md
+++ b/STATE.md
@@ -505,6 +505,14 @@ the n=9 counts and spot-checks row0 singleton IDs `0`, `63`, and `125`, but the
 n=10 package is an audit target only and is not promoted to the source-of-truth
 finite-case result.
 
+The bounded `n=10` row0-index-0 turn pilot remains finite bookkeeping only:
+turn inequalities kill 156 of 160 raw assignments, while the four weak-turn SAT
+escapes are all killed by row0-local vertex-circle self-edge templates. The
+derived template artifact records those four first self-edges compactly; it is
+not a proof of `n=10`, not a complete `n=10` search, and not a counterexample.
+See `docs/n10-turn-row0-pilot.md` and
+`docs/n10-turn-row0-escape-self-edges.md`.
+
 ## Best saved near-miss
 
 The best saved near-miss is still the historical `B12_3x4_danzer_lift`

--- a/data/certificates/n10_turn_row0_escape_self_edges.json
+++ b/data/certificates/n10_turn_row0_escape_self_edges.json
@@ -1,0 +1,208 @@
+{
+  "claim_scope": "Derived diagnostic for the four weak-turn SAT escapes in the bounded n=10 row0-index-0 pilot; records only their row0-local vertex-circle self-edge templates, not a proof of n=10, not a complete n=10 search, not a counterexample, and not a global status update.",
+  "escape_records": [
+    {
+      "assignment_index_1based": 74,
+      "distance_equality_path_length": 7,
+      "distance_equality_path_rows": [
+        1,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2
+      ],
+      "inner_class": [
+        0,
+        1
+      ],
+      "inner_pair": [
+        1,
+        2
+      ],
+      "inner_span": 1,
+      "outer_class": [
+        0,
+        1
+      ],
+      "outer_pair": [
+        1,
+        4
+      ],
+      "outer_span": 3,
+      "row": 0,
+      "shared_endpoint_count": 1,
+      "template": "[1, 4] > [1, 2]",
+      "witness_order": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_index_1based": 103,
+      "distance_equality_path_length": 3,
+      "distance_equality_path_rows": [
+        3,
+        0,
+        1
+      ],
+      "inner_class": [
+        0,
+        1
+      ],
+      "inner_pair": [
+        1,
+        2
+      ],
+      "inner_span": 1,
+      "outer_class": [
+        0,
+        1
+      ],
+      "outer_pair": [
+        1,
+        3
+      ],
+      "outer_span": 2,
+      "row": 0,
+      "shared_endpoint_count": 1,
+      "template": "[1, 3] > [1, 2]",
+      "witness_order": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_index_1based": 156,
+      "distance_equality_path_length": 5,
+      "distance_equality_path_rows": [
+        2,
+        1,
+        0,
+        4,
+        3
+      ],
+      "inner_class": [
+        0,
+        1
+      ],
+      "inner_pair": [
+        2,
+        3
+      ],
+      "inner_span": 1,
+      "outer_class": [
+        0,
+        1
+      ],
+      "outer_pair": [
+        2,
+        4
+      ],
+      "outer_span": 2,
+      "row": 0,
+      "shared_endpoint_count": 1,
+      "template": "[2, 4] > [2, 3]",
+      "witness_order": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_index_1based": 157,
+      "distance_equality_path_length": 4,
+      "distance_equality_path_rows": [
+        1,
+        0,
+        4,
+        3
+      ],
+      "inner_class": [
+        0,
+        1
+      ],
+      "inner_pair": [
+        2,
+        3
+      ],
+      "inner_span": 1,
+      "outer_class": [
+        0,
+        1
+      ],
+      "outer_pair": [
+        1,
+        3
+      ],
+      "outer_span": 2,
+      "row": 0,
+      "shared_endpoint_count": 1,
+      "template": "[1, 3] > [2, 3]",
+      "witness_order": [
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  ],
+  "forbidden_claims": [
+    "n=10 is proved",
+    "turn inequalities close n=10",
+    "row0 pilot is a completeness result",
+    "source-of-truth strongest result",
+    "official/global status update",
+    "counterexample to Erdos Problem #97",
+    "general proof of Erdos Problem #97"
+  ],
+  "interpretation": "The bounded row0-index-0 turn pilot has four weak-turn SAT escapes. In all four, the first vertex-circle contradiction is a row0 self-edge on witness order [1,2,3,4], with equal-distance class [0,1] forced to be both the outer and inner chord class.",
+  "provenance": {
+    "command": "python scripts/check_n10_turn_row0_escape_self_edges.py --write --assert-expected",
+    "generator": "scripts/check_n10_turn_row0_escape_self_edges.py",
+    "source": "data/certificates/n10_turn_row0_pilot.json"
+  },
+  "schema": "erdos97.n10_turn_row0_escape_self_edges.v1",
+  "source_artifact": "data/certificates/n10_turn_row0_pilot.json",
+  "status": "N10_ROW0_ESCAPE_SELF_EDGE_TEMPLATE_DIAGNOSTIC",
+  "summary": {
+    "common_equal_distance_class": [
+      0,
+      1
+    ],
+    "common_witness_order": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "distinct_template_count": 4,
+    "path_length_histogram": {
+      "3": 1,
+      "4": 1,
+      "5": 1,
+      "7": 1
+    },
+    "row0_self_edge_count": 4,
+    "row_counts": {
+      "0": 4
+    },
+    "shared_endpoint_count_distribution": {
+      "1": 4
+    },
+    "source_turn_sat_escape_count": 4
+  },
+  "templates": [
+    "[1, 3] > [1, 2]",
+    "[1, 3] > [2, 3]",
+    "[1, 4] > [1, 2]",
+    "[2, 4] > [2, 3]"
+  ],
+  "trust": "FINITE_BOOKKEEPING_NOT_A_PROOF"
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -335,6 +335,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n10-turn-row0-pilot.md`](n10-turn-row0-pilot.md): bounded `n=10`
   row0-index-0 turn-frontier pilot; finite bookkeeping only, not a proof of
   `n=10`.
+- [`n10-turn-row0-escape-self-edges.md`](n10-turn-row0-escape-self-edges.md):
+  compact row0-local self-edge templates for the four weak-turn SAT escapes
+  in the bounded `n=10` row0 pilot.
 - [`octagon-trap.html`](octagon-trap.html): interactive visualization of the
   isosceles-triangle count and octagon equality trap.
 - [`reproduction-log.md`](reproduction-log.md): fast, artifact, and exhaustive

--- a/docs/n10-turn-row0-escape-self-edges.md
+++ b/docs/n10-turn-row0-escape-self-edges.md
@@ -1,0 +1,43 @@
+# n=10 Row0 Escape Self-Edge Templates
+
+Status: `FINITE_BOOKKEEPING_NOT_A_PROOF`.
+
+This derived diagnostic isolates the four weak-turn SAT escapes from the
+bounded `n=10` row0-index-0 turn pilot. It records only the first
+vertex-circle self-edge template that kills each escape.
+
+It is not a proof of `n=10`, not a complete `n=10` search, not a
+counterexample, and not a source-of-truth status update.
+
+## Artifact
+
+```bash
+data/certificates/n10_turn_row0_escape_self_edges.json
+```
+
+Regenerate and check it with:
+
+```bash
+python scripts/check_n10_turn_row0_escape_self_edges.py --write --assert-expected
+python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json
+```
+
+The check command is registered in the scheduled/manual artifact audit runner
+(`make audit-artifacts`).
+
+## Summary
+
+All four weak-turn SAT escapes have their first vertex-circle contradiction in
+row `0`, with witness order `[1,2,3,4]`. In each case the equal-distance class
+`[0,1]` is forced to be both the outer chord class and the inner chord class,
+contradicting the strict chord inequality on a selected circle.
+
+The four recorded row0 templates are:
+
+- `[1, 3] > [1, 2]`
+- `[1, 3] > [2, 3]`
+- `[1, 4] > [1, 2]`
+- `[2, 4] > [2, 3]`
+
+This is useful as a compact target for a future local lemma combining weak
+turn certificates with row-local vertex-circle self-edge templates.

--- a/docs/n10-turn-row0-pilot.md
+++ b/docs/n10-turn-row0-pilot.md
@@ -59,4 +59,5 @@ are still killed by the existing vertex-circle self-edge filter.
 So the next proof-facing move should not be "turn inequalities alone scale to
 `n=10`." A realistic next step is to combine turn certificates with a compact
 vertex-circle self-edge template, or to mine the four weak-turn escapes for a
-small reusable obstruction.
+small reusable obstruction. The derived self-edge template artifact in
+`docs/n10-turn-row0-escape-self-edges.md` records that compact target.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2872,6 +2872,50 @@ artifacts:
       - counterexample to Erdos Problem #97
       - general proof of Erdos Problem #97
 
+  - id: n10_turn_row0_escape_self_edges
+    path: data/certificates/n10_turn_row0_escape_self_edges.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n10_turn_row0_escape_self_edges.py
+    command: python scripts/check_n10_turn_row0_escape_self_edges.py --write --assert-expected
+    checker: scripts/check_n10_turn_row0_escape_self_edges.py
+    check_command: python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+    claim_scope: Derived diagnostic for the four weak-turn SAT escapes in the bounded n=10 row0-index-0 pilot; records only their row0-local vertex-circle self-edge templates, not a proof of n=10, not a complete n=10 search, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n10_turn_row0_escape_self_edges.v1
+      status: N10_ROW0_ESCAPE_SELF_EDGE_TEMPLATE_DIAGNOSTIC
+      trust: FINITE_BOOKKEEPING_NOT_A_PROOF
+      source_artifact: data/certificates/n10_turn_row0_pilot.json
+      summary.source_turn_sat_escape_count: 4
+      summary.row0_self_edge_count: 4
+      summary.distinct_template_count: 4
+      summary.common_witness_order:
+        - 1
+        - 2
+        - 3
+        - 4
+      summary.common_equal_distance_class:
+        - 0
+        - 1
+      summary.row_counts.0: 4
+      summary.shared_endpoint_count_distribution.1: 4
+      summary.path_length_histogram.3: 1
+      summary.path_length_histogram.4: 1
+      summary.path_length_histogram.5: 1
+      summary.path_length_histogram.7: 1
+      provenance.command: python scripts/check_n10_turn_row0_escape_self_edges.py --write --assert-expected
+    forbidden_claims:
+      - n=10 is proved
+      - turn inequalities close n=10
+      - row0 pilot is a completeness result
+      - source-of-truth strongest result
+      - official/global status update
+      - counterexample to Erdos Problem #97
+      - general proof of Erdos Problem #97
+
   - id: bootstrap_core_crosswalk
     path: data/certificates/bootstrap_core_crosswalk.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n10_turn_row0_escape_self_edges.py
+++ b/scripts/check_n10_turn_row0_escape_self_edges.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Generate or check the n=10 row0 weak-turn escape self-edge template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE = ROOT / "data" / "certificates" / "n10_turn_row0_pilot.json"
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n10_turn_row0_escape_self_edges.json"
+
+SCHEMA = "erdos97.n10_turn_row0_escape_self_edges.v1"
+STATUS = "N10_ROW0_ESCAPE_SELF_EDGE_TEMPLATE_DIAGNOSTIC"
+TRUST = "FINITE_BOOKKEEPING_NOT_A_PROOF"
+CLAIM_SCOPE = (
+    "Derived diagnostic for the four weak-turn SAT escapes in the bounded "
+    "n=10 row0-index-0 pilot; records only their row0-local vertex-circle "
+    "self-edge templates, not a proof of n=10, not a complete n=10 search, "
+    "not a counterexample, and not a global status update."
+)
+EXPECTED_SUMMARY = {
+    "source_turn_sat_escape_count": 4,
+    "row0_self_edge_count": 4,
+    "distinct_template_count": 4,
+    "common_witness_order": [1, 2, 3, 4],
+    "common_equal_distance_class": [0, 1],
+    "row_counts": {"0": 4},
+    "shared_endpoint_count_distribution": {"1": 4},
+    "path_length_histogram": {"3": 1, "4": 1, "5": 1, "7": 1},
+}
+FORBIDDEN_CLAIMS = [
+    "n=10 is proved",
+    "turn inequalities close n=10",
+    "row0 pilot is a completeness result",
+    "source-of-truth strongest result",
+    "official/global status update",
+    "counterexample to Erdos Problem #97",
+    "general proof of Erdos Problem #97",
+]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} did not contain a JSON object")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _display(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path)
+
+
+def _template_key(edge: dict[str, Any]) -> str:
+    return f"{edge['outer_pair']} > {edge['inner_pair']}"
+
+
+def _escape_record(raw: dict[str, Any]) -> dict[str, Any]:
+    self_edge = raw.get("self_edge")
+    if not isinstance(self_edge, dict):
+        raise ValueError("escape record is missing self_edge object")
+
+    path = self_edge.get("distance_equality_path")
+    if not isinstance(path, list):
+        raise ValueError("escape self_edge is missing distance_equality_path")
+
+    row = self_edge.get("row")
+    witness_order = self_edge.get("witness_order")
+    outer_class = self_edge.get("outer_class")
+    inner_class = self_edge.get("inner_class")
+    shared_endpoint_count = self_edge.get("shared_endpoint_count")
+    if row != 0:
+        raise ValueError(f"expected row0 self-edge, got row {row!r}")
+    if witness_order != EXPECTED_SUMMARY["common_witness_order"]:
+        raise ValueError(f"unexpected witness order {witness_order!r}")
+    if outer_class != EXPECTED_SUMMARY["common_equal_distance_class"]:
+        raise ValueError(f"unexpected outer class {outer_class!r}")
+    if inner_class != EXPECTED_SUMMARY["common_equal_distance_class"]:
+        raise ValueError(f"unexpected inner class {inner_class!r}")
+    if shared_endpoint_count != 1:
+        raise ValueError(f"unexpected shared endpoint count {shared_endpoint_count!r}")
+
+    outer_span = self_edge.get("outer_span")
+    inner_span = self_edge.get("inner_span")
+    if not isinstance(outer_span, int) or not isinstance(inner_span, int):
+        raise ValueError("missing integer span data")
+    if outer_span <= inner_span:
+        raise ValueError("self-edge template does not have a strict outer span")
+
+    return {
+        "assignment_index_1based": raw["assignment_index_1based"],
+        "row": row,
+        "witness_order": witness_order,
+        "outer_pair": self_edge["outer_pair"],
+        "inner_pair": self_edge["inner_pair"],
+        "outer_span": outer_span,
+        "inner_span": inner_span,
+        "outer_class": outer_class,
+        "inner_class": inner_class,
+        "shared_endpoint_count": shared_endpoint_count,
+        "distance_equality_path_length": len(path),
+        "distance_equality_path_rows": [step["row"] for step in path],
+        "template": _template_key(self_edge),
+    }
+
+
+def build_payload(source: Path = DEFAULT_SOURCE) -> dict[str, Any]:
+    source_payload = _load_json(source)
+    raw_escapes = source_payload.get("turn_sat_escape_self_edges")
+    if not isinstance(raw_escapes, list):
+        raise ValueError("source artifact is missing turn_sat_escape_self_edges")
+
+    records = [_escape_record(raw) for raw in raw_escapes]
+    row_counts = Counter(str(record["row"]) for record in records)
+    shared_endpoint_counts = Counter(
+        str(record["shared_endpoint_count"]) for record in records
+    )
+    path_lengths = Counter(
+        str(record["distance_equality_path_length"]) for record in records
+    )
+    templates = sorted({str(record["template"]) for record in records})
+
+    summary = {
+        "source_turn_sat_escape_count": source_payload.get("turn_sat_escape_count"),
+        "row0_self_edge_count": len(records),
+        "distinct_template_count": len(templates),
+        "common_witness_order": EXPECTED_SUMMARY["common_witness_order"],
+        "common_equal_distance_class": EXPECTED_SUMMARY["common_equal_distance_class"],
+        "row_counts": dict(sorted(row_counts.items())),
+        "shared_endpoint_count_distribution": dict(
+            sorted(shared_endpoint_counts.items())
+        ),
+        "path_length_histogram": dict(sorted(path_lengths.items())),
+    }
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "source_artifact": _display(source),
+        "summary": summary,
+        "templates": templates,
+        "escape_records": records,
+        "interpretation": (
+            "The bounded row0-index-0 turn pilot has four weak-turn SAT "
+            "escapes. In all four, the first vertex-circle contradiction is a "
+            "row0 self-edge on witness order [1,2,3,4], with equal-distance "
+            "class [0,1] forced to be both the outer and inner chord class."
+        ),
+        "forbidden_claims": FORBIDDEN_CLAIMS,
+        "provenance": {
+            "generator": "scripts/check_n10_turn_row0_escape_self_edges.py",
+            "command": (
+                "python scripts/check_n10_turn_row0_escape_self_edges.py "
+                "--write --assert-expected"
+            ),
+            "source": _display(source),
+        },
+    }
+
+
+def assert_expected_payload(payload: dict[str, Any]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected schema")
+    if payload.get("status") != STATUS:
+        raise AssertionError("unexpected status")
+    if payload.get("trust") != TRUST:
+        raise AssertionError("unexpected trust")
+    if payload.get("summary") != EXPECTED_SUMMARY:
+        raise AssertionError("unexpected summary")
+    templates = payload.get("templates")
+    if not isinstance(templates, list) or len(templates) != 4:
+        raise AssertionError("unexpected templates")
+    records = payload.get("escape_records")
+    if not isinstance(records, list) or len(records) != 4:
+        raise AssertionError("unexpected escape records")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    source = _resolve(args.source)
+    out = _resolve(args.out)
+    payload = build_payload(source)
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.check:
+        existing = _load_json(out)
+        if existing != payload:
+            print(f"{_display(out)} does not match regenerated payload", file=sys.stderr)
+            return 1
+
+    if args.write:
+        _write_json(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("n=10 row0 weak-turn escape self-edge template")
+        print(f"source escapes: {payload['summary']['source_turn_sat_escape_count']}")
+        print(f"row0 self-edges: {payload['summary']['row0_self_edge_count']}")
+        print(f"templates: {payload['summary']['distinct_template_count']}")
+        if args.check:
+            print(f"OK: {_display(out)} matches regenerated payload")
+        if args.write:
+            print(f"wrote {_display(out)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1769,6 +1769,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n10_turn_row0_escape_self_edges",
+        command=(
+            "python",
+            "scripts/check_n10_turn_row0_escape_self_edges.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Derived diagnostic for the four weak-turn SAT escapes in the "
+            "bounded n=10 row0-index-0 pilot; records only their row0-local "
+            "vertex-circle self-edge templates, not a proof of n=10, not a "
+            "complete n=10 search, not a counterexample, and not a global "
+            "status update."
+        ),
+    ),
+    AuditCommand(
         ident="n10_vertex_circle_singleton_draft",
         command=(
             "python",

--- a/tests/test_n10_turn_row0_escape_self_edges.py
+++ b/tests/test_n10_turn_row0_escape_self_edges.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n10_turn_row0_escape_self_edges import (  # noqa: E402
+    DEFAULT_OUT,
+    assert_expected_payload,
+    build_payload,
+)
+
+
+def test_n10_turn_row0_escape_self_edges_match_expected() -> None:
+    payload = build_payload()
+
+    assert_expected_payload(payload)
+
+
+def test_n10_turn_row0_escape_self_edges_artifact_is_current() -> None:
+    checked_in = json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))
+
+    assert checked_in == build_payload()

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -639,8 +639,20 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n10_turn_row0_escape_self_edges.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n10_turn_row0_pilot.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n10_turn_row0_escape_self_edges.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n10_turn_row0_escape_self_edges.py --check "
         "--assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n10_vertex_circle_singletons.py --assert-expected "


### PR DESCRIPTION
## Summary
- add a derived artifact for the four weak-turn SAT escapes in the bounded n=10 row0-index-0 pilot
- record the row0-local vertex-circle self-edge template that kills each escape
- register the checker in metadata, README, and the unified artifact audit runner
- add docs and tests while preserving the finite-bookkeeping/not-a-proof scope

## Verification
- `python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json` (JSON output suppressed locally)
- `python -m pytest tests/test_n10_turn_row0_escape_self_edges.py tests/test_n10_turn_row0_pilot.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/check_n10_turn_row0_escape_self_edges.py tests/test_n10_turn_row0_escape_self_edges.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`