### PR TITLE
Sync n10 review Makefile audits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_block6_oriented_block_reversal_closure.py --check --assert-expected --json
 
 verify-n10-review:
+	$(PYTHON) scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_singleton_input_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
 	$(PYTHON) scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -255,3 +255,36 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
 
     positions = [commands.index(command) for command in expected_chain]
     assert positions == sorted(positions)
+
+
+def test_verify_n10_review_includes_turn_audits() -> None:
+    commands = _make_target_commands("verify-n10-review")
+    expected_chain = [
+        (
+            "python scripts/check_n10_turn_row0_pilot.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n10_turn_row0_escape_self_edges.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n10_singleton_input_audit.py "
+            "--check --assert-expected --json"
+        ),
+        (
+            "python scripts/check_n10_vertex_circle_singletons.py "
+            "--assert-expected --spot-check-row0 0 --spot-check-row0 63 "
+            "--spot-check-row0 125"
+        ),
+        (
+            "python scripts/check_n10_secondary_singleton_replay.py "
+            "--check --assert-expected --json"
+        ),
+    ]
+
+    for command in expected_chain:
+        assert command in commands
+
+    positions = [commands.index(command) for command in expected_chain]
+    assert positions == sorted(positions)


### PR DESCRIPTION
## Summary
- add the documented n=10 turn-row audit commands to `verify-n10-review`
- extend the Makefile parser test to check n=10 review command presence and ordering

## Scope
This is review-command wiring only. It does not change generated artifacts, promote n=10 review claims, alter source-of-truth status, or claim a proof/counterexample.

## Verification
- `python -m pytest tests/test_makefile_targets.py -q`
- `python -m ruff check tests/test_makefile_targets.py`
- `python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json`
- `python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1035 passed, 299 deselected`)

`make` is not available in this Windows shell, so I ran the explicit commands directly.