### PR TITLE
Sync n9 review Makefile audits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,24 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 	$(PYTHON) scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
 	$(PYTHON) scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_core_templates.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_motif_classification.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_path_join.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert-expected --json

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_target_commands(target: str) -> list[str]:
+    lines = (ROOT / "Makefile").read_text(encoding="utf-8").splitlines()
+    header = f"{target}:"
+    start = lines.index(header) + 1
+    commands: list[str] = []
+    for line in lines[start:]:
+        if line and not line.startswith("\t"):
+            break
+        if line.startswith("\t"):
+            commands.append(line.strip().replace("$(PYTHON)", "python"))
+    return commands
+
+
+def test_verify_n9_review_includes_documented_frontier_audits() -> None:
+    commands = _make_target_commands("verify-n9-review")
+    expected_chain = [
+        "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",
+        (
+            "python scripts/analyze_n9_vertex_circle_obstruction_shapes.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/analyze_n9_vertex_circle_motif_families.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_turn_inequality_frontier.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_input_audit.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_incidence_filters.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_branch_options.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_dynamic_mro_choices.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_mro_branching_replay.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_strict_edge_geometry.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_local_core_packet.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_local_core_subset_audit.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_core_templates.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_frontier_motif_classification.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_motif_obstruction_audit.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/compare_n9_vertex_circle_frontier.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_frontier_assignment_audit.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_partial_pruning.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_self_edge_path_join.py "
+            "--check --assert-expected --json"
+        ),
+    ]
+
+    for command in expected_chain:
+        assert command in commands
+
+    positions = [commands.index(command) for command in expected_chain]
+    assert positions == sorted(positions)


### PR DESCRIPTION
## Summary
- add the documented n=9 frontier/input/branching/motif audit commands to `verify-n9-review`
- add a focused Makefile parser test that checks the early n=9 review command chain and ordering

## Scope
This is review-command wiring only. It does not change generated artifacts, promote the n=9 review-pending layer, alter source-of-truth status, or claim a proof/counterexample.

## Verification
- `python -m pytest tests/test_makefile_targets.py -q`
- `python -m ruff check tests/test_makefile_targets.py`
- newly wired commands:
  - `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
  - `python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
  - `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1033 passed, 299 deselected`)

`make` is not available in this Windows shell, so I ran the explicit commands directly.