### PR TITLE
Add T04 self-edge mini-replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t06_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t07_self_edge_lemma_packet.py --check --assert-expected --json

--- a/data/certificates/n9_t04_self_edge_minireplay.json
+++ b/data/certificates/n9_t04_self_edge_minireplay.json
@@ -1,0 +1,128 @@
+{
+  "claim_scope": "Minimal input-data replay of the focused T04/F13 self-edge local lemma packet; not a proof of n=9, not an independent review of the full checker, not a counterexample, and not a global status update.",
+  "interpretation": "The T04/F13 family packet identifies the strict outer and inner chord pairs by selected-distance equality steps, while its listed vertex-circle row makes the outer chord strictly longer than the inner chord.",
+  "ok": true,
+  "provenance": {
+    "command": "python scripts/check_n9_t04_self_edge_minireplay.py --write --assert-expected",
+    "generator": "scripts/check_n9_t04_self_edge_minireplay.py"
+  },
+  "replay": {
+    "all_self_edge_contradictions": true,
+    "assignment_count": 2,
+    "assignment_counts": {
+      "F13": 2
+    },
+    "family_count": 1,
+    "family_ids": [
+      "F13"
+    ],
+    "family_replays": [
+      {
+        "assignment_count": 2,
+        "core_centers": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "core_row_count": 4,
+        "equality_chain": [
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            5
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        "equality_step_count": 3,
+        "equality_steps": [
+          {
+            "left_pair": [
+              1,
+              5
+            ],
+            "right_pair": [
+              3,
+              5
+            ],
+            "row": 5
+          },
+          {
+            "left_pair": [
+              3,
+              5
+            ],
+            "right_pair": [
+              1,
+              3
+            ],
+            "row": 3
+          },
+          {
+            "left_pair": [
+              1,
+              3
+            ],
+            "right_pair": [
+              1,
+              2
+            ],
+            "row": 1
+          }
+        ],
+        "family_id": "F13",
+        "self_edge_contradiction": true,
+        "strict_inequality": {
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            5
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ]
+        }
+      }
+    ],
+    "path_length_counts": {
+      "3": 1
+    },
+    "source_template_id": "T04",
+    "strict_rows": {
+      "F13": 0
+    }
+  },
+  "schema": "erdos97.n9_t04_self_edge_minireplay.v1",
+  "source_packet": "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json",
+  "source_packet_schema": "erdos97.n9_vertex_circle_t04_self_edge_lemma_packet.v1",
+  "status": "REVIEW_PENDING_T04_SELF_EDGE_MINIREPLAY",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": []
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -44,6 +44,7 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json`,
+   `python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`,
    and

--- a/docs/codex-strategy-instructions.md
+++ b/docs/codex-strategy-instructions.md
@@ -87,7 +87,7 @@ Useful work:
   template, and what the template does not prove.
 
 Good inputs include `docs/n9-vertex-circle-template-lemma-catalog.md`, the
-focused T01/T02/T03 self-edge notes, the focused T10/T11/T12 strict-cycle
+focused T01/T02/T03/T04 self-edge notes, the focused T10/T11/T12 strict-cycle
 notes, and their checked JSON packets under `data/certificates/`.
 
 ### Stronger fragile-cover bridges

--- a/docs/gpt55-solver-brief.md
+++ b/docs/gpt55-solver-brief.md
@@ -393,7 +393,8 @@ Start from:
 
 - `docs/n9-vertex-circle-template-lemma-catalog.md`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
-- focused T01/T02/T03 self-edge packets and T10/T11/T12 strict-cycle packets.
+- focused T01/T02/T03/T04 self-edge packets and T10/T11/T12 strict-cycle
+  packets.
 
 ### L2. Strengthen the minimal fragile-cover bridge
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -302,6 +302,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t04-self-edge-lemma.md`](n9-vertex-circle-t04-self-edge-lemma.md):
   focused review-pending T04/F13 self-edge local lemma packet for proof
   mining.
