### PR TITLE
[codex] Add n9 rich-class projection pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For a partial bridge theorem from minimality to fragile-cover witness
   systems, read
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
-- For exact-four radius-blocker packet diagnostics, including the full
+- For radius-blocker packet diagnostics, including the full exact-four
   natural-order `n=9` blocker `{0,1,2,3}` packet, the natural-order
-  four-blocker shape sweep, and its order-reduction crosswalk, read
+  four-blocker shape sweep, its order-reduction crosswalk, and a bounded
+  richer-class projection pilot, read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
   [`docs/n9-full-radius-blocker-vertex-circle-packet.md`](docs/n9-full-radius-blocker-vertex-circle-packet.md)
   and
   [`docs/n9-radius-blocker-shape-sweep.md`](docs/n9-radius-blocker-shape-sweep.md)
   and
-  [`docs/n9-radius-blocker-order-reduction.md`](docs/n9-radius-blocker-order-reduction.md).
+  [`docs/n9-radius-blocker-order-reduction.md`](docs/n9-radius-blocker-order-reduction.md)
+  and
+  [`docs/n9-radius-blocker-rich-projection-pilot.md`](docs/n9-radius-blocker-rich-projection-pilot.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -287,6 +287,18 @@ See `docs/n9-radius-blocker-order-reduction.md`,
 `scripts/check_n9_radius_blocker_order_reduction_crosswalk.py`, and
 `data/certificates/n9_radius_blocker_order_reduction_crosswalk.json`.
 
+A bounded richer-class projection pilot starts from one checked `n=9`
+`{0,1,2,3}` obstruction example and enlarges every center row to one synthetic
+size-five rich class while preserving blocker compatibility. Expanding each
+larger class to all exact four-subsets gives projected row-option counts
+`[5,5,5,5,5,5,5,5,5]`, with raw upper bound `1,953,125`; after the same
+filters, the one incidence survivor is killed by a vertex-circle self-edge.
+This is a forgetful selected-row projection only, not full rich-class quotient
+replay, not an `n=9` theorem, not a bridge proof, and not a counterexample.
+See `docs/n9-radius-blocker-rich-projection-pilot.md`,
+`scripts/check_n9_radius_blocker_rich_projection_pilot.py`, and
+`data/certificates/n9_radius_blocker_rich_projection_pilot.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -181,6 +181,15 @@ four-blocker reduce to the stored `126` labelled natural-order blocker
 coverage, still only within the exact-four packet semantics. See
 `docs/n9-radius-blocker-order-reduction.md`.
 
+A bounded richer-class projection pilot enlarges one checked `n=9`
+`{0,1,2,3}` obstruction example so each center has one synthetic size-five
+rich class. Expanding each larger class to all exact four-subsets gives
+`5^9 = 1,953,125` projected selected-row choices; after incidence/order
+filters, the single survivor is vertex-circle obstructed. This is only a
+forgetful projection diagnostic, not full rich-class quotient replay, not an
+`n=9` proof, and not a counterexample. See
+`docs/n9-radius-blocker-rich-projection-pilot.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_rich_projection_pilot.json
+++ b/data/certificates/n9_radius_blocker_rich_projection_pilot.json
@@ -1,0 +1,842 @@
+{
+  "claim_scope": "Bounded n=9 radius-blocker projection pilot. Each center has one synthetic size-five rich class obtained from a checked exact-four obstructed source row by adding one label while preserving blocker compatibility. The replay expands each larger class to its exact four-subsets and checks only the projected selected-row packet; this is not a proof of n=9, not a proof of the adaptive blocker bridge, and not a counterexample.",
+  "expanded_centers": [
+    {
+      "added_label": 5,
+      "center": 0,
+      "projected_four_rows": [
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          1,
+          4,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          6
+        ]
+      ],
+      "rich_class": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ],
+      "source_exact_row": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "added_label": 0,
+      "center": 1,
+      "projected_four_rows": [
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          8
+        ],
+        [
+          0,
+          2,
+          7,
+          8
+        ],
+        [
+          0,
+          5,
+          7,
+          8
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ]
+      ],
+      "rich_class": [
+        0,
+        2,
+        5,
+        7,
+        8
+      ],
+      "source_exact_row": [
+        2,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "added_label": 5,
+      "center": 2,
+      "projected_four_rows": [
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ],
+        [
+          3,
+          4,
+          5,
+          8
+        ]
+      ],
+      "rich_class": [
+        1,
+        3,
+        4,
+        5,
+        8
+      ],
+      "source_exact_row": [
+        1,
+        3,
+        4,
+        8
+      ]
+    },
+    {
+      "added_label": 5,
+      "center": 3,
+      "projected_four_rows": [
+        [
+          0,
+          2,
+          4,
+          5
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ]
+      ],
+      "rich_class": [
+        0,
+        2,
+        4,
+        5,
+        7
+      ],
+      "source_exact_row": [
+        0,
+        2,
+        4,
+        7
+      ]
+    },
+    {
+      "added_label": 7,
+      "center": 4,
+      "projected_four_rows": [
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          5,
+          7
+        ],
+        [
+          0,
+          1,
+          6,
+          7
+        ],
+        [
+          0,
+          5,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          6,
+          7
+        ]
+      ],
+      "rich_class": [
+        0,
+        1,
+        5,
+        6,
+        7
+      ],
+      "source_exact_row": [
+        0,
+        1,
+        5,
+        6
+      ]
+    },
+    {
+      "added_label": 4,
+      "center": 5,
+      "projected_four_rows": [
+        [
+          2,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          3,
+          4,
+          8
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          3,
+          4,
+          6,
+          8
+        ]
+      ],
+      "rich_class": [
+        2,
+        3,
+        4,
+        6,
+        8
+      ],
+      "source_exact_row": [
+        2,
+        3,
+        6,
+        8
+      ]
+    },
+    {
+      "added_label": 4,
+      "center": 6,
+      "projected_four_rows": [
+        [
+          1,
+          3,
+          4,
+          5
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          4,
+          5,
+          7
+        ]
+      ],
+      "rich_class": [
+        1,
+        3,
+        4,
+        5,
+        7
+      ],
+      "source_exact_row": [
+        1,
+        3,
+        5,
+        7
+      ]
+    },
+    {
+      "added_label": 1,
+      "center": 7,
+      "projected_four_rows": [
+        [
+          0,
+          1,
+          4,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          8
+        ],
+        [
+          0,
+          1,
+          5,
+          8
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          1,
+          4,
+          5,
+          8
+        ]
+      ],
+      "rich_class": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ],
+      "source_exact_row": [
+        0,
+        4,
+        5,
+        8
+      ]
+    },
+    {
+      "added_label": 4,
+      "center": 8,
+      "projected_four_rows": [
+        [
+          0,
+          3,
+          4,
+          6
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ]
+      ],
+      "rich_class": [
+        0,
+        3,
+        4,
+        6,
+        7
+      ],
+      "source_exact_row": [
+        0,
+        3,
+        6,
+        7
+      ]
+    }
+  ],
+  "interpretation_warnings": [
+    "This is one bounded synthetic size-five rich-class packet only.",
+    "The replay checks the exact four-subset projection, not the full rich-class quotient.",
+    "The result does not classify arbitrary n=9 rich-class systems.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "projected_rich_classes": [
+    [
+      [
+        1,
+        2,
+        4,
+        5,
+        6
+      ]
+    ],
+    [
+      [
+        0,
+        2,
+        5,
+        7,
+        8
+      ]
+    ],
+    [
+      [
+        1,
+        3,
+        4,
+        5,
+        8
+      ]
+    ],
+    [
+      [
+        0,
+        2,
+        4,
+        5,
+        7
+      ]
+    ],
+    [
+      [
+        0,
+        1,
+        5,
+        6,
+        7
+      ]
+    ],
+    [
+      [
+        2,
+        3,
+        4,
+        6,
+        8
+      ]
+    ],
+    [
+      [
+        1,
+        3,
+        4,
+        5,
+        7
+      ]
+    ],
+    [
+      [
+        0,
+        1,
+        4,
+        5,
+        8
+      ]
+    ],
+    [
+      [
+        0,
+        3,
+        4,
+        6,
+        7
+      ]
+    ]
+  ],
+  "projection_rule": {
+    "forgetful_boundary": "The projection forgets equality constraints involving the vertices omitted from a chosen four-subset.",
+    "rule": "Each rich class contributes every exact four-subset as a candidate selected row for the existing finite packet replay.",
+    "why_blocker_is_preserved": "For centers in the blocker, the synthetic size-five class still intersects the blocker in at most two vertices."
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_rich_projection_pilot.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_rich_projection_pilot.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_shape_sweep.json",
+      "src/erdos97/radius_blocker_packets.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "result": {
+    "aborted": false,
+    "all_incidence_survivors_obstructed": true,
+    "blocker": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "claim_scope": "Finite exact-four-row radius-blocker packet diagnostic. It may obstruct the encoded row-option packet under the supplied cyclic order, but it is not a proof of the adaptive blocker bridge, not a proof of Erdos Problem #97, and not a counterexample.",
+    "incidence_survivors": 1,
+    "interpretation": "Diagnostic for this finite exact-four row-option packet only. A positive obstruction count does not prove the adaptive radius-blocker bridge or Erdos Problem #97.",
+    "n": 9,
+    "name": "n9_radius_blocker_size_five_projection_pilot_U0123_natural_order",
+    "nodes_visited": 20,
+    "obstruction_examples": {
+      "self_edge": [
+        {
+          "selected_rows": [
+            [
+              1,
+              2,
+              4,
+              6
+            ],
+            [
+              2,
+              5,
+              7,
+              8
+            ],
+            [
+              1,
+              3,
+              4,
+              8
+            ],
+            [
+              0,
+              2,
+              4,
+              7
+            ],
+            [
+              0,
+              1,
+              5,
+              6
+            ],
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              5,
+              7
+            ],
+            [
+              0,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              6,
+              7
+            ]
+          ],
+          "vertex_circle_replay": {
+            "cycle_edges": [],
+            "n": 9,
+            "obstructed": true,
+            "order": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8
+            ],
+            "selected_row_count": 9,
+            "self_edge_conflicts": [
+              {
+                "inner_class": [
+                  0,
+                  3
+                ],
+                "inner_interval": [
+                  0,
+                  1
+                ],
+                "inner_pair": [
+                  1,
+                  7
+                ],
+                "outer_class": [
+                  0,
+                  3
+                ],
+                "outer_interval": [
+                  0,
+                  2
+                ],
+                "outer_pair": [
+                  3,
+                  7
+                ],
+                "row": 6,
+                "witness_order": [
+                  7,
+                  1,
+                  3,
+                  5
+                ]
+              }
+            ],
+            "status": "self_edge",
+            "strict_edge_count": 81,
+            "type": "vertex_circle_quotient_replay_result"
+          }
+        }
+      ]
+    },
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "radius_blocker_ok": true,
+    "raw_selection_upper_bound": 1953125,
+    "rejection_counts": {
+      "column_pair_cap": 13,
+      "row_pair_cap": 68,
+      "two_overlap_crossing": 137
+    },
+    "row_option_counts": [
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5
+    ],
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "survivor_examples": [],
+    "trust": "REVIEW_PENDING_DIAGNOSTIC",
+    "vertex_circle_status_counts": {
+      "self_edge": 1
+    }
+  },
+  "schema": "erdos97.n9_radius_blocker_rich_projection_pilot.v1",
+  "source_selected_rows": [
+    [
+      1,
+      2,
+      4,
+      6
+    ],
+    [
+      2,
+      5,
+      7,
+      8
+    ],
+    [
+      1,
+      3,
+      4,
+      8
+    ],
+    [
+      0,
+      2,
+      4,
+      7
+    ],
+    [
+      0,
+      1,
+      5,
+      6
+    ],
+    [
+      2,
+      3,
+      6,
+      8
+    ],
+    [
+      1,
+      3,
+      5,
+      7
+    ],
+    [
+      0,
+      4,
+      5,
+      8
+    ],
+    [
+      0,
+      3,
+      6,
+      7
+    ]
+  ],
+  "source_shape_sweep": {
+    "path": "data/certificates/n9_radius_blocker_shape_sweep.json",
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "sha256": "a5291621ebf8a3ef8cc7eb9502933ef768c4da81b314096ffaea68aa96b19100",
+    "source_blocker": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "source_case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+    "source_case_vertex_circle_status_counts": {
+      "self_edge": 70,
+      "strict_cycle": 20
+    },
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_RICH_PROJECTION_PILOT_ONLY",
+  "summary": {
+    "all_projected_incidence_survivors_obstructed": true,
+    "blocker": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "expanded_center_count": 9,
+    "incidence_survivors": 1,
+    "max_rich_class_size": 5,
+    "n": 9,
+    "nodes_visited": 20,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "projected_raw_selection_upper_bound": 1953125,
+    "projected_row_option_counts": [
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5
+    ],
+    "radius_blocker_ok": true,
+    "rejection_counts": {
+      "column_pair_cap": 13,
+      "row_pair_cap": 68,
+      "two_overlap_crossing": 137
+    },
+    "vertex_circle_status_counts": {
+      "self_edge": 1
+    }
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -144,9 +144,14 @@ Use this queue when no more specific issue is selected.
    obstructed. The order-reduction crosswalk
    `python scripts/check_n9_radius_blocker_order_reduction_crosswalk.py --check --assert-expected --json`
    records that arbitrary cyclic-order placements of the same exact-four
-   four-blocker packet relabel to that natural-order shape sweep. This is
-   still finite packet evidence only; the next widening is
-   richer-than-exact-four class semantics.
+   four-blocker packet relabel to that natural-order shape sweep. The bounded
+   richer-class projection pilot
+   `python scripts/check_n9_radius_blocker_rich_projection_pilot.py --check --assert-expected --json`
+   expands one synthetic size-five class at each center to all exact
+   four-subsets and leaves one vertex-circle-obstructed incidence survivor.
+   This is still finite packet evidence only; the next widening is full
+   richer-than-exact-four quotient semantics, or a bridge lemma making such a
+   projection sound.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-order-reduction.md`](n9-radius-blocker-order-reduction.md):
   relabelling crosswalk reducing arbitrary cyclic-order placements of the
   exact-four four-blocker packet to the natural-order shape sweep.
+- [`n9-radius-blocker-rich-projection-pilot.md`](n9-radius-blocker-rich-projection-pilot.md):
+  bounded size-five richer-class projection pilot; finite packet evidence
+  only, not full rich-class quotient replay.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-radius-blocker-order-reduction.md
+++ b/docs/n9-radius-blocker-order-reduction.md
@@ -44,3 +44,7 @@ This closes the cyclic-order placement gap for the full `n=9` exact-four
 four-blocker packet, not for arbitrary `n=9` rich-class systems. It still does
 not handle rich classes larger than four, and it does not prove that every
 hypothetical counterexample reduces to this packet.
+
+The follow-up `docs/n9-radius-blocker-rich-projection-pilot.md` records one
+bounded size-five projection diagnostic. It is still not full rich-class
+quotient replay.

--- a/docs/n9-radius-blocker-rich-projection-pilot.md
+++ b/docs/n9-radius-blocker-rich-projection-pilot.md
@@ -1,0 +1,52 @@
+# n=9 radius-blocker richer-class projection pilot
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note records a first bounded check beyond the exact-four radius-blocker
+packet. It does not add full rich-class quotient semantics. Instead it uses a
+forgetful projection: a rich class of size larger than four contributes every
+exact four-subset as a possible selected row, and the existing finite packet
+replay checks those selected-row options.
+
+The pilot starts from the checked `U = {0,1,2,3}` obstruction example in
+`data/certificates/n9_radius_blocker_shape_sweep.json`. At every center, the
+source exact four-row is enlarged to one synthetic size-five rich class by
+adding a label that keeps the blocker condition valid for centers in `U`.
+Thus the projected packet has row-option counts
+
+```text
+[5,5,5,5,5,5,5,5,5],
+```
+
+for a raw upper bound of `5^9 = 1,953,125` selected-row projections.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_rich_projection_pilot.json
+```
+
+Regenerate and verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_rich_projection_pilot.py --check --assert-expected
+```
+
+The exact search visits `20` packet nodes after the incidence/order filters.
+It finds `1` incidence survivor, and that survivor is obstructed by
+selected-distance vertex-circle replay with status `self_edge`.
+
+## Projection Boundary
+
+This pilot is deliberately weaker than the missing rich-class bridge. The
+projection checks selected four-subsets of larger rich classes, but it forgets
+the equality data involving vertices omitted from a chosen four-subset. It
+therefore does not prove that arbitrary richer-than-four rich-class systems
+reduce to exact-four packets, and it does not classify `n=9`.
+
+The useful next target is a full rich-class quotient replay, or a bridge lemma
+showing that a suitable four-subset projection is sound for the obstruction
+being used.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -573,8 +573,12 @@ condition that the surviving multi-block family does not automatically satisfy:
 - the order-reduction crosswalk recorded in
   `docs/n9-radius-blocker-order-reduction.md`, which reduces arbitrary
   cyclic-order placements of the same exact-four four-blocker packet to the
-  natural-order shape sweep. The next review target is richer-than-exact-four
-  class semantics.
+  natural-order shape sweep.
+- the bounded richer-class projection pilot recorded in
+  `docs/n9-radius-blocker-rich-projection-pilot.md`, which expands one
+  synthetic size-five class at each center to exact four-subset row options.
+  This is finite packet evidence only; the next review target is full
+  richer-than-exact-four quotient semantics or a sound projection bridge.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2901,6 +2901,44 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_rich_projection_pilot
+    path: data/certificates/n9_radius_blocker_rich_projection_pilot.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_rich_projection_pilot.py
+    command: python scripts/check_n9_radius_blocker_rich_projection_pilot.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_rich_projection_pilot.py
+    check_command: python scripts/check_n9_radius_blocker_rich_projection_pilot.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Bounded n=9 radius-blocker richer-class projection pilot; one synthetic size-five rich class at every center is expanded to exact four-subset selected-row options and checked by the finite packet replay, but this is not full rich-class quotient replay, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_rich_projection_pilot.v1
+      status: N9_RADIUS_BLOCKER_RICH_PROJECTION_PILOT_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.expanded_center_count: 9
+      summary.max_rich_class_size: 5
+      summary.projected_raw_selection_upper_bound: 1953125
+      summary.radius_blocker_ok: true
+      summary.all_projected_incidence_survivors_obstructed: true
+      summary.nodes_visited: 20
+      summary.incidence_survivors: 1
+      summary.vertex_circle_status_counts.self_edge: 1
+      source_shape_sweep.path: data/certificates/n9_radius_blocker_shape_sweep.json
+      provenance.command: python scripts/check_n9_radius_blocker_rich_projection_pilot.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - arbitrary rich-class systems reduce to exact-four packets
+      - full rich-class quotient replay is implemented
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_rich_projection_pilot.py
+++ b/scripts/check_n9_radius_blocker_rich_projection_pilot.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Check a bounded n=9 radius-blocker richer-class projection pilot.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.radius_blocker_packets import (  # noqa: E402
+    TRUST,
+    PacketConfig,
+    analyze_radius_blocker_projection_packet,
+    exact_four_rich_classes_from_rows,
+    four_subset_options_from_rich_classes,
+    result_to_packet_json,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_rich_projection_pilot.v1"
+STATUS = "N9_RADIUS_BLOCKER_RICH_PROJECTION_PILOT_ONLY"
+DEFAULT_SHAPE_SWEEP = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_shape_sweep.json"
+)
+DEFAULT_OUT = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_rich_projection_pilot.json"
+)
+N = 9
+ORDER = list(range(N))
+SOURCE_BLOCKER = (0, 1, 2, 3)
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "blocker": [0, 1, 2, 3],
+    "expanded_center_count": 9,
+    "max_rich_class_size": 5,
+    "projected_row_option_counts": [5, 5, 5, 5, 5, 5, 5, 5, 5],
+    "projected_raw_selection_upper_bound": 1_953_125,
+    "radius_blocker_ok": True,
+    "all_projected_incidence_survivors_obstructed": True,
+    "nodes_visited": 20,
+    "incidence_survivors": 1,
+    "vertex_circle_status_counts": {"self_edge": 1},
+    "rejection_counts": {
+        "column_pair_cap": 13,
+        "row_pair_cap": 68,
+        "two_overlap_crossing": 137,
+    },
+}
+EXPECTED_EXPANSIONS = [
+    {
+        "center": 0,
+        "source_exact_row": [1, 2, 4, 6],
+        "added_label": 5,
+        "rich_class": [1, 2, 4, 5, 6],
+    },
+    {
+        "center": 1,
+        "source_exact_row": [2, 5, 7, 8],
+        "added_label": 0,
+        "rich_class": [0, 2, 5, 7, 8],
+    },
+    {
+        "center": 2,
+        "source_exact_row": [1, 3, 4, 8],
+        "added_label": 5,
+        "rich_class": [1, 3, 4, 5, 8],
+    },
+    {
+        "center": 3,
+        "source_exact_row": [0, 2, 4, 7],
+        "added_label": 5,
+        "rich_class": [0, 2, 4, 5, 7],
+    },
+    {
+        "center": 4,
+        "source_exact_row": [0, 1, 5, 6],
+        "added_label": 7,
+        "rich_class": [0, 1, 5, 6, 7],
+    },
+    {
+        "center": 5,
+        "source_exact_row": [2, 3, 6, 8],
+        "added_label": 4,
+        "rich_class": [2, 3, 4, 6, 8],
+    },
+    {
+        "center": 6,
+        "source_exact_row": [1, 3, 5, 7],
+        "added_label": 4,
+        "rich_class": [1, 3, 4, 5, 7],
+    },
+    {
+        "center": 7,
+        "source_exact_row": [0, 4, 5, 8],
+        "added_label": 1,
+        "rich_class": [0, 1, 4, 5, 8],
+    },
+    {
+        "center": 8,
+        "source_exact_row": [0, 3, 6, 7],
+        "added_label": 4,
+        "rich_class": [0, 3, 4, 6, 7],
+    },
+]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_shape_sweep(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise AssertionError("shape sweep artifact is not an object")
+    return payload
+
+
+def source_case(payload: Mapping[str, object]) -> Mapping[str, object]:
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+    for case in cases:
+        if not isinstance(case, Mapping):
+            raise AssertionError(f"shape sweep case is not an object: {case!r}")
+        if tuple(int(label) for label in case["blocker"]) == SOURCE_BLOCKER:
+            return case
+    raise AssertionError(f"missing source blocker case: {SOURCE_BLOCKER}")
+
+
+def source_selected_rows(case: Mapping[str, object]) -> list[list[int]]:
+    examples = case.get("obstruction_examples")
+    if not isinstance(examples, Mapping):
+        raise AssertionError("source case has no obstruction examples")
+    self_edge_examples = examples.get("self_edge")
+    if not isinstance(self_edge_examples, list) or not self_edge_examples:
+        raise AssertionError("source case has no self-edge example")
+    first = self_edge_examples[0]
+    if not isinstance(first, Mapping):
+        raise AssertionError("source self-edge example is not an object")
+    rows = first.get("selected_rows")
+    if not isinstance(rows, list):
+        raise AssertionError("source self-edge example has no selected rows")
+    return [[int(label) for label in row] for row in rows]
+
+
+def safe_extra_label(center: int, row: Sequence[int], blocker: Sequence[int]) -> int:
+    row_set = set(int(label) for label in row)
+    blocker_set = set(int(label) for label in blocker)
+    for label in range(N):
+        if label == center or label in row_set:
+            continue
+        if len((row_set | {label}) & blocker_set) <= 2:
+            return label
+    raise AssertionError(f"no safe size-five extension for center {center}")
+
+
+def build_projected_rich_classes(
+    rows: Sequence[Sequence[int]],
+    blocker: Sequence[int],
+) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    rich_classes = [list(classes) for classes in exact_four_rich_classes_from_rows(rows)]
+    for center, row in enumerate(rows):
+        extra = safe_extra_label(center, row, blocker)
+        rich_classes[center] = (tuple(sorted(set(row) | {extra})),)
+    return tuple(tuple(classes) for classes in rich_classes)
+
+
+def expansion_records(
+    rows: Sequence[Sequence[int]],
+    rich_classes: Sequence[Sequence[Sequence[int]]],
+    blocker: Sequence[int],
+) -> list[dict[str, object]]:
+    options = four_subset_options_from_rich_classes(rich_classes)
+    records: list[dict[str, object]] = []
+    for center, row in enumerate(rows):
+        rich_class = list(rich_classes[center][0])
+        records.append(
+            {
+                "center": center,
+                "source_exact_row": [int(label) for label in row],
+                "added_label": safe_extra_label(center, row, blocker),
+                "rich_class": rich_class,
+                "projected_four_rows": [list(option) for option in options[center]],
+            }
+        )
+    return records
+
+
+def build_payload(shape_sweep_path: Path = DEFAULT_SHAPE_SWEEP) -> dict[str, object]:
+    """Build the deterministic richer-class projection pilot payload."""
+
+    source = load_shape_sweep(shape_sweep_path)
+    case = source_case(source)
+    rows = source_selected_rows(case)
+    rich_classes = build_projected_rich_classes(rows, SOURCE_BLOCKER)
+    result = analyze_radius_blocker_projection_packet(
+        "n9_radius_blocker_size_five_projection_pilot_U0123_natural_order",
+        rich_classes,
+        SOURCE_BLOCKER,
+        ORDER,
+        PacketConfig(
+            max_nodes=100_000,
+            max_survivor_examples=1,
+            max_obstruction_examples_per_status=1,
+        ),
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Bounded n=9 radius-blocker projection pilot. Each center has "
+            "one synthetic size-five rich class obtained from a checked "
+            "exact-four obstructed source row by adding one label while "
+            "preserving blocker compatibility. The replay expands each "
+            "larger class to its exact four-subsets and checks only the "
+            "projected selected-row packet; this is not a proof of n=9, not "
+            "a proof of the adaptive blocker bridge, and not a counterexample."
+        ),
+        "summary": {
+            "n": N,
+            "order": ORDER,
+            "blocker": list(SOURCE_BLOCKER),
+            "expanded_center_count": len(rich_classes),
+            "max_rich_class_size": max(
+                len(rich_class)
+                for center_classes in rich_classes
+                for rich_class in center_classes
+            ),
+            "projected_row_option_counts": list(result.row_option_counts),
+            "projected_raw_selection_upper_bound": result.raw_selection_upper_bound,
+            "radius_blocker_ok": result.radius_blocker_ok,
+            "all_projected_incidence_survivors_obstructed": (
+                result.all_incidence_survivors_obstructed
+            ),
+            "nodes_visited": result.nodes_visited,
+            "incidence_survivors": result.incidence_survivors,
+            "vertex_circle_status_counts": dict(result.vertex_circle_status_counts),
+            "rejection_counts": dict(result.rejection_counts),
+        },
+        "source_shape_sweep": {
+            "path": shape_sweep_path.relative_to(ROOT).as_posix(),
+            "schema": source.get("schema"),
+            "status": source.get("status"),
+            "trust": source.get("trust"),
+            "sha256": sha256_file(shape_sweep_path),
+            "source_blocker": list(SOURCE_BLOCKER),
+            "source_case_name": case.get("name"),
+            "source_case_vertex_circle_status_counts": dict(
+                case["vertex_circle_status_counts"]
+            ),
+        },
+        "source_selected_rows": rows,
+        "projected_rich_classes": [
+            [list(rich_class) for rich_class in center_classes]
+            for center_classes in rich_classes
+        ],
+        "expanded_centers": expansion_records(rows, rich_classes, SOURCE_BLOCKER),
+        "projection_rule": {
+            "rule": (
+                "Each rich class contributes every exact four-subset as a "
+                "candidate selected row for the existing finite packet replay."
+            ),
+            "forgetful_boundary": (
+                "The projection forgets equality constraints involving the "
+                "vertices omitted from a chosen four-subset."
+            ),
+            "why_blocker_is_preserved": (
+                "For centers in the blocker, the synthetic size-five class "
+                "still intersects the blocker in at most two vertices."
+            ),
+        },
+        "result": result_to_packet_json(result),
+        "interpretation_warnings": [
+            "This is one bounded synthetic size-five rich-class packet only.",
+            "The replay checks the exact four-subset projection, not the full rich-class quotient.",
+            "The result does not classify arbitrary n=9 rich-class systems.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_rich_projection_pilot.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_rich_projection_pilot.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_shape_sweep.json",
+                "src/erdos97/radius_blocker_packets.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def compact_expansions(records: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    return [
+        {
+            "center": int(record["center"]),
+            "source_exact_row": list(record["source_exact_row"]),
+            "added_label": int(record["added_label"]),
+            "rich_class": list(record["rich_class"]),
+        }
+        for record in records
+    ]
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable richer-class projection pilot counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    records = payload.get("expanded_centers")
+    if not isinstance(records, list):
+        raise AssertionError("expanded center records are missing")
+    if compact_expansions(records) != EXPECTED_EXPANSIONS:
+        raise AssertionError("expanded center records changed")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker richer-class projection pilot")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"expanded centers: {summary['expanded_center_count']}")
+    print(f"row option counts: {summary['projected_row_option_counts']}")
+    print(f"raw projected selections: {summary['projected_raw_selection_upper_bound']}")
+    print(f"nodes visited: {summary['nodes_visited']}")
+    print(f"incidence survivors: {summary['incidence_survivors']}")
+    print(
+        "all projected incidence survivors obstructed: "
+        f"{summary['all_projected_incidence_survivors_obstructed']}"
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SHAPE_SWEEP)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.source)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1406,6 +1406,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_rich_projection_pilot",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_rich_projection_pilot.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Bounded n=9 radius-blocker richer-class projection pilot; one "
+            "synthetic size-five rich class at every center is expanded to "
+            "exact four-subset selected-row options and checked by finite "
+            "packet replay, but this is not full rich-class quotient replay, "
+            "not a proof of Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/src/erdos97/radius_blocker_packets.py
+++ b/src/erdos97/radius_blocker_packets.py
@@ -205,6 +205,32 @@ def row_options_from_rich_classes(rich_classes: RichClasses) -> tuple[tuple[Row,
     return tuple(options)
 
 
+def four_subset_options_from_rich_classes(
+    rich_classes: RichClasses,
+) -> tuple[tuple[Row, ...], ...]:
+    """Project arbitrary rich classes to deterministic four-subset row options.
+
+    This is a forgetful projection: a rich class of size larger than four
+    contributes every exact four-subset as a possible selected row, but the
+    replay does not retain the equality information involving omitted vertices.
+    """
+
+    validate_rich_classes(rich_classes)
+    options: list[tuple[Row, ...]] = []
+    for classes in rich_classes:
+        center_options: list[Row] = []
+        seen: set[Row] = set()
+        for rich_class in classes:
+            labels = tuple(sorted(int(label) for label in rich_class))
+            for row in combinations(labels, 4):
+                typed_row = (row[0], row[1], row[2], row[3])
+                if typed_row not in seen:
+                    seen.add(typed_row)
+                    center_options.append(typed_row)
+        options.append(tuple(center_options))
+    return tuple(options)
+
+
 def analyze_radius_blocker_packet(
     name: str,
     rich_classes: RichClasses,
@@ -216,13 +242,61 @@ def analyze_radius_blocker_packet(
 
     config = config or PacketConfig()
     options = row_options_from_rich_classes(rich_classes)
+    radius_blocker_ok = is_radius_blocker(rich_classes, blocker)
+    return _analyze_radius_blocker_options(
+        name,
+        options,
+        blocker,
+        order,
+        radius_blocker_ok,
+        config,
+    )
+
+
+def analyze_radius_blocker_projection_packet(
+    name: str,
+    rich_classes: RichClasses,
+    blocker: Sequence[int],
+    order: Sequence[int] | None = None,
+    config: PacketConfig | None = None,
+) -> RadiusBlockerPacketResult:
+    """Replay the four-subset projection of arbitrary rich classes.
+
+    The projection is a bounded diagnostic for selected-row obstruction only.
+    It does not replay the full quotient constraints of a larger rich distance
+    class, and a positive obstruction is not a bridge theorem.
+    """
+
+    config = config or PacketConfig()
+    options = four_subset_options_from_rich_classes(rich_classes)
+    radius_blocker_ok = is_radius_blocker(rich_classes, blocker)
+    return _analyze_radius_blocker_options(
+        name,
+        options,
+        blocker,
+        order,
+        radius_blocker_ok,
+        config,
+    )
+
+
+def _analyze_radius_blocker_options(
+    name: str,
+    options: Sequence[Sequence[Row]],
+    blocker: Sequence[int],
+    order: Sequence[int] | None,
+    radius_blocker_ok: bool,
+    config: PacketConfig,
+) -> RadiusBlockerPacketResult:
+    """Replay an already-expanded finite row-option packet."""
+
     n = len(options)
     if order is None:
         order = tuple(range(n))
     order_tuple = tuple(int(label) for label in order)
     _validate_order(order_tuple, n)
     blocker_tuple = tuple(sorted(int(label) for label in blocker))
-    radius_blocker_ok = is_radius_blocker(rich_classes, blocker_tuple)
+    option_tuple = tuple(tuple(row for row in center_options) for center_options in options)
 
     max_indegree = 2 * (n - 1) // 3
     assigned: dict[int, Row] = {}
@@ -298,7 +372,7 @@ def analyze_radius_blocker_packet(
             )
 
     def viable_options(center: int) -> list[Row]:
-        return [row for row in options[center] if row_is_valid(center, row)]
+        return [row for row in option_tuple[center] if row_is_valid(center, row)]
 
     def choose_center() -> tuple[int | None, list[Row]]:
         best_center: int | None = None
@@ -352,8 +426,8 @@ def analyze_radius_blocker_packet(
         order=order_tuple,
         blocker=blocker_tuple,
         radius_blocker_ok=radius_blocker_ok,
-        row_option_counts=tuple(len(rows) for rows in options),
-        raw_selection_upper_bound=prod(len(rows) for rows in options),
+        row_option_counts=tuple(len(rows) for rows in option_tuple),
+        raw_selection_upper_bound=prod(len(rows) for rows in option_tuple),
         nodes_visited=nodes_visited,
         incidence_survivors=incidence_survivors,
         aborted=aborted,

--- a/tests/test_n9_radius_blocker_rich_projection_pilot.py
+++ b/tests/test_n9_radius_blocker_rich_projection_pilot.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_radius_blocker_rich_projection_pilot import (  # noqa: E402
+    DEFAULT_OUT,
+    assert_expected_payload,
+    build_payload,
+)
+
+
+def test_n9_radius_blocker_rich_projection_pilot_matches_expected() -> None:
+    payload = build_payload()
+
+    assert_expected_payload(payload)
+
+
+def test_n9_radius_blocker_rich_projection_pilot_artifact_is_current() -> None:
+    checked_in = json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))
+
+    assert checked_in == build_payload()

--- a/tests/test_radius_blocker_packets.py
+++ b/tests/test_radius_blocker_packets.py
@@ -6,10 +6,12 @@ from erdos97.adaptive_blockers import first_blocker
 from erdos97.bridge_negative_controls import c13_sidon_rows
 from erdos97.radius_blocker_packets import (
     analyze_radius_blocker_packet,
+    analyze_radius_blocker_projection_packet,
     canonical_dihedral_subset,
     dihedral_subset_images,
     dihedral_subset_representatives,
     exact_four_rich_classes_from_rows,
+    four_subset_options_from_rich_classes,
     full_exact_four_radius_blocker_rich_classes,
     row_options_from_rich_classes,
     subset_positions_in_order,
@@ -51,6 +53,46 @@ def test_packet_accepts_multiple_exact_four_options() -> None:
     assert result.radius_blocker_ok
     assert result.row_option_counts[0] == 2
     assert result.raw_selection_upper_bound == 2
+    assert not result.aborted
+
+
+def test_projection_expands_larger_rich_classes_to_four_subsets() -> None:
+    rich_classes = (
+        ((1, 2, 3, 4, 5), (1, 2, 3, 4)),
+        ((0, 2, 3, 4),),
+        ((0, 1, 3, 4),),
+        ((0, 1, 2, 4),),
+        ((0, 1, 2, 3),),
+        ((0, 1, 2, 3),),
+    )
+
+    options = four_subset_options_from_rich_classes(rich_classes)
+
+    assert options[0] == (
+        (1, 2, 3, 4),
+        (1, 2, 3, 5),
+        (1, 2, 4, 5),
+        (1, 3, 4, 5),
+        (2, 3, 4, 5),
+    )
+    assert [len(rows) for rows in options] == [5, 1, 1, 1, 1, 1]
+
+
+def test_projection_packet_replays_larger_rich_class_options() -> None:
+    rows = c13_sidon_rows()
+    rich_classes = list(exact_four_rich_classes_from_rows(rows))
+    rich_classes[0] = ((1, 2, 4, 5, 10),)
+
+    result = analyze_radius_blocker_projection_packet(
+        "c13-row0-five-class-projection",
+        tuple(rich_classes),
+        [0, 1, 2, 3],
+        list(range(13)),
+    )
+
+    assert result.radius_blocker_ok
+    assert result.row_option_counts[0] == 5
+    assert result.raw_selection_upper_bound == 5
     assert not result.aborted
 
 


### PR DESCRIPTION
## Summary

- add explicit four-subset projection helpers for larger rich classes while keeping the existing exact-four replay strict
- add a bounded n=9 synthetic size-five radius-blocker projection pilot artifact and checker
- document the projection boundary in README/STATE/RESULTS/backlog/review notes and include the artifact in provenance/audit metadata

## Scope

This is finite packet evidence only. It does not implement full rich-class quotient replay, prove n=9, prove the adaptive blocker bridge, update official/global status, or claim a counterexample.

## Validation

- `python scripts/check_n9_radius_blocker_rich_projection_pilot.py --check --assert-expected --json`
- `python -m pytest tests/test_radius_blocker_packets.py tests/test_n9_radius_blocker_rich_projection_pilot.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1048 passed, 299 deselected`)
- artifact-tier commands from `AGENTS.md` run directly because `make verify-artifacts` is unavailable in this shell (`make` not installed); all direct commands passed.