### PR TITLE
Sync n9 review artifact commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,22 +43,38 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t05_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t05_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t06_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t06_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t07_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t07_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t09_self_edge_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 	$(PYTHON) scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
+	$(PYTHON) scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check -
 python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json


### PR DESCRIPTION
## Summary
- add the focused packet audit and focused mini-replay crosswalk to `verify-n9-review`
- expose all focused packet mini-replays, the T10 paired-square companion, and the relation-skeleton/local-lemma crosswalk through the n9 review make target
- add the missing relation-skeleton/local-lemma crosswalk command to the README raw artifact command list

## Verification
- `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_relation_skeleton_local_lemma_crosswalk.py -q`
- all newly exposed `scripts/check_n9_t*_minireplay.py --check --assert-expected --json` commands
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1032 passed, 299 deselected`)

`make verify-fast` / `make verify-n9-review` were not used because this Windows shell does not provide make; the explicit commands above were run instead.