+- [`n9-t04-self-edge-minireplay.md`](n9-t04-self-edge-minireplay.md):
+  minimal input-data replay of the T04/F13 local self-edge family packet;
+  proof-mining scaffolding only.
 - [`n9-vertex-circle-t05-self-edge-lemma.md`](n9-vertex-circle-t05-self-edge-lemma.md):
   focused review-pending T05/F10 self-edge local lemma packet for proof
   mining.

--- a/docs/n9-t04-self-edge-minireplay.md
+++ b/docs/n9-t04-self-edge-minireplay.md
@@ -1,0 +1,64 @@
+# n=9 T04/F13 Self-edge Mini-replay
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This mini-replay is a deliberately small verifier for the focused T04/F13
+self-edge local lemma packet. It does not enumerate `n=9` selected-witness
+systems, does not review the full vertex-circle checker, does not prove `n=9`,
+does not claim a counterexample, and does not update the global status of
+Erdos Problem #97.
+
+## Scope
+
+The source packet is:
+
+```bash
+data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json
+```
+
+The mini-replay reads that packet as input data and checks only:
+
+- the stored T04 family packet `F13`;
+- its four local selected rows;
+- its selected-distance equality chain of length `3`;
+- its listed vertex-circle witness order;
+- that the listed outer chord properly contains the inner chord in that row
+  order;
+- that the strict outer and inner chord pairs are joined by the same
+  selected-distance equality chain.
+
+This is intentionally independent of the larger quotient-replay helper and the
+full exhaustive brancher. It is a second, smaller input-data replay of one
+focused local lemma candidate.
+
+## Artifact
+
+```bash
+data/certificates/n9_t04_self_edge_minireplay.json
+```
+
+Generate and check:
+
+```bash
+python scripts/check_n9_t04_self_edge_minireplay.py --write --assert-expected
+python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
+```
+
+Targeted test:
+
+```bash
+python -m pytest tests/test_n9_t04_self_edge_minireplay.py -q
+```
+
+## Interpretation
+
+The replay confirms that the stored T04/F13 packet supports the local
+contradiction shape:
+
+```text
+outer pair = inner pair
+outer pair > inner pair
+```
+
+This covers only the exact T04/F13 family packet listed above. It is
+proof-mining scaffolding, not a finite-case completeness result.

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -556,12 +556,13 @@ python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --ass
 ```
 
 The focused mini-replay artifacts are even smaller packet-specific inputs. The
-T02 and T03 replays now check their stored self-edge family packets without
-sharing the aggregate quotient helper:
+T02, T03, and T04 replays now check their stored self-edge family packets
+without sharing the aggregate quotient helper:
 
 ```bash
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
 ```
 
 For a self-edge family, the replay verifies that every equality-path step is a

--- a/docs/n9-vertex-circle-t04-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t04-self-edge-lemma.md
@@ -130,12 +130,18 @@ python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py \
   --check \
   --assert-expected \
   --json
+
+python scripts/check_n9_t04_self_edge_minireplay.py \
+  --check \
+  --assert-expected \
+  --json
 ```
 
 Run the targeted artifact tests:
 
 ```bash
 python -m pytest tests/test_n9_vertex_circle_t04_self_edge_lemma_packet.py -q
+python -m pytest tests/test_n9_t04_self_edge_minireplay.py -q
 ```
 
 ## Review standard

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -66,6 +66,8 @@ python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --as
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -384,6 +384,7 @@ Next steps:
   `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json`,
+  `scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`,
   and

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -86,6 +86,8 @@ python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --as
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1122,6 +1122,45 @@ artifacts:
       - the local lemma packet is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_t04_self_edge_minireplay
