### PR TITLE
State reusable T01 self-edge lemma form

### DIFF
--- a/docs/n9-vertex-circle-t01-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t01-self-edge-lemma.md
@@ -11,6 +11,48 @@ Erdos Problem #97.
 The labels `T01` and `F09` are retained only as packet/catalog navigation. They
 are not theorem hypotheses.
 
+## Reusable Five-label Form
+
+The local obstruction does not intrinsically use all nine labels. It has the
+following reusable shape.
+
+Let `C,A,B,D,E` be five distinct vertices of a strictly convex polygon, with
+`A,B,D,E` occurring in that order in the vertex cone at `C`; the first and
+last of these vertices may lie on the two boundary rays of the cone. Assume:
+
+```text
+center C selects A,B,D,E
+center A selects C,E
+center B selects A,C
+```
+
+Here "center X selects Y,Z" means that the selected witness row at `X`
+contains both `Y` and `Z`, so `|XY|=|XZ|`. The first row says that
+`A,B,D,E` lie on one circle centered at `C`.
+
+Then the selected-distance equalities give
+
+```text
+|AE| = |AC| = |CB| = |AB|.
+```
+
+But on the circle centered at `C`, the chord `AE` strictly contains the chord
+`AB` in angular span, because the witnesses occur as `A,B,D,E` inside an
+angle smaller than `pi`. Thus
+
+```text
+|AE| > |AB|,
+```
+
+contradicting the equality chain. Therefore no strictly convex realization can
+satisfy this five-label local pattern.
+
+The n=9 packet below is the specialization
+
+```text
+C=0, A=1, B=2, D=4, E=8.
+```
+
 ## Exact Local Hypotheses
 
 Let `p_0,...,p_8` be distinct vertices of a strictly convex nonagon in cyclic


### PR DESCRIPTION
## Summary
- add a reusable five-label formulation of the T01/F09 self-edge local obstruction
- identify the n=9 packet labels as one specialization of that local shape

## Scope
This is proof-mining documentation only. It does not promote the T01 packet to a theorem, prove n=9, alter source-of-truth status, or claim a counterexample.

## Bridge
Strengthens the reusable vertex-circle lemma bridge by restating one packet shape as a local pattern that can be searched for or proved against in larger configurations.

## Verification
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1035 passed, 299 deselected`)

`make` is not available in this Windows shell, so I ran the explicit commands directly.