### PR TITLE
Echo mini-replay assignment counts

### DIFF
--- a/data/certificates/n9_t01_self_edge_minireplay.json
+++ b/data/certificates/n9_t01_self_edge_minireplay.json
@@ -7,6 +7,10 @@
     "generator": "scripts/check_n9_t01_self_edge_minireplay.py"
   },
   "replay": {
+    "assignment_count": 6,
+    "assignment_counts": {
+      "F09": 6
+    },
     "core_centers": [
       0,
       1,
@@ -66,6 +70,10 @@
         ],
         "row": 2
       }
+    ],
+    "family_count": 1,
+    "family_ids": [
+      "F09"
     ],
     "self_edge_contradiction": true,
     "source_family_id": "F09",

--- a/data/certificates/n9_t10_strict_cycle_minireplay.json
+++ b/data/certificates/n9_t10_strict_cycle_minireplay.json
@@ -7,6 +7,10 @@
     "generator": "scripts/check_n9_t10_strict_cycle_minireplay.py"
   },
   "replay": {
+    "assignment_count": 18,
+    "assignment_counts": {
+      "F12": 18
+    },
     "core_centers": [
       0,
       3,
@@ -137,6 +141,10 @@
           ]
         }
       }
+    ],
+    "family_count": 1,
+    "family_ids": [
+      "F12"
     ],
     "source_family_id": "F12",
     "source_template_id": "T10",

--- a/data/certificates/n9_t11_strict_cycle_minireplay.json
+++ b/data/certificates/n9_t11_strict_cycle_minireplay.json
@@ -7,6 +7,10 @@
     "generator": "scripts/check_n9_t11_strict_cycle_minireplay.py"
   },
   "replay": {
+    "assignment_count": 6,
+    "assignment_counts": {
+      "F07": 6
+    },
     "core_centers": [
       0,
       1,
@@ -174,6 +178,10 @@
           ]
         }
       }
+    ],
+    "family_count": 1,
+    "family_ids": [
+      "F07"
     ],
     "source_family_id": "F07",
     "source_template_id": "T11",

--- a/data/certificates/n9_t12_strict_cycle_minireplay.json
+++ b/data/certificates/n9_t12_strict_cycle_minireplay.json
@@ -7,6 +7,10 @@
     "generator": "scripts/check_n9_t12_strict_cycle_minireplay.py"
   },
   "replay": {
+    "assignment_count": 2,
+    "assignment_counts": {
+      "F16": 2
+    },
     "core_centers": [
       0,
       1,
@@ -192,6 +196,10 @@
           ]
         }
       }
+    ],
+    "family_count": 1,
+    "family_ids": [
+      "F16"
     ],
     "source_family_id": "F16",
     "source_template_id": "T12",

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -871,6 +871,11 @@ artifacts:
       source_packet_schema: erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1
       replay.source_template_id: T01
       replay.source_family_id: F09
+      replay.family_count: 1
+      replay.family_ids:
+        - F09
+      replay.assignment_count: 6
+      replay.assignment_counts.F09: 6
       replay.core_row_count: 3
       replay.equality_step_count: 3
       replay.self_edge_contradiction: true
@@ -1647,6 +1652,11 @@ artifacts:
       source_packet_schema: erdos97.n9_vertex_circle_t10_strict_cycle_lemma_packet.v1
       replay.source_template_id: T10
       replay.source_family_id: F12
+      replay.family_count: 1
+      replay.family_ids:
+        - F12
+      replay.assignment_count: 18
+      replay.assignment_counts.F12: 18
       replay.core_row_count: 4
       replay.cycle_length: 2
       replay.strict_cycle_contradiction: true
@@ -1826,6 +1836,11 @@ artifacts:
       source_packet_schema: erdos97.n9_vertex_circle_t11_strict_cycle_lemma_packet.v1
       replay.source_template_id: T11
       replay.source_family_id: F07