+    path: data/certificates/n9_t04_self_edge_minireplay.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_t04_self_edge_minireplay.py
+    command: python scripts/check_n9_t04_self_edge_minireplay.py --write --assert-expected
+    checker: scripts/check_n9_t04_self_edge_minireplay.py
+    check_command: python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Minimal input-data replay of the focused T04/F13 self-edge local lemma packet; not a proof of n=9, not an independent review of the full checker, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_t04_self_edge_minireplay.v1
+      status: REVIEW_PENDING_T04_SELF_EDGE_MINIREPLAY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      ok: true
+      source_packet: data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json
+      source_packet_schema: erdos97.n9_vertex_circle_t04_self_edge_lemma_packet.v1
+      replay.source_template_id: T04
+      replay.family_count: 1
+      replay.family_ids:
+        - F13
+      replay.assignment_count: 2
+      replay.assignment_counts.F13: 2
+      replay.path_length_counts.3: 1
+      replay.strict_rows.F13: 0
+      replay.all_self_edge_contradictions: true
+      provenance.command: python scripts/check_n9_t04_self_edge_minireplay.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - T04 proves n=9
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - template labels are theorem names
+      - the mini-replay is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_t05_self_edge_lemma_packet
     path: data/certificates/n9_vertex_circle_t05_self_edge_lemma_packet.json
     kind: certificate_diagnostic_artifact

