### PR TITLE
[codex] Add n9 radius-blocker order reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ This repository is a public research log and reproducibility workspace for Erdő
   systems, read
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
 - For exact-four radius-blocker packet diagnostics, including the full
-  natural-order `n=9` blocker `{0,1,2,3}` packet and the natural-order
-  four-blocker shape sweep, read
+  natural-order `n=9` blocker `{0,1,2,3}` packet, the natural-order
+  four-blocker shape sweep, and its order-reduction crosswalk, read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
   [`docs/n9-full-radius-blocker-vertex-circle-packet.md`](docs/n9-full-radius-blocker-vertex-circle-packet.md)
   and
-  [`docs/n9-radius-blocker-shape-sweep.md`](docs/n9-radius-blocker-shape-sweep.md).
+  [`docs/n9-radius-blocker-shape-sweep.md`](docs/n9-radius-blocker-shape-sweep.md)
+  and
+  [`docs/n9-radius-blocker-order-reduction.md`](docs/n9-radius-blocker-order-reduction.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -278,6 +278,15 @@ a bridge proof, and not a counterexample. See
 `scripts/check_n9_radius_blocker_shape_sweep.py`, and
 `data/certificates/n9_radius_blocker_shape_sweep.json`.
 
+The order-reduction crosswalk for that sweep records the relabelling
+`order[i] -> i`, which sends any supplied cyclic order and four-blocker subset
+to a natural-order labelled four-blocker already covered by the shape sweep.
+This closes the cyclic-order placement gap only for the exact-four packet
+semantics; it does not handle richer classes and does not prove the bridge.
+See `docs/n9-radius-blocker-order-reduction.md`,
+`scripts/check_n9_radius_blocker_order_reduction_crosswalk.py`, and
+`data/certificates/n9_radius_blocker_order_reduction_crosswalk.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -174,6 +174,13 @@ incidence survivors are all vertex-circle obstructed (`1,164` self-edges and
 proof, a bridge proof, or a counterexample. See
 `docs/n9-radius-blocker-shape-sweep.md`.
 
+The order-reduction crosswalk records that any supplied cyclic order and
+four-blocker subset for this exact-four packet relabels to natural order by
+sending `order[i]` to `i`. Thus arbitrary cyclic-order placements of a
+four-blocker reduce to the stored `126` labelled natural-order blocker
+coverage, still only within the exact-four packet semantics. See
+`docs/n9-radius-blocker-order-reduction.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_order_reduction_crosswalk.json
+++ b/data/certificates/n9_radius_blocker_order_reduction_crosswalk.json
@@ -1,0 +1,307 @@
+{
+  "claim_scope": "Order-reduction crosswalk for the n=9 exact-four radius-blocker shape sweep. It records that any supplied cyclic order and four-blocker subset relabels to the natural-order labelled four-blocker coverage already stored in the shape sweep. This does not prove n=9, does not prove the adaptive blocker bridge, and is not a counterexample.",
+  "interpretation_warnings": [
+    "This is a relabelling crosswalk for exact-four row-option packets only.",
+    "It does not add richer-than-four rich-class semantics.",
+    "It does not classify arbitrary n=9 rich-class systems.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_order_reduction_crosswalk.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_shape_sweep.json",
+      "src/erdos97/radius_blocker_packets.py"
+    ]
+  },
+  "reduction_rule": {
+    "blocker_image": "the transformed blocker is sorted(label_map[label] for label in blocker)",
+    "label_map": "for a cyclic order order, send each label order[i] to i",
+    "why_this_matches_the_shape_sweep": "The exact-four row-option rule depends only on the center label and blocker membership. Under this relabelling, row options, row-pair crossing in the supplied order, witness-pair caps, indegree caps, and selected-distance vertex-circle replay are transported to the natural-order packet for the transformed blocker."
+  },
+  "sample_reductions": [
+    {
+      "blocker": [
+        0,
+        2,
+        6,
+        8
+      ],
+      "canonical_representative": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "natural_blocker": [
+        1,
+        2,
+        5,
+        8
+      ],
+      "order": [
+        3,
+        0,
+        8,
+        1,
+        4,
+        2,
+        5,
+        7,
+        6
+      ]
+    },
+    {
+      "blocker": [
+        1,
+        3,
+        4,
+        8
+      ],
+      "canonical_representative": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "natural_blocker": [
+        0,
+        2,
+        5,
+        8
+      ],
+      "order": [
+        4,
+        7,
+        1,
+        5,
+        0,
+        8,
+        2,
+        6,
+        3
+      ]
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        5,
+        7
+      ],
+      "canonical_representative": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "natural_blocker": [
+        4,
+        5,
+        6,
+        8
+      ],
+      "order": [
+        8,
+        6,
+        4,
+        2,
+        0,
+        7,
+        5,
+        3,
+        1
+      ]
+    }
+  ],
+  "schema": "erdos97.n9_radius_blocker_order_reduction_crosswalk.v1",
+  "shape_representatives": [
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "dihedral_orbit_size": 9,
+      "incidence_survivors": 90,
+      "vertex_circle_status_counts": {
+        "self_edge": 70,
+        "strict_cycle": 20
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "dihedral_orbit_size": 18,
+      "incidence_survivors": 118,
+      "vertex_circle_status_counts": {
+        "self_edge": 97,
+        "strict_cycle": 21
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "dihedral_orbit_size": 18,
+      "incidence_survivors": 111,
+      "vertex_circle_status_counts": {
+        "self_edge": 93,
+        "strict_cycle": 18
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "dihedral_orbit_size": 9,
+      "incidence_survivors": 148,
+      "vertex_circle_status_counts": {
+        "self_edge": 134,
+        "strict_cycle": 14
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "dihedral_orbit_size": 18,
+      "incidence_survivors": 142,
+      "vertex_circle_status_counts": {
+        "self_edge": 121,
+        "strict_cycle": 21
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "dihedral_orbit_size": 18,
+      "incidence_survivors": 141,
+      "vertex_circle_status_counts": {
+        "self_edge": 125,
+        "strict_cycle": 16
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "dihedral_orbit_size": 9,
+      "incidence_survivors": 136,
+      "vertex_circle_status_counts": {
+        "self_edge": 120,
+        "strict_cycle": 16
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "dihedral_orbit_size": 9,
+      "incidence_survivors": 168,
+      "vertex_circle_status_counts": {
+        "self_edge": 144,
+        "strict_cycle": 24
+      }
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "dihedral_orbit_size": 9,
+      "incidence_survivors": 158,
+      "vertex_circle_status_counts": {
+        "self_edge": 136,
+        "strict_cycle": 22
+      }
+    },
+    {
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "dihedral_orbit_size": 9,
+      "incidence_survivors": 146,
+      "vertex_circle_status_counts": {
+        "self_edge": 124,
+        "strict_cycle": 22
+      }
+    }
+  ],
+  "source_shape_sweep": {
+    "path": "data/certificates/n9_radius_blocker_shape_sweep.json",
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "sha256": "a5291621ebf8a3ef8cc7eb9502933ef768c4da81b314096ffaea68aa96b19100",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "summary": {
+      "all_cases_finished": true,
+      "all_cases_have_radius_blocker": true,
+      "all_dihedral_labelled_blockers_covered": true,
+      "all_incidence_survivors_obstructed": true,
+      "dihedral_orbit_size_counts": {
+        "18": 4,
+        "9": 6
+      },
+      "labelled_blocker_count": 126,
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "shape_count": 10,
+      "total_incidence_survivors": 1358,
+      "total_nodes_visited": 754505,
+      "vertex_circle_status_totals": {
+        "self_edge": 1164,
+        "strict_cycle": 194
+      }
+    },
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_ORDER_REDUCTION_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_labelled_four_blockers_covered": true,
+    "covered_labelled_blocker_count": 126,
+    "n": 9,
+    "order_reduction_scope": "Every supplied cyclic order and four-blocker subset relabels to natural order by sending order[i] to i.",
+    "sample_reduction_count": 3,
+    "source_shape_count": 10
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -136,8 +136,12 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected --json`,
    which checks all `10` cyclic-dihedral four-blocker shapes in the natural
    order and records `1,358` incidence survivors, all vertex-circle
-   obstructed. This is still finite packet evidence only; the next widening is
-   non-natural cyclic orders and richer-than-exact-four class semantics.
+   obstructed. The order-reduction crosswalk
+   `python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --check --assert-expected --json`
+   records that arbitrary cyclic-order placements of the same exact-four
+   four-blocker packet relabel to that natural-order shape sweep. This is
+   still finite packet evidence only; the next widening is
+   richer-than-exact-four class semantics.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-shape-sweep.md`](n9-radius-blocker-shape-sweep.md):
   natural-order exact-four row-option sweep over all `10` cyclic-dihedral
   four-blocker shapes; finite packet evidence only.
+- [`n9-radius-blocker-order-reduction.md`](n9-radius-blocker-order-reduction.md):
+  relabelling crosswalk reducing arbitrary cyclic-order placements of the
+  exact-four four-blocker packet to the natural-order shape sweep.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-full-radius-blocker-vertex-circle-packet.md
+++ b/docs/n9-full-radius-blocker-vertex-circle-packet.md
@@ -54,6 +54,8 @@ because the cyclic order and blocker subset are fixed and the packet is
 restricted to exact four-row classes.
 
 The dihedral blocker-placement widening is now recorded in
-`docs/n9-radius-blocker-shape-sweep.md`. The useful next widening is
-non-natural cyclic orders that arise from current stuck-set and fragile-cover
-searches, or a replay semantics for rich classes larger than four.
+`docs/n9-radius-blocker-shape-sweep.md`, and
+`docs/n9-radius-blocker-order-reduction.md` records why arbitrary cyclic-order
+placements of the same exact-four four-blocker packet reduce to that shape
+sweep. The useful next widening is a replay semantics for rich classes larger
+than four.

--- a/docs/n9-radius-blocker-order-reduction.md
+++ b/docs/n9-radius-blocker-order-reduction.md
@@ -1,0 +1,46 @@
+# n=9 radius-blocker order reduction
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet crosswalk. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note records the relabelling scope of
+`docs/n9-radius-blocker-shape-sweep.md`. For the exact-four radius-blocker
+packet, a supplied cyclic order and four-vertex blocker reduce to the natural
+order by the label map
+
+```text
+order[i] -> i.
+```
+
+The blocker becomes the sorted set of positions occupied by its vertices in
+that order. The exact-four row-option rule depends only on the center and
+blocker membership, so this relabelling transports row options, two-overlap
+crossing in the supplied order, witness-pair caps, indegree caps, and
+selected-distance vertex-circle replay to the natural-order packet for the
+transformed blocker.
+
+## Checked Crosswalk
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_order_reduction_crosswalk.json
+```
+
+Regenerate and verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --check --assert-expected
+```
+
+The crosswalk checks that the shape-sweep representatives cover all `126`
+labelled four-vertex blockers in natural order. Therefore, for this exact-four
+packet only, arbitrary cyclic-order placements of a four-blocker are reduced to
+the already checked natural-order shape sweep.
+
+## Interpretation
+
+This closes the cyclic-order placement gap for the full `n=9` exact-four
+four-blocker packet, not for arbitrary `n=9` rich-class systems. It still does
+not handle rich classes larger than four, and it does not prove that every
+hypothetical counterexample reduces to this packet.

--- a/docs/n9-radius-blocker-shape-sweep.md
+++ b/docs/n9-radius-blocker-shape-sweep.md
@@ -66,6 +66,8 @@ all dihedrally distinct four-vertex blocker shapes in the fixed natural order.
 It is still not a proof of the full adaptive blocker bridge, because the cyclic
 order is fixed and the packet is restricted to exact four-row rich classes.
 
-The useful next widening is non-natural cyclic orders or a rich-class replay
-semantics that handles classes larger than four without prematurely choosing
-one exact four-subset.
+The order-reduction crosswalk in `docs/n9-radius-blocker-order-reduction.md`
+records why arbitrary cyclic-order placements of a four-blocker reduce to this
+natural-order shape sweep for the exact-four packet. The useful next widening
+is therefore a rich-class replay semantics that handles classes larger than
+four without prematurely choosing one exact four-subset.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -569,8 +569,12 @@ condition that the surviving multi-block family does not automatically satisfy:
 - the natural-order `n=9` radius-blocker shape sweep recorded in
   `docs/n9-radius-blocker-shape-sweep.md`, where all `10` cyclic-dihedral
   four-blocker shapes have obstructed incidence survivors. This is finite
-  packet evidence only; the next review target is widening cyclic orders and
-  exact-four semantics.
+  packet evidence only.
+- the order-reduction crosswalk recorded in
+  `docs/n9-radius-blocker-order-reduction.md`, which reduces arbitrary
+  cyclic-order placements of the same exact-four four-blocker packet to the
+  natural-order shape sweep. The next review target is richer-than-exact-four
+  class semantics.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2868,6 +2868,39 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_order_reduction_crosswalk
+    path: data/certificates/n9_radius_blocker_order_reduction_crosswalk.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_order_reduction_crosswalk.py
+    command: python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_order_reduction_crosswalk.py
+    check_command: python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Order-reduction crosswalk for the n=9 exact-four radius-blocker shape sweep; arbitrary cyclic-order placements of a four-blocker reduce to the stored natural-order shape sweep, but this is not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_order_reduction_crosswalk.v1
+      status: N9_RADIUS_BLOCKER_ORDER_REDUCTION_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.source_shape_count: 10
+      summary.covered_labelled_blocker_count: 126
+      summary.all_labelled_four_blockers_covered: true
+      summary.sample_reduction_count: 3
+      source_shape_sweep.path: data/certificates/n9_radius_blocker_shape_sweep.json
+      provenance.command: python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - arbitrary rich-class systems reduce to exact-four packets
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_order_reduction_crosswalk.py
+++ b/scripts/check_n9_radius_blocker_order_reduction_crosswalk.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Check the order-reduction scope of the n=9 radius-blocker shape sweep.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from itertools import combinations
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.radius_blocker_packets import (  # noqa: E402
+    TRUST,
+    canonical_dihedral_subset,
+    dihedral_subset_images,
+    subset_positions_in_order,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_order_reduction_crosswalk.v1"
+STATUS = "N9_RADIUS_BLOCKER_ORDER_REDUCTION_DIAGNOSTIC_ONLY"
+DEFAULT_SHAPE_SWEEP = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_shape_sweep.json"
+)
+DEFAULT_OUT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_radius_blocker_order_reduction_crosswalk.json"
+)
+N = 9
+SAMPLE_ORDER_BLOCKERS = (
+    {
+        "order": [3, 0, 8, 1, 4, 2, 5, 7, 6],
+        "blocker": [0, 2, 6, 8],
+        "natural_blocker": [1, 2, 5, 8],
+        "canonical_representative": [0, 1, 3, 6],
+    },
+    {
+        "order": [4, 7, 1, 5, 0, 8, 2, 6, 3],
+        "blocker": [1, 3, 4, 8],
+        "natural_blocker": [0, 2, 5, 8],
+        "canonical_representative": [0, 1, 3, 6],
+    },
+    {
+        "order": [8, 6, 4, 2, 0, 7, 5, 3, 1],
+        "blocker": [0, 1, 5, 7],
+        "natural_blocker": [4, 5, 6, 8],
+        "canonical_representative": [0, 1, 2, 4],
+    },
+)
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "source_shape_count": 10,
+    "covered_labelled_blocker_count": 126,
+    "all_labelled_four_blockers_covered": True,
+    "sample_reduction_count": 3,
+    "order_reduction_scope": (
+        "Every supplied cyclic order and four-blocker subset relabels to "
+        "natural order by sending order[i] to i."
+    ),
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_shape_sweep(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise AssertionError("shape sweep artifact is not an object")
+    return payload
+
+
+def shape_cases(payload: Mapping[str, object]) -> list[Mapping[str, object]]:
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+    out: list[Mapping[str, object]] = []
+    for case in cases:
+        if not isinstance(case, Mapping):
+            raise AssertionError(f"shape sweep case is not an object: {case!r}")
+        out.append(case)
+    return out
+
+
+def compact_case_records(cases: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for case in cases:
+        records.append(
+            {
+                "blocker": list(case["blocker"]),
+                "dihedral_orbit_size": int(case["dihedral_orbit_size"]),
+                "incidence_survivors": int(case["incidence_survivors"]),
+                "vertex_circle_status_counts": dict(
+                    case["vertex_circle_status_counts"]
+                ),
+            }
+        )
+    return sorted(records, key=lambda record: record["blocker"])
+
+
+def sample_reductions() -> list[dict[str, object]]:
+    samples: list[dict[str, object]] = []
+    for sample in SAMPLE_ORDER_BLOCKERS:
+        order = sample["order"]
+        blocker = sample["blocker"]
+        natural_blocker = list(subset_positions_in_order(order, blocker))
+        canonical = list(canonical_dihedral_subset(N, natural_blocker))
+        samples.append(
+            {
+                "order": list(order),
+                "blocker": list(blocker),
+                "natural_blocker": natural_blocker,
+                "canonical_representative": canonical,
+            }
+        )
+    return samples
+
+
+def build_payload(shape_sweep_path: Path = DEFAULT_SHAPE_SWEEP) -> dict[str, object]:
+    """Build the deterministic order-reduction crosswalk payload."""
+
+    source = load_shape_sweep(shape_sweep_path)
+    cases = shape_cases(source)
+    representatives = [tuple(int(label) for label in case["blocker"]) for case in cases]
+    covered_labelled_blockers = sorted(
+        {
+            image
+            for representative in representatives
+            for image in dihedral_subset_images(N, representative)
+        }
+    )
+    all_labelled_blockers = sorted(combinations(range(N), 4))
+    samples = sample_reductions()
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Order-reduction crosswalk for the n=9 exact-four radius-blocker "
+            "shape sweep. It records that any supplied cyclic order and "
+            "four-blocker subset relabels to the natural-order labelled "
+            "four-blocker coverage already stored in the shape sweep. This "
+            "does not prove n=9, does not prove the adaptive blocker bridge, "
+            "and is not a counterexample."
+        ),
+        "summary": {
+            "n": N,
+            "source_shape_count": len(cases),
+            "covered_labelled_blocker_count": len(covered_labelled_blockers),
+            "all_labelled_four_blockers_covered": (
+                covered_labelled_blockers == all_labelled_blockers
+            ),
+            "sample_reduction_count": len(samples),
+            "order_reduction_scope": (
+                "Every supplied cyclic order and four-blocker subset relabels "
+                "to natural order by sending order[i] to i."
+            ),
+        },
+        "source_shape_sweep": {
+            "path": shape_sweep_path.relative_to(ROOT).as_posix(),
+            "schema": source.get("schema"),
+            "status": source.get("status"),
+            "trust": source.get("trust"),
+            "sha256": sha256_file(shape_sweep_path),
+            "summary": source.get("summary"),
+        },
+        "shape_representatives": compact_case_records(cases),
+        "sample_reductions": samples,
+        "reduction_rule": {
+            "label_map": "for a cyclic order order, send each label order[i] to i",
+            "blocker_image": (
+                "the transformed blocker is sorted(label_map[label] for label "
+                "in blocker)"
+            ),
+            "why_this_matches_the_shape_sweep": (
+                "The exact-four row-option rule depends only on the center "
+                "label and blocker membership. Under this relabelling, row "
+                "options, row-pair crossing in the supplied order, witness-pair "
+                "caps, indegree caps, and selected-distance vertex-circle "
+                "replay are transported to the natural-order packet for the "
+                "transformed blocker."
+            ),
+        },
+        "interpretation_warnings": [
+            "This is a relabelling crosswalk for exact-four row-option packets only.",
+            "It does not add richer-than-four rich-class semantics.",
+            "It does not classify arbitrary n=9 rich-class systems.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_order_reduction_crosswalk.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_shape_sweep.json",
+                "src/erdos97/radius_blocker_packets.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    if payload.get("sample_reductions") != list(SAMPLE_ORDER_BLOCKERS):
+        raise AssertionError("sample reductions changed")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker order-reduction crosswalk")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"source shapes: {summary['source_shape_count']}")
+    print(f"labelled blockers covered: {summary['covered_labelled_blocker_count']}")
+    print(
+        "all labelled four-blockers covered: "
+        f"{summary['all_labelled_four_blockers_covered']}"
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SHAPE_SWEEP)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.source)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1389,6 +1389,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_order_reduction_crosswalk",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_order_reduction_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Order-reduction crosswalk for the n=9 exact-four radius-blocker "
+            "shape sweep; arbitrary cyclic-order placements of a "
+            "four-blocker reduce to the stored natural-order shape sweep, "
+            "but this is not a proof of Erdos Problem #97 and not a "
+            "counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/src/erdos97/radius_blocker_packets.py
+++ b/src/erdos97/radius_blocker_packets.py
@@ -70,6 +70,20 @@ def dihedral_subset_representatives(n: int, size: int) -> tuple[Subset, ...]:
     )
 
 
+def subset_positions_in_order(order: Sequence[int], subset: Iterable[int]) -> Subset:
+    """Relabel ``subset`` by positions in ``order``.
+
+    The returned subset is the image of the original labels under the unique
+    relabelling that sends the supplied cyclic order to natural order.
+    """
+
+    order_tuple = tuple(int(label) for label in order)
+    _validate_order(order_tuple, len(order_tuple))
+    subset_tuple = _validate_subset(len(order_tuple), subset)
+    positions = {label: index for index, label in enumerate(order_tuple)}
+    return tuple(sorted(positions[label] for label in subset_tuple))
+
+
 @dataclass(frozen=True)
 class PacketConfig:
     """Search controls for a radius-blocker packet."""

--- a/tests/test_radius_blocker_packets.py
+++ b/tests/test_radius_blocker_packets.py
@@ -12,6 +12,7 @@ from erdos97.radius_blocker_packets import (
     exact_four_rich_classes_from_rows,
     full_exact_four_radius_blocker_rich_classes,
     row_options_from_rich_classes,
+    subset_positions_in_order,
 )
 
 
@@ -91,6 +92,14 @@ def test_dihedral_four_blocker_representatives_cover_n9_subsets() -> None:
     )
     assert sum(len(dihedral_subset_images(9, rep)) for rep in representatives) == 126
     assert canonical_dihedral_subset(9, [5, 6, 7, 8]) == (0, 1, 2, 3)
+
+
+def test_subset_positions_in_order_reduces_blocker_to_natural_order() -> None:
+    order = (3, 0, 8, 1, 4, 2, 5, 7, 6)
+    natural_blocker = subset_positions_in_order(order, [0, 2, 6, 8])
+
+    assert natural_blocker == (1, 2, 5, 8)
+    assert canonical_dihedral_subset(9, natural_blocker) == (0, 1, 3, 6)
 
 
 def test_large_rich_classes_are_rejected_until_semantics_are_added() -> None:


### PR DESCRIPTION
## Summary

- add a relabelling helper for sending a blocker in an arbitrary cyclic order to natural-order positions
- add a checked order-reduction crosswalk showing the merged shape sweep covers all 126 labelled four-blockers for the exact-four packet semantics
- document that arbitrary cyclic-order placements reduce to the natural-order shape sweep only within this exact-four packet scope

## Scope

This does not claim an `n=9` proof, a bridge proof, a counterexample, or that arbitrary rich-class systems reduce to exact-four packets. The new crosswalk only records relabelling coverage for the exact-four n=9 four-blocker packet.

## Validation

- `python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --write --assert-expected`
- `python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --check --assert-expected`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1041 passed, 299 deselected`)