+      replay.family_count: 1
+      replay.family_ids:
+        - F07
+      replay.assignment_count: 6
+      replay.assignment_counts.F07: 6
       replay.core_row_count: 4
       replay.cycle_length: 3
       replay.strict_cycle_contradiction: true
@@ -1911,6 +1926,11 @@ artifacts:
       source_packet_schema: erdos97.n9_vertex_circle_t12_strict_cycle_lemma_packet.v1
       replay.source_template_id: T12
       replay.source_family_id: F16
+      replay.family_count: 1
+      replay.family_ids:
+        - F16
+      replay.assignment_count: 2
+      replay.assignment_counts.F16: 2
       replay.core_row_count: 6
       replay.cycle_length: 3
       replay.strict_cycle_contradiction: true

--- a/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -82,9 +82,9 @@ EXPECTED_STATUS_COUNTS = {"self_edge": 9, "strict_cycle": 3}
 EXPECTED_STATUS_ASSIGNMENT_COUNTS = {"self_edge": 158, "strict_cycle": 26}
 EXPECTED_FAMILY_COUNT = 16
 EXPECTED_ASSIGNMENT_COUNT = 184
-EXPECTED_REPEATED_ASSIGNMENT_COUNT = 152
-EXPECTED_SOURCE_ONLY_ASSIGNMENT_COUNT = 32
-EXPECTED_SOURCE_ONLY_TEMPLATES = ["T01", "T10", "T11", "T12"]
+EXPECTED_REPEATED_ASSIGNMENT_COUNT = 184
+EXPECTED_SOURCE_ONLY_ASSIGNMENT_COUNT = 0
+EXPECTED_SOURCE_ONLY_TEMPLATES: list[str] = []
 EXPECTED_SELF_EDGE_PATH_LENGTH_COUNTS = {"3": 9, "4": 2, "5": 1, "6": 1}
 EXPECTED_STRICT_CYCLE_LENGTH_COUNTS = {"2": 1, "3": 2}
 
@@ -182,8 +182,8 @@ def assert_expected_focused_minireplay_crosswalk(payload: Mapping[str, Any]) -> 
         "source_assignment_count": EXPECTED_ASSIGNMENT_COUNT,
         "source_family_count": EXPECTED_FAMILY_COUNT,
         "obstruction_flagged_count": 12,
-        "assignment_count_repeated_template_count": 8,
-        "assignment_count_source_only_template_count": 4,
+        "assignment_count_repeated_template_count": 12,
+        "assignment_count_source_only_template_count": 0,
         "assignment_count_repeated_total": EXPECTED_REPEATED_ASSIGNMENT_COUNT,
         "assignment_count_source_only_total": EXPECTED_SOURCE_ONLY_ASSIGNMENT_COUNT,
         "assignment_count_source_only_templates": EXPECTED_SOURCE_ONLY_TEMPLATES,

--- a/src/erdos97/n9_t01_self_edge_minireplay.py
+++ b/src/erdos97/n9_t01_self_edge_minireplay.py
@@ -14,6 +14,8 @@ STATUS = "REVIEW_PENDING_T01_SELF_EDGE_MINIREPLAY"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 SOURCE_PACKET_SCHEMA = "erdos97.n9_vertex_circle_t01_self_edge_lemma_packet.v1"
 SOURCE_PACKET = "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json"
+EXPECTED_ASSIGNMENT_COUNT = 6
+EXPECTED_ASSIGNMENT_COUNTS = {"F09": 6}
 
 
 def _pair(value: Any, label: str, errors: list[str]) -> list[int]:
@@ -221,6 +223,10 @@ def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]
     summary = {
         "source_template_id": packet.get("template_id"),
         "source_family_id": packet.get("family_id"),
+        "family_count": 1,
+        "family_ids": [packet.get("family_id")],
+        "assignment_count": packet.get("assignment_count"),
+        "assignment_counts": {str(packet.get("family_id")): packet.get("assignment_count")},
         "core_row_count": len(rows),
         "core_centers": sorted(rows),
         "equality_chain": equality_chain,
@@ -234,6 +240,10 @@ def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]
             and equality_chain[-1] == strict_summary.get("inner_pair")
         ),
     }
