### PR TITLE
[codex] Add radius-blocker vertex-circle pilot

### DIFF
--- a/data/certificates/radius_blocker_vertex_circle_pilot.json
+++ b/data/certificates/radius_blocker_vertex_circle_pilot.json
@@ -1,0 +1,1279 @@
+{
+  "cases": [
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "incidence_survivors": 1,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 13,
+      "name": "C13_sidon_fixed_rows_natural_order",
+      "nodes_visited": 13,
+      "obstruction_examples": {
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                10
+              ],
+              [
+                2,
+                3,
+                5,
+                11
+              ],
+              [
+                3,
+                4,
+                6,
+                12
+              ],
+              [
+                0,
+                4,
+                5,
+                7
+              ],
+              [
+                1,
+                5,
+                6,
+                8
+              ],
+              [
+                2,
+                6,
+                7,
+                9
+              ],
+              [
+                3,
+                7,
+                8,
+                10
+              ],
+              [
+                4,
+                8,
+                9,
+                11
+              ],
+              [
+                5,
+                9,
+                10,
+                12
+              ],
+              [
+                0,
+                6,
+                10,
+                11
+              ],
+              [
+                1,
+                7,
+                11,
+                12
+              ],
+              [
+                0,
+                2,
+                8,
+                12
+              ],
+              [
+                0,
+                1,
+                3,
+                9
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    2,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    5
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    2,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    11
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    1
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 12,
+                  "witness_order": [
+                    0,
+                    1,
+                    3,
+                    9
+                  ]
+                }
+              ],
+              "n": 13,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+              ],
+              "selected_row_count": 13,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 117,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 1,
+      "rejection_counts": {},
+      "row_option_counts": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "strict_cycle": 1
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "incidence_survivors": 1,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 12,
+      "name": "two_block_no_forward_fixed_rows",
+      "nodes_visited": 12,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                4
+              ],
+              [
+                3,
+                6,
+                7,
+                11
+              ],
+              [
+                1,
+                5,
+                9,
+                11
+              ],
+              [
+                0,
+                2,
+                4,
+                5
+              ],
+              [
+                0,
+                3,
+                6,
+                9
+              ],
+              [
+                0,
+                2,
+                10,
+                11
+              ],
+              [
+                7,
+                8,
+                9,
+                10
+              ],
+              [
+                0,
+                1,
+                8,
+                9
+              ],
+              [
+                4,
+                5,
+                7,
+                11
+              ],
+              [
+                6,
+                8,
+                10,
+                11
+              ],
+              [
+                1,
+                5,
+                6,
+                7
+              ],
+              [
+                0,
+                3,
+                5,
+                8
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 12,
+              "obstructed": true,
+              "order": [
+                0,
+                4,
+                3,
+                1,
+                2,
+                5,
+                6,
+                10,
+                9,
+                7,
+                8,
+                11
+              ],
+              "selected_row_count": 12,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    9,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    5,
+                    11
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    5,
+                    9,
+                    11,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    0,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    11
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    10,
+                    11,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    9,
+                    10
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    7,
+                    10
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    10,
+                    9,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    7,
+                    9
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    7,
+                    10
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    10,
+                    9,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    7,
+                    9
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    8,
+                    9
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    10,
+                    9,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    8,
+                    9
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    10,
+                    9,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    8,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    6,
+                    8
+                  ],
+                  "row": 9,
+                  "witness_order": [
+                    8,
+                    11,
+                    6,
+                    10
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    6,
+                    7
+                  ],
+                  "row": 10,
+                  "witness_order": [
+                    7,
+                    1,
+                    5,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    6,
+                    7
+                  ],
+                  "row": 10,
+                  "witness_order": [
+                    7,
+                    1,
+                    5,
+                    6
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 108,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        4,
+        3,
+        1,
+        2,
+        5,
+        6,
+        10,
+        9,
+        7,
+        8,
+        11
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 1,
+      "rejection_counts": {},
+      "row_option_counts": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 1
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "incidence_survivors": 1,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 12,
+      "name": "block6_two_copy_full_extension_fixed_rows",
+      "nodes_visited": 12,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                4
+              ],
+              [
+                3,
+                6,
+                9,
+                11
+              ],
+              [
+                1,
+                3,
+                5,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                5
+              ],
+              [
+                0,
+                3,
+                8,
+                11
+              ],
+              [
+                0,
+                1,
+                6,
+                7
+              ],
+              [
+                7,
+                8,
+                9,
+                10
+              ],
+              [
+                0,
+                4,
+                6,
+                9
+              ],
+              [
+                0,
+                5,
+                7,
+                10
+              ],
+              [
+                6,
+                8,
+                10,
+                11
+              ],
+              [
+                2,
+                5,
+                9,
+                11
+              ],
+              [
+                1,
+                5,
+                6,
+                10
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 12,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11
+              ],
+              "selected_row_count": 12,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    6,
+                    9
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    6,
+                    11
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    6,
+                    9,
+                    11
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    9,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    6,
+                    11
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    6,
+                    9,
+                    11
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    0,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    0,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    8,
+                    9
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    7,
+                    9
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    10,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    6,
+                    10
+                  ],
+                  "row": 9,
+                  "witness_order": [
+                    10,
+                    11,
+                    6,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    6,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    6,
+                    10
+                  ],
+                  "row": 9,
+                  "witness_order": [
+                    10,
+                    11,
+                    6,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    11
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    9,
+                    11
+                  ],
+                  "row": 10,
+                  "witness_order": [
+                    11,
+                    2,
+                    5,
+                    9
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    7
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    6,
+                    10
+                  ],
+                  "outer_class": [
+                    0,
+                    7
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    10
+                  ],
+                  "row": 11,
+                  "witness_order": [
+                    1,
+                    5,
+                    6,
+                    10
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 108,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 1,
+      "rejection_counts": {},
+      "row_option_counts": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 1
+      }
+    }
+  ],
+  "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+  "interpretation_warnings": [
+    "This is a fixed exact-four row-option pilot, not a proof of the blocker bridge.",
+    "The C13 case is already retired by a stronger all-order Kalmanson certificate.",
+    "The two-block cases are bridge stress controls, not Euclidean counterexamples.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_radius_blocker_vertex_circle_pilot.py --write --assert-expected",
+    "generator": "scripts/check_radius_blocker_vertex_circle_pilot.py",
+    "sources": [
+      "src/erdos97/radius_blocker_packets.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py",
+      "src/erdos97/bridge_negative_controls.py"
+    ]
+  },
+  "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+  "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_cases_have_radius_blocker": true,
+    "all_incidence_survivors_obstructed": true,
+    "case_count": 3,
+    "total_incidence_survivors": 3,
+    "vertex_circle_status_totals": {
+      "self_edge": 2,
+      "strict_cycle": 1
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -125,6 +125,10 @@ Use this queue when no more specific issue is selected.
 3. Continue the minimal fragile-cover bridge after the stored block-6
    vertex-circle full-extension audit
    `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.
+   Use `scripts/check_radius_blocker_vertex_circle_pilot.py --check --assert-expected --json`
+   as the first exact-four row-option packet replay for radius-blocker shapes,
+   then mine true multi-option blocker packets rather than only fixed selected
+   rows.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,6 +144,9 @@ put detailed reconciliation in the canonical synthesis.
   proof-mining targets.
 - [`adaptive-radius-blocker-bridge.md`](adaptive-radius-blocker-bridge.md):
   adaptive selected-witness peeling versus radius-blocker bridge fork.
+- [`radius-blocker-vertex-circle-pilot.md`](radius-blocker-vertex-circle-pilot.md):
+  first exact-four-row radius-blocker packet diagnostic using vertex-circle
+  quotient replay; bridge tooling only, not a proof.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/radius-blocker-vertex-circle-pilot.md
+++ b/docs/radius-blocker-vertex-circle-pilot.md
@@ -1,0 +1,75 @@
+# Radius-blocker vertex-circle pilot
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / bridge diagnostic. No general proof of
+Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note records a first exact-four-row pilot for the bridge direction
+
+```text
+minimal fragile cover + full badness + radius-blocker
+    => vertex-circle self-edge or strict cycle.
+```
+
+It does not prove that implication. It supplies replayable tooling for finite
+packets where each center has one or more exact four-rich row options, a
+candidate radius-blocker subset, and a supplied cyclic order.
+
+## What the checker does
+
+The core module is `src/erdos97/radius_blocker_packets.py`. For a packet of
+exact four-row options it checks:
+
+- the supplied subset is a radius-blocker for the listed rich classes;
+- selected row choices satisfy the row-pair cap and the two-overlap crossing
+  rule in the supplied cyclic order;
+- selected witness-pairs occur in at most two rows;
+- selected indegrees satisfy the standard pair-cap upper bound;
+- each incidence survivor is replayed through the selected-distance quotient
+  and vertex-circle strict-edge check.
+
+The checker intentionally rejects rich classes of size greater than four for
+now. A larger rich class carries equality information for all vertices in that
+class, not only for a chosen four-subset, so it needs a separate replay
+semantics before it can be used soundly.
+
+## Pilot artifact
+
+The checked artifact is:
+
+```text
+data/certificates/radius_blocker_vertex_circle_pilot.json
+```
+
+Regenerate and verify it with:
+
+```bash
+python scripts/check_radius_blocker_vertex_circle_pilot.py --check --assert-expected
+```
+
+The current pilot covers three fixed exact-four row packets:
+
+| Packet | blocker | incidence survivors | vertex-circle result |
+| --- | --- | ---: | --- |
+| `C13_sidon_fixed_rows_natural_order` | `[0,1,2,3]` | 1 | strict cycle |
+| `two_block_no_forward_fixed_rows` | `[0,1,2,5]` | 1 | self-edge |
+| `block6_two_copy_full_extension_fixed_rows` | `[0,1,2,5]` | 1 | self-edge |
+
+These are stress controls, not new live counterexample candidates. The C13
+fixed pattern is already retired by the stronger all-order Kalmanson/Farkas
+certificate. The two-block packets are abstract bridge controls and are not
+Euclidean realization certificates.
+
+## Research use
+
+The useful next step is to replace the fixed-row pilot cases with true
+multi-option blocker packets mined from stuck-set or fragile-cover searches.
+The hoped-for output is a small local lemma of the form:
+
+```text
+If a minimal counterexample has this radius-blocker/fragile-cover shape,
+then every exact four-row selection compatible with it forces a
+vertex-circle quotient self-edge or strict cycle.
+```
+
+That would strengthen the adaptive blocker bridge. Until such a lemma is
+proved and independently reviewed, this pilot remains a finite diagnostic only.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -558,6 +558,10 @@ condition that the surviving multi-block family does not automatically satisfy:
 - adaptive radius-blocker analysis, as recorded in
   `docs/adaptive-radius-blocker-bridge.md`, which keeps all rich distance
   classes visible instead of fixing one selected row per center.
+- the exact-four-row radius-blocker/vertex-circle pilot recorded in
+  `docs/radius-blocker-vertex-circle-pilot.md`, as a first replayable packet
+  format for testing blocker shapes against quotient self-edges and strict
+  cycles.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2763,6 +2763,38 @@ artifacts:
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
 
+  - id: radius_blocker_vertex_circle_pilot
+    path: data/certificates/radius_blocker_vertex_circle_pilot.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_radius_blocker_vertex_circle_pilot.py
+    command: python scripts/check_radius_blocker_vertex_circle_pilot.py --write --assert-expected
+    checker: scripts/check_radius_blocker_vertex_circle_pilot.py
+    check_command: python scripts/check_radius_blocker_vertex_circle_pilot.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Finite exact-four-row radius-blocker packet diagnostic; not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.radius_blocker_vertex_circle_packet.v1
+      status: RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.case_count: 3
+      summary.all_cases_have_radius_blocker: true
+      summary.all_incidence_survivors_obstructed: true
+      summary.total_incidence_survivors: 3
+      summary.vertex_circle_status_totals.self_edge: 2
+      summary.vertex_circle_status_totals.strict_cycle: 1
+      provenance.command: python scripts/check_radius_blocker_vertex_circle_pilot.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - radius-blockers are impossible
+      - n=9 is proved
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_radius_blocker_vertex_circle_pilot.py
+++ b/scripts/check_radius_blocker_vertex_circle_pilot.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Check the radius-blocker plus vertex-circle pilot packet artifact.
+
+The generated payload is a bridge diagnostic only. It does not claim a proof
+of the adaptive blocker bridge, Erdos Problem #97, or a counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.adaptive_blockers import first_blocker  # noqa: E402
+from erdos97.bridge_negative_controls import (  # noqa: E402
+    c13_sidon_rows,
+    output7_two_block_rows,
+)
+from erdos97.fragile_hypergraph import block6_family, full_selected_extension  # noqa: E402
+from erdos97.radius_blocker_packets import (  # noqa: E402
+    CLAIM_SCOPE,
+    SCHEMA,
+    STATUS,
+    TRUST,
+    PacketConfig,
+    analyze_radius_blocker_packet,
+    exact_four_rich_classes_from_rows,
+    result_to_packet_json,
+)
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "radius_blocker_vertex_circle_pilot.json"
+
+EXPECTED_CASES = {
+    "C13_sidon_fixed_rows_natural_order": {
+        "blocker": [0, 1, 2, 3],
+        "incidence_survivors": 1,
+        "vertex_circle_status_counts": {"strict_cycle": 1},
+    },
+    "two_block_no_forward_fixed_rows": {
+        "blocker": [0, 1, 2, 5],
+        "incidence_survivors": 1,
+        "vertex_circle_status_counts": {"self_edge": 1},
+    },
+    "block6_two_copy_full_extension_fixed_rows": {
+        "blocker": [0, 1, 2, 5],
+        "incidence_survivors": 1,
+        "vertex_circle_status_counts": {"self_edge": 1},
+    },
+}
+
+
+def _fixed_rows_case(
+    name: str,
+    rows: Sequence[Sequence[int]],
+    order: Sequence[int],
+    blocker_max_size: int = 6,
+) -> dict[str, object]:
+    rich_classes = exact_four_rich_classes_from_rows(rows)
+    blocker = first_blocker(rich_classes, max_size=blocker_max_size)
+    if blocker is None:
+        raise AssertionError(f"{name} has no radius-blocker through size {blocker_max_size}")
+    result = analyze_radius_blocker_packet(
+        name,
+        rich_classes,
+        blocker,
+        order,
+        PacketConfig(max_nodes=10_000),
+    )
+    return result_to_packet_json(result)
+
+
+def _block6_two_copy_extension_case() -> dict[str, object]:
+    n, fragile_rows = block6_family(2)
+    extension = full_selected_extension(n, fragile_rows)
+    if not extension.ok or extension.full_rows is None:
+        raise AssertionError("expected the two-block fragile family to extend")
+    rows = [extension.full_rows[center] for center in range(n)]
+    return _fixed_rows_case(
+        "block6_two_copy_full_extension_fixed_rows",
+        rows,
+        list(range(n)),
+    )
+
+
+def build_payload() -> dict[str, object]:
+    """Build the deterministic pilot payload."""
+
+    cases = [
+        _fixed_rows_case(
+            "C13_sidon_fixed_rows_natural_order",
+            c13_sidon_rows(),
+            list(range(13)),
+        ),
+        _fixed_rows_case(
+            "two_block_no_forward_fixed_rows",
+            output7_two_block_rows(),
+            [0, 4, 3, 1, 2, 5, 6, 10, 9, 7, 8, 11],
+        ),
+        _block6_two_copy_extension_case(),
+    ]
+    status_totals: dict[str, int] = {}
+    for case in cases:
+        counts = case["vertex_circle_status_counts"]
+        if not isinstance(counts, Mapping):
+            raise AssertionError("case status counts should be a mapping")
+        for status, count in counts.items():
+            status_totals[str(status)] = status_totals.get(str(status), 0) + int(count)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "summary": {
+            "case_count": len(cases),
+            "all_cases_have_radius_blocker": all(
+                bool(case["radius_blocker_ok"]) for case in cases
+            ),
+            "all_incidence_survivors_obstructed": all(
+                bool(case["all_incidence_survivors_obstructed"]) for case in cases
+            ),
+            "total_incidence_survivors": sum(
+                int(case["incidence_survivors"]) for case in cases
+            ),
+            "vertex_circle_status_totals": dict(sorted(status_totals.items())),
+        },
+        "cases": cases,
+        "interpretation_warnings": [
+            "This is a fixed exact-four row-option pilot, not a proof of the blocker bridge.",
+            "The C13 case is already retired by a stronger all-order Kalmanson certificate.",
+            "The two-block cases are bridge stress controls, not Euclidean counterexamples.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_radius_blocker_vertex_circle_pilot.py",
+            "command": (
+                "python scripts/check_radius_blocker_vertex_circle_pilot.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "src/erdos97/radius_blocker_packets.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+                "src/erdos97/bridge_negative_controls.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable pilot counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    expected_summary = {
+        "case_count": 3,
+        "all_cases_have_radius_blocker": True,
+        "all_incidence_survivors_obstructed": True,
+        "total_incidence_survivors": 3,
+        "vertex_circle_status_totals": {"self_edge": 2, "strict_cycle": 1},
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("cases should be a list")
+    by_name = {
+        str(case["name"]): case for case in cases if isinstance(case, Mapping)
+    }
+    for name, expected in EXPECTED_CASES.items():
+        case = by_name.get(name)
+        if case is None:
+            raise AssertionError(f"missing case {name}")
+        for key, value in expected.items():
+            if case.get(key) != value:
+                raise AssertionError(
+                    f"{name}[{key!r}] is {case.get(key)!r}, expected {value!r}"
+                )
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("Radius-blocker vertex-circle pilot")
+    print(f"claim scope: {CLAIM_SCOPE}")
+    print(f"cases: {summary['case_count']}")
+    print(f"all blockers: {summary['all_cases_have_radius_blocker']}")
+    print(
+        "all incidence survivors obstructed: "
+        f"{summary['all_incidence_survivors_obstructed']}"
+    )
+    print(f"status totals: {summary['vertex_circle_status_totals']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload()
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1342,6 +1342,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="radius_blocker_vertex_circle_pilot",
+        command=(
+            "python",
+            "scripts/check_radius_blocker_vertex_circle_pilot.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Finite exact-four-row radius-blocker packet diagnostic; not a "
+            "proof of the adaptive blocker bridge, not a proof of Erdos "
+            "Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/src/erdos97/radius_blocker_packets.py
+++ b/src/erdos97/radius_blocker_packets.py
@@ -1,0 +1,352 @@
+"""Radius-blocker packet diagnostics with vertex-circle replay.
+
+This module is bridge-program tooling.  It checks finite packets of possible
+exact four-witness rows against the radius-blocker condition, incidence/order
+filters, and the existing vertex-circle selected-distance quotient replay.
+Passing or failing a packet is not a proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations
+from math import prod
+from typing import Mapping, Sequence
+
+from erdos97.adaptive_blockers import RichClasses, is_radius_blocker, validate_rich_classes
+from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
+from erdos97.vertex_circle_quotient_replay import (
+    SelectedRow,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+Pair = tuple[int, int]
+Row = tuple[int, int, int, int]
+Rows = list[list[int]]
+
+SCHEMA = "erdos97.radius_blocker_vertex_circle_packet.v1"
+STATUS = "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct "
+    "the encoded row-option packet under the supplied cyclic order, but it is "
+    "not a proof of the adaptive blocker bridge, not a proof of Erdos Problem "
+    "#97, and not a counterexample."
+)
+
+
+@dataclass(frozen=True)
+class PacketConfig:
+    """Search controls for a radius-blocker packet."""
+
+    max_nodes: int = 100_000
+    max_survivor_examples: int = 8
+    max_obstruction_examples_per_status: int = 2
+    enforce_pair_filters: bool = True
+    enforce_column_pair_cap: bool = True
+    enforce_indegree_cap: bool = True
+
+
+@dataclass(frozen=True)
+class RadiusBlockerPacketResult:
+    """Summary of one finite packet replay."""
+
+    name: str
+    n: int
+    order: tuple[int, ...]
+    blocker: tuple[int, ...]
+    radius_blocker_ok: bool
+    row_option_counts: tuple[int, ...]
+    raw_selection_upper_bound: int
+    nodes_visited: int
+    incidence_survivors: int
+    aborted: bool
+    vertex_circle_status_counts: Mapping[str, int]
+    survivor_examples: tuple[Rows, ...]
+    obstruction_examples: Mapping[str, tuple[dict[str, object], ...]]
+    rejection_counts: Mapping[str, int]
+
+    @property
+    def all_incidence_survivors_obstructed(self) -> bool:
+        return (
+            self.incidence_survivors > 0
+            and self.vertex_circle_status_counts.get("ok", 0) == 0
+            and not self.aborted
+        )
+
+
+def exact_four_rich_classes_from_rows(rows: Sequence[Sequence[int]]) -> RichClasses:
+    """Treat each selected four-row as the only exact rich class at its center."""
+
+    out: list[tuple[tuple[int, ...], ...]] = []
+    for center, row in enumerate(rows):
+        normalized = tuple(sorted(int(label) for label in row))
+        if len(normalized) != 4 or len(set(normalized)) != 4:
+            raise ValueError(f"row {center} is not a four-set")
+        if center in normalized:
+            raise ValueError(f"row {center} selects its center")
+        out.append((normalized,))
+    return tuple(out)
+
+
+def row_options_from_rich_classes(rich_classes: RichClasses) -> tuple[tuple[Row, ...], ...]:
+    """Return deterministic exact-four row options for every center.
+
+    The first bridge diagnostic intentionally accepts only exact four-rich
+    classes.  Larger rich classes need a separate sound replay convention,
+    because their full equality information is stronger than a chosen
+    four-subset.
+    """
+
+    validate_rich_classes(rich_classes)
+    options: list[tuple[Row, ...]] = []
+    for center, classes in enumerate(rich_classes):
+        center_options: list[Row] = []
+        seen: set[Row] = set()
+        for class_index, rich_class in enumerate(classes):
+            row = tuple(sorted(int(label) for label in rich_class))
+            if len(row) != 4:
+                raise ValueError(
+                    "radius-blocker packet replay currently requires exact "
+                    f"four-rich classes; center {center} class {class_index} "
+                    f"has size {len(row)}"
+                )
+            typed_row = (row[0], row[1], row[2], row[3])
+            if typed_row not in seen:
+                seen.add(typed_row)
+                center_options.append(typed_row)
+        options.append(tuple(center_options))
+    return tuple(options)
+
+
+def analyze_radius_blocker_packet(
+    name: str,
+    rich_classes: RichClasses,
+    blocker: Sequence[int],
+    order: Sequence[int] | None = None,
+    config: PacketConfig | None = None,
+) -> RadiusBlockerPacketResult:
+    """Replay one exact-four radius-blocker packet in a supplied cyclic order."""
+
+    config = config or PacketConfig()
+    options = row_options_from_rich_classes(rich_classes)
+    n = len(options)
+    if order is None:
+        order = tuple(range(n))
+    order_tuple = tuple(int(label) for label in order)
+    _validate_order(order_tuple, n)
+    blocker_tuple = tuple(sorted(int(label) for label in blocker))
+    radius_blocker_ok = is_radius_blocker(rich_classes, blocker_tuple)
+
+    max_indegree = 2 * (n - 1) // 3
+    assigned: dict[int, Row] = {}
+    column_counts = [0] * n
+    witness_pair_counts: Counter[Pair] = Counter()
+    nodes_visited = 0
+    incidence_survivors = 0
+    aborted = False
+    vertex_status_counts: Counter[str] = Counter()
+    rejection_counts: Counter[str] = Counter()
+    survivor_examples: list[Rows] = []
+    obstruction_examples: dict[str, list[dict[str, object]]] = {}
+
+    def row_is_valid(center: int, row: Row) -> bool:
+        if config.enforce_indegree_cap:
+            if any(column_counts[target] >= max_indegree for target in row):
+                rejection_counts["indegree_cap"] += 1
+                return False
+        if config.enforce_column_pair_cap:
+            for pair_item in combinations(row, 2):
+                if witness_pair_counts[_pair(*pair_item)] >= 2:
+                    rejection_counts["column_pair_cap"] += 1
+                    return False
+        if config.enforce_pair_filters:
+            for other, other_row in assigned.items():
+                reason = _row_pair_rejection(
+                    center,
+                    row,
+                    other,
+                    other_row,
+                    order_tuple,
+                )
+                if reason is not None:
+                    rejection_counts[reason] += 1
+                    return False
+        return True
+
+    def add_row(row: Row) -> None:
+        for target in row:
+            column_counts[target] += 1
+        for pair_item in combinations(row, 2):
+            witness_pair_counts[_pair(*pair_item)] += 1
+
+    def remove_row(row: Row) -> None:
+        for pair_item in combinations(row, 2):
+            witness_pair_counts[_pair(*pair_item)] -= 1
+        for target in row:
+            column_counts[target] -= 1
+
+    def current_rows() -> Rows:
+        return [list(assigned[center]) for center in range(n)]
+
+    def replay_full_assignment() -> None:
+        nonlocal incidence_survivors
+        incidence_survivors += 1
+        selected = [
+            SelectedRow(center=center, witnesses=assigned[center])
+            for center in range(n)
+        ]
+        replay = replay_vertex_circle_quotient(n, order_tuple, selected)
+        vertex_status_counts[replay.status] += 1
+        if replay.status == "ok":
+            if len(survivor_examples) < config.max_survivor_examples:
+                survivor_examples.append(current_rows())
+            return
+        bucket = obstruction_examples.setdefault(replay.status, [])
+        if len(bucket) < config.max_obstruction_examples_per_status:
+            bucket.append(
+                {
+                    "selected_rows": current_rows(),
+                    "vertex_circle_replay": result_to_json(replay),
+                }
+            )
+
+    def viable_options(center: int) -> list[Row]:
+        return [row for row in options[center] if row_is_valid(center, row)]
+
+    def choose_center() -> tuple[int | None, list[Row]]:
+        best_center: int | None = None
+        best_options: list[Row] = []
+        for center in range(n):
+            if center in assigned:
+                continue
+            rows = viable_options(center)
+            if best_center is None or len(rows) < len(best_options):
+                best_center = center
+                best_options = rows
+            if not rows:
+                break
+        return best_center, best_options
+
+    def search() -> None:
+        nonlocal aborted
+        nonlocal nodes_visited
+        if aborted:
+            return
+        if len(assigned) == n:
+            replay_full_assignment()
+            return
+        if nodes_visited >= config.max_nodes:
+            aborted = True
+            return
+        center, rows = choose_center()
+        if center is None:
+            replay_full_assignment()
+            return
+        if not rows:
+            return
+        for row in rows:
+            if nodes_visited >= config.max_nodes:
+                aborted = True
+                return
+            nodes_visited += 1
+            assigned[center] = row
+            add_row(row)
+            search()
+            remove_row(row)
+            del assigned[center]
+            if aborted:
+                return
+
+    search()
+
+    return RadiusBlockerPacketResult(
+        name=name,
+        n=n,
+        order=order_tuple,
+        blocker=blocker_tuple,
+        radius_blocker_ok=radius_blocker_ok,
+        row_option_counts=tuple(len(rows) for rows in options),
+        raw_selection_upper_bound=prod(len(rows) for rows in options),
+        nodes_visited=nodes_visited,
+        incidence_survivors=incidence_survivors,
+        aborted=aborted,
+        vertex_circle_status_counts=dict(sorted(vertex_status_counts.items())),
+        survivor_examples=tuple(survivor_examples),
+        obstruction_examples={
+            status: tuple(examples)
+            for status, examples in sorted(obstruction_examples.items())
+        },
+        rejection_counts=dict(sorted(rejection_counts.items())),
+    )
+
+
+def result_to_packet_json(result: RadiusBlockerPacketResult) -> dict[str, object]:
+    """Return a JSON-safe packet result."""
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "name": result.name,
+        "n": result.n,
+        "order": list(result.order),
+        "blocker": list(result.blocker),
+        "radius_blocker_ok": result.radius_blocker_ok,
+        "row_option_counts": list(result.row_option_counts),
+        "raw_selection_upper_bound": result.raw_selection_upper_bound,
+        "nodes_visited": result.nodes_visited,
+        "incidence_survivors": result.incidence_survivors,
+        "aborted": result.aborted,
+        "vertex_circle_status_counts": dict(result.vertex_circle_status_counts),
+        "all_incidence_survivors_obstructed": (
+            result.all_incidence_survivors_obstructed
+        ),
+        "survivor_examples": list(result.survivor_examples),
+        "obstruction_examples": {
+            status: list(examples)
+            for status, examples in result.obstruction_examples.items()
+        },
+        "rejection_counts": dict(result.rejection_counts),
+        "interpretation": (
+            "Diagnostic for this finite exact-four row-option packet only. "
+            "A positive obstruction count does not prove the adaptive "
+            "radius-blocker bridge or Erdos Problem #97."
+        ),
+    }
+
+
+def _validate_order(order: Sequence[int], n: int) -> None:
+    if len(order) != n or set(order) != set(range(n)):
+        missing = sorted(set(range(n)) - set(order))
+        extra = sorted(set(order) - set(range(n)))
+        raise ValueError(
+            f"cyclic order is not a permutation; missing={missing}, extra={extra}"
+        )
+
+
+def _pair(left: int, right: int) -> Pair:
+    if left == right:
+        raise ValueError("loop pair")
+    return (left, right) if left < right else (right, left)
+
+
+def _row_pair_rejection(
+    left: int,
+    left_row: Sequence[int],
+    right: int,
+    right_row: Sequence[int],
+    order: Sequence[int],
+) -> str | None:
+    inter = sorted(set(left_row) & set(right_row))
+    if len(inter) > 2:
+        return "row_pair_cap"
+    if len(inter) == 2:
+        source = normalize_chord(left, right)
+        target = normalize_chord(inter[0], inter[1])
+        if not chords_cross_in_order(source, target, order):
+            return "two_overlap_crossing"
+    return None

--- a/tests/test_radius_blocker_packets.py
+++ b/tests/test_radius_blocker_packets.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.adaptive_blockers import first_blocker
+from erdos97.bridge_negative_controls import c13_sidon_rows
+from erdos97.radius_blocker_packets import (
+    analyze_radius_blocker_packet,
+    exact_four_rich_classes_from_rows,
+    row_options_from_rich_classes,
+)
+
+
+def test_c13_fixed_packet_has_blocker_and_strict_cycle() -> None:
+    rows = c13_sidon_rows()
+    rich_classes = exact_four_rich_classes_from_rows(rows)
+    blocker = first_blocker(rich_classes, max_size=4)
+
+    assert blocker == [0, 1, 2, 3]
+
+    result = analyze_radius_blocker_packet(
+        "c13-test",
+        rich_classes,
+        blocker,
+        list(range(13)),
+    )
+
+    assert result.radius_blocker_ok
+    assert result.incidence_survivors == 1
+    assert result.vertex_circle_status_counts == {"strict_cycle": 1}
+    assert result.all_incidence_survivors_obstructed
+
+
+def test_packet_accepts_multiple_exact_four_options() -> None:
+    rows = c13_sidon_rows()
+    rich_classes = list(exact_four_rich_classes_from_rows(rows))
+    rich_classes[0] = (tuple(rows[0]), (1, 3, 4, 10))
+
+    result = analyze_radius_blocker_packet(
+        "c13-two-row0-options",
+        tuple(rich_classes),
+        [0, 1, 2, 3],
+        list(range(13)),
+    )
+
+    assert result.radius_blocker_ok
+    assert result.row_option_counts[0] == 2
+    assert result.raw_selection_upper_bound == 2
+    assert not result.aborted
+
+
+def test_large_rich_classes_are_rejected_until_semantics_are_added() -> None:
+    rich_classes = (
+        ((1, 2, 3, 4, 5),),
+        ((0, 2, 3, 4),),
+        ((0, 1, 3, 4),),
+        ((0, 1, 2, 4),),
+        ((0, 1, 2, 3),),
+        ((0, 1, 2, 3),),
+    )
+
+    with pytest.raises(ValueError, match="requires exact four-rich classes"):
+        row_options_from_rich_classes(rich_classes)


### PR DESCRIPTION
## Summary

- add a radius-blocker packet replay module for exact-four row-option packets
- add a pilot checker and checked JSON artifact for three bridge stress packets
- wire the artifact into provenance and artifact audit coverage
- document the pilot as review-pending bridge diagnostics only

## Scope

This is a finite packet diagnostic. It does not claim a proof of the adaptive blocker bridge, a proof of Erdos Problem #97, or a counterexample.

## Validation

- `python scripts/check_radius_blocker_vertex_circle_pilot.py --check --assert-expected`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_radius_blocker_packets.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1038 passed, 299 deselected`)