### PR TITLE
Add focused mini-replay crosswalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -24,7 +24,11 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
    now checks that the focused packet coverage, source template records,
    source catalog records, and aggregate focused-note crosschecks agree before
-   packet soundness review.
+   packet soundness review. The focused mini-replay crosswalk
+   `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+   joins those same 12 focused packets to their packet-specific mini-replay
+   artifacts without promoting the layer to packet soundness or local-lemma
+   completeness.
 2. Use the stored simple replay artifact
    `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` as a
    reviewer-facing input for the aggregate local-template coverage. The replay

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -91,6 +91,11 @@ checks that the 12 focused packet JSON files, the source template packets, the
 template catalog, and the aggregate local-lemma focused-note ledger agree on
 packet coverage. This is bookkeeping only, not packet soundness or an `n=9`
 proof.
+The focused mini-replay crosswalk
+`scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+then joins those focused packets to their 12 packet-specific mini-replay
+artifacts, checking identity, families, source schemas, obstruction flags, and
+compact local shape counts only.
 
 The audit command
 `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py` checks the

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -606,6 +606,14 @@ aggregate scan and the simpler replay audit describe the same stored local
 template coverage. It does not certify that the packet family list is complete
 for `n=9`, and it does not promote the review-pending exhaustive checker.
 
+The focused packet/minireplay crosswalk checks that the 12 packet-specific
+mini-replays agree with their source focused packets on identity, source
+schema, family coverage, obstruction flags, and compact local shape counts:
+
+```bash
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
+```
+
 The related exhaustive/local-lemma crosswalk checks the upstream count chain
 from the review-pending exhaustive artifact through the motif classification
 before joining to the local-lemma replay artifacts:

--- a/docs/n9-vertex-circle-template-lemma-catalog.md
+++ b/docs/n9-vertex-circle-template-lemma-catalog.md
@@ -61,12 +61,17 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py \
   --check \
   --assert-expected \
   --json
