### PR TITLE
[codex] Add n9 radius-blocker shape sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,13 @@ This repository is a public research log and reproducibility workspace for Erdő
   systems, read
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
 - For exact-four radius-blocker packet diagnostics, including the full
-  natural-order `n=9` blocker `{0,1,2,3}` packet, read
+  natural-order `n=9` blocker `{0,1,2,3}` packet and the natural-order
+  four-blocker shape sweep, read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
-  [`docs/n9-full-radius-blocker-vertex-circle-packet.md`](docs/n9-full-radius-blocker-vertex-circle-packet.md).
+  [`docs/n9-full-radius-blocker-vertex-circle-packet.md`](docs/n9-full-radius-blocker-vertex-circle-packet.md)
+  and
+  [`docs/n9-radius-blocker-shape-sweep.md`](docs/n9-radius-blocker-shape-sweep.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -267,6 +267,17 @@ counterexample. See `docs/n9-full-radius-blocker-vertex-circle-packet.md`,
 `scripts/check_n9_full_radius_blocker_vertex_circle_packet.py`, and
 `data/certificates/n9_full_radius_blocker_vertex_circle_packet.json`.
 
+The natural-order `n=9` radius-blocker shape sweep widens the same exact-four
+packet to all `10` cyclic-dihedral four-blocker representatives. Their orbit
+sizes sum to all `126` labelled four-vertex blockers in the fixed natural
+order. After the same filters, the sweep finds `1,358` incidence survivors;
+all are killed by vertex-circle replay (`1,164` self-edges and `194` strict
+cycles). This is still finite packet evidence only, not an `n=9` theorem, not
+a bridge proof, and not a counterexample. See
+`docs/n9-radius-blocker-shape-sweep.md`,
+`scripts/check_n9_radius_blocker_shape_sweep.py`, and
+`data/certificates/n9_radius_blocker_shape_sweep.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -166,6 +166,14 @@ self-edges and `20` strict cycles). This is finite packet evidence only, not an
 `n=9` proof, a bridge proof, or a counterexample. See
 `docs/n9-full-radius-blocker-vertex-circle-packet.md`.
 
+The natural-order `n=9` radius-blocker shape sweep repeats that exact-four
+packet over all `10` cyclic-dihedral four-blocker shapes, covering all `126`
+labelled four-vertex blockers in the fixed natural order. Its `1,358`
+incidence survivors are all vertex-circle obstructed (`1,164` self-edges and
+`194` strict cycles). This is still finite packet evidence only, not an `n=9`
+proof, a bridge proof, or a counterexample. See
+`docs/n9-radius-blocker-shape-sweep.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_shape_sweep.json
+++ b/data/certificates/n9_radius_blocker_shape_sweep.json
@@ -1,0 +1,8479 @@
+{
+  "cases": [
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 9,
+      "dihedral_representative": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "gap_cycle": [
+        1,
+        1,
+        1,
+        6
+      ],
+      "incidence_survivors": 90,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "nodes_visited": 58742,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                6
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                1,
+                3,
+                4,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                0,
+                1,
+                5,
+                6
+              ],
+              [
+                2,
+                3,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                0,
+                4,
+                5,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    1,
+                    3,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                3,
+                5,
+                8
+              ],
+              [
+                1,
+                3,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                2,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                4,
+                6,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                0,
+                1,
+                3,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    4,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    5
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    5,
+                    8,
+                    0
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 4679361,
+        "row_pair_cap": 2637115,
+        "two_overlap_crossing": 4410497
+      },
+      "row_option_counts": [
+        65,
+        65,
+        65,
+        65,
+        70,
+        70,
+        70,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 70,
+        "strict_cycle": 20
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 18,
+      "dihedral_representative": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "gap_cycle": [
+        1,
+        1,
+        2,
+        5
+      ],
+      "incidence_survivors": 118,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "nodes_visited": 63685,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                2,
+                4,
+                6,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                0,
+                2,
+                5,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    3,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    4,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    4,
+                    8
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    4,
+                    8
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    0,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    3,
+                    8
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    6,
+                    8,
+                    0,
+                    3
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    3,
+                    8
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    6,
+                    8,
+                    0,
+                    3
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    2,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    4,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    1,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    1,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    5,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    1
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    1,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    1,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    4,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    7
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    2,
+                    5,
+                    7
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    7
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    2,
+                    5,
+                    7
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    7
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    2,
+                    5,
+                    7
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                5,
+                6
+              ],
+              [
+                2,
+                4,
+                7,
+                8
+              ],
+              [
+                1,
+                3,
+                5,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                0,
+                2,
+                5,
+                7
+              ],
+              [
+                2,
+                3,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                4,
+                7
+              ],
+              [
+                0,
+                4,
+                5,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    6
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    3,
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    1
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    0,
+                    1
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 5216230,
+        "row_pair_cap": 2791181,
+        "two_overlap_crossing": 4700795
+      },
+      "row_option_counts": [
+        65,
+        65,
+        65,
+        70,
+        65,
+        70,
+        70,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 97,
+        "strict_cycle": 21
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 18,
+      "dihedral_representative": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "gap_cycle": [
+        1,
+        1,
+        3,
+        4
+      ],
+      "incidence_survivors": 111,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "nodes_visited": 63328,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                3,
+                5,
+                8
+              ],
+              [
+                1,
+                3,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                2,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                4,
+                6,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                0,
+                1,
+                3,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    4,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    5
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    5,
+                    8,
+                    0
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 5116365,
+        "row_pair_cap": 2797681,
+        "two_overlap_crossing": 4693701
+      },
+      "row_option_counts": [
+        65,
+        65,
+        65,
+        70,
+        70,
+        65,
+        70,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 93,
+        "strict_cycle": 18
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 9,
+      "dihedral_representative": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "gap_cycle": [
+        1,
+        2,
+        1,
+        5
+      ],
+      "incidence_survivors": 148,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "nodes_visited": 79875,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                2,
+                3,
+                5
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                3,
+                5,
+                6,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 6742977,
+        "row_pair_cap": 3202228,
+        "two_overlap_crossing": 5567523
+      },
+      "row_option_counts": [
+        65,
+        65,
+        70,
+        65,
+        65,
+        70,
+        70,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 134,
+        "strict_cycle": 14
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 18,
+      "dihedral_representative": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "gap_cycle": [
+        1,
+        2,
+        2,
+        4
+      ],
+      "incidence_survivors": 142,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "nodes_visited": 80794,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                5,
+                6
+              ],
+              [
+                2,
+                4,
+                7,
+                8
+              ],
+              [
+                1,
+                3,
+                5,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                0,
+                2,
+                5,
+                7
+              ],
+              [
+                2,
+                3,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                4,
+                7
+              ],
+              [
+                0,
+                4,
+                5,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    6
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    3,
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    1
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    0,
+                    1
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 6798628,
+        "row_pair_cap": 3255905,
+        "two_overlap_crossing": 5692769
+      },
+      "row_option_counts": [
+        65,
+        65,
+        70,
+        65,
+        70,
+        65,
+        70,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 121,
+        "strict_cycle": 21
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 18,
+      "dihedral_representative": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "gap_cycle": [
+        1,
+        2,
+        3,
+        3
+      ],
+      "incidence_survivors": 141,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "nodes_visited": 79741,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                2,
+                3,
+                5
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                3,
+                5,
+                6,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 6707012,
+        "row_pair_cap": 3220411,
+        "two_overlap_crossing": 5644015
+      },
+      "row_option_counts": [
+        65,
+        65,
+        70,
+        65,
+        70,
+        70,
+        65,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 125,
+        "strict_cycle": 16
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 9,
+      "dihedral_representative": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "gap_cycle": [
+        1,
+        2,
+        4,
+        2
+      ],
+      "incidence_survivors": 136,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "nodes_visited": 78302,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                2,
+                3,
+                5
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                3,
+                5,
+                6,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 6626461,
+        "row_pair_cap": 3154534,
+        "two_overlap_crossing": 5537339
+      },
+      "row_option_counts": [
+        65,
+        65,
+        70,
+        65,
+        70,
+        70,
+        70,
+        65,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 120,
+        "strict_cycle": 16
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 9,
+      "dihedral_representative": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "gap_cycle": [
+        1,
+        3,
+        1,
+        4
+      ],
+      "incidence_survivors": 168,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "nodes_visited": 81654,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                2,
+                3,
+                5
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                3,
+                5,
+                6,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 6780162,
+        "row_pair_cap": 3350024,
+        "two_overlap_crossing": 5755696
+      },
+      "row_option_counts": [
+        65,
+        65,
+        70,
+        70,
+        65,
+        65,
+        70,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 144,
+        "strict_cycle": 24
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 9,
+      "dihedral_representative": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "gap_cycle": [
+        1,
+        3,
+        2,
+        3
+      ],
+      "incidence_survivors": 158,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "nodes_visited": 81257,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                2,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                7
+              ],
+              [
+                1,
+                4,
+                6,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                3,
+                4,
+                6,
+                7
+              ],
+              [
+                2,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                5
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    3,
+                    7
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    7,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    4
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    6,
+                    8,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    5,
+                    6,
+                    0,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    3,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    4
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    4
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    8
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    2,
+                    5
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                2,
+                3,
+                5
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                3,
+                5,
+                6,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                6,
+                8
+              ],
+              [
+                1,
+                3,
+                6,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    3
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    2
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    3
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    2,
+                    3,
+                    5,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 6788067,
+        "row_pair_cap": 3317453,
+        "two_overlap_crossing": 5759554
+      },
+      "row_option_counts": [
+        65,
+        65,
+        70,
+        70,
+        65,
+        70,
+        65,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 136,
+        "strict_cycle": 22
+      }
+    },
+    {
+      "aborted": false,
+      "all_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+      "dihedral_orbit_size": 9,
+      "dihedral_representative": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "gap_cycle": [
+        2,
+        2,
+        2,
+        3
+      ],
+      "incidence_survivors": 146,
+      "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+      "n": 9,
+      "name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "nodes_visited": 87127,
+      "obstruction_examples": {
+        "self_edge": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                3,
+                8
+              ],
+              [
+                0,
+                3,
+                4,
+                7
+              ],
+              [
+                1,
+                3,
+                5,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                8
+              ],
+              [
+                0,
+                3,
+                6,
+                8
+              ],
+              [
+                2,
+                4,
+                6,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                1,
+                4,
+                6
+              ],
+              [
+                0,
+                2,
+                5,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    1,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    3,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    8
+                  ],
+                  "row": 0,
+                  "witness_order": [
+                    1,
+                    2,
+                    3,
+                    8
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    3
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    4,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    4,
+                    7,
+                    0
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    3,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    5,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    4,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    4,
+                    8
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    4,
+                    8
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    5,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    2,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    2,
+                    5
+                  ],
+                  "row": 3,
+                  "witness_order": [
+                    4,
+                    5,
+                    8,
+                    2
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    0,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    3,
+                    8
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    6,
+                    8,
+                    0,
+                    3
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    3
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    3,
+                    8
+                  ],
+                  "row": 4,
+                  "witness_order": [
+                    6,
+                    8,
+                    0,
+                    3
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    2,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    6,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    4,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    4,
+                    6
+                  ],
+                  "row": 5,
+                  "witness_order": [
+                    6,
+                    7,
+                    2,
+                    4
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    1,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    7,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    2
+                  ],
+                  "inner_pair": [
+                    1,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    3
+                  ],
+                  "inner_pair": [
+                    5,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    5,
+                    7
+                  ],
+                  "row": 6,
+                  "witness_order": [
+                    7,
+                    8,
+                    1,
+                    5
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    1
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    1,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    2
+                  ],
+                  "outer_pair": [
+                    0,
+                    4
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    1,
+                    4
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    4,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    6
+                  ],
+                  "row": 7,
+                  "witness_order": [
+                    0,
+                    1,
+                    4,
+                    6
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    0,
+                    1
+                  ],
+                  "inner_pair": [
+                    0,
+                    2
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    7
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    2,
+                    5,
+                    7
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    1,
+                    2
+                  ],
+                  "inner_pair": [
+                    2,
+                    5
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    7
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    2,
+                    5,
+                    7
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    5,
+                    7
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    7
+                  ],
+                  "row": 8,
+                  "witness_order": [
+                    0,
+                    2,
+                    5,
+                    7
+                  ]
+                }
+              ],
+              "status": "self_edge",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ],
+        "strict_cycle": [
+          {
+            "selected_rows": [
+              [
+                1,
+                2,
+                4,
+                8
+              ],
+              [
+                0,
+                3,
+                5,
+                8
+              ],
+              [
+                1,
+                3,
+                4,
+                6
+              ],
+              [
+                2,
+                4,
+                5,
+                7
+              ],
+              [
+                2,
+                3,
+                6,
+                8
+              ],
+              [
+                0,
+                4,
+                6,
+                7
+              ],
+              [
+                1,
+                5,
+                7,
+                8
+              ],
+              [
+                0,
+                2,
+                5,
+                6
+              ],
+              [
+                0,
+                1,
+                3,
+                7
+              ]
+            ],
+            "vertex_circle_replay": {
+              "cycle_edges": [
+                {
+                  "inner_class": [
+                    0,
+                    5
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    1,
+                    6
+                  ],
+                  "outer_class": [
+                    0,
+                    1
+                  ],
+                  "outer_interval": [
+                    0,
+                    3
+                  ],
+                  "outer_pair": [
+                    1,
+                    3
+                  ],
+                  "row": 2,
+                  "witness_order": [
+                    3,
+                    4,
+                    6,
+                    1
+                  ]
+                },
+                {
+                  "inner_class": [
+                    0,
+                    1
+                  ],
+                  "inner_interval": [
+                    2,
+                    3
+                  ],
+                  "inner_pair": [
+                    0,
+                    8
+                  ],
+                  "outer_class": [
+                    0,
+                    5
+                  ],
+                  "outer_interval": [
+                    1,
+                    3
+                  ],
+                  "outer_pair": [
+                    0,
+                    5
+                  ],
+                  "row": 1,
+                  "witness_order": [
+                    3,
+                    5,
+                    8,
+                    0
+                  ]
+                }
+              ],
+              "n": 9,
+              "obstructed": true,
+              "order": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+              ],
+              "selected_row_count": 9,
+              "self_edge_conflicts": [],
+              "status": "strict_cycle",
+              "strict_edge_count": 81,
+              "type": "vertex_circle_quotient_replay_result"
+            }
+          }
+        ]
+      },
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "radius_blocker_ok": true,
+      "raw_selection_upper_bound": 30001545437500000,
+      "rejection_counts": {
+        "column_pair_cap": 7198066,
+        "row_pair_cap": 3502252,
+        "two_overlap_crossing": 6429970
+      },
+      "row_option_counts": [
+        65,
+        70,
+        65,
+        70,
+        65,
+        70,
+        65,
+        70,
+        70
+      ],
+      "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+      "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "survivor_examples": [],
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "vertex_circle_status_counts": {
+        "self_edge": 124,
+        "strict_cycle": 22
+      }
+    }
+  ],
+  "claim_scope": "Natural-order n=9 exact-four row-option sweep over all 10 dihedral classes of four-vertex blockers. This obstructs only those finite packets under the encoded incidence/order filters and selected-distance vertex-circle replay; it is not a proof of Erdos Problem #97 and not a counterexample.",
+  "interpretation_warnings": [
+    "The sweep quantifies over exact four-row options only.",
+    "The cyclic order is fixed to natural order.",
+    "The blocker is varied only up to dihedral shape in that order.",
+    "The result does not classify all n=9 rich-class systems.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_shape_sweep.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_shape_sweep.py",
+    "sources": [
+      "src/erdos97/radius_blocker_packets.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+  "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_cases_finished": true,
+    "all_cases_have_radius_blocker": true,
+    "all_dihedral_labelled_blockers_covered": true,
+    "all_incidence_survivors_obstructed": true,
+    "dihedral_orbit_size_counts": {
+      "18": 4,
+      "9": 6
+    },
+    "labelled_blocker_count": 126,
+    "n": 9,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "shape_count": 10,
+    "total_incidence_survivors": 1358,
+    "total_nodes_visited": 754505,
+    "vertex_circle_status_totals": {
+      "self_edge": 1164,
+      "strict_cycle": 194
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -132,9 +132,12 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected --json`,
    which checks the natural-order `n=9` blocker `{0,1,2,3}` over all exact
    four-row choices compatible with that blocker and records 90 incidence
-   survivors, all vertex-circle obstructed. This is still finite packet
-   evidence only; the next widening is dihedral blocker placements and
-   non-natural cyclic orders.
+   survivors, all vertex-circle obstructed. The next shape widening is now
+   `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected --json`,
+   which checks all `10` cyclic-dihedral four-blocker shapes in the natural
+   order and records `1,358` incidence survivors, all vertex-circle
+   obstructed. This is still finite packet evidence only; the next widening is
+   non-natural cyclic orders and richer-than-exact-four class semantics.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,6 +151,9 @@ put detailed reconciliation in the canonical synthesis.
   full exact-four row-option packet for the fixed `n=9` natural-order blocker
   `{0,1,2,3}`; all incidence survivors are vertex-circle obstructed, but this
   is still finite packet evidence only.
+- [`n9-radius-blocker-shape-sweep.md`](n9-radius-blocker-shape-sweep.md):
+  natural-order exact-four row-option sweep over all `10` cyclic-dihedral
+  four-blocker shapes; finite packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-full-radius-blocker-vertex-circle-packet.md
+++ b/docs/n9-full-radius-blocker-vertex-circle-packet.md
@@ -53,6 +53,7 @@ natural order. It is still not a proof of the full adaptive blocker bridge,
 because the cyclic order and blocker subset are fixed and the packet is
 restricted to exact four-row classes.
 
-The useful next widening is to repeat the same full-packet check over dihedrally
-distinct blocker placements and then over non-natural cyclic orders that arise
-from current stuck-set and fragile-cover searches.
+The dihedral blocker-placement widening is now recorded in
+`docs/n9-radius-blocker-shape-sweep.md`. The useful next widening is
+non-natural cyclic orders that arise from current stuck-set and fragile-cover
+searches, or a replay semantics for rich classes larger than four.

--- a/docs/n9-radius-blocker-shape-sweep.md
+++ b/docs/n9-radius-blocker-shape-sweep.md
@@ -1,0 +1,71 @@
+# n=9 radius-blocker shape sweep
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note records the natural-order widening of the full exact-four
+radius-blocker packet. Instead of fixing only
+
+```text
+U = {0,1,2,3},
+```
+
+it checks all `10` four-vertex blocker shapes up to cyclic-dihedral symmetry in
+the natural cyclic order `[0,1,2,3,4,5,6,7,8]`. Their orbit sizes sum to
+`126 = binom(9,4)`, so every labelled four-vertex blocker in this fixed order
+is represented.
+
+For each blocker `U`, the packet includes every exact four-row avoiding the
+center and containing at most two vertices of `U` for centers in `U`; centers
+outside `U` keep every exact four-row avoiding the center. Thus `U` is a
+radius-blocker for each packet by construction.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_shape_sweep.json
+```
+
+Regenerate and verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected
+```
+
+The exact search visits `754,505` packet nodes across the `10` shape
+representatives and finds `1,358` incidence survivors after the row-pair cap,
+witness-pair cap, indegree cap, and two-overlap crossing filters. Every
+incidence survivor is obstructed by selected-distance vertex-circle replay:
+
+| vertex-circle status | count |
+| --- | ---: |
+| `self_edge` | 1,164 |
+| `strict_cycle` | 194 |
+
+The per-shape counts are:
+
+| blocker representative | orbit size | incidence survivors | self-edge | strict-cycle |
+| --- | ---: | ---: | ---: | ---: |
+| `[0,1,2,3]` | 9 | 90 | 70 | 20 |
+| `[0,1,2,4]` | 18 | 118 | 97 | 21 |
+| `[0,1,2,5]` | 18 | 111 | 93 | 18 |
+| `[0,1,3,4]` | 9 | 148 | 134 | 14 |
+| `[0,1,3,5]` | 18 | 142 | 121 | 21 |
+| `[0,1,3,6]` | 18 | 141 | 125 | 16 |
+| `[0,1,3,7]` | 9 | 136 | 120 | 16 |
+| `[0,1,4,5]` | 9 | 168 | 144 | 24 |
+| `[0,1,4,6]` | 9 | 158 | 136 | 22 |
+| `[0,2,4,6]` | 9 | 146 | 124 | 22 |
+
+## Interpretation
+
+This widens the previous full `{0,1,2,3}` packet from one blocker placement to
+all dihedrally distinct four-vertex blocker shapes in the fixed natural order.
+It is still not a proof of the full adaptive blocker bridge, because the cyclic
+order is fixed and the packet is restricted to exact four-row rich classes.
+
+The useful next widening is non-natural cyclic orders or a rich-class replay
+semantics that handles classes larger than four without prematurely choosing
+one exact four-subset.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -565,8 +565,12 @@ condition that the surviving multi-block family does not automatically satisfy:
 - the full `n=9` exact-four radius-blocker packet recorded in
   `docs/n9-full-radius-blocker-vertex-circle-packet.md`, where the fixed
   natural-order blocker `{0,1,2,3}` has 90 incidence survivors and all are
-  vertex-circle obstructed. This is finite packet evidence only; the next
-  review target is widening blocker placements and cyclic orders.
+  vertex-circle obstructed.
+- the natural-order `n=9` radius-blocker shape sweep recorded in
+  `docs/n9-radius-blocker-shape-sweep.md`, where all `10` cyclic-dihedral
+  four-blocker shapes have obstructed incidence survivors. This is finite
+  packet evidence only; the next review target is widening cyclic orders and
+  exact-four semantics.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2832,6 +2832,42 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_shape_sweep
+    path: data/certificates/n9_radius_blocker_shape_sweep.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_shape_sweep.py
+    command: python scripts/check_n9_radius_blocker_shape_sweep.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_shape_sweep.py
+    check_command: python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Natural-order n=9 exact-four row-option sweep over all 10 dihedral classes of four-vertex blockers; all incidence survivors are vertex-circle obstructed, but this is not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.radius_blocker_vertex_circle_packet.v1
+      status: RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.shape_count: 10
+      summary.labelled_blocker_count: 126
+      summary.all_dihedral_labelled_blockers_covered: true
+      summary.all_cases_have_radius_blocker: true
+      summary.all_cases_finished: true
+      summary.all_incidence_survivors_obstructed: true
+      summary.total_incidence_survivors: 1358
+      summary.vertex_circle_status_totals.self_edge: 1164
+      summary.vertex_circle_status_totals.strict_cycle: 194
+      provenance.command: python scripts/check_n9_radius_blocker_shape_sweep.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - all n=9 cyclic orders are obstructed
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_shape_sweep.py
+++ b/scripts/check_n9_radius_blocker_shape_sweep.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Check all n=9 natural-order exact-four radius-blocker shapes.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from math import comb
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.radius_blocker_packets import (  # noqa: E402
+    SCHEMA,
+    STATUS,
+    TRUST,
+    PacketConfig,
+    dihedral_subset_images,
+    dihedral_subset_representatives,
+    analyze_radius_blocker_packet,
+    full_exact_four_radius_blocker_rich_classes,
+    result_to_packet_json,
+)
+
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_radius_blocker_shape_sweep.json"
+
+N = 9
+ORDER = list(range(N))
+EXPECTED_SUMMARY = {
+    "shape_count": 10,
+    "labelled_blocker_count": 126,
+    "all_dihedral_labelled_blockers_covered": True,
+    "all_cases_have_radius_blocker": True,
+    "all_cases_finished": True,
+    "all_incidence_survivors_obstructed": True,
+    "total_nodes_visited": 754_505,
+    "total_incidence_survivors": 1_358,
+    "vertex_circle_status_totals": {"self_edge": 1_164, "strict_cycle": 194},
+    "dihedral_orbit_size_counts": {"9": 6, "18": 4},
+}
+EXPECTED_CASES = {
+    (0, 1, 2, 3): {
+        "dihedral_orbit_size": 9,
+        "gap_cycle": [1, 1, 1, 6],
+        "nodes_visited": 58_742,
+        "incidence_survivors": 90,
+        "vertex_circle_status_counts": {"self_edge": 70, "strict_cycle": 20},
+        "rejection_counts": {
+            "column_pair_cap": 4_679_361,
+            "row_pair_cap": 2_637_115,
+            "two_overlap_crossing": 4_410_497,
+        },
+    },
+    (0, 1, 2, 4): {
+        "dihedral_orbit_size": 18,
+        "gap_cycle": [1, 1, 2, 5],
+        "nodes_visited": 63_685,
+        "incidence_survivors": 118,
+        "vertex_circle_status_counts": {"self_edge": 97, "strict_cycle": 21},
+        "rejection_counts": {
+            "column_pair_cap": 5_216_230,
+            "row_pair_cap": 2_791_181,
+            "two_overlap_crossing": 4_700_795,
+        },
+    },
+    (0, 1, 2, 5): {
+        "dihedral_orbit_size": 18,
+        "gap_cycle": [1, 1, 3, 4],
+        "nodes_visited": 63_328,
+        "incidence_survivors": 111,
+        "vertex_circle_status_counts": {"self_edge": 93, "strict_cycle": 18},
+        "rejection_counts": {
+            "column_pair_cap": 5_116_365,
+            "row_pair_cap": 2_797_681,
+            "two_overlap_crossing": 4_693_701,
+        },
+    },
+    (0, 1, 3, 4): {
+        "dihedral_orbit_size": 9,
+        "gap_cycle": [1, 2, 1, 5],
+        "nodes_visited": 79_875,
+        "incidence_survivors": 148,
+        "vertex_circle_status_counts": {"self_edge": 134, "strict_cycle": 14},
+        "rejection_counts": {
+            "column_pair_cap": 6_742_977,
+            "row_pair_cap": 3_202_228,
+            "two_overlap_crossing": 5_567_523,
+        },
+    },
+    (0, 1, 3, 5): {
+        "dihedral_orbit_size": 18,
+        "gap_cycle": [1, 2, 2, 4],
+        "nodes_visited": 80_794,
+        "incidence_survivors": 142,
+        "vertex_circle_status_counts": {"self_edge": 121, "strict_cycle": 21},
+        "rejection_counts": {
+            "column_pair_cap": 6_798_628,
+            "row_pair_cap": 3_255_905,
+            "two_overlap_crossing": 5_692_769,
+        },
+    },
+    (0, 1, 3, 6): {
+        "dihedral_orbit_size": 18,
+        "gap_cycle": [1, 2, 3, 3],
+        "nodes_visited": 79_741,
+        "incidence_survivors": 141,
+        "vertex_circle_status_counts": {"self_edge": 125, "strict_cycle": 16},
+        "rejection_counts": {
+            "column_pair_cap": 6_707_012,
+            "row_pair_cap": 3_220_411,
+            "two_overlap_crossing": 5_644_015,
+        },
+    },
+    (0, 1, 3, 7): {
+        "dihedral_orbit_size": 9,
+        "gap_cycle": [1, 2, 4, 2],
+        "nodes_visited": 78_302,
+        "incidence_survivors": 136,
+        "vertex_circle_status_counts": {"self_edge": 120, "strict_cycle": 16},
+        "rejection_counts": {
+            "column_pair_cap": 6_626_461,
+            "row_pair_cap": 3_154_534,
+            "two_overlap_crossing": 5_537_339,
+        },
+    },
+    (0, 1, 4, 5): {
+        "dihedral_orbit_size": 9,
+        "gap_cycle": [1, 3, 1, 4],
+        "nodes_visited": 81_654,
+        "incidence_survivors": 168,
+        "vertex_circle_status_counts": {"self_edge": 144, "strict_cycle": 24},
+        "rejection_counts": {
+            "column_pair_cap": 6_780_162,
+            "row_pair_cap": 3_350_024,
+            "two_overlap_crossing": 5_755_696,
+        },
+    },
+    (0, 1, 4, 6): {
+        "dihedral_orbit_size": 9,
+        "gap_cycle": [1, 3, 2, 3],
+        "nodes_visited": 81_257,
+        "incidence_survivors": 158,
+        "vertex_circle_status_counts": {"self_edge": 136, "strict_cycle": 22},
+        "rejection_counts": {
+            "column_pair_cap": 6_788_067,
+            "row_pair_cap": 3_317_453,
+            "two_overlap_crossing": 5_759_554,
+        },
+    },
+    (0, 2, 4, 6): {
+        "dihedral_orbit_size": 9,
+        "gap_cycle": [2, 2, 2, 3],
+        "nodes_visited": 87_127,
+        "incidence_survivors": 146,
+        "vertex_circle_status_counts": {"self_edge": 124, "strict_cycle": 22},
+        "rejection_counts": {
+            "column_pair_cap": 7_198_066,
+            "row_pair_cap": 3_502_252,
+            "two_overlap_crossing": 6_429_970,
+        },
+    },
+}
+
+
+def blocker_label(blocker: Sequence[int]) -> str:
+    return "U" + "".join(str(label) for label in blocker)
+
+
+def gap_cycle(blocker: Sequence[int]) -> list[int]:
+    labels = list(blocker)
+    return [
+        int((labels[(index + 1) % len(labels)] - labels[index]) % N)
+        for index in range(len(labels))
+    ]
+
+
+def json_counter(counter: Counter[object]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def expected_row_option_counts(blocker: Sequence[int]) -> list[int]:
+    blocker_set = set(blocker)
+    return [65 if center in blocker_set else 70 for center in range(N)]
+
+
+def build_case(blocker: Sequence[int]) -> dict[str, object]:
+    """Build one deterministic blocker-shape packet payload."""
+
+    blocker_tuple = tuple(int(label) for label in blocker)
+    rich_classes = full_exact_four_radius_blocker_rich_classes(N, blocker_tuple)
+    result = analyze_radius_blocker_packet(
+        f"n9_full_exact_four_radius_blocker_shape_{blocker_label(blocker_tuple)}_natural_order",
+        rich_classes,
+        blocker_tuple,
+        ORDER,
+        PacketConfig(
+            max_nodes=100_000,
+            max_survivor_examples=1,
+            max_obstruction_examples_per_status=1,
+        ),
+    )
+    case = result_to_packet_json(result)
+    case.update(
+        {
+            "dihedral_representative": list(blocker_tuple),
+            "dihedral_orbit_size": len(dihedral_subset_images(N, blocker_tuple)),
+            "gap_cycle": gap_cycle(blocker_tuple),
+        }
+    )
+    return case
+
+
+def build_payload() -> dict[str, object]:
+    """Build the deterministic all-shape n=9 radius-blocker payload."""
+
+    representatives = dihedral_subset_representatives(N, 4)
+    cases = [build_case(blocker) for blocker in representatives]
+    status_totals: Counter[str] = Counter()
+    orbit_sizes: Counter[int] = Counter()
+    for case in cases:
+        orbit_sizes[int(case["dihedral_orbit_size"])] += 1
+        status_totals.update(case["vertex_circle_status_counts"])
+
+    labelled_blocker_count = sum(
+        int(case["dihedral_orbit_size"]) for case in cases
+    )
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Natural-order n=9 exact-four row-option sweep over all 10 "
+            "dihedral classes of four-vertex blockers. This obstructs only "
+            "those finite packets under the encoded incidence/order filters "
+            "and selected-distance vertex-circle replay; it is not a proof "
+            "of Erdos Problem #97 and not a counterexample."
+        ),
+        "summary": {
+            "n": N,
+            "order": ORDER,
+            "shape_count": len(cases),
+            "labelled_blocker_count": labelled_blocker_count,
+            "all_dihedral_labelled_blockers_covered": (
+                labelled_blocker_count == comb(N, 4)
+            ),
+            "all_cases_have_radius_blocker": all(
+                bool(case["radius_blocker_ok"]) for case in cases
+            ),
+            "all_cases_finished": all(not bool(case["aborted"]) for case in cases),
+            "all_incidence_survivors_obstructed": all(
+                bool(case["all_incidence_survivors_obstructed"]) for case in cases
+            ),
+            "total_nodes_visited": sum(int(case["nodes_visited"]) for case in cases),
+            "total_incidence_survivors": sum(
+                int(case["incidence_survivors"]) for case in cases
+            ),
+            "vertex_circle_status_totals": json_counter(status_totals),
+            "dihedral_orbit_size_counts": json_counter(orbit_sizes),
+        },
+        "cases": cases,
+        "interpretation_warnings": [
+            "The sweep quantifies over exact four-row options only.",
+            "The cyclic order is fixed to natural order.",
+            "The blocker is varied only up to dihedral shape in that order.",
+            "The result does not classify all n=9 rich-class systems.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_shape_sweep.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_shape_sweep.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "src/erdos97/radius_blocker_packets.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable blocker-shape sweep counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("cases are missing")
+    by_blocker: dict[tuple[int, ...], Mapping[str, object]] = {}
+    for case in cases:
+        if not isinstance(case, Mapping):
+            raise AssertionError(f"case is not a mapping: {case!r}")
+        blocker = tuple(int(label) for label in case["blocker"])
+        by_blocker[blocker] = case
+    if set(by_blocker) != set(EXPECTED_CASES):
+        raise AssertionError(f"unexpected blockers: {sorted(by_blocker)}")
+
+    for blocker, expected_case in EXPECTED_CASES.items():
+        case = by_blocker[blocker]
+        if case.get("row_option_counts") != expected_row_option_counts(blocker):
+            raise AssertionError(f"unexpected row options for {blocker}")
+        if case.get("aborted") is not False:
+            raise AssertionError(f"packet search aborted for {blocker}")
+        if case.get("radius_blocker_ok") is not True:
+            raise AssertionError(f"blocker is not a radius-blocker for {blocker}")
+        if case.get("all_incidence_survivors_obstructed") is not True:
+            raise AssertionError(f"clean incidence survivor for {blocker}")
+        for key, expected in expected_case.items():
+            if case.get(key) != expected:
+                raise AssertionError(
+                    f"case {blocker} [{key!r}] is {case.get(key)!r}, "
+                    f"expected {expected!r}"
+                )
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker shape sweep")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"shape count: {summary['shape_count']}")
+    print(f"labelled blockers covered: {summary['labelled_blocker_count']}")
+    print(f"nodes visited: {summary['total_nodes_visited']}")
+    print(f"incidence survivors: {summary['total_incidence_survivors']}")
+    print(
+        "all incidence survivors obstructed: "
+        f"{summary['all_incidence_survivors_obstructed']}"
+    )
+    print(f"status totals: {summary['vertex_circle_status_totals']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload()
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1373,6 +1373,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_shape_sweep",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_shape_sweep.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Natural-order n=9 exact-four row-option sweep over all 10 "
+            "dihedral classes of four-vertex blockers; all incidence "
+            "survivors are vertex-circle obstructed, but this is not a proof "
+            "of Erdos Problem #97 and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/src/erdos97/radius_blocker_packets.py
+++ b/src/erdos97/radius_blocker_packets.py
@@ -25,6 +25,7 @@ from erdos97.vertex_circle_quotient_replay import (
 Pair = tuple[int, int]
 Row = tuple[int, int, int, int]
 Rows = list[list[int]]
+Subset = tuple[int, ...]
 
 SCHEMA = "erdos97.radius_blocker_vertex_circle_packet.v1"
 STATUS = "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY"
@@ -35,6 +36,38 @@ CLAIM_SCOPE = (
     "not a proof of the adaptive blocker bridge, not a proof of Erdos Problem "
     "#97, and not a counterexample."
 )
+
+
+def dihedral_subset_images(n: int, subset: Iterable[int]) -> tuple[Subset, ...]:
+    """Return the cyclic-dihedral images of a labelled subset."""
+
+    subset_tuple = _validate_subset(n, subset)
+    images: set[Subset] = set()
+    for shift in range(n):
+        images.add(tuple(sorted((label + shift) % n for label in subset_tuple)))
+        images.add(tuple(sorted((shift - label) % n for label in subset_tuple)))
+    return tuple(sorted(images))
+
+
+def canonical_dihedral_subset(n: int, subset: Iterable[int]) -> Subset:
+    """Return the lexicographic cyclic-dihedral representative of ``subset``."""
+
+    return dihedral_subset_images(n, subset)[0]
+
+
+def dihedral_subset_representatives(n: int, size: int) -> tuple[Subset, ...]:
+    """Return labelled ``size``-subset representatives up to dihedral symmetry."""
+
+    if size < 0 or size > n:
+        raise ValueError(f"invalid subset size {size} for n={n}")
+    return tuple(
+        sorted(
+            {
+                canonical_dihedral_subset(n, subset)
+                for subset in combinations(range(n), size)
+            }
+        )
+    )
 
 
 @dataclass(frozen=True)
@@ -363,6 +396,18 @@ def _validate_order(order: Sequence[int], n: int) -> None:
         raise ValueError(
             f"cyclic order is not a permutation; missing={missing}, extra={extra}"
         )
+
+
+def _validate_subset(n: int, subset: Iterable[int]) -> Subset:
+    if n <= 0:
+        raise ValueError(f"expected positive n, got {n}")
+    subset_tuple = tuple(sorted(int(label) for label in subset))
+    if len(set(subset_tuple)) != len(subset_tuple):
+        raise ValueError(f"subset contains duplicate labels: {subset_tuple!r}")
+    bad = [label for label in subset_tuple if label < 0 or label >= n]
+    if bad:
+        raise ValueError(f"subset contains out-of-range labels: {bad}")
+    return subset_tuple
 
 
 def _pair(left: int, right: int) -> Pair:

--- a/tests/test_radius_blocker_packets.py
+++ b/tests/test_radius_blocker_packets.py
@@ -6,6 +6,9 @@ from erdos97.adaptive_blockers import first_blocker
 from erdos97.bridge_negative_controls import c13_sidon_rows
 from erdos97.radius_blocker_packets import (
     analyze_radius_blocker_packet,
+    canonical_dihedral_subset,
+    dihedral_subset_images,
+    dihedral_subset_representatives,
     exact_four_rich_classes_from_rows,
     full_exact_four_radius_blocker_rich_classes,
     row_options_from_rich_classes,
@@ -69,6 +72,25 @@ def test_full_exact_four_radius_blocker_options_enforce_blocker() -> None:
             len({0, 1, 2, 3}.intersection(row)) <= 2
             for row in rich_classes[center]
         )
+
+
+def test_dihedral_four_blocker_representatives_cover_n9_subsets() -> None:
+    representatives = dihedral_subset_representatives(9, 4)
+
+    assert representatives == (
+        (0, 1, 2, 3),
+        (0, 1, 2, 4),
+        (0, 1, 2, 5),
+        (0, 1, 3, 4),
+        (0, 1, 3, 5),
+        (0, 1, 3, 6),
+        (0, 1, 3, 7),
+        (0, 1, 4, 5),
+        (0, 1, 4, 6),
+        (0, 2, 4, 6),
+    )
+    assert sum(len(dihedral_subset_images(9, rep)) for rep in representatives) == 126
+    assert canonical_dihedral_subset(9, [5, 6, 7, 8]) == (0, 1, 2, 3)
 
 
 def test_large_rich_classes_are_rejected_until_semantics_are_added() -> None:


### PR DESCRIPTION
## Summary

- add a natural-order `n=9` exact-four radius-blocker shape sweep over all 10 cyclic-dihedral four-blocker representatives
- record `data/certificates/n9_radius_blocker_shape_sweep.json` with 1,358 incidence survivors, all obstructed by vertex-circle replay
- document the scope as finite packet evidence only, and wire the artifact into provenance/audit metadata

## Scope

This does not claim an `n=9` proof, a bridge proof, a counterexample, or any global Erdos Problem #97 status change. The sweep is fixed to the natural cyclic order and exact-four row-option semantics.

## Validation

- `python scripts/check_n9_radius_blocker_shape_sweep.py --write --assert-expected`
- `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1040 passed, 299 deselected`)
