### PR TITLE
State reusable T02 self-edge lemma form

### DIFF
--- a/docs/n9-vertex-circle-t02-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t02-self-edge-lemma.md
@@ -53,6 +53,34 @@ on the row circle, chord length is strictly increasing with the enclosed
 central angle in this range. If the row witness order is `a,b,c,d`, then the
 chord `[a,d]` strictly contains `[a,b]`, so `d(a,d) > d(a,b)`.
 
+All four packet families are instances of this reusable five-label form. Let
+`C,A,B,D,E` be distinct vertices of a strictly convex polygon, with
+`A,B,D,E` occurring in that order in the vertex cone at `C`; the first and
+last of these vertices may lie on the two boundary rays of the cone. Assume:
+
+```text
+center C selects A,B,D,E
+center E selects A,C
+center A selects B,C
+```
+
+Then the selected-distance equalities give
+
+```text
+|AE| = |CE| = |CA| = |AB|.
+```
+
+The first equality comes from the row at `E`, the second from the row at `C`,
+and the third from the row at `A`. But row `C` puts `A,B,D,E` on one circle
+centered at `C`, so the outer chord `AE` has strictly larger angular span
+than the inner chord `AB`. Hence
+
+```text
+|AE| > |AB|,
+```
+
+contradicting the equality chain.
+
 For `F01`, the three selected rows are
 
 ```text


### PR DESCRIPTION
## Summary
- add a reusable five-label formulation covering the four T02 self-edge packet families
- keep the family-specific n=9 rows as specializations beneath the general local pattern

## Scope
This is proof-mining documentation only. It does not promote the T02 packet to a theorem, prove n=9, alter source-of-truth status, or claim a proof/counterexample.

## Bridge
Strengthens the reusable vertex-circle lemma bridge by restating another packet shape as a local obstruction pattern that can be searched for or proved against in larger configurations.

## Verification
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1035 passed, 299 deselected`)

`make` is not available in this Windows shell, so I ran the explicit commands directly.