+
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py \
+  --check \
+  --assert-expected \
+  --json
 ```
 
 That audit is JSON bookkeeping only. It verifies agreement among checked-in
-packet, source-template, catalog, and aggregate scan records; it does not
-prove packet soundness, local-lemma completeness, frontier coverage, `n=9`, or
-a counterexample.
+packet, source-template, catalog, aggregate scan, and mini-replay records; it
+does not prove packet soundness, local-lemma completeness, frontier coverage,
+`n=9`, or a counterexample.
 
 ## Review standard
 

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -61,6 +61,7 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -365,6 +365,11 @@ Next steps:
   to cross-check the 12 focused packet JSON files against the source template
   packets, template catalog, and aggregate focused-note ledger before reviewing
   packet soundness;
+- use
+  `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+  to join the same 12 focused packets to their packet-specific mini-replay
+  artifacts, checking identity, source schemas, families, obstruction flags,
+  and compact shape counts only;
 - use `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` to
   replay the aggregate local-template coverage from stored packet JSON without
   sharing the main quotient-replay helper;

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -81,6 +81,7 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""Cross-check focused n=9 local-lemma packets against mini-replay artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.path_display import display_path  # noqa: E402
+
+EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
+SELF_EDGE_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 10)]
+STRICT_CYCLE_TEMPLATE_IDS = [f"T{index:02d}" for index in range(10, 13)]
+
+DEFAULT_PACKET_PATHS = {
+    **{
+        template_id: (
+            ROOT
+            / "data"
+            / "certificates"
+            / f"n9_vertex_circle_t{index:02d}_self_edge_lemma_packet.json"
+        )
+        for index, template_id in enumerate(SELF_EDGE_TEMPLATE_IDS, start=1)
+    },
+    **{
+        template_id: (
+            ROOT
+            / "data"
+            / "certificates"
+            / f"n9_vertex_circle_t{index:02d}_strict_cycle_lemma_packet.json"
+        )
+        for index, template_id in enumerate(STRICT_CYCLE_TEMPLATE_IDS, start=10)
+    },
+}
+DEFAULT_MINIREPLAY_PATHS = {
+    **{
+        template_id: (
+            ROOT / "data" / "certificates" / f"n9_t{index:02d}_self_edge_minireplay.json"
+        )
+        for index, template_id in enumerate(SELF_EDGE_TEMPLATE_IDS, start=1)
+    },
+    **{
+        template_id: (
+            ROOT
+            / "data"
+            / "certificates"
+            / f"n9_t{index:02d}_strict_cycle_minireplay.json"
+        )
+        for index, template_id in enumerate(STRICT_CYCLE_TEMPLATE_IDS, start=10)
+    },
+}
+
+SCHEMA = "erdos97.n9_vertex_circle_focused_minireplay_crosswalk.v1"
+STATUS = "REVIEW_PENDING_FOCUSED_MINIREPLAY_CROSSWALK"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "JSON-only cross-artifact audit joining the 12 focused n=9 local-lemma "
+    "packets to their packet-specific mini-replay artifacts. It checks "
+    "identity, source schema, family coverage, obstruction flags, and local "
+    "shape counts only. It does not prove mini-replay soundness, packet "
+    "soundness, local-lemma completeness, frontier coverage, n=9, a "
+    "counterexample, or any official/global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py "
+        "--check --assert-expected --json"
+    ),
+}
+
+EXPECTED_STATUS_COUNTS = {"self_edge": 9, "strict_cycle": 3}
+EXPECTED_STATUS_ASSIGNMENT_COUNTS = {"self_edge": 158, "strict_cycle": 26}
+EXPECTED_FAMILY_COUNT = 16
+EXPECTED_ASSIGNMENT_COUNT = 184
+EXPECTED_REPEATED_ASSIGNMENT_COUNT = 152
+EXPECTED_SOURCE_ONLY_ASSIGNMENT_COUNT = 32
+EXPECTED_SOURCE_ONLY_TEMPLATES = ["T01", "T10", "T11", "T12"]
+EXPECTED_SELF_EDGE_PATH_LENGTH_COUNTS = {"3": 9, "4": 2, "5": 1, "6": 1}
+EXPECTED_STRICT_CYCLE_LENGTH_COUNTS = {"2": 1, "3": 2}
+
+
+def load_json(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def focused_minireplay_crosswalk_payload(
+    *,
+    packet_paths: Mapping[str, Path] | None = None,
+    minireplay_paths: Mapping[str, Path] | None = None,
+) -> dict[str, Any]:
+    """Return a JSON-only packet/minireplay crosswalk payload."""
+
+    resolved_packets = {
+        template_id: _resolve(path)
+        for template_id, path in (packet_paths or DEFAULT_PACKET_PATHS).items()
+    }
+    resolved_minireplays = {
+        template_id: _resolve(path)
+        for template_id, path in (minireplay_paths or DEFAULT_MINIREPLAY_PATHS).items()
+    }
+    packet_payloads = {
+        template_id: load_json(path) for template_id, path in resolved_packets.items()
+    }
+    minireplay_payloads = {
+        template_id: load_json(path) for template_id, path in resolved_minireplays.items()
+    }
+    errors: list[str] = []
+    summary = _audit(
+        packet_payloads,
+        minireplay_payloads,
+        resolved_packets,
+        resolved_minireplays,
+        errors,
+    )
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "focused_minireplay_crosswalk": summary,
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "interpretation": (
+            "A passed crosswalk says the stored focused packets and the "
+            "small packet-specific mini-replays agree on identity, families, "
+            "source schemas, obstruction flags, and compact local shapes. "
+            "This is bookkeeping only."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def assert_expected_focused_minireplay_crosswalk(payload: Mapping[str, Any]) -> None:
+    """Assert stable counts for the focused packet/minireplay crosswalk."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not prove mini-replay soundness",
+        "packet soundness",
+        "local-lemma completeness",
+        "frontier coverage",
+        "n=9",
+        "counterexample",
+        "official/global status update",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+    if payload.get("validation_status") != "passed":
+        raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+
+    summary = payload.get("focused_minireplay_crosswalk")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("focused_minireplay_crosswalk missing")
+    expected = {
+        "packet_count": 12,
+        "minireplay_count": 12,
+        "template_ids": EXPECTED_TEMPLATE_IDS,
+        "status_counts": EXPECTED_STATUS_COUNTS,
+        "status_assignment_counts": EXPECTED_STATUS_ASSIGNMENT_COUNTS,
+        "source_assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "source_family_count": EXPECTED_FAMILY_COUNT,
+        "obstruction_flagged_count": 12,
+        "assignment_count_repeated_template_count": 8,
+        "assignment_count_source_only_template_count": 4,
+        "assignment_count_repeated_total": EXPECTED_REPEATED_ASSIGNMENT_COUNT,
+        "assignment_count_source_only_total": EXPECTED_SOURCE_ONLY_ASSIGNMENT_COUNT,
+        "assignment_count_source_only_templates": EXPECTED_SOURCE_ONLY_TEMPLATES,
+        "source_packet_mismatch_count": 0,
+        "source_schema_mismatch_count": 0,
+        "family_mismatch_count": 0,
+        "assignment_count_mismatch_count": 0,
+        "obstruction_flag_mismatch_count": 0,
+        "self_edge_path_length_family_counts": EXPECTED_SELF_EDGE_PATH_LENGTH_COUNTS,
+        "strict_cycle_length_family_counts": EXPECTED_STRICT_CYCLE_LENGTH_COUNTS,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(f"{key} mismatch: {summary.get(key)!r} != {value!r}")
+
+
+def _audit(
+    packets: Mapping[str, Any],
+    minireplays: Mapping[str, Any],
+    packet_paths: Mapping[str, Path],
+    minireplay_paths: Mapping[str, Path],
+    errors: list[str],
+) -> dict[str, Any]:
+    missing_packets = sorted(set(EXPECTED_TEMPLATE_IDS) - set(packets))
+    missing_minireplays = sorted(set(EXPECTED_TEMPLATE_IDS) - set(minireplays))
+    extra_packets = sorted(set(packets) - set(EXPECTED_TEMPLATE_IDS))
+    extra_minireplays = sorted(set(minireplays) - set(EXPECTED_TEMPLATE_IDS))
+    for label, values in (
+        ("missing focused packets", missing_packets),
+        ("missing mini-replays", missing_minireplays),
+        ("extra focused packets", extra_packets),
+        ("extra mini-replays", extra_minireplays),
+    ):
+        if values:
+            errors.append(f"{label}: {values!r}")
+
+    records: list[dict[str, Any]] = []
+    status_counts: Counter[str] = Counter()
+    status_assignment_counts: Counter[str] = Counter()
+    self_edge_path_lengths: Counter[str] = Counter()
+    strict_cycle_lengths: Counter[str] = Counter()
+    source_packet_mismatch_count = 0
+    source_schema_mismatch_count = 0
+    family_mismatch_count = 0
+    assignment_count_mismatch_count = 0
+    obstruction_flag_mismatch_count = 0
+    assignment_count_repeated_total = 0
+    assignment_count_source_only_total = 0
+    assignment_count_source_only_templates: list[str] = []
+    family_ids: list[str] = []
+
+    for template_id in EXPECTED_TEMPLATE_IDS:
+        packet = packets.get(template_id)
+        minireplay = minireplays.get(template_id)
+        if not isinstance(packet, Mapping):
+            errors.append(f"{template_id}: focused packet must be an object")
+            continue
+        if not isinstance(minireplay, Mapping):
+            errors.append(f"{template_id}: mini-replay must be an object")
+            continue
+        source = _source_record(template_id, packet, packet_paths.get(template_id), errors)
+        record = _minireplay_record(
+            template_id,
+            source,
+            minireplay,
+            minireplay_paths.get(template_id),
+            errors,
+        )
+        records.append(record)
+        status_counts[source["status"]] += 1
+        status_assignment_counts[source["status"]] += source["assignment_count"]
+        family_ids.extend(source["family_ids"])
+
+        if record["source_packet_matches"] is not True:
+            source_packet_mismatch_count += 1
+        if record["source_schema_matches"] is not True:
+            source_schema_mismatch_count += 1
+        if record["family_ids_match"] is not True:
+            family_mismatch_count += 1
+        if record["assignment_count_matches"] is False:
+            assignment_count_mismatch_count += 1
+        if record["obstruction_confirmed"] is not True:
+            obstruction_flag_mismatch_count += 1
+
+        if record["assignment_count_repeated"]:
+            assignment_count_repeated_total += source["assignment_count"]
+        else:
+            assignment_count_source_only_total += source["assignment_count"]
+            assignment_count_source_only_templates.append(template_id)
+
+        if source["status"] == "self_edge":
+            self_edge_path_lengths.update(record["shape_counts"])
+        elif source["status"] == "strict_cycle":
+            strict_cycle_lengths.update(record["shape_counts"])
+
+    return {
+        "packet_count": len([item for item in packets.values() if isinstance(item, Mapping)]),
+        "minireplay_count": len(
+            [item for item in minireplays.values() if isinstance(item, Mapping)]
+        ),
+        "template_ids": [record["template_id"] for record in records],
+        "status_counts": dict(sorted(status_counts.items())),
+        "status_assignment_counts": dict(sorted(status_assignment_counts.items())),
+        "source_assignment_count": sum(status_assignment_counts.values()),
+        "source_family_count": len(set(family_ids)),
+        "obstruction_flagged_count": sum(
+            1 for record in records if record["obstruction_confirmed"] is True
+        ),
+        "assignment_count_repeated_template_count": sum(
+            1 for record in records if record["assignment_count_repeated"] is True
+        ),
+        "assignment_count_source_only_template_count": len(
+            assignment_count_source_only_templates
+        ),
+        "assignment_count_repeated_total": assignment_count_repeated_total,
+        "assignment_count_source_only_total": assignment_count_source_only_total,
+        "assignment_count_source_only_templates": assignment_count_source_only_templates,
+        "source_packet_mismatch_count": source_packet_mismatch_count,
+        "source_schema_mismatch_count": source_schema_mismatch_count,
+        "family_mismatch_count": family_mismatch_count,
+        "assignment_count_mismatch_count": assignment_count_mismatch_count,
+        "obstruction_flag_mismatch_count": obstruction_flag_mismatch_count,
+        "self_edge_path_length_family_counts": dict(sorted(self_edge_path_lengths.items())),
+        "strict_cycle_length_family_counts": dict(sorted(strict_cycle_lengths.items())),
+        "records": records,
+    }
+
+
+def _source_record(
+    template_id: str,
+    packet: Mapping[str, Any],
+    path: Path | None,
+    errors: list[str],
+) -> dict[str, Any]:
+    if packet.get("template_id") != template_id:
+        errors.append(f"{template_id}: focused packet template_id mismatch")
+    status = "unknown"
+    source_catalog = packet.get("source_catalog_record")
+    if isinstance(source_catalog, Mapping):
+        status = str(source_catalog.get("status"))
+    family_ids = _family_ids(packet)
+    assignment_count = int(packet.get("assignment_count", -1))
+    family_assignment_counts = _family_assignment_counts(packet, family_ids, assignment_count)
+    return {
+        "template_id": template_id,
+        "path": _relative_posix(path),
+        "schema": packet.get("schema"),
+        "status": status,
+        "family_ids": family_ids,
+        "family_assignment_counts": family_assignment_counts,
+        "assignment_count": assignment_count,
+    }
+
+
+def _minireplay_record(
+    template_id: str,
+    source: Mapping[str, Any],
+    minireplay: Mapping[str, Any],
+    path: Path | None,
+    errors: list[str],
+) -> dict[str, Any]:
+    replay = minireplay.get("replay")
+    if not isinstance(replay, Mapping):
+        errors.append(f"{template_id}: mini-replay replay must be an object")
+        replay = {}
+    expected_status_suffix = (
+        "SELF_EDGE_MINIREPLAY" if source["status"] == "self_edge" else "STRICT_CYCLE_MINIREPLAY"
+    )
+    expected_status = f"REVIEW_PENDING_{template_id}_{expected_status_suffix}"
+    if minireplay.get("status") != expected_status:
+        errors.append(f"{template_id}: mini-replay status mismatch")
+    if minireplay.get("trust") != TRUST:
+        errors.append(f"{template_id}: mini-replay trust mismatch")
+    if minireplay.get("ok") is not True:
+        errors.append(f"{template_id}: mini-replay ok flag is not true")
+    if minireplay.get("validation_errors") != []:
+        errors.append(f"{template_id}: mini-replay validation_errors is not empty")
+
+    source_packet_matches = minireplay.get("source_packet") == source["path"]
+    if not source_packet_matches:
+        errors.append(f"{template_id}: mini-replay source_packet mismatch")
+    source_schema_matches = minireplay.get("source_packet_schema") == source["schema"]
+    if not source_schema_matches:
+        errors.append(f"{template_id}: mini-replay source schema mismatch")
+    if replay.get("source_template_id") != template_id:
+        errors.append(f"{template_id}: mini-replay source_template_id mismatch")
+
+    replay_family_ids = _replay_family_ids(replay)
+    family_ids_match = replay_family_ids == source["family_ids"]
+    if not family_ids_match:
+        errors.append(f"{template_id}: mini-replay family ids mismatch")
+
+    assignment_count_matches: bool | None = None
+    assignment_count_repeated = isinstance(replay.get("assignment_count"), int)
+    if assignment_count_repeated:
+        assignment_count_matches = replay.get("assignment_count") == source["assignment_count"]
+        if not assignment_count_matches:
+            errors.append(f"{template_id}: mini-replay assignment_count mismatch")
+    replay_assignment_counts = _int_map(replay.get("assignment_counts"))
+    if replay_assignment_counts and replay_assignment_counts != source["family_assignment_counts"]:
+        assignment_count_matches = False
+        errors.append(f"{template_id}: mini-replay assignment_counts mismatch")
+
+    obstruction_confirmed = _obstruction_confirmed(source["status"], replay)
+    if not obstruction_confirmed:
+        errors.append(f"{template_id}: mini-replay obstruction flag mismatch")
+    shape_counts = _shape_counts(source["status"], replay, template_id, errors)
+    return {
+        "template_id": template_id,
+        "status": source["status"],
+        "source_packet_path": source["path"],
+        "minireplay_path": _relative_posix(path),
+        "family_ids": source["family_ids"],
+        "source_assignment_count": source["assignment_count"],
+        "assignment_count_repeated": assignment_count_repeated,
+        "assignment_count_matches": assignment_count_matches,
+        "source_packet_matches": source_packet_matches,
+        "source_schema_matches": source_schema_matches,
+        "family_ids_match": family_ids_match,
+        "obstruction_confirmed": obstruction_confirmed,
+        "shape_counts": shape_counts,
+    }
+
+
+def _family_ids(packet: Mapping[str, Any]) -> list[str]:
+    family_ids = packet.get("family_ids")
+    if isinstance(family_ids, list):
+        return [str(item) for item in family_ids]
+    family_id = packet.get("family_id")
+    return [str(family_id)] if isinstance(family_id, str) else []
+
+
+def _family_assignment_counts(
+    packet: Mapping[str, Any],
+    family_ids: Sequence[str],
+    assignment_count: int,
+) -> dict[str, int]:
+    counts = _int_map(packet.get("family_assignment_counts"))
+    if counts:
+        return counts
+    if len(family_ids) == 1:
+        return {family_ids[0]: assignment_count}
+    return {}
+
+
+def _replay_family_ids(replay: Mapping[str, Any]) -> list[str]:
+    family_ids = replay.get("family_ids")
+    if isinstance(family_ids, list):
+        return [str(item) for item in family_ids]
+    family_id = replay.get("source_family_id")
+    return [str(family_id)] if isinstance(family_id, str) else []
+
+
+def _obstruction_confirmed(status: str, replay: Mapping[str, Any]) -> bool:
+    if status == "self_edge":
+        if "all_self_edge_contradictions" in replay:
+            return replay.get("all_self_edge_contradictions") is True
+        return replay.get("self_edge_contradiction") is True
+    if status == "strict_cycle":
+        return replay.get("strict_cycle_contradiction") is True
+    return False
+
+
+def _shape_counts(
+    status: str,
+    replay: Mapping[str, Any],
+    template_id: str,
+    errors: list[str],
+) -> dict[str, int]:
+    if status == "self_edge":
+        path_counts = _int_map(replay.get("path_length_counts"))
+        if path_counts:
+            return path_counts
+        try:
+            return {str(int(replay["equality_step_count"])): 1}
+        except (KeyError, TypeError, ValueError):
+            errors.append(f"{template_id}: missing self-edge equality path length")
+            return {}
+    if status == "strict_cycle":
+        try:
+            return {str(int(replay["cycle_length"])): 1}
+        except (KeyError, TypeError, ValueError):
+            errors.append(f"{template_id}: missing strict-cycle length")
+            return {}
+    errors.append(f"{template_id}: unknown source status {status!r}")
+    return {}
+
+
+def _int_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): int(item) for key, item in value.items()}
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _relative_posix(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return path.resolve().relative_to(ROOT.resolve()).as_posix()
+    except ValueError:
+        return display_path(path, ROOT).replace("\\", "/")
+
+
+def summary_lines(payload: Mapping[str, Any]) -> list[str]:
+    summary = payload["focused_minireplay_crosswalk"]
+    return [
+        f"schema: {payload['schema']}",
+        f"status: {payload['status']}",
+        f"validation: {payload['validation_status']}",
+        f"mini-replays checked: {summary['minireplay_count']}",
+        f"source assignments covered: {summary['source_assignment_count']}",
+        f"source families covered: {summary['source_family_count']}",
+        f"obstruction flags checked: {summary['obstruction_flagged_count']}",
+        f"assignment counts repeated directly: {summary['assignment_count_repeated_total']}",
+    ]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate the crosswalk")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        payload = focused_minireplay_crosswalk_payload()
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        payload = {
+            "schema": SCHEMA,
+            "status": STATUS,
+            "trust": TRUST,
+            "claim_scope": CLAIM_SCOPE,
+            "validation_status": "failed",
+            "validation_errors": [str(exc)],
+            "provenance": dict(PROVENANCE),
+        }
+
+    if args.assert_expected:
+        assert_expected_focused_minireplay_crosswalk(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif payload.get("validation_status") == "passed":
+        print("n=9 focused mini-replay crosswalk")
+        for line in summary_lines(payload):
+            print(line)
+        print("OK: focused mini-replay crosswalk checks passed")
+    else:
+        print("FAILED: n=9 focused mini-replay crosswalk", file=sys.stderr)
+        for error in payload.get("validation_errors", []):
+            print(f"- {error}", file=sys.stderr)
+
+    if args.check and payload.get("validation_status") != "passed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -591,6 +591,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_focused_minireplay_crosswalk",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "JSON-only cross-artifact audit joining the 12 focused n=9 "
+            "local-lemma packets to their mini-replay artifacts; not "
+            "mini-replay soundness, packet soundness, local-lemma "
+            "completeness, frontier coverage, proof of n=9, counterexample, "
+            "or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_local_lemma_simple_replay",
         command=(
             "python",

--- a/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_n9_vertex_circle_focused_minireplay_crosswalk import (
+    DEFAULT_MINIREPLAY_PATHS,
+    assert_expected_focused_minireplay_crosswalk,
+    focused_minireplay_crosswalk_payload,
+    load_json,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def test_focused_minireplay_crosswalk_counts_and_scope() -> None:
+    payload = focused_minireplay_crosswalk_payload()
+
+    assert_expected_focused_minireplay_crosswalk(payload)
+    summary = payload["focused_minireplay_crosswalk"]
+    assert payload["validation_status"] == "passed"
+    assert payload["status"] == "REVIEW_PENDING_FOCUSED_MINIREPLAY_CROSSWALK"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert "bookkeeping only" in payload["interpretation"]
+    assert "does not prove mini-replay soundness" in payload["claim_scope"]
+    assert "counterexample" in payload["claim_scope"]
+    assert "official/global status update" in payload["claim_scope"]
+    assert summary["template_ids"] == [f"T{index:02d}" for index in range(1, 13)]
+    assert summary["status_counts"] == {"self_edge": 9, "strict_cycle": 3}
+    assert summary["status_assignment_counts"] == {"self_edge": 158, "strict_cycle": 26}
+    assert summary["source_assignment_count"] == 184
+    assert summary["source_family_count"] == 16
+    assert summary["obstruction_flagged_count"] == 12
+    assert summary["assignment_count_repeated_total"] == 152
+    assert summary["assignment_count_source_only_total"] == 32
+
+
+def test_focused_minireplay_crosswalk_rejects_source_packet_drift(
+    tmp_path: Path,
+) -> None:
+    t09_path = tmp_path / "t09_minireplay.json"
+    t09_minireplay = load_json(DEFAULT_MINIREPLAY_PATHS["T09"])
+    t09_minireplay["source_packet"] = (
+        "data/certificates/n9_vertex_circle_t08_self_edge_lemma_packet.json"
+    )
+    _write_json(t09_path, t09_minireplay)
+    minireplay_paths = dict(DEFAULT_MINIREPLAY_PATHS)
+    minireplay_paths["T09"] = t09_path
+
+    payload = focused_minireplay_crosswalk_payload(minireplay_paths=minireplay_paths)
+
+    assert payload["validation_status"] == "failed"
+    assert "T09: mini-replay source_packet mismatch" in payload["validation_errors"]
+    summary = payload["focused_minireplay_crosswalk"]
+    assert summary["source_packet_mismatch_count"] == 1
+
+
+def test_focused_minireplay_crosswalk_rejects_family_drift(
+    tmp_path: Path,
+) -> None:
+    t02_path = tmp_path / "t02_minireplay.json"
+    t02_minireplay = load_json(DEFAULT_MINIREPLAY_PATHS["T02"])
+    t02_minireplay["replay"]["family_ids"] = ["F01", "F04", "F08"]
+    _write_json(t02_path, t02_minireplay)
+    minireplay_paths = dict(DEFAULT_MINIREPLAY_PATHS)
+    minireplay_paths["T02"] = t02_path
+
+    payload = focused_minireplay_crosswalk_payload(minireplay_paths=minireplay_paths)
+
+    assert payload["validation_status"] == "failed"
+    assert "T02: mini-replay family ids mismatch" in payload["validation_errors"]
+    summary = payload["focused_minireplay_crosswalk"]
+    assert summary["family_mismatch_count"] == 1
+
+
+def test_focused_minireplay_crosswalk_rejects_obstruction_flag_drift(
+    tmp_path: Path,
+) -> None:
+    t10_path = tmp_path / "t10_minireplay.json"
+    t10_minireplay = load_json(DEFAULT_MINIREPLAY_PATHS["T10"])
+    t10_minireplay["replay"]["strict_cycle_contradiction"] = False
+    _write_json(t10_path, t10_minireplay)
+    minireplay_paths = dict(DEFAULT_MINIREPLAY_PATHS)
+    minireplay_paths["T10"] = t10_path
+
+    payload = focused_minireplay_crosswalk_payload(minireplay_paths=minireplay_paths)
+
+    assert payload["validation_status"] == "failed"
+    assert "T10: mini-replay obstruction flag mismatch" in payload["validation_errors"]
+    summary = payload["focused_minireplay_crosswalk"]
+    assert summary["obstruction_flag_mismatch_count"] == 1
+
+
+def test_focused_minireplay_crosswalk_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    parsed = json.loads(result.stdout)
+    assert parsed["validation_status"] == "passed"
+    summary = parsed["focused_minireplay_crosswalk"]
+    assert summary["source_assignment_count"] == 184
+    assert summary["obstruction_flagged_count"] == 12

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -526,6 +526,18 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py "
         "--check --assert-expected --json"
     ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py "
+        "--check --assert-expected --json"
+    )
+    assert (
+        "python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py "
         "--check --assert-expected --json"
     )


### PR DESCRIPTION
## Summary
- add a JSON-only crosswalk joining the 12 focused n=9 local-lemma packets to their packet-specific mini-replay artifacts
- check source packet identity, source schema, family coverage, obstruction flags, repeated assignment counts where present, and compact local shape counts
- register the command in the artifact audit runner and document it in the local-lemma/reviewer/reproduction command lists

## Verification
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (1032 passed, 299 deselected)

`make verify-fast` was not used because `make` is unavailable in this Windows shell; the explicit fast-tier commands above were run instead.