+    if summary["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        errors.append(f"unexpected assignment_count {summary['assignment_count']!r}")
+    if summary["assignment_counts"] != EXPECTED_ASSIGNMENT_COUNTS:
+        errors.append(f"unexpected assignment_counts {summary['assignment_counts']!r}")
     if not summary["self_edge_contradiction"]:
         errors.append("strict inequality does not close on an equality-chain self-edge")
     return summary, errors
@@ -294,6 +304,10 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
     expected = {
         "source_template_id": "T01",
         "source_family_id": "F09",
+        "family_count": 1,
+        "family_ids": ["F09"],
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_counts": EXPECTED_ASSIGNMENT_COUNTS,
         "core_row_count": 3,
         "core_centers": [0, 1, 2],
         "equality_chain": [[1, 8], [0, 1], [0, 2], [1, 2]],

--- a/src/erdos97/n9_t10_strict_cycle_minireplay.py
+++ b/src/erdos97/n9_t10_strict_cycle_minireplay.py
@@ -18,6 +18,8 @@ SOURCE_PACKET = "data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packe
 TEMPLATE_ID = "T10"
 FAMILY_ID = "F12"
 EXPECTED_CYCLE_LENGTH = 2
+EXPECTED_ASSIGNMENT_COUNT = 18
+EXPECTED_ASSIGNMENT_COUNTS = {"F12": 18}
 EXPECTED_STRICT_WITNESS_ORDERS = [
     [0, 3, 6, 7],
     [4, 6, 0, 1],
@@ -338,12 +340,20 @@ def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]
     summary = {
         "source_template_id": packet.get("template_id"),
         "source_family_id": family.get("family_id"),
+        "family_count": 1,
+        "family_ids": [family.get("family_id")],
+        "assignment_count": packet.get("assignment_count"),
+        "assignment_counts": {str(family.get("family_id")): packet.get("assignment_count")},
         "core_row_count": len(rows),
         "core_centers": sorted(rows),
         "cycle_length": len(cycle_steps),
         "cycle_steps": steps,
         "strict_cycle_contradiction": closes,
     }
+    if summary["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        errors.append(f"unexpected assignment_count {summary['assignment_count']!r}")
+    if summary["assignment_counts"] != EXPECTED_ASSIGNMENT_COUNTS:
+        errors.append(f"unexpected assignment_counts {summary['assignment_counts']!r}")
     if not closes:
         errors.append("strict inequalities and equality connectors do not close a cycle")
     return summary, errors
@@ -408,6 +418,10 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
     expected = {
         "source_template_id": "T10",
         "source_family_id": "F12",
+        "family_count": 1,
+        "family_ids": ["F12"],
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_counts": EXPECTED_ASSIGNMENT_COUNTS,
         "core_row_count": 4,
         "core_centers": [0, 3, 6, 8],
         "cycle_length": 2,

--- a/src/erdos97/n9_t11_strict_cycle_minireplay.py
+++ b/src/erdos97/n9_t11_strict_cycle_minireplay.py
@@ -18,6 +18,8 @@ SOURCE_PACKET = "data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packe
 TEMPLATE_ID = "T11"
 FAMILY_ID = "F07"
 EXPECTED_CYCLE_LENGTH = 3
+EXPECTED_ASSIGNMENT_COUNT = 6
+EXPECTED_ASSIGNMENT_COUNTS = {"F07": 6}
 EXPECTED_STRICT_WITNESS_ORDERS = [
     [2, 3, 5, 0],
     [2, 3, 5, 0],
@@ -339,12 +341,20 @@ def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]
     summary = {
         "source_template_id": packet.get("template_id"),
         "source_family_id": family.get("family_id"),
+        "family_count": 1,
+        "family_ids": [family.get("family_id")],
+        "assignment_count": packet.get("assignment_count"),
+        "assignment_counts": {str(family.get("family_id")): packet.get("assignment_count")},
         "core_row_count": len(rows),
         "core_centers": sorted(rows),
         "cycle_length": len(cycle_steps),
         "cycle_steps": steps,
         "strict_cycle_contradiction": closes,
     }
+    if summary["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        errors.append(f"unexpected assignment_count {summary['assignment_count']!r}")
+    if summary["assignment_counts"] != EXPECTED_ASSIGNMENT_COUNTS:
+        errors.append(f"unexpected assignment_counts {summary['assignment_counts']!r}")
     if not closes:
         errors.append("strict inequalities and equality connectors do not close a cycle")
     return summary, errors
@@ -409,6 +419,10 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
     expected = {
         "source_template_id": TEMPLATE_ID,
         "source_family_id": FAMILY_ID,
+        "family_count": 1,
+        "family_ids": [FAMILY_ID],
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_counts": EXPECTED_ASSIGNMENT_COUNTS,
         "core_row_count": 4,
         "core_centers": [0, 1, 5, 6],
         "cycle_length": EXPECTED_CYCLE_LENGTH,

--- a/src/erdos97/n9_t12_strict_cycle_minireplay.py
+++ b/src/erdos97/n9_t12_strict_cycle_minireplay.py
@@ -18,6 +18,8 @@ SOURCE_PACKET = "data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packe
 TEMPLATE_ID = "T12"
 FAMILY_ID = "F16"
 EXPECTED_CYCLE_LENGTH = 3
+EXPECTED_ASSIGNMENT_COUNT = 2
+EXPECTED_ASSIGNMENT_COUNTS = {"F16": 2}
 EXPECTED_STRICT_WITNESS_ORDERS = [
     [3, 5, 8, 0],
     [2, 4, 7, 8],
@@ -339,12 +341,20 @@ def replay_packet(packet: dict[str, Any]) -> tuple[dict[str, object], list[str]]
     summary = {
         "source_template_id": packet.get("template_id"),
         "source_family_id": family.get("family_id"),
+        "family_count": 1,
+        "family_ids": [family.get("family_id")],
+        "assignment_count": packet.get("assignment_count"),
+        "assignment_counts": {str(family.get("family_id")): packet.get("assignment_count")},
         "core_row_count": len(rows),
         "core_centers": sorted(rows),
         "cycle_length": len(cycle_steps),
         "cycle_steps": steps,
         "strict_cycle_contradiction": closes,
     }
+    if summary["assignment_count"] != EXPECTED_ASSIGNMENT_COUNT:
+        errors.append(f"unexpected assignment_count {summary['assignment_count']!r}")
+    if summary["assignment_counts"] != EXPECTED_ASSIGNMENT_COUNTS:
+        errors.append(f"unexpected assignment_counts {summary['assignment_counts']!r}")
     if not closes:
         errors.append("strict inequalities and equality connectors do not close a cycle")
     return summary, errors
@@ -409,6 +419,10 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
     expected = {
         "source_template_id": TEMPLATE_ID,
         "source_family_id": FAMILY_ID,
+        "family_count": 1,
+        "family_ids": [FAMILY_ID],
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "assignment_counts": EXPECTED_ASSIGNMENT_COUNTS,
         "core_row_count": 6,
         "core_centers": [0, 1, 2, 3, 4, 8],
         "cycle_length": EXPECTED_CYCLE_LENGTH,

--- a/tests/test_n9_t01_self_edge_minireplay.py
+++ b/tests/test_n9_t01_self_edge_minireplay.py
@@ -27,6 +27,9 @@ def test_t01_minireplay_replays_local_self_edge() -> None:
     replay, errors = replay_packet(packet)
 
     assert errors == []
+    assert replay["family_ids"] == ["F09"]
+    assert replay["assignment_count"] == 6
+    assert replay["assignment_counts"] == {"F09": 6}
     assert replay["equality_chain"] == [[1, 8], [0, 1], [0, 2], [1, 2]]
     assert replay["self_edge_contradiction"] is True
     assert replay["strict_inequality"] == {

--- a/tests/test_n9_t10_strict_cycle_minireplay.py
+++ b/tests/test_n9_t10_strict_cycle_minireplay.py
@@ -27,6 +27,9 @@ def test_t10_minireplay_replays_local_strict_cycle() -> None:
     replay, errors = replay_packet(packet)
 
     assert errors == []
+    assert replay["family_ids"] == ["F12"]
+    assert replay["assignment_count"] == 18
+    assert replay["assignment_counts"] == {"F12": 18}
     assert replay["core_centers"] == [0, 3, 6, 8]
     assert replay["cycle_length"] == 2
     assert replay["strict_cycle_contradiction"] is True

--- a/tests/test_n9_t11_strict_cycle_minireplay.py
+++ b/tests/test_n9_t11_strict_cycle_minireplay.py
@@ -27,6 +27,9 @@ def test_t11_minireplay_replays_local_strict_cycle() -> None:
     replay, errors = replay_packet(packet)
 
     assert errors == []
+    assert replay["family_ids"] == ["F07"]
+    assert replay["assignment_count"] == 6
+    assert replay["assignment_counts"] == {"F07": 6}
     assert replay["core_centers"] == [0, 1, 5, 6]
     assert replay["cycle_length"] == 3
     assert replay["strict_cycle_contradiction"] is True

--- a/tests/test_n9_t12_strict_cycle_minireplay.py
+++ b/tests/test_n9_t12_strict_cycle_minireplay.py
@@ -27,6 +27,9 @@ def test_t12_minireplay_replays_local_strict_cycle() -> None:
     replay, errors = replay_packet(packet)
 
     assert errors == []
+    assert replay["family_ids"] == ["F16"]
+    assert replay["assignment_count"] == 2
+    assert replay["assignment_counts"] == {"F16": 2}
     assert replay["core_centers"] == [0, 1, 2, 3, 4, 8]
     assert replay["cycle_length"] == 3
     assert replay["strict_cycle_contradiction"] is True

--- a/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -37,8 +37,8 @@ def test_focused_minireplay_crosswalk_counts_and_scope() -> None:
     assert summary["source_assignment_count"] == 184
     assert summary["source_family_count"] == 16
     assert summary["obstruction_flagged_count"] == 12
-    assert summary["assignment_count_repeated_total"] == 152
-    assert summary["assignment_count_source_only_total"] == 32
+    assert summary["assignment_count_repeated_total"] == 184
+    assert summary["assignment_count_source_only_total"] == 0
 
 
 def test_focused_minireplay_crosswalk_rejects_source_packet_drift(


### PR DESCRIPTION
## Summary
- echo source assignment totals and per-family assignment counts in the T01 and T10-T12 mini-replay payloads
- regenerate the four affected mini-replay artifacts and tighten manifest expectations
- update the focused mini-replay crosswalk so every focused mini-replay directly repeats its assignment count coverage

## Verification
- `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_t01_self_edge_minireplay.py tests/test_n9_t10_strict_cycle_minireplay.py tests/test_n9_t11_strict_cycle_minireplay.py tests/test_n9_t12_strict_cycle_minireplay.py tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py -q`
- `python -m ruff check src/erdos97/n9_t01_self_edge_minireplay.py src/erdos97/n9_t10_strict_cycle_minireplay.py src/erdos97/n9_t11_strict_cycle_minireplay.py src/erdos97/n9_t12_strict_cycle_minireplay.py tests/test_n9_t01_self_edge_minireplay.py tests/test_n9_t10_strict_cycle_minireplay.py tests/test_n9_t11_strict_cycle_minireplay.py tests/test_n9_t12_strict_cycle_minireplay.py scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1032 passed, 299 deselected`)

`make verify-fast` was not used because this Windows shell does not provide make; the explicit fast-tier commands above were run instead.