### PR TITLE
Register n9 obstruction motif diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ verify-kalmanson:
 
 verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+	$(PYTHON) scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
+	$(PYTHON) scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected 
 python scripts/check_speculative_circulant_frontier_obstructions.py --check --json
 python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
+python scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -163,6 +163,11 @@ Generate and check the motif-family artifact:
 python scripts/analyze_n9_vertex_circle_motif_families.py \
   --assert-expected \
   --write
+
+python scripts/analyze_n9_vertex_circle_motif_families.py \
+  --check \
+  --assert-expected \
+  --json
 ```
 
 Generate and check the assignment-level motif classification:

--- a/docs/n9-vertex-circle-obstruction-shapes.md
+++ b/docs/n9-vertex-circle-obstruction-shapes.md
@@ -72,6 +72,11 @@ Generate and check the diagnostic artifact:
 python scripts/analyze_n9_vertex_circle_obstruction_shapes.py \
   --assert-expected \
   --write
+
+python scripts/analyze_n9_vertex_circle_obstruction_shapes.py \
+  --check \
+  --assert-expected \
+  --json
 ```
 
 Run the targeted artifact test:

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -55,6 +55,8 @@ python scripts/analyze_n8_exact_survivors.py --check --json \
   --check-compatible-orders-data data/incidence/n8_compatible_orders.json \
   --check-exact-analysis-data certificates/n8_exact_analysis.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected
+python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
+python scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -73,6 +73,8 @@ python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
+python scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -261,6 +261,69 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_obstruction_shapes
+    path: data/certificates/n9_vertex_circle_obstruction_shapes.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/analyze_n9_vertex_circle_obstruction_shapes.py
+    command: python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --assert-expected --write
+    checker: scripts/analyze_n9_vertex_circle_obstruction_shapes.py
+    check_command: python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Obstruction-shape diagnostic for the 184 n=9 pre-vertex-circle selected-witness assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      n: 9
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      pre_vertex_circle_search.full_assignments: 184
+      obstruction_status_counts.self_edge: 158
+      obstruction_status_counts.strict_cycle: 26
+      strict_cycle_summary.cycle_length_counts.2: 22
+      strict_cycle_summary.cycle_length_counts.3: 4
+      self_edge_summary.max_equality_path_length: 8
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - obstruction-shape diagnostic is an independent proof
+      - general proof of Erdos Problem #97
+
+  - id: n9_vertex_circle_motif_families
+    path: data/certificates/n9_vertex_circle_motif_families.json
+    kind: certificate_diagnostic_artifact
+    generator: scripts/analyze_n9_vertex_circle_motif_families.py
+    command: python scripts/analyze_n9_vertex_circle_motif_families.py --assert-expected --write
+    checker: scripts/analyze_n9_vertex_circle_motif_families.py
+    check_command: python scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: manifest_only_legacy
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Dihedral motif-family diagnostic for the 184 n=9 pre-vertex-circle selected-witness assignments; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      n: 9
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      pre_vertex_circle_search.full_assignments: 184
+      obstruction_status_counts.self_edge: 158
+      obstruction_status_counts.strict_cycle: 26
+      dihedral_incidence_families.family_count: 16
+      dihedral_incidence_families.orbit_size_counts.2: 5
+      dihedral_incidence_families.orbit_size_counts.6: 2
+      dihedral_incidence_families.orbit_size_counts.18: 9
+      dihedral_incidence_families.status_family_counts.self_edge: 13
+      dihedral_incidence_families.status_family_counts.strict_cycle: 3
+      loose_obstruction_shapes.self_edge_shape_family_count: 16
+      loose_obstruction_shapes.strict_cycle_span_family_count: 8
+    forbidden_claims:
+      - n=9 is proved
+      - independent review of the exhaustive checker is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - motif-family diagnostic is an independent proof
+      - general proof of Erdos Problem #97
+
   - id: n9_turn_inequality_frontier
     path: data/certificates/n9_turn_inequality_frontier.json
     kind: finite_case_artifact

--- a/scripts/analyze_n9_vertex_circle_motif_families.py
+++ b/scripts/analyze_n9_vertex_circle_motif_families.py
@@ -22,24 +22,76 @@ from erdos97.path_display import display_path  # noqa: E402
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_motif_families.json"
 
 
+def _load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(payload: object, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print stable JSON")
     parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
     parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument(
+        "--artifact",
+        default=str(DEFAULT_OUT),
+        help="path loaded by --check",
+    )
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
     parser.add_argument("--assert-expected", action="store_true")
     args = parser.parse_args()
 
-    payload = motif_family_summary()
-    if args.assert_expected:
-        assert_expected_motif_family_counts(payload)
+    generated = motif_family_summary()
+    errors: list[str] = []
+    if args.check:
+        artifact = Path(args.artifact)
+        try:
+            payload = _load_json(artifact)
+        except (OSError, json.JSONDecodeError) as exc:
+            payload = {}
+            errors.append(f"could not load artifact: {exc}")
+        else:
+            if payload != generated:
+                errors.append("artifact does not match regenerated motif-family payload")
+    else:
+        artifact = Path(args.out)
+        payload = generated
+
+    if args.assert_expected and not errors:
+        try:
+            assert_expected_motif_family_counts(payload)  # type: ignore[arg-type]
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"expected motif-family counts failed: {exc}")
     if args.write:
         out = Path(args.out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        with out.open("w", encoding="utf-8", newline="\n") as handle:
-            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        _write_json(generated, out)
     if args.json:
-        print(json.dumps(payload, indent=2, sort_keys=True))
+        if errors:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "artifact": display_path(artifact, ROOT),
+                        "validation_errors": errors,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
     else:
         search = payload["pre_vertex_circle_search"]
         families = payload["dihedral_incidence_families"]
@@ -59,9 +111,11 @@ def main() -> int:
         )
         if args.assert_expected:
             print("OK: motif-family counts verified")
