### PR TITLE
Add T02 self-edge mini-replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --chec
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json

--- a/data/certificates/n9_t02_self_edge_minireplay.json
+++ b/data/certificates/n9_t02_self_edge_minireplay.json
@@ -1,0 +1,412 @@
+{
+  "claim_scope": "Minimal input-data replay of the focused T02 multi-family self-edge local lemma packet; not a proof of n=9, not an independent review of the full checker, not a counterexample, and not a global status update.",
+  "interpretation": "Each T02 family packet identifies the strict outer and inner chord pairs by selected-distance equality steps, while its listed vertex-circle row makes the outer chord strictly longer than the inner chord.",
+  "ok": true,
+  "provenance": {
+    "command": "python scripts/check_n9_t02_self_edge_minireplay.py --write --assert-expected",
+    "generator": "scripts/check_n9_t02_self_edge_minireplay.py"
+  },
+  "replay": {
+    "all_self_edge_contradictions": true,
+    "assignment_count": 40,
+    "assignment_counts": {
+      "F01": 18,
+      "F04": 18,
+      "F08": 2,
+      "F14": 2
+    },
+    "family_count": 4,
+    "family_ids": [
+      "F01",
+      "F04",
+      "F08",
+      "F14"
+    ],
+    "family_replays": [
+      {
+        "assignment_count": 18,
+        "core_centers": [
+          0,
+          1,
+          8
+        ],
+        "core_row_count": 3,
+        "equality_chain": [
+          [
+            1,
+            8
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        "equality_step_count": 3,
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "family_id": "F01",
+        "self_edge_contradiction": true,
+        "strict_inequality": {
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ]
+        }
+      },
+      {
+        "assignment_count": 18,
+        "core_centers": [
+          0,
+          1,
+          2
+        ],
+        "core_row_count": 3,
+        "equality_chain": [
+          [
+            0,
+            2
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        "equality_step_count": 3,
+        "equality_steps": [
+          {
+            "left_pair": [
+              0,
+              2
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          },
+          {
+            "left_pair": [
+              1,
+              2
+            ],
+            "right_pair": [
+              2,
+              3
+            ],
+            "row": 2
+          }
+        ],
+        "family_id": "F04",
+        "self_edge_contradiction": true,
+        "strict_inequality": {
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            2,
+            3
+          ],
+          "inner_span": 1,
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            0,
+            2
+          ],
+          "outer_span": 3,
+          "row": 1,
+          "witness_order": [
+            2,
+            3,
+            5,
+            0
+          ]
+        }
+      },
+      {
+        "assignment_count": 2,
+        "core_centers": [
+          0,
+          1,
+          8
+        ],
+        "core_row_count": 3,
+        "equality_chain": [
+          [
+            1,
+            8
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        "equality_step_count": 3,
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "family_id": "F08",
+        "self_edge_contradiction": true,
+        "strict_inequality": {
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            8
+          ]
+        }
+      },
+      {
+        "assignment_count": 2,
+        "core_centers": [
+          0,
+          1,
+          8
+        ],
+        "core_row_count": 3,
+        "equality_chain": [
+          [
+            1,
+            8
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            0,
+            1
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        "equality_step_count": 3,
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              8
+            ],
+            "right_pair": [
+              0,
+              8
+            ],
+            "row": 8
+          },
+          {
+            "left_pair": [
+              0,
+              8
+            ],
+            "right_pair": [
+              0,
+              1
+            ],
+            "row": 0
+          },
+          {
+            "left_pair": [
+              0,
+              1
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "family_id": "F14",
+        "self_edge_contradiction": true,
+        "strict_inequality": {
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            6,
+            8
+          ]
+        }
+      }
+    ],
+    "path_length_counts": {
+      "3": 4
+    },
+    "source_template_id": "T02",
+    "strict_rows": {
+      "F01": 0,
+      "F04": 1,
+      "F08": 0,
+      "F14": 0
+    }
+  },
+  "schema": "erdos97.n9_t02_self_edge_minireplay.v1",
+  "source_packet": "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json",
+  "source_packet_schema": "erdos97.n9_vertex_circle_t02_self_edge_lemma_packet.v1",
+  "status": "REVIEW_PENDING_T02_SELF_EDGE_MINIREPLAY",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": []
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -42,6 +42,7 @@ Use this queue when no more specific issue is selected.
    aggregate/simple-replay family accounting.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
+   `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`,
    and

--- a/docs/index.md
+++ b/docs/index.md
@@ -290,6 +290,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t02-self-edge-lemma.md`](n9-vertex-circle-t02-self-edge-lemma.md):
   focused review-pending T02 multi-family self-edge local lemma packet for
   proof mining.
+- [`n9-t02-self-edge-minireplay.md`](n9-t02-self-edge-minireplay.md):
+  minimal input-data replay of the four T02 local self-edge family packets;
+  proof-mining scaffolding only.
 - [`n9-vertex-circle-t03-self-edge-lemma.md`](n9-vertex-circle-t03-self-edge-lemma.md):
   focused review-pending T03 multi-family self-edge local lemma packet for
   proof mining.

--- a/docs/n9-t02-self-edge-minireplay.md
+++ b/docs/n9-t02-self-edge-minireplay.md
@@ -1,0 +1,64 @@
+# n=9 T02 Self-edge Mini-replay
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This mini-replay is a deliberately small verifier for the focused T02
+multi-family self-edge local lemma packet. It does not enumerate `n=9`
+selected-witness systems, does not review the full vertex-circle checker, does
+not prove `n=9`, does not claim a counterexample, and does not update the
+global status of Erdos Problem #97.
+
+## Scope
+
+The source packet is:
+
+```bash
+data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json
+```
+
+The mini-replay reads that packet as input data and checks only:
+
+- the four stored T02 family packets `F01`, `F04`, `F08`, and `F14`;
+- each family's three local selected rows;
+- each selected-distance equality chain of length `3`;
+- each listed vertex-circle witness order;
+- that the listed outer chord properly contains the inner chord in that row
+  order;
+- that every strict outer and inner chord pair is joined by the same
+  selected-distance equality chain.
+
+This is intentionally independent of the larger quotient-replay helper and the
+full exhaustive brancher. It is a second, smaller input-data replay of one
+multi-family local lemma candidate.
+
+## Artifact
+
+```bash
+data/certificates/n9_t02_self_edge_minireplay.json
+```
+
+Generate and check:
+
+```bash
+python scripts/check_n9_t02_self_edge_minireplay.py --write --assert-expected
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
+```
+
+Targeted test:
+
+```bash
+python -m pytest tests/test_n9_t02_self_edge_minireplay.py -q
+```
+
+## Interpretation
+
+The replay confirms that each stored T02 family packet supports the local
+contradiction shape:
+
+```text
+outer pair = inner pair
+outer pair > inner pair
+```
+
+This covers only the exact T02 family packets listed above. It is proof-mining
+scaffolding, not a finite-case completeness result.

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -555,6 +555,14 @@ python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --assert-expe
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 ```
 
+The focused mini-replay artifacts are even smaller packet-specific inputs. The
+T02 replay now checks the four stored self-edge family packets without sharing
+the aggregate quotient helper:
+
+```bash
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
+```
+
 For a self-edge family, the replay verifies that every equality-path step is a
 selected-distance equality in the named row, that the stored outer and inner
 pairs are the endpoints of nested intervals in the row's cyclic witness order,

--- a/docs/n9-vertex-circle-t02-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t02-self-edge-lemma.md
@@ -223,6 +223,13 @@ Run the targeted artifact tests:
 python -m pytest tests/test_n9_vertex_circle_t02_self_edge_lemma_packet.py -q -m "artifact"
 ```
 
+The smaller mini-replay treats the checked packet as input data and replays
+only the four local equality-chain/self-edge contradictions:
+
+```bash
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
+```
+
 ## Review standard
 
 Before treating this as a reusable local lemma, a reviewer should restate the

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -63,6 +63,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -382,6 +382,7 @@ Next steps:
   aggregate/simple-replay local-lemma family accounting;
 - use the focused mini-replay commands
   `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
+  `scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`,
   and

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -83,6 +83,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -941,6 +941,54 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_t02_self_edge_minireplay
+    path: data/certificates/n9_t02_self_edge_minireplay.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_t02_self_edge_minireplay.py
+    command: python scripts/check_n9_t02_self_edge_minireplay.py --write --assert-expected
+    checker: scripts/check_n9_t02_self_edge_minireplay.py
+    check_command: python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Minimal input-data replay of the focused T02 multi-family self-edge local lemma packet; not a proof of n=9, not an independent review of the full checker, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_t02_self_edge_minireplay.v1
+      status: REVIEW_PENDING_T02_SELF_EDGE_MINIREPLAY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      ok: true
+      source_packet: data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json
+      source_packet_schema: erdos97.n9_vertex_circle_t02_self_edge_lemma_packet.v1
+      replay.source_template_id: T02
+      replay.family_count: 4
+      replay.family_ids:
+        - F01
+        - F04
+        - F08
+        - F14
+      replay.assignment_count: 40
+      replay.assignment_counts.F01: 18
+      replay.assignment_counts.F04: 18
+      replay.assignment_counts.F08: 2
+      replay.assignment_counts.F14: 2
+      replay.path_length_counts.3: 4
+      replay.strict_rows.F01: 0
+      replay.strict_rows.F04: 1
+      replay.strict_rows.F08: 0
+      replay.strict_rows.F14: 0
+      replay.all_self_edge_contradictions: true
+      provenance.command: python scripts/check_n9_t02_self_edge_minireplay.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - T02 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the mini-replay is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t03_self_edge_lemma_packet
     path: data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_t02_self_edge_minireplay.py
+++ b/scripts/check_n9_t02_self_edge_minireplay.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate or check the minimal T02 self-edge mini-replay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_t02_self_edge_minireplay import (  # noqa: E402
+    assert_expected_payload,
+    minireplay_payload,
+    validate_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_SOURCE = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t02_self_edge_lemma_packet.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_t02_self_edge_minireplay.json"
+)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected object payload in {display_path(path, ROOT)}")
+    return payload
+
+
+def _write(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="validate stored artifact")
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    source = _resolve(args.source)
+    artifact = _resolve(args.artifact)
+    out = _resolve(args.out)
+    if args.write and args.check and artifact != out:
+        raise SystemExit("--write --check requires --artifact and --out to match")
+
+    source_packet = _load(source)
+    payload = _load(artifact) if args.check else minireplay_payload(source_packet)
+    errors = validate_payload(payload, source_packet)
+    if errors:
+        raise SystemExit("; ".join(errors[:5]))
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        _write(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        replay = payload["replay"]
+        assert isinstance(replay, dict)
+        print("n=9 T02 self-edge mini-replay")
+        print(f"ok: {payload['ok']}")
+        print(f"families: {replay['family_ids']}")
+        print(f"assignments: {replay['assignment_count']}")
+        print(f"all self-edge contradictions: {replay['all_self_edge_contradictions']}")
+        if args.assert_expected:
+            print("OK: T02 mini-replay matches expected data")
+        if args.check:
+            print(f"checked {display_path(artifact, ROOT)}")
+        if args.write:
+            print(f"wrote {display_path(out, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -681,6 +681,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_t02_self_edge_minireplay",
+        command=(
+            "python",
+            "scripts/check_n9_t02_self_edge_minireplay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Minimal input-data replay of the focused T02 multi-family "
+            "self-edge local lemma packet; proof-mining scaffolding only, "
+            "not a proof of n=9, counterexample, or independent review "
+            "completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t03_self_edge_lemma_packet",
         command=(
             "python",

--- a/src/erdos97/n9_t02_self_edge_minireplay.py
+++ b/src/erdos97/n9_t02_self_edge_minireplay.py
@@ -1,0 +1,415 @@
+"""Minimal replay for the n=9 T02 self-edge local lemma packet.
+
+This module treats the focused T02 packet as input data and checks only the
+small local proof skeleton for its four family packets: selected-distance
+equality steps plus one strict vertex-circle chord containment. It is
+proof-mining scaffolding only.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+SCHEMA = "erdos97.n9_t02_self_edge_minireplay.v1"
+STATUS = "REVIEW_PENDING_T02_SELF_EDGE_MINIREPLAY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SOURCE_PACKET_SCHEMA = "erdos97.n9_vertex_circle_t02_self_edge_lemma_packet.v1"
+SOURCE_PACKET = "data/certificates/n9_vertex_circle_t02_self_edge_lemma_packet.json"
+
+EXPECTED_FAMILY_IDS = ["F01", "F04", "F08", "F14"]
+EXPECTED_ASSIGNMENT_COUNT = 40
+EXPECTED_ASSIGNMENT_COUNTS = {"F01": 18, "F04": 18, "F08": 2, "F14": 2}
+EXPECTED_STRICT_ROWS = {"F01": 0, "F04": 1, "F08": 0, "F14": 0}
+EXPECTED_OUTER_PAIRS = {
+    "F01": [1, 8],
+    "F04": [0, 2],
+    "F08": [1, 8],
+    "F14": [1, 8],
+}
+EXPECTED_INNER_PAIRS = {
+    "F01": [1, 2],
+    "F04": [2, 3],
+    "F08": [1, 2],
+    "F14": [1, 2],
+}
+
+
+def _pair(value: Any, label: str, errors: list[str]) -> list[int]:
+    if not isinstance(value, list) or len(value) != 2:
+        errors.append(f"{label} must be a two-element list")
+        return []
+    try:
+        left, right = sorted(int(item) for item in value)
+    except (TypeError, ValueError):
+        errors.append(f"{label} must contain integer labels")
+        return []
+    if left == right:
+        errors.append(f"{label} must contain two distinct labels")
+    return [left, right]
+
+
+def _rows(packet: dict[str, Any], family_id: str, errors: list[str]) -> dict[int, list[int]]:
+    raw_rows = packet.get("core_selected_rows")
+    if not isinstance(raw_rows, list):
+        errors.append(f"{family_id}: core_selected_rows must be a list")
+        return {}
+    rows: dict[int, list[int]] = {}
+    for index, raw_row in enumerate(raw_rows):
+        if not isinstance(raw_row, list) or len(raw_row) != 5:
+            errors.append(
+                f"{family_id}: core_selected_rows[{index}] must have center plus four witnesses"
+            )
+            continue
+        try:
+            center = int(raw_row[0])
+            witnesses = [int(value) for value in raw_row[1:]]
+        except (TypeError, ValueError):
+            errors.append(f"{family_id}: core_selected_rows[{index}] must contain integer labels")
+            continue
+        if center in rows:
+            errors.append(f"{family_id}: duplicate core row for center {center}")
+        if center in witnesses:
+            errors.append(f"{family_id}: core row {center} contains its own center")
+        if len(set(witnesses)) != 4:
+            errors.append(f"{family_id}: core row {center} has duplicate witnesses")
+        rows[center] = witnesses
+    return rows
+
+
+def _other_endpoint(pair_value: list[int], center: int) -> int | None:
+    if len(pair_value) != 2:
+        return None
+    if center == pair_value[0]:
+        return pair_value[1]
+    if center == pair_value[1]:
+        return pair_value[0]
+    return None
+
+
+def _replay_equality_chain(
+    packet: dict[str, Any],
+    rows: dict[int, list[int]],
+    family_id: str,
+    errors: list[str],
+) -> tuple[list[list[int]], list[dict[str, object]]]:
+    equality = packet.get("distance_equality")
+    if not isinstance(equality, dict):
+        errors.append(f"{family_id}: distance_equality must be an object")
+        return [], []
+    current = _pair(
+        equality.get("start_pair"),
+        f"{family_id}: distance_equality.start_pair",
+        errors,
+    )
+    end_pair = _pair(
+        equality.get("end_pair"),
+        f"{family_id}: distance_equality.end_pair",
+        errors,
+    )
+    path = equality.get("path")
+    if not isinstance(path, list):
+        errors.append(f"{family_id}: distance_equality.path must be a list")
+        return [], []
+
+    chain = [current]
+    steps: list[dict[str, object]] = []
+    for step_index, step in enumerate(path):
+        if not isinstance(step, dict):
+            errors.append(f"{family_id}: distance_equality.path[{step_index}] must be an object")
+            continue
+        try:
+            row = int(step["row"])
+        except (KeyError, TypeError, ValueError):
+            errors.append(f"{family_id}: distance_equality.path[{step_index}].row must be an integer")
+            continue
+        next_pair = _pair(
+            step.get("next_pair"),
+            f"{family_id}: distance_equality.path[{step_index}].next_pair",
+            errors,
+        )
+        witnesses = rows.get(row)
+        if witnesses is None:
+            errors.append(f"{family_id}: equality step {step_index} uses missing row {row}")
+            continue
+        current_other = _other_endpoint(current, row)
+        next_other = _other_endpoint(next_pair, row)
+        if current_other is None:
+            errors.append(f"{family_id}: equality step {step_index} does not start at row center {row}")
+        elif current_other not in witnesses:
+            errors.append(
+                f"{family_id}: equality step {step_index} current endpoint {current_other} "
+                f"is not selected by row {row}"
+            )
+        if next_other is None:
+            errors.append(f"{family_id}: equality step {step_index} does not end at row center {row}")
+        elif next_other not in witnesses:
+            errors.append(
+                f"{family_id}: equality step {step_index} next endpoint {next_other} "
+                f"is not selected by row {row}"
+            )
+        steps.append(
+            {
+                "row": row,
+                "left_pair": current,
+                "right_pair": next_pair,
+            }
+        )
+        current = next_pair
+        chain.append(current)
+
+    if current != end_pair:
+        errors.append(f"{family_id}: equality chain ends at {current}, not {end_pair}")
+    stored_chain = packet.get("equality_chain")
+    if stored_chain != chain:
+        errors.append(f"{family_id}: stored equality_chain mismatch: {stored_chain!r} != {chain!r}")
+    return chain, steps
+
+
+def _interval_for_pair(witness_order: list[int], pair_value: list[int]) -> list[int]:
+    positions = sorted(witness_order.index(endpoint) for endpoint in pair_value)
+    return [int(positions[0]), int(positions[1])]
+
+
+def _replay_strict_inequality(
+    packet: dict[str, Any],
+    rows: dict[int, list[int]],
+    equality_chain: list[list[int]],
+    family_id: str,
+    errors: list[str],
+) -> dict[str, object]:
+    strict = packet.get("strict_inequality")
+    if not isinstance(strict, dict):
+        errors.append(f"{family_id}: strict_inequality must be an object")
+        return {}
+    try:
+        row = int(strict["row"])
+        witness_order = [int(value) for value in strict["witness_order"]]
+    except (KeyError, TypeError, ValueError):
+        errors.append(f"{family_id}: strict_inequality row and witness_order must be present")
+        return {}
+    row_witnesses = rows.get(row)
+    if row_witnesses is None:
+        errors.append(f"{family_id}: strict_inequality uses missing row {row}")
+    elif sorted(row_witnesses) != sorted(witness_order):
+        errors.append(f"{family_id}: strict_inequality witness_order must list the row witnesses")
+
+    outer_pair = _pair(strict.get("outer_pair"), f"{family_id}: strict_inequality.outer_pair", errors)
+    inner_pair = _pair(strict.get("inner_pair"), f"{family_id}: strict_inequality.inner_pair", errors)
+    for label, pair_value in (("outer", outer_pair), ("inner", inner_pair)):
+        for endpoint in pair_value:
+            if endpoint not in witness_order:
+                errors.append(
+                    f"{family_id}: strict_inequality {label}_pair endpoint {endpoint} is not a witness"
+                )
+    if errors:
+        return {}
+
+    outer_interval = _interval_for_pair(witness_order, outer_pair)
+    inner_interval = _interval_for_pair(witness_order, inner_pair)
+    if strict.get("outer_interval") != outer_interval:
+        errors.append(f"{family_id}: strict_inequality outer_interval mismatch")
+    if strict.get("inner_interval") != inner_interval:
+        errors.append(f"{family_id}: strict_inequality inner_interval mismatch")
+    if not (
+        outer_interval[0] <= inner_interval[0]
+        and inner_interval[1] <= outer_interval[1]
+        and outer_interval != inner_interval
+    ):
+        errors.append(f"{family_id}: strict outer interval must properly contain inner interval")
+    if strict.get("outer_span") != outer_interval[1] - outer_interval[0]:
+        errors.append(f"{family_id}: strict_inequality outer_span mismatch")
+    if strict.get("inner_span") != inner_interval[1] - inner_interval[0]:
+        errors.append(f"{family_id}: strict_inequality inner_span mismatch")
+    if equality_chain and (equality_chain[0] != outer_pair or equality_chain[-1] != inner_pair):
+        errors.append(f"{family_id}: equality chain endpoints must match strict outer and inner pairs")
+
+    return {
+        "row": row,
+        "witness_order": witness_order,
+        "outer_pair": outer_pair,
+        "inner_pair": inner_pair,
+        "outer_interval": outer_interval,
+        "inner_interval": inner_interval,
+        "outer_span": outer_interval[1] - outer_interval[0],
+        "inner_span": inner_interval[1] - inner_interval[0],
+    }
+
+
+def replay_family(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]:
+    """Replay one T02 family packet and return a compact summary plus errors."""
+    errors: list[str] = []
+    family_id = str(packet.get("family_id"))
+    if family_id not in EXPECTED_FAMILY_IDS:
+        errors.append(f"unexpected family_id: {family_id!r}")
+    rows = _rows(packet, family_id, errors)
+    equality_chain, equality_steps = _replay_equality_chain(packet, rows, family_id, errors)
+    strict_summary = _replay_strict_inequality(packet, rows, equality_chain, family_id, errors)
+    summary = {
+        "family_id": family_id,
+        "assignment_count": packet.get("assignment_count"),
+        "core_row_count": len(rows),
+        "core_centers": sorted(rows),
+        "equality_chain": equality_chain,
+        "equality_step_count": len(equality_steps),
+        "equality_steps": equality_steps,
+        "strict_inequality": strict_summary,
+        "self_edge_contradiction": bool(
+            equality_chain
+            and strict_summary
+            and equality_chain[0] == strict_summary.get("outer_pair")
+            and equality_chain[-1] == strict_summary.get("inner_pair")
+        ),
+    }
+    if summary["assignment_count"] != EXPECTED_ASSIGNMENT_COUNTS.get(family_id):
+        errors.append(
+            f"{family_id}: unexpected assignment_count "
+            f"{summary['assignment_count']!r}"
+        )
+    if not summary["self_edge_contradiction"]:
+        errors.append(f"{family_id}: strict inequality does not close on an equality-chain self-edge")
+    return summary, errors
+
+
+def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]:
+    """Replay the T02 packet and return a compact summary plus errors."""
+    errors: list[str] = []
+    if packet.get("schema") != SOURCE_PACKET_SCHEMA:
+        errors.append(f"unexpected source schema: {packet.get('schema')!r}")
+    if packet.get("template_id") != "T02":
+        errors.append(f"unexpected template_id: {packet.get('template_id')!r}")
+    if packet.get("cyclic_order") != list(range(9)):
+        errors.append("cyclic_order must be the natural nonagon order")
+    if packet.get("family_ids") != EXPECTED_FAMILY_IDS:
+        errors.append(f"family_ids mismatch: {packet.get('family_ids')!r}")
+    family_packets = packet.get("family_packets")
+    if not isinstance(family_packets, list):
+        errors.append("family_packets must be a list")
+        family_packets = []
+
+    families: list[dict[str, object]] = []
+    for raw_family in family_packets:
+        if not isinstance(raw_family, dict):
+            errors.append("family_packets entries must be objects")
+            continue
+        family_summary, family_errors = replay_family(raw_family)
+        families.append(family_summary)
+        errors.extend(family_errors)
+
+    family_ids = [str(item.get("family_id")) for item in families]
+    if family_ids != EXPECTED_FAMILY_IDS:
+        errors.append(f"replayed family order mismatch: {family_ids!r}")
+    assignment_counts = {
+        str(item["family_id"]): int(item["assignment_count"])
+        for item in families
+        if isinstance(item.get("assignment_count"), int)
+    }
+    if sum(assignment_counts.values()) != EXPECTED_ASSIGNMENT_COUNT:
+        errors.append("family assignment counts do not sum to expected T02 count")
+    path_lengths = Counter(str(item.get("equality_step_count")) for item in families)
+    strict_rows = {
+        str(item["family_id"]): item.get("strict_inequality", {}).get("row")
+        for item in families
+        if isinstance(item.get("strict_inequality"), dict)
+    }
+    summary = {
+        "source_template_id": packet.get("template_id"),
+        "family_count": len(families),
+        "family_ids": family_ids,
+        "assignment_count": sum(assignment_counts.values()),
+        "assignment_counts": assignment_counts,
+        "path_length_counts": dict(sorted(path_lengths.items())),
+        "strict_rows": strict_rows,
+        "family_replays": families,
+        "all_self_edge_contradictions": all(
+            bool(item.get("self_edge_contradiction")) for item in families
+        ),
+    }
+    if not summary["all_self_edge_contradictions"]:
+        errors.append("not every T02 family replay closed a self-edge contradiction")
+    return summary, errors
+
+
+def minireplay_payload(packet: dict[str, Any]) -> dict[str, object]:
+    """Build the stable mini-replay artifact payload."""
+    replay, errors = replay_packet(packet)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Minimal input-data replay of the focused T02 multi-family self-edge "
+            "local lemma packet; not a proof of n=9, not an independent review "
+            "of the full checker, not a counterexample, and not a global status "
+            "update."
+        ),
+        "source_packet": SOURCE_PACKET,
+        "source_packet_schema": SOURCE_PACKET_SCHEMA,
+        "ok": not errors,
+        "validation_errors": errors,
+        "replay": replay,
+        "interpretation": (
+            "Each T02 family packet identifies the strict outer and inner chord "
+            "pairs by selected-distance equality steps, while its listed "
+            "vertex-circle row makes the outer chord strictly longer than the "
+            "inner chord."
+        ),
+        "provenance": {
+            "generator": "scripts/check_n9_t02_self_edge_minireplay.py",
+            "command": "python scripts/check_n9_t02_self_edge_minireplay.py --write --assert-expected",
+        },
+    }
+
+
+def validate_payload(payload: dict[str, Any], source_packet: dict[str, Any]) -> list[str]:
+    """Validate a stored mini-replay payload against the source packet."""
+    errors: list[str] = []
+    expected = minireplay_payload(source_packet)
+    for key in ("schema", "status", "trust", "source_packet", "source_packet_schema", "ok"):
+        if payload.get(key) != expected.get(key):
+            errors.append(f"{key} mismatch: {payload.get(key)!r} != {expected.get(key)!r}")
+    if payload.get("validation_errors") != expected["validation_errors"]:
+        errors.append("validation_errors mismatch")
+    if payload.get("replay") != expected["replay"]:
+        errors.append("replay mismatch")
+    return errors
+
+
+def assert_expected_payload(payload: dict[str, Any]) -> None:
+    """Assert the stable expected T02 mini-replay facts."""
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected schema")
+    if payload.get("ok") is not True:
+        raise AssertionError(f"mini-replay is not ok: {payload.get('validation_errors')!r}")
+    replay = payload.get("replay")
+    if not isinstance(replay, dict):
+        raise AssertionError("missing replay object")
+    expected = {
+        "source_template_id": "T02",
+        "family_count": 4,
+        "family_ids": EXPECTED_FAMILY_IDS,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_counts": EXPECTED_ASSIGNMENT_COUNTS,
+        "path_length_counts": {"3": 4},
+        "strict_rows": EXPECTED_STRICT_ROWS,
+        "all_self_edge_contradictions": True,
+    }
+    for key, expected_value in expected.items():
+        if replay.get(key) != expected_value:
+            raise AssertionError(
+                f"unexpected replay {key}: {replay.get(key)!r} != {expected_value!r}"
+            )
+    family_replays = replay.get("family_replays")
+    if not isinstance(family_replays, list) or len(family_replays) != 4:
+        raise AssertionError("unexpected family_replays")
+    for family in family_replays:
+        if not isinstance(family, dict):
+            raise AssertionError("family replay is not an object")
+        family_id = str(family.get("family_id"))
+        strict = family.get("strict_inequality")
+        if not isinstance(strict, dict):
+            raise AssertionError(f"{family_id}: missing strict_inequality")
+        if strict.get("outer_pair") != EXPECTED_OUTER_PAIRS[family_id]:
+            raise AssertionError(f"{family_id}: unexpected outer_pair")
+        if strict.get("inner_pair") != EXPECTED_INNER_PAIRS[family_id]:
+            raise AssertionError(f"{family_id}: unexpected inner_pair")

--- a/tests/test_n9_t02_self_edge_minireplay.py
+++ b/tests/test_n9_t02_self_edge_minireplay.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_t02_self_edge_minireplay import (
+    assert_expected_payload,
+    minireplay_payload,
+    replay_packet,
+    validate_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "data" / "certificates" / "n9_vertex_circle_t02_self_edge_lemma_packet.json"
+
+
+def _source_packet() -> dict[str, object]:
+    payload = json.loads(SOURCE.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_t02_minireplay_replays_all_local_self_edges() -> None:
+    packet = _source_packet()
+    replay, errors = replay_packet(packet)
+
+    assert errors == []
+    assert replay["family_ids"] == ["F01", "F04", "F08", "F14"]
+    assert replay["assignment_count"] == 40
+    assert replay["assignment_counts"] == {"F01": 18, "F04": 18, "F08": 2, "F14": 2}
+    assert replay["path_length_counts"] == {"3": 4}
+    assert replay["all_self_edge_contradictions"] is True
+
+
+def test_t02_minireplay_rejects_broken_family_equality_step() -> None:
+    packet = _source_packet()
+    families = packet["family_packets"]
+    assert isinstance(families, list)
+    family = families[1]
+    assert isinstance(family, dict)
+    equality = family["distance_equality"]
+    assert isinstance(equality, dict)
+    path = equality["path"]
+    assert isinstance(path, list)
+    bad_step = dict(path[1])
+    bad_step["next_pair"] = [4, 7]
+    path[1] = bad_step
+
+    _, errors = replay_packet(packet)
+
+    assert any("F04: equality step 1 does not end at row center 1" in error for error in errors)
+    assert any("F04: stored equality_chain mismatch" in error for error in errors)
+
+
+def test_t02_minireplay_rejects_reordered_strict_witnesses() -> None:
+    packet = _source_packet()
+    families = packet["family_packets"]
+    assert isinstance(families, list)
+    family = families[0]
+    assert isinstance(family, dict)
+    strict = family["strict_inequality"]
+    assert isinstance(strict, dict)
+    strict["witness_order"] = [1, 3, 2, 8]
+
+    _, errors = replay_packet(packet)
+
+    assert "F01: strict_inequality inner_interval mismatch" in errors
+    assert "F01: strict_inequality inner_span mismatch" in errors
+
+
+@pytest.mark.artifact
+def test_t02_minireplay_payload_validates_against_source() -> None:
+    packet = _source_packet()
+    payload = minireplay_payload(packet)
+
+    assert validate_payload(payload, packet) == []
+    assert_expected_payload(payload)

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -567,6 +567,25 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_t02_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t02_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_t02_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary
- add a minimal T02 multi-family self-edge mini-replay checker and generated artifact
- register the checker in generated-artifact metadata and the artifact audit runner
- document the replay in the local-lemma docs, reviewer lists, and README command list
- add targeted tests that replay the packet and catch equality/strict-order drift

## Verification
- `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_text_clean.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1006 passed, 292 deselected`)