### PR TITLE
[codex] Add n9 full radius-blocker packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For a partial bridge theorem from minimality to fragile-cover witness
   systems, read
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
+- For exact-four radius-blocker packet diagnostics, including the full
+  natural-order `n=9` blocker `{0,1,2,3}` packet, read
+  [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
+  and
+  [`docs/n9-full-radius-blocker-vertex-circle-packet.md`](docs/n9-full-radius-blocker-vertex-circle-packet.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -257,6 +257,16 @@ realizability; see `docs/bootstrap-core-crosswalk.md`,
 `scripts/check_bootstrap_core_crosswalk.py`, and
 `data/certificates/bootstrap_core_crosswalk.json`.
 
+The full `n=9` exact-four radius-blocker packet fixes the natural cyclic order
+and blocker `{0,1,2,3}`, then quantifies over every exact four-row compatible
+with that blocker. After the row-pair, witness-pair, indegree, and two-overlap
+crossing filters, it finds `90` incidence survivors; all `90` are killed by
+vertex-circle replay (`70` self-edges and `20` strict cycles). This is finite
+packet evidence only, not an `n=9` theorem, not a bridge proof, and not a
+counterexample. See `docs/n9-full-radius-blocker-vertex-circle-packet.md`,
+`scripts/check_n9_full_radius_blocker_vertex_circle_packet.py`, and
+`data/certificates/n9_full_radius_blocker_vertex_circle_packet.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -159,6 +159,13 @@ current fixed-row frontier motifs and records that the audited singleton-rich
 cases have rank greater than 3 but still pass the weighted capacity check; see
 `docs/bootstrap-core-crosswalk.md`.
 
+The full `n=9` exact-four radius-blocker packet fixes natural order and blocker
+`{0,1,2,3}` and quantifies over all exact four-row choices compatible with that
+blocker. Its 90 incidence survivors are all vertex-circle obstructed (`70`
+self-edges and `20` strict cycles). This is finite packet evidence only, not an
+`n=9` proof, a bridge proof, or a counterexample. See
+`docs/n9-full-radius-blocker-vertex-circle-packet.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_full_radius_blocker_vertex_circle_packet.json
+++ b/data/certificates/n9_full_radius_blocker_vertex_circle_packet.json
@@ -1,0 +1,1697 @@
+{
+  "case": {
+    "aborted": false,
+    "all_incidence_survivors_obstructed": true,
+    "blocker": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+    "incidence_survivors": 90,
+    "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+    "n": 9,
+    "name": "n9_full_exact_four_radius_blocker_U0123_natural_order",
+    "nodes_visited": 58742,
+    "obstruction_examples": {
+      "self_edge": [
+        {
+          "selected_rows": [
+            [
+              1,
+              2,
+              4,
+              6
+            ],
+            [
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              1,
+              3,
+              4,
+              8
+            ],
+            [
+              0,
+              2,
+              4,
+              7
+            ],
+            [
+              0,
+              1,
+              5,
+              6
+            ],
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              5,
+              7
+            ],
+            [
+              0,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              6,
+              7
+            ]
+          ],
+          "vertex_circle_replay": {
+            "cycle_edges": [],
+            "n": 9,
+            "obstructed": true,
+            "order": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "selected_row_count": 9,
+            "self_edge_conflicts": [
+              {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  1,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  7
+                ],
+                "row": 6,
+                "witness_order": [
+                  7,
+                  1,
+                  3,
+                  5
+                ]
+              }
+            ],
+            "status": "self_edge",
+            "strict_edge_count": 81,
+            "type": "vertex_circle_quotient_replay_result"
+          }
+        },
+        {
+          "selected_rows": [
+            [
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              3,
+              5,
+              8
+            ],
+            [
+              2,
+              4,
+              5,
+              6
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              4,
+              6,
+              8
+            ],
+            [
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              0,
+              2,
+              3,
+              6
+            ],
+            [
+              0,
+              1,
+              5,
+              7
+            ]
+          ],
+          "vertex_circle_replay": {
+            "cycle_edges": [],
+            "n": 9,
+            "obstructed": true,
+            "order": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "selected_row_count": 9,
+            "self_edge_conflicts": [
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  1,
+                  2
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  1,
+                  4
+                ],
+                "row": 0,
+                "witness_order": [
+                  1,
+                  2,
+                  4,
+                  8
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  1,
+                  2
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  8
+                ],
+                "row": 0,
+                "witness_order": [
+                  1,
+                  2,
+                  4,
+                  8
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  1,
+                  4
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  8
+                ],
+                "row": 0,
+                "witness_order": [
+                  1,
+                  2,
+                  4,
+                  8
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  2,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  8
+                ],
+                "row": 0,
+                "witness_order": [
+                  1,
+                  2,
+                  4,
+                  8
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  4
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  7
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  4,
+                  7,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  4,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  7
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  4,
+                  7,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  4,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  4
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  4,
+                  7,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  4
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  4,
+                  7,
+                  0
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  3,
+                  5
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  3
+                ],
+                "row": 2,
+                "witness_order": [
+                  3,
+                  5,
+                  8,
+                  1
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  5,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  3
+                ],
+                "row": 2,
+                "witness_order": [
+                  3,
+                  5,
+                  8,
+                  1
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  3
+                ],
+                "row": 2,
+                "witness_order": [
+                  3,
+                  5,
+                  8,
+                  1
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  4,
+                  5
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  4,
+                  6
+                ],
+                "row": 3,
+                "witness_order": [
+                  4,
+                  5,
+                  6,
+                  2
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  5,
+                  6
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  4,
+                  6
+                ],
+                "row": 3,
+                "witness_order": [
+                  4,
+                  5,
+                  6,
+                  2
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  5,
+                  6
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  2,
+                  5
+                ],
+                "row": 3,
+                "witness_order": [
+                  4,
+                  5,
+                  6,
+                  2
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  2,
+                  6
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  2,
+                  5
+                ],
+                "row": 3,
+                "witness_order": [
+                  4,
+                  5,
+                  6,
+                  2
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  6,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  6
+                ],
+                "row": 4,
+                "witness_order": [
+                  6,
+                  7,
+                  1,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  1,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  6
+                ],
+                "row": 4,
+                "witness_order": [
+                  6,
+                  7,
+                  1,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  6
+                ],
+                "row": 4,
+                "witness_order": [
+                  6,
+                  7,
+                  1,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  3
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  6
+                ],
+                "row": 4,
+                "witness_order": [
+                  6,
+                  7,
+                  1,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  1,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  7
+                ],
+                "row": 4,
+                "witness_order": [
+                  6,
+                  7,
+                  1,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  3
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  3,
+                  7
+                ],
+                "row": 4,
+                "witness_order": [
+                  6,
+                  7,
+                  1,
+                  3
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  6,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  4,
+                  6
+                ],
+                "row": 5,
+                "witness_order": [
+                  6,
+                  8,
+                  0,
+                  4
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  4,
+                  6
+                ],
+                "row": 5,
+                "witness_order": [
+                  6,
+                  8,
+                  0,
+                  4
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  4
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  4,
+                  6
+                ],
+                "row": 5,
+                "witness_order": [
+                  6,
+                  8,
+                  0,
+                  4
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  7,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  2,
+                  7
+                ],
+                "row": 6,
+                "witness_order": [
+                  7,
+                  8,
+                  2,
+                  5
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  2,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  2,
+                  7
+                ],
+                "row": 6,
+                "witness_order": [
+                  7,
+                  8,
+                  2,
+                  5
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  2,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  5,
+                  8
+                ],
+                "row": 6,
+                "witness_order": [
+                  7,
+                  8,
+                  2,
+                  5
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  2,
+                  5
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  5,
+                  8
+                ],
+                "row": 6,
+                "witness_order": [
+                  7,
+                  8,
+                  2,
+                  5
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  2
+                ],
+                "inner_pair": [
+                  2,
+                  3
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  2,
+                  6
+                ],
+                "row": 7,
+                "witness_order": [
+                  0,
+                  2,
+                  3,
+                  6
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  3,
+                  6
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  2,
+                  6
+                ],
+                "row": 7,
+                "witness_order": [
+                  0,
+                  2,
+                  3,
+                  6
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  0,
+                  1
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  5
+                ],
+                "row": 8,
+                "witness_order": [
+                  0,
+                  1,
+                  5,
+                  7
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  0,
+                  1
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  7
+                ],
+                "row": 8,
+                "witness_order": [
+                  0,
+                  1,
+                  5,
+                  7
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  0,
+                  2
+                ],
+                "inner_pair": [
+                  0,
+                  5
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  7
+                ],
+                "row": 8,
+                "witness_order": [
+                  0,
+                  1,
+                  5,
+                  7
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  1,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  7
+                ],
+                "row": 8,
+                "witness_order": [
+                  0,
+                  1,
+                  5,
+                  7
+                ]
+              }
+            ],
+            "status": "self_edge",
+            "strict_edge_count": 81,
+            "type": "vertex_circle_quotient_replay_result"
+          }
+        }
+      ],
+      "strict_cycle": [
+        {
+          "selected_rows": [
+            [
+              1,
+              2,
+              4,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              1,
+              3,
+              4,
+              6
+            ],
+            [
+              2,
+              4,
+              5,
+              7
+            ],
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              4,
+              6,
+              7
+            ],
+            [
+              1,
+              5,
+              7,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              1,
+              3,
+              7
+            ]
+          ],
+          "vertex_circle_replay": {
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  0,
+                  5
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  1,
+                  6
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  3
+                ],
+                "row": 2,
+                "witness_order": [
+                  3,
+                  4,
+                  6,
+                  1
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  8
+                ],
+                "outer_class": [
+                  0,
+                  5
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  0,
+                  5
+                ],
+                "row": 1,
+                "witness_order": [
+                  3,
+                  5,
+                  8,
+                  0
+                ]
+              }
+            ],
+            "n": 9,
+            "obstructed": true,
+            "order": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "selected_row_count": 9,
+            "self_edge_conflicts": [],
+            "status": "strict_cycle",
+            "strict_edge_count": 81,
+            "type": "vertex_circle_quotient_replay_result"
+          }
+        },
+        {
+          "selected_rows": [
+            [
+              1,
+              2,
+              5,
+              6
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              1,
+              3,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              0,
+              2,
+              5,
+              7
+            ],
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              6,
+              7
+            ]
+          ],
+          "vertex_circle_replay": {
+            "cycle_edges": [
+              {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  0,
+                  3
+                ],
+                "outer_class": [
+                  0,
+                  1
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  0,
+                  6
+                ],
+                "row": 8,
+                "witness_order": [
+                  0,
+                  3,
+                  6,
+                  7
+                ]
+              },
+              {
+                "inner_class": [
+                  0,
+                  1
+                ],
+                "inner_interval": [
+                  2,
+                  3
+                ],
+                "inner_pair": [
+                  0,
+                  1
+                ],
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  1,
+                  3
+                ],
+                "outer_pair": [
+                  1,
+                  6
+                ],
+                "row": 3,
+                "witness_order": [
+                  4,
+                  6,
+                  0,
+                  1
+                ]
+              }
+            ],
+            "n": 9,
+            "obstructed": true,
+            "order": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "selected_row_count": 9,
+            "self_edge_conflicts": [],
+            "status": "strict_cycle",
+            "strict_edge_count": 81,
+            "type": "vertex_circle_quotient_replay_result"
+          }
+        }
+      ]
+    },
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "radius_blocker_ok": true,
+    "raw_selection_upper_bound": 30001545437500000,
+    "rejection_counts": {
+      "column_pair_cap": 4679361,
+      "row_pair_cap": 2637115,
+      "two_overlap_crossing": 4410497
+    },
+    "row_option_counts": [
+      65,
+      65,
+      65,
+      65,
+      70,
+      70,
+      70,
+      70,
+      70
+    ],
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "survivor_examples": [],
+    "trust": "REVIEW_PENDING_DIAGNOSTIC",
+    "vertex_circle_status_counts": {
+      "self_edge": 70,
+      "strict_cycle": 20
+    }
+  },
+  "claim_scope": "Full exact-four row-option packet for n=9, natural cyclic order, and blocker {0,1,2,3}. This obstructs only that finite packet under the encoded incidence/order filters and selected-distance vertex-circle replay; it is not a proof of Erdos Problem #97 and not a counterexample.",
+  "interpretation_warnings": [
+    "The packet quantifies over exact four-row options only.",
+    "The cyclic order and blocker subset are fixed.",
+    "The result does not classify all n=9 rich-class systems.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --write --assert-expected",
+    "generator": "scripts/check_n9_full_radius_blocker_vertex_circle_packet.py",
+    "sources": [
+      "src/erdos97/radius_blocker_packets.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+  "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_cases_have_radius_blocker": true,
+    "all_incidence_survivors_obstructed": true,
+    "case_count": 1,
+    "total_incidence_survivors": 90,
+    "vertex_circle_status_totals": {
+      "self_edge": 70,
+      "strict_cycle": 20
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -128,7 +128,13 @@ Use this queue when no more specific issue is selected.
    Use `scripts/check_radius_blocker_vertex_circle_pilot.py --check --assert-expected --json`
    as the first exact-four row-option packet replay for radius-blocker shapes,
    then mine true multi-option blocker packets rather than only fixed selected
-   rows.
+   rows. The first full packet widening is now
+   `python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected --json`,
+   which checks the natural-order `n=9` blocker `{0,1,2,3}` over all exact
+   four-row choices compatible with that blocker and records 90 incidence
+   survivors, all vertex-circle obstructed. This is still finite packet
+   evidence only; the next widening is dihedral blocker placements and
+   non-natural cyclic orders.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`radius-blocker-vertex-circle-pilot.md`](radius-blocker-vertex-circle-pilot.md):
   first exact-four-row radius-blocker packet diagnostic using vertex-circle
   quotient replay; bridge tooling only, not a proof.
+- [`n9-full-radius-blocker-vertex-circle-packet.md`](n9-full-radius-blocker-vertex-circle-packet.md):
+  full exact-four row-option packet for the fixed `n=9` natural-order blocker
+  `{0,1,2,3}`; all incidence survivors are vertex-circle obstructed, but this
+  is still finite packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-full-radius-blocker-vertex-circle-packet.md
+++ b/docs/n9-full-radius-blocker-vertex-circle-packet.md
@@ -1,0 +1,58 @@
+# n=9 full radius-blocker vertex-circle packet
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note records a finite exact-four row-option packet:
+
+```text
+n = 9
+cyclic order = [0,1,2,3,4,5,6,7,8]
+blocker U = {0,1,2,3}
+```
+
+For every center in `U`, the packet includes every exact four-row avoiding the
+center and containing at most two vertices of `U`. For centers outside `U`, the
+packet includes every exact four-row avoiding the center. Thus `U` is a
+radius-blocker for the packet by construction.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_full_radius_blocker_vertex_circle_packet.json
+```
+
+Regenerate and verify it with:
+
+```bash
+python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected
+```
+
+The exact search visits `58,742` packet nodes and finds `90` incidence survivors
+after the row-pair cap, witness-pair cap, indegree cap, and two-overlap crossing
+filters. Every survivor is obstructed by selected-distance vertex-circle replay:
+
+| vertex-circle status | count |
+| --- | ---: |
+| `self_edge` | 70 |
+| `strict_cycle` | 20 |
+
+The row-option counts are:
+
+```text
+[65,65,65,65,70,70,70,70,70]
+```
+
+## Interpretation
+
+This is stronger than the first fixed-row pilot because it quantifies over all
+exact four-row choices compatible with the fixed blocker `U` in the fixed
+natural order. It is still not a proof of the full adaptive blocker bridge,
+because the cyclic order and blocker subset are fixed and the packet is
+restricted to exact four-row classes.
+
+The useful next widening is to repeat the same full-packet check over dihedrally
+distinct blocker placements and then over non-natural cyclic orders that arise
+from current stuck-set and fragile-cover searches.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -562,6 +562,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/radius-blocker-vertex-circle-pilot.md`, as a first replayable packet
   format for testing blocker shapes against quotient self-edges and strict
   cycles.
+- the full `n=9` exact-four radius-blocker packet recorded in
+  `docs/n9-full-radius-blocker-vertex-circle-packet.md`, where the fixed
+  natural-order blocker `{0,1,2,3}` has 90 incidence survivors and all are
+  vertex-circle obstructed. This is finite packet evidence only; the next
+  review target is widening blocker placements and cyclic orders.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2795,6 +2795,43 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_full_radius_blocker_vertex_circle_packet
+    path: data/certificates/n9_full_radius_blocker_vertex_circle_packet.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_full_radius_blocker_vertex_circle_packet.py
+    command: python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --write --assert-expected
+    checker: scripts/check_n9_full_radius_blocker_vertex_circle_packet.py
+    check_command: python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Full exact-four row-option packet for n=9, natural cyclic order, and blocker {0,1,2,3}; all incidence survivors are vertex-circle obstructed, but this is not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.radius_blocker_vertex_circle_packet.v1
+      status: RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.case_count: 1
+      summary.all_cases_have_radius_blocker: true
+      summary.all_incidence_survivors_obstructed: true
+      summary.total_incidence_survivors: 90
+      summary.vertex_circle_status_totals.self_edge: 70
+      summary.vertex_circle_status_totals.strict_cycle: 20
+      case.nodes_visited: 58742
+      case.incidence_survivors: 90
+      case.vertex_circle_status_counts.self_edge: 70
+      case.vertex_circle_status_counts.strict_cycle: 20
+      provenance.command: python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - all n=9 cyclic orders are obstructed
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_full_radius_blocker_vertex_circle_packet.py
+++ b/scripts/check_n9_full_radius_blocker_vertex_circle_packet.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Check the full n=9 exact-four radius-blocker packet.
+
+This is a finite bridge diagnostic only.  It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.radius_blocker_packets import (  # noqa: E402
+    SCHEMA,
+    STATUS,
+    TRUST,
+    PacketConfig,
+    analyze_radius_blocker_packet,
+    full_exact_four_radius_blocker_rich_classes,
+    result_to_packet_json,
+)
+
+DEFAULT_OUT = (
+    ROOT / "data" / "certificates" / "n9_full_radius_blocker_vertex_circle_packet.json"
+)
+
+PACKET_NAME = "n9_full_exact_four_radius_blocker_U0123_natural_order"
+N = 9
+ORDER = list(range(N))
+BLOCKER = [0, 1, 2, 3]
+EXPECTED = {
+    "row_option_counts": [65, 65, 65, 65, 70, 70, 70, 70, 70],
+    "nodes_visited": 58_742,
+    "incidence_survivors": 90,
+    "vertex_circle_status_counts": {"self_edge": 70, "strict_cycle": 20},
+    "rejection_counts": {
+        "column_pair_cap": 4_679_361,
+        "row_pair_cap": 2_637_115,
+        "two_overlap_crossing": 4_410_497,
+    },
+}
+
+
+def build_payload() -> dict[str, object]:
+    """Build the deterministic n=9 full-blocker packet payload."""
+
+    rich_classes = full_exact_four_radius_blocker_rich_classes(N, BLOCKER)
+    result = analyze_radius_blocker_packet(
+        PACKET_NAME,
+        rich_classes,
+        BLOCKER,
+        ORDER,
+        PacketConfig(max_nodes=100_000),
+    )
+    case = result_to_packet_json(result)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Full exact-four row-option packet for n=9, natural cyclic order, "
+            "and blocker {0,1,2,3}. This obstructs only that finite packet "
+            "under the encoded incidence/order filters and selected-distance "
+            "vertex-circle replay; it is not a proof of Erdos Problem #97 and "
+            "not a counterexample."
+        ),
+        "summary": {
+            "case_count": 1,
+            "all_cases_have_radius_blocker": bool(case["radius_blocker_ok"]),
+            "all_incidence_survivors_obstructed": bool(
+                case["all_incidence_survivors_obstructed"]
+            ),
+            "total_incidence_survivors": int(case["incidence_survivors"]),
+            "vertex_circle_status_totals": dict(
+                case["vertex_circle_status_counts"]
+            ),
+        },
+        "case": case,
+        "interpretation_warnings": [
+            "The packet quantifies over exact four-row options only.",
+            "The cyclic order and blocker subset are fixed.",
+            "The result does not classify all n=9 rich-class systems.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_full_radius_blocker_vertex_circle_packet.py",
+            "command": (
+                "python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "src/erdos97/radius_blocker_packets.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable full-blocker packet counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    expected_summary = {
+        "case_count": 1,
+        "all_cases_have_radius_blocker": True,
+        "all_incidence_survivors_obstructed": True,
+        "total_incidence_survivors": 90,
+        "vertex_circle_status_totals": {"self_edge": 70, "strict_cycle": 20},
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    case = payload.get("case")
+    if not isinstance(case, Mapping):
+        raise AssertionError("case is missing")
+    if case.get("name") != PACKET_NAME:
+        raise AssertionError(f"unexpected packet name: {case.get('name')!r}")
+    for key, expected in EXPECTED.items():
+        if case.get(key) != expected:
+            raise AssertionError(
+                f"case[{key!r}] is {case.get(key)!r}, expected {expected!r}"
+            )
+    if case.get("aborted") is not False:
+        raise AssertionError(f"packet search aborted: {case.get('aborted')!r}")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    case = payload["case"]
+    assert isinstance(summary, Mapping)
+    assert isinstance(case, Mapping)
+    print("n=9 full radius-blocker vertex-circle packet")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"row options: {case['row_option_counts']}")
+    print(f"nodes visited: {case['nodes_visited']}")
+    print(f"incidence survivors: {case['incidence_survivors']}")
+    print(f"all incidence survivors obstructed: {summary['all_incidence_survivors_obstructed']}")
+    print(f"status totals: {summary['vertex_circle_status_totals']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload()
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1357,6 +1357,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_full_radius_blocker_vertex_circle_packet",
+        command=(
+            "python",
+            "scripts/check_n9_full_radius_blocker_vertex_circle_packet.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Full exact-four row-option packet for n=9, natural cyclic order, "
+            "and blocker {0,1,2,3}; all incidence survivors are vertex-circle "
+            "obstructed, but this is not a proof of Erdos Problem #97 and not "
+            "a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/src/erdos97/radius_blocker_packets.py
+++ b/src/erdos97/radius_blocker_packets.py
@@ -12,7 +12,7 @@ from collections import Counter
 from dataclasses import dataclass
 from itertools import combinations
 from math import prod
-from typing import Mapping, Sequence
+from typing import Iterable, Mapping, Sequence
 
 from erdos97.adaptive_blockers import RichClasses, is_radius_blocker, validate_rich_classes
 from erdos97.incidence_filters import chords_cross_in_order, normalize_chord
@@ -89,6 +89,43 @@ def exact_four_rich_classes_from_rows(rows: Sequence[Sequence[int]]) -> RichClas
             raise ValueError(f"row {center} selects its center")
         out.append((normalized,))
     return tuple(out)
+
+
+def full_exact_four_radius_blocker_rich_classes(
+    n: int,
+    blocker: Iterable[int],
+    threshold: int = 3,
+) -> tuple[tuple[Row, ...], ...]:
+    """Return all exact-four rows compatible with ``blocker`` being blocked.
+
+    For centers inside the blocker, every row option is required to contain
+    fewer than ``threshold`` blocker vertices.  For centers outside the
+    blocker, all exact four-subsets avoiding the center are allowed.
+    """
+
+    if n < 4:
+        raise ValueError(f"expected at least four centers, got {n}")
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+    blocker_set = set(int(label) for label in blocker)
+    bad = sorted(label for label in blocker_set if label < 0 or label >= n)
+    if bad:
+        raise ValueError(f"blocker contains out-of-range labels: {bad}")
+    if len(blocker_set) < threshold + 1:
+        raise ValueError(
+            f"blocker must have at least {threshold + 1} vertices, got "
+            f"{len(blocker_set)}"
+        )
+
+    options: list[tuple[Row, ...]] = []
+    for center in range(n):
+        center_options: list[Row] = []
+        for row in combinations((label for label in range(n) if label != center), 4):
+            if center in blocker_set and len(blocker_set.intersection(row)) >= threshold:
+                continue
+            center_options.append((row[0], row[1], row[2], row[3]))
+        options.append(tuple(center_options))
+    return tuple(options)
 
 
 def row_options_from_rich_classes(rich_classes: RichClasses) -> tuple[tuple[Row, ...], ...]:

--- a/tests/test_radius_blocker_packets.py
+++ b/tests/test_radius_blocker_packets.py
@@ -7,6 +7,7 @@ from erdos97.bridge_negative_controls import c13_sidon_rows
 from erdos97.radius_blocker_packets import (
     analyze_radius_blocker_packet,
     exact_four_rich_classes_from_rows,
+    full_exact_four_radius_blocker_rich_classes,
     row_options_from_rich_classes,
 )
 
@@ -47,6 +48,27 @@ def test_packet_accepts_multiple_exact_four_options() -> None:
     assert result.row_option_counts[0] == 2
     assert result.raw_selection_upper_bound == 2
     assert not result.aborted
+
+
+def test_full_exact_four_radius_blocker_options_enforce_blocker() -> None:
+    rich_classes = full_exact_four_radius_blocker_rich_classes(9, [0, 1, 2, 3])
+
+    assert [len(rows) for rows in rich_classes] == [
+        65,
+        65,
+        65,
+        65,
+        70,
+        70,
+        70,
+        70,
+        70,
+    ]
+    for center in [0, 1, 2, 3]:
+        assert all(
+            len({0, 1, 2, 3}.intersection(row)) <= 2
+            for row in rich_classes[center]
+        )
 
 
 def test_large_rich_classes_are_rejected_until_semantics_are_added() -> None:


### PR DESCRIPTION
## Summary

- add a reusable generator for full exact-four row-option packets compatible with a fixed radius-blocker
- add a checked natural-order `n=9` packet for blocker `{0,1,2,3}`
- record the exact result: 90 incidence survivors, all vertex-circle obstructed (`70` self-edge, `20` strict-cycle)
- wire the generated artifact into docs, provenance metadata, and artifact audit coverage

## Scope

This is finite packet evidence only. It does not prove the adaptive blocker bridge, does not prove `n=9`, does not prove Erdos Problem #97, and is not a counterexample.

## Validation

- `python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --write --assert-expected`
- `python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected`
- `python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected --json`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_radius_blocker_packets.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1039 passed, 299 deselected`)