--- a/scripts/check_n9_t04_self_edge_minireplay.py
+++ b/scripts/check_n9_t04_self_edge_minireplay.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Generate or check the minimal T04/F13 self-edge mini-replay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.n9_t04_self_edge_minireplay import (  # noqa: E402
+    assert_expected_payload,
+    minireplay_payload,
+    validate_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+DEFAULT_SOURCE = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_t04_self_edge_lemma_packet.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_t04_self_edge_minireplay.json"
+)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected object payload in {display_path(path, ROOT)}")
+    return payload
+
+
+def _write(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--check", action="store_true", help="validate stored artifact")
+    parser.add_argument("--write", action="store_true", help="write generated artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    source = _resolve(args.source)
+    artifact = _resolve(args.artifact)
+    out = _resolve(args.out)
+    if args.write and args.check and artifact != out:
+        raise SystemExit("--write --check requires --artifact and --out to match")
+
+    source_packet = _load(source)
+    payload = _load(artifact) if args.check else minireplay_payload(source_packet)
+    errors = validate_payload(payload, source_packet)
+    if errors:
+        raise SystemExit("; ".join(errors[:5]))
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        _write(out, payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        replay = payload["replay"]
+        assert isinstance(replay, dict)
+        print("n=9 T04/F13 self-edge mini-replay")
+        print(f"ok: {payload['ok']}")
+        print(f"families: {replay['family_ids']}")
+        print(f"assignments: {replay['assignment_count']}")
+        print(f"all self-edge contradictions: {replay['all_self_edge_contradictions']}")
+        if args.assert_expected:
+            print("OK: T04/F13 mini-replay matches expected data")
+        if args.check:
+            print(f"checked {display_path(artifact, ROOT)}")
+        if args.write:
+            print(f"wrote {display_path(out, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -743,6 +743,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_t04_self_edge_minireplay",
+        command=(
+            "python",
+            "scripts/check_n9_t04_self_edge_minireplay.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Minimal input-data replay of the focused T04/F13 self-edge "
+            "local lemma packet; proof-mining scaffolding only, not a proof "
+            "of n=9, counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t05_self_edge_lemma_packet",
         command=(
             "python",

--- a/src/erdos97/n9_t04_self_edge_minireplay.py
+++ b/src/erdos97/n9_t04_self_edge_minireplay.py
@@ -1,0 +1,210 @@
+"""Minimal replay for the n=9 T04/F13 self-edge local lemma packet.
+
+This module treats the focused T04 packet as input data and checks only the
+small local proof skeleton for its F13 family packet: selected-distance
+equality steps plus one strict vertex-circle chord containment. It is
+proof-mining scaffolding only.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from erdos97.n9_t02_self_edge_minireplay import (
+    _replay_equality_chain,
+    _replay_strict_inequality,
+    _rows,
+)
+
+SCHEMA = "erdos97.n9_t04_self_edge_minireplay.v1"
+STATUS = "REVIEW_PENDING_T04_SELF_EDGE_MINIREPLAY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SOURCE_PACKET_SCHEMA = "erdos97.n9_vertex_circle_t04_self_edge_lemma_packet.v1"
+SOURCE_PACKET = "data/certificates/n9_vertex_circle_t04_self_edge_lemma_packet.json"
+
+EXPECTED_FAMILY_IDS = ["F13"]
+EXPECTED_ASSIGNMENT_COUNT = 2
+EXPECTED_ASSIGNMENT_COUNTS = {"F13": 2}
+EXPECTED_STRICT_ROWS = {"F13": 0}
+EXPECTED_OUTER_PAIRS = {"F13": [1, 5]}
+EXPECTED_INNER_PAIRS = {"F13": [1, 2]}
+
+
+def replay_family(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]:
+    """Replay the T04/F13 family packet and return a compact summary plus errors."""
+    errors: list[str] = []
+    family_id = str(packet.get("family_id"))
+    if family_id not in EXPECTED_FAMILY_IDS:
+        errors.append(f"unexpected family_id: {family_id!r}")
+    rows = _rows(packet, family_id, errors)
+    equality_chain, equality_steps = _replay_equality_chain(packet, rows, family_id, errors)
+    strict_summary = _replay_strict_inequality(packet, rows, equality_chain, family_id, errors)
+    summary = {
+        "family_id": family_id,
+        "assignment_count": packet.get("assignment_count"),
+        "core_row_count": len(rows),
+        "core_centers": sorted(rows),
+        "equality_chain": equality_chain,
+        "equality_step_count": len(equality_steps),
+        "equality_steps": equality_steps,
+        "strict_inequality": strict_summary,
+        "self_edge_contradiction": bool(
+            equality_chain
+            and strict_summary
+            and equality_chain[0] == strict_summary.get("outer_pair")
+            and equality_chain[-1] == strict_summary.get("inner_pair")
+        ),
+    }
+    if summary["assignment_count"] != EXPECTED_ASSIGNMENT_COUNTS.get(family_id):
+        errors.append(
+            f"{family_id}: unexpected assignment_count "
+            f"{summary['assignment_count']!r}"
+        )
+    if not summary["self_edge_contradiction"]:
+        errors.append(f"{family_id}: strict inequality does not close on an equality-chain self-edge")
+    return summary, errors
+
+
+def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]:
+    """Replay the T04 packet and return a compact summary plus errors."""
+    errors: list[str] = []
+    if packet.get("schema") != SOURCE_PACKET_SCHEMA:
+        errors.append(f"unexpected source schema: {packet.get('schema')!r}")
+    if packet.get("template_id") != "T04":
+        errors.append(f"unexpected template_id: {packet.get('template_id')!r}")
+    if packet.get("cyclic_order") != list(range(9)):
+        errors.append("cyclic_order must be the natural nonagon order")
+    if packet.get("family_ids") != EXPECTED_FAMILY_IDS:
+        errors.append(f"family_ids mismatch: {packet.get('family_ids')!r}")
+    family_packets = packet.get("family_packets")
+    if not isinstance(family_packets, list):
+        errors.append("family_packets must be a list")
+        family_packets = []
+
+    families: list[dict[str, object]] = []
+    for raw_family in family_packets:
+        if not isinstance(raw_family, dict):
+            errors.append("family_packets entries must be objects")
+            continue
+        family_summary, family_errors = replay_family(raw_family)
+        families.append(family_summary)
+        errors.extend(family_errors)
+
+    family_ids = [str(item.get("family_id")) for item in families]
+    if family_ids != EXPECTED_FAMILY_IDS:
+        errors.append(f"replayed family order mismatch: {family_ids!r}")
+    assignment_counts = {
+        str(item["family_id"]): int(item["assignment_count"])
+        for item in families
+        if isinstance(item.get("assignment_count"), int)
+    }
+    if sum(assignment_counts.values()) != EXPECTED_ASSIGNMENT_COUNT:
+        errors.append("family assignment counts do not sum to expected T04 count")
+    path_lengths = Counter(str(item.get("equality_step_count")) for item in families)
+    strict_rows = {
+        str(item["family_id"]): item.get("strict_inequality", {}).get("row")
+        for item in families
+        if isinstance(item.get("strict_inequality"), dict)
+    }
+    summary = {
+        "source_template_id": packet.get("template_id"),
+        "family_count": len(families),
+        "family_ids": family_ids,
+        "assignment_count": sum(assignment_counts.values()),
+        "assignment_counts": assignment_counts,
+        "path_length_counts": dict(sorted(path_lengths.items())),
+        "strict_rows": strict_rows,
+        "family_replays": families,
+        "all_self_edge_contradictions": all(
+            bool(item.get("self_edge_contradiction")) for item in families
+        ),
+    }
+    if not summary["all_self_edge_contradictions"]:
+        errors.append("not every T04 family replay closed a self-edge contradiction")
+    return summary, errors
+
+
+def minireplay_payload(packet: dict[str, Any]) -> dict[str, object]:
+    """Build the stable mini-replay artifact payload."""
+    replay, errors = replay_packet(packet)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Minimal input-data replay of the focused T04/F13 self-edge "
+            "local lemma packet; not a proof of n=9, not an independent review "
+            "of the full checker, not a counterexample, and not a global status "
+            "update."
+        ),
+        "source_packet": SOURCE_PACKET,
+        "source_packet_schema": SOURCE_PACKET_SCHEMA,
+        "ok": not errors,
+        "validation_errors": errors,
+        "replay": replay,
+        "interpretation": (
+            "The T04/F13 family packet identifies the strict outer and inner "
+            "chord pairs by selected-distance equality steps, while its listed "
+            "vertex-circle row makes the outer chord strictly longer than the "
+            "inner chord."
+        ),
+        "provenance": {
+            "generator": "scripts/check_n9_t04_self_edge_minireplay.py",
+            "command": "python scripts/check_n9_t04_self_edge_minireplay.py --write --assert-expected",
+        },
+    }
+
+
+def validate_payload(payload: dict[str, Any], source_packet: dict[str, Any]) -> list[str]:
+    """Validate a stored mini-replay payload against the source packet."""
+    errors: list[str] = []
+    expected = minireplay_payload(source_packet)
+    for key in ("schema", "status", "trust", "source_packet", "source_packet_schema", "ok"):
+        if payload.get(key) != expected.get(key):
+            errors.append(f"{key} mismatch: {payload.get(key)!r} != {expected.get(key)!r}")
+    if payload.get("validation_errors") != expected["validation_errors"]:
+        errors.append("validation_errors mismatch")
+    if payload.get("replay") != expected["replay"]:
+        errors.append("replay mismatch")
+    return errors
+
+
+def assert_expected_payload(payload: dict[str, Any]) -> None:
+    """Assert the stable expected T04/F13 mini-replay facts."""
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError("unexpected schema")
+    if payload.get("ok") is not True:
+        raise AssertionError(f"mini-replay is not ok: {payload.get('validation_errors')!r}")
+    replay = payload.get("replay")
+    if not isinstance(replay, dict):
+        raise AssertionError("missing replay object")
+    expected = {
+        "source_template_id": "T04",
+        "family_count": 1,
+        "family_ids": EXPECTED_FAMILY_IDS,
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_counts": EXPECTED_ASSIGNMENT_COUNTS,
+        "path_length_counts": {"3": 1},
+        "strict_rows": EXPECTED_STRICT_ROWS,
+        "all_self_edge_contradictions": True,
+    }
+    for key, expected_value in expected.items():
+        if replay.get(key) != expected_value:
+            raise AssertionError(
+                f"unexpected replay {key}: {replay.get(key)!r} != {expected_value!r}"
+            )
+    family_replays = replay.get("family_replays")
+    if not isinstance(family_replays, list) or len(family_replays) != 1:
+        raise AssertionError("unexpected family_replays")
+    family = family_replays[0]
+    if not isinstance(family, dict):
+        raise AssertionError("family replay is not an object")
+    family_id = str(family.get("family_id"))
+    strict = family.get("strict_inequality")
+    if not isinstance(strict, dict):
+        raise AssertionError(f"{family_id}: missing strict_inequality")
+    if strict.get("outer_pair") != EXPECTED_OUTER_PAIRS[family_id]:
+        raise AssertionError(f"{family_id}: unexpected outer_pair")
+    if strict.get("inner_pair") != EXPECTED_INNER_PAIRS[family_id]:
+        raise AssertionError(f"{family_id}: unexpected inner_pair")

--- a/tests/test_n9_t04_self_edge_minireplay.py
+++ b/tests/test_n9_t04_self_edge_minireplay.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.n9_t04_self_edge_minireplay import (
+    assert_expected_payload,
+    minireplay_payload,
+    replay_packet,
+    validate_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "data" / "certificates" / "n9_vertex_circle_t04_self_edge_lemma_packet.json"
+
+
+def _source_packet() -> dict[str, object]:
+    payload = json.loads(SOURCE.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_t04_minireplay_replays_f13_local_self_edge() -> None:
+    packet = _source_packet()
+    replay, errors = replay_packet(packet)
+
+    assert errors == []
+    assert replay["family_ids"] == ["F13"]
+    assert replay["assignment_count"] == 2
+    assert replay["assignment_counts"] == {"F13": 2}
+    assert replay["path_length_counts"] == {"3": 1}
+    assert replay["all_self_edge_contradictions"] is True
+    family = replay["family_replays"][0]
+    assert family["equality_chain"] == [[1, 5], [3, 5], [1, 3], [1, 2]]
+    assert family["strict_inequality"] == {
+        "row": 0,
+        "witness_order": [1, 2, 5, 7],
+        "outer_pair": [1, 5],
+        "inner_pair": [1, 2],
+        "outer_interval": [0, 2],
+        "inner_interval": [0, 1],
+        "outer_span": 2,
+        "inner_span": 1,
+    }
+
+
+def test_t04_minireplay_rejects_broken_equality_step() -> None:
+    packet = _source_packet()
+    families = packet["family_packets"]
+    assert isinstance(families, list)
+    family = families[0]
+    assert isinstance(family, dict)
+    equality = family["distance_equality"]
+    assert isinstance(equality, dict)
+    path = equality["path"]
+    assert isinstance(path, list)
+    bad_step = dict(path[0])
+    bad_step["next_pair"] = [0, 8]
+    path[0] = bad_step
+
+    _, errors = replay_packet(packet)
+
+    assert any("F13: equality step 0 does not end at row center 5" in error for error in errors)
+    assert any("F13: stored equality_chain mismatch" in error for error in errors)
+
+
+def test_t04_minireplay_rejects_reordered_strict_witnesses() -> None:
+    packet = _source_packet()
+    families = packet["family_packets"]
+    assert isinstance(families, list)
+    family = families[0]
+    assert isinstance(family, dict)
+    strict = family["strict_inequality"]
+    assert isinstance(strict, dict)
+    strict["witness_order"] = [1, 5, 2, 7]
+
+    _, errors = replay_packet(packet)
+
+    assert "F13: strict_inequality outer_interval mismatch" in errors
+    assert "F13: strict outer interval must properly contain inner interval" in errors
+
+
+@pytest.mark.artifact
+def test_t04_minireplay_payload_validates_against_source() -> None:
+    packet = _source_packet()
+    payload = minireplay_payload(packet)
+
+    assert validate_payload(payload, packet) == []
+    assert_expected_payload(payload)

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -610,6 +610,30 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
     )
     assert (
+        "python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert (
+        "python scripts/check_n9_t04_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_t04_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_t04_self_edge_minireplay.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary
- add a minimal T04/F13 self-edge mini-replay checker and generated artifact
- register the checker in generated-artifact metadata and the artifact audit runner
- document the replay in local-lemma, reviewer, reproduction, and README command lists
- add targeted tests for the equality chain, witness-order strict interval, and audit ordering

## Verification
- `python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_t04_self_edge_minireplay.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check src/erdos97/n9_t04_self_edge_minireplay.py scripts/check_n9_t04_self_edge_minireplay.py tests/test_n9_t04_self_edge_minireplay.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1012 passed, 294 deselected`)

Note: `make verify-fast` could not run in this Windows shell because `make` is not installed; the equivalent explicit fast-tier commands above were run.