### PR TITLE
Sync reviewer local lemma commands

### DIFF
--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -61,8 +61,14 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
@@ -80,8 +86,14 @@ python scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --
 python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t09_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
+python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
+python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
 python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -81,8 +81,14 @@ python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --ass
 python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
@@ -100,8 +106,14 @@ python scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --
 python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t09_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
+python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
+python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
 python scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 python scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json


### PR DESCRIPTION
## Summary
- add the missing local-lemma audit commands to `docs/reviewer-guide.md`
- mirror the same T01/T10/T11/T12 mini-replays and relation-skeleton commands in `docs/reproduction-log.md`
- keep this as command-list/reproduction guidance only, with no source-of-truth claim changes

## Verification
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1032 passed, 299 deselected`)

`make` was not available in this Windows shell, so I ran the explicit fast-tier commands directly.