### PR TITLE
Register closure activation controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ verify-n9-review:
 
 verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+	$(PYTHON) scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json
+	$(PYTHON) scripts/check_closure_activation_negative_controls.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json
+	$(PYTHON) scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json
 	$(PYTHON) scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json
 	$(PYTHON) scripts/check_block6_terminal_crossing_vertex_circle_sample.py --check --assert-expected --json
 	$(PYTHON) scripts/check_block6_terminal_crossing_vertex_circle_sample.py --full-sweep --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -577,7 +577,10 @@ python scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --ass
 python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
 python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
 python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
+python scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json
 python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json
+python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json
+python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json
 python scripts/check_block6_fragile_vertex_circle_extension.py --check --assert-expected --json
 python scripts/check_block6_terminal_crossing_vertex_circle_sample.py --check --assert-expected --json
 python scripts/check_block6_terminal_crossing_vertex_circle_sample.py --full-sweep --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -5003,6 +5003,35 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: closure_activation_wrong_fourth_negative_control
+    path: data/certificates/closure_activation_wrong_fourth_negative_control.json
+    kind: negative_control_artifact
+    generator: scripts/check_closure_activation_wrong_fourth_negative_control.py
+    command: python scripts/check_closure_activation_wrong_fourth_negative_control.py --write --assert-expected
+    checker: scripts/check_closure_activation_wrong_fourth_negative_control.py
+    check_command: python scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_PROVENANCE
+    claim_scope: Wrong-fourth closure activation negative control only; not a Euclidean realization, not a proof of row forcing, not a proof of the bootstrap bridge, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      type: closure_activation_wrong_fourth_negative_control_v1
+      status: EXACT_NEGATIVE_CONTROL
+      trust_label: NEGATIVE_CONTROL
+      claim_status: abstract_incidence_closure_stress_test_only
+      run_id: RS-2026-05-10-A
+      n: 10
+    forbidden_claims:
+      - closure activation proves row forcing
+      - wrong-fourth control proves a bridge lemma
+      - n=9 is proved
+      - bootstrap bridge is proved
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: closure_activation_negative_controls
     path: data/certificates/closure_activation_negative_controls.json
     kind: negative_control_artifact
@@ -5026,6 +5055,64 @@ artifacts:
       - rich-class closure proves row forcing
       - n=9 is proved
       - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap bridge is proved
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
+  - id: bootstrap_t12_anti_activation_negative_control
+    path: data/certificates/bootstrap_t12_anti_activation_negative_control.json
+    kind: negative_control_artifact
+    generator: scripts/check_bootstrap_t12_anti_activation_negative_control.py
+    command: python scripts/check_bootstrap_t12_anti_activation_negative_control.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_anti_activation_negative_control.py
+    check_command: python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_PROVENANCE
+    claim_scope: Full selected-row closure anti-activation negative control only; not a Euclidean realization, not a proof of row forcing, not a proof of the bootstrap bridge, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      type: bootstrap_t12_full_row_anti_activation_negative_control_v1
+      status: EXACT_NEGATIVE_CONTROL
+      trust_label: NEGATIVE_CONTROL
+      claim_status: abstract_full_selected_row_closure_stress_test_only
+      run_id: RS-2026-05-10-A
+      n: 10
+    forbidden_claims:
+      - closure activation proves row forcing
+      - anti-activation control proves a bridge lemma
+      - n=9 is proved
+      - bootstrap bridge is proved
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
+  - id: closure_visibility_anti_activation_control
+    path: data/certificates/closure_visibility_anti_activation_control.json
+    kind: negative_control_artifact
+    generator: scripts/check_closure_visibility_anti_activation_control.py
+    command: python scripts/check_closure_visibility_anti_activation_control.py --write --assert-expected
+    checker: scripts/check_closure_visibility_anti_activation_control.py
+    check_command: python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_PROVENANCE
+    claim_scope: Closure-visibility anti-activation negative control only; not a Euclidean realization, not a proof of row forcing, not a proof of the bootstrap bridge, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      type: closure_visibility_anti_activation_control_v1
+      status: EXACT_NEGATIVE_CONTROL
+      trust_label: NEGATIVE_CONTROL
+      claim_status: abstract_incidence_closure_stress_test_only
+      run_id: RS-2026-05-10-A
+    forbidden_claims:
+      - closure visibility proves row forcing
+      - closure activation proves row forcing
+      - visibility control proves a bridge lemma
+      - n=9 is proved
       - bootstrap bridge is proved
       - official/global status update
       - source-of-truth strongest result

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1688,6 +1688,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="closure_activation_wrong_fourth_negative_control",
+        command=(
+            "python",
+            "scripts/check_closure_activation_wrong_fourth_negative_control.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Wrong-fourth closure activation negative control only; not a "
+            "Euclidean realization, not a proof of row forcing, not a proof "
+            "of the bootstrap bridge, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="closure_activation_negative_controls",
         command=(
             "python",
@@ -1700,6 +1715,36 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "Abstract rich-class closure activation negative controls only; "
             "not a Euclidean realization, not a proof of n=9, not a proof of "
             "the bootstrap bridge, and not a proof of Erdos Problem #97."
+        ),
+    ),
+    AuditCommand(
+        ident="bootstrap_t12_anti_activation_negative_control",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_anti_activation_negative_control.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Full selected-row anti-activation negative control only; not a "
+            "Euclidean realization, not a proof of row forcing, not a proof "
+            "of the bootstrap bridge, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
+        ident="closure_visibility_anti_activation_control",
+        command=(
+            "python",
+            "scripts/check_closure_visibility_anti_activation_control.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Closure-visibility anti-activation negative control only; not a "
+            "Euclidean realization, not a proof of row forcing, not a proof "
+            "of the bootstrap bridge, and not a counterexample."
         ),
     ),
     AuditCommand(

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -254,7 +254,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--assert-expected --json",
         "python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check "
         "--assert-expected --json",
+        "python scripts/check_closure_activation_wrong_fourth_negative_control.py "
+        "--check --assert-expected --json",
         "python scripts/check_closure_activation_negative_controls.py --check "
+        "--assert-expected --json",
+        "python scripts/check_bootstrap_t12_anti_activation_negative_control.py "
+        "--check --assert-expected --json",
+        "python scripts/check_closure_visibility_anti_activation_control.py --check "
         "--assert-expected --json",
     )
     for command in bootstrap_bridge_commands:


### PR DESCRIPTION
## Summary
- register the wrong-fourth, full-row anti-activation, and closure-visibility negative-control JSON artifacts in `metadata/generated_artifacts.yaml`
- add their check commands to artifact audit and bridge-frontier command paths
- expose the same commands in the README raw artifact list

## Verification
- `python scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json`
- `python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json`
- `python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json`
- `python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json`
- `python -m pytest tests/test_closure_activation_negative_controls.py tests/test_run_artifact_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1032 passed, 299 deselected`)

`make` was not available in this Windows shell, so I ran the explicit fast-tier commands directly.