+        if args.check:
+            print("OK: stored motif-family artifact matches regenerated payload")
         if args.write:
             print(f"wrote {display_path(args.out, ROOT)}")
-    return 0
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/scripts/analyze_n9_vertex_circle_obstruction_shapes.py
+++ b/scripts/analyze_n9_vertex_circle_obstruction_shapes.py
@@ -22,24 +22,76 @@ from erdos97.path_display import display_path  # noqa: E402
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_obstruction_shapes.json"
 
 
+def _load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(payload: object, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print stable JSON")
     parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
     parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
+    parser.add_argument(
+        "--artifact",
+        default=str(DEFAULT_OUT),
+        help="path loaded by --check",
+    )
+    parser.add_argument("--check", action="store_true", help="validate an existing artifact")
     parser.add_argument("--assert-expected", action="store_true")
     args = parser.parse_args()
 
-    payload = obstruction_shape_summary()
-    if args.assert_expected:
-        assert_expected_counts(payload)
+    generated = obstruction_shape_summary()
+    errors: list[str] = []
+    if args.check:
+        artifact = Path(args.artifact)
+        try:
+            payload = _load_json(artifact)
+        except (OSError, json.JSONDecodeError) as exc:
+            payload = {}
+            errors.append(f"could not load artifact: {exc}")
+        else:
+            if payload != generated:
+                errors.append("artifact does not match regenerated obstruction-shape payload")
+    else:
+        artifact = Path(args.out)
+        payload = generated
+
+    if args.assert_expected and not errors:
+        try:
+            assert_expected_counts(payload)  # type: ignore[arg-type]
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"expected obstruction-shape counts failed: {exc}")
     if args.write:
         out = Path(args.out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        with out.open("w", encoding="utf-8", newline="\n") as handle:
-            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        _write_json(generated, out)
     if args.json:
-        print(json.dumps(payload, indent=2, sort_keys=True))
+        if errors:
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "artifact": display_path(artifact, ROOT),
+                        "validation_errors": errors,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+    elif errors:
+        print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
     else:
         search = payload["pre_vertex_circle_search"]
         print("n=9 vertex-circle obstruction shape diagnostic")
@@ -56,9 +108,11 @@ def main() -> int:
         )
         if args.assert_expected:
             print("OK: obstruction shape counts verified")
+        if args.check:
+            print("OK: stored obstruction-shape artifact matches regenerated payload")
         if args.write:
             print(f"wrote {display_path(args.out, ROOT)}")
-    return 0
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -200,6 +200,36 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope="Review-pending n=9 selected-witness finite-case checker; not an official/global status update.",
     ),
     AuditCommand(
+        ident="n9_vertex_circle_obstruction_shapes",
+        command=(
+            "python",
+            "scripts/analyze_n9_vertex_circle_obstruction_shapes.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Review-pending n=9 obstruction-shape diagnostic for the stored "
+            "pre-vertex-circle frontier; not a proof of n=9, counterexample, "
+            "independent review completion, or official/global status update."
+        ),
+    ),
+    AuditCommand(
+        ident="n9_vertex_circle_motif_families",
+        command=(
+            "python",
+            "scripts/analyze_n9_vertex_circle_motif_families.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Review-pending n=9 motif-family diagnostic for the stored "
+            "pre-vertex-circle frontier; not a proof of n=9, counterexample, "
+            "independent review completion, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_turn_inequality_frontier",
         command=(
             "python",

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -287,6 +287,16 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert (
+        "python scripts/analyze_n9_vertex_circle_motif_families.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_turn_inequality_frontier.py --check "
         "--assert-expected --json"
         in command_texts
@@ -318,6 +328,20 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/analyze_n9_vertex_circle_motif_families.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/analyze_n9_vertex_circle_motif_families.py --check "
+        "--assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_turn_inequality_frontier.py --check "
         "--assert-expected --json"


### PR DESCRIPTION
## Summary
- add `--check` mode to the n=9 obstruction-shape and motif-family diagnostic analyzers
- register their stored JSON artifacts in the generated-artifact manifest and artifact audit command set
- expose the check commands through Makefile, README, reviewer guide, reproduction log, and the two diagnostic docs

## Scope
This is diagnostic/provenance wiring only. It keeps both artifacts review-pending and does not promote `n=9`, alter source-of-truth status, or claim a counterexample.

## Verification
- `python scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json`
- `python scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `python -m pytest tests/test_n9_vertex_circle_obstruction_shapes.py tests/test_n9_vertex_circle_motif_families.py tests/test_run_artifact_audit.py -q`
- `python -m ruff check scripts/analyze_n9_vertex_circle_obstruction_shapes.py scripts/analyze_n9_vertex_circle_motif_families.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1032 passed, 299 deselected`)

`make` was not available in this Windows shell, so I ran the explicit commands directly.