### PR TITLE
[codex] Add rich-class vertex-circle replay pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   [`docs/minimal-fragile-cover-bridge.md`](docs/minimal-fragile-cover-bridge.md).
 - For radius-blocker packet diagnostics, including the full exact-four
   natural-order `n=9` blocker `{0,1,2,3}` packet, the natural-order
-  four-blocker shape sweep, its order-reduction crosswalk, and a bounded
-  richer-class projection pilot, read
+  four-blocker shape sweep, its order-reduction crosswalk, a bounded
+  richer-class projection pilot, and a full rich-class quotient replay pilot,
+  read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
   [`docs/n9-full-radius-blocker-vertex-circle-packet.md`](docs/n9-full-radius-blocker-vertex-circle-packet.md)
@@ -77,7 +78,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-radius-blocker-order-reduction.md`](docs/n9-radius-blocker-order-reduction.md)
   and
-  [`docs/n9-radius-blocker-rich-projection-pilot.md`](docs/n9-radius-blocker-rich-projection-pilot.md).
+  [`docs/n9-radius-blocker-rich-projection-pilot.md`](docs/n9-radius-blocker-rich-projection-pilot.md)
+  and
+  [`docs/n9-radius-blocker-rich-quotient-pilot.md`](docs/n9-radius-blocker-rich-quotient-pilot.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -299,6 +299,16 @@ See `docs/n9-radius-blocker-rich-projection-pilot.md`,
 `scripts/check_n9_radius_blocker_rich_projection_pilot.py`, and
 `data/certificates/n9_radius_blocker_rich_projection_pilot.json`.
 
+A full rich-class quotient replay now checks the same synthetic size-five
+family without choosing selected four-subsets. It unions all center-to-witness
+distances in each rich class and generates nested-chord inequalities from each
+full class. The resulting quotient has `225` strict edges and is obstructed by
+`193` self-edge conflicts. This is one finite rich-class family only, not an
+`n=9` theorem, not a bridge proof, and not a counterexample. See
+`docs/n9-radius-blocker-rich-quotient-pilot.md`,
+`scripts/check_n9_radius_blocker_rich_quotient_pilot.py`, and
+`data/certificates/n9_radius_blocker_rich_quotient_pilot.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -190,6 +190,14 @@ forgetful projection diagnostic, not full rich-class quotient replay, not an
 `n=9` proof, and not a counterexample. See
 `docs/n9-radius-blocker-rich-projection-pilot.md`.
 
+A full rich-class quotient replay now checks the same synthetic size-five
+family without choosing exact four-subsets. It unions every center-to-witness
+distance in each rich class and generates nested-chord inequalities from the
+full class. The resulting quotient has `225` strict edges and is obstructed by
+`193` self-edge conflicts. This is one finite rich-class family only, not an
+`n=9` proof or bridge proof. See
+`docs/n9-radius-blocker-rich-quotient-pilot.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_rich_quotient_pilot.json
+++ b/data/certificates/n9_radius_blocker_rich_quotient_pilot.json
@@ -1,0 +1,6792 @@
+{
+  "claim_scope": "Full rich-class vertex-circle quotient replay for the bounded n=9 synthetic size-five radius-blocker pilot. It checks this one finite rich-class family without choosing exact four-subsets, but it is not a proof of n=9, not a proof of the adaptive blocker bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This checks one synthetic size-five rich-class family only.",
+    "It is full quotient replay for that family, not a classification of n=9.",
+    "It does not prove the adaptive radius-blocker bridge.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_rich_quotient_pilot.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_rich_projection_pilot.json",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "replay": {
+    "cycle_edges": [],
+    "n": 9,
+    "obstructed": true,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "selected_row_count": 9,
+    "self_edge_conflicts": [
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          2
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          1,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 0,
+        "witness_order": [
+          1,
+          2,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          8
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          8
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          8
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          2,
+          8
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          0,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          2
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          7,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 1,
+        "witness_order": [
+          2,
+          5,
+          7,
+          8,
+          0
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          3,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          4,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          4,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          1,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          1,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          5,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          1,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 2,
+        "witness_order": [
+          3,
+          4,
+          5,
+          8,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          0,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          2,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          2
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          2
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          2,
+          5
+        ],
+        "row": 3,
+        "witness_order": [
+          4,
+          5,
+          7,
+          0,
+          2
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          5,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          5,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          0,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          1,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          6
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          0,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          1,
+          7
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          1,
+          7
+        ],
+        "row": 4,
+        "witness_order": [
+          5,
+          6,
+          7,
+          0,
+          1
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          3,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          6,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          3,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          3,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          4,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          4,
+          6
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          2,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          3,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          2,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          2,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          2,
+          4
+        ],
+        "row": 5,
+        "witness_order": [
+          6,
+          8,
+          2,
+          3,
+          4
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          3,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          1,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          3,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          1,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          3,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          7
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          1,
+          4
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          3,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          3,
+          5
+        ],
+        "row": 6,
+        "witness_order": [
+          7,
+          1,
+          3,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          1,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          1,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          4,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          1,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          4,
+          8
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          0,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          1,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          5,
+          8
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          0,
+          1
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          0,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          1,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          0,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          1,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          4,
+          5
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          1,
+          5
+        ],
+        "row": 7,
+        "witness_order": [
+          8,
+          0,
+          1,
+          4,
+          5
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          2
+        ],
+        "outer_pair": [
+          0,
+          4
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          0,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          3,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          3
+        ],
+        "outer_pair": [
+          0,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          1
+        ],
+        "inner_pair": [
+          0,
+          3
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          2
+        ],
+        "inner_pair": [
+          0,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          0,
+          3
+        ],
+        "inner_pair": [
+          0,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          3,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          4
+        ],
+        "inner_pair": [
+          3,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          0,
+          4
+        ],
+        "outer_pair": [
+          0,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          3
+        ],
+        "outer_pair": [
+          3,
+          6
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          2
+        ],
+        "inner_pair": [
+          3,
+          4
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          1,
+          3
+        ],
+        "inner_pair": [
+          3,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          4
+        ],
+        "inner_pair": [
+          4,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          1,
+          4
+        ],
+        "outer_pair": [
+          3,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          2,
+          3
+        ],
+        "inner_pair": [
+          4,
+          6
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "inner_class": [
+          0,
+          1
+        ],
+        "inner_interval": [
+          3,
+          4
+        ],
+        "inner_pair": [
+          6,
+          7
+        ],
+        "outer_class": [
+          0,
+          1
+        ],
+        "outer_interval": [
+          2,
+          4
+        ],
+        "outer_pair": [
+          4,
+          7
+        ],
+        "row": 8,
+        "witness_order": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ]
+      }
+    ],
+    "status": "self_edge",
+    "strict_edge_count": 225,
+    "type": "vertex_circle_quotient_replay_result"
+  },
+  "rich_rows": [
+    {
+      "center": 0,
+      "witnesses": [
+        1,
+        2,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "center": 1,
+      "witnesses": [
+        0,
+        2,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "center": 2,
+      "witnesses": [
+        1,
+        3,
+        4,
+        5,
+        8
+      ]
+    },
+    {
+      "center": 3,
+      "witnesses": [
+        0,
+        2,
+        4,
+        5,
+        7
+      ]
+    },
+    {
+      "center": 4,
+      "witnesses": [
+        0,
+        1,
+        5,
+        6,
+        7
+      ]
+    },
+    {
+      "center": 5,
+      "witnesses": [
+        2,
+        3,
+        4,
+        6,
+        8
+      ]
+    },
+    {
+      "center": 6,
+      "witnesses": [
+        1,
+        3,
+        4,
+        5,
+        7
+      ]
+    },
+    {
+      "center": 7,
+      "witnesses": [
+        0,
+        1,
+        4,
+        5,
+        8
+      ]
+    },
+    {
+      "center": 8,
+      "witnesses": [
+        0,
+        3,
+        4,
+        6,
+        7
+      ]
+    }
+  ],
+  "schema": "erdos97.n9_radius_blocker_rich_quotient_pilot.v1",
+  "self_edge_rows": {
+    "0": 19,
+    "1": 21,
+    "2": 16,
+    "3": 21,
+    "4": 25,
+    "5": 21,
+    "6": 20,
+    "7": 25,
+    "8": 25
+  },
+  "source_projection_pilot": {
+    "path": "data/certificates/n9_radius_blocker_rich_projection_pilot.json",
+    "schema": "erdos97.n9_radius_blocker_rich_projection_pilot.v1",
+    "sha256": "43948ead0c2e68a7206183115a25bf415f6ea8c739c404c24c68bcce25f93f37",
+    "status": "N9_RADIUS_BLOCKER_RICH_PROJECTION_PILOT_ONLY",
+    "summary": {
+      "all_projected_incidence_survivors_obstructed": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "expanded_center_count": 9,
+      "incidence_survivors": 1,
+      "max_rich_class_size": 5,
+      "n": 9,
+      "nodes_visited": 20,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "projected_raw_selection_upper_bound": 1953125,
+      "projected_row_option_counts": [
+        5,
+        5,
+        5,
+        5,
+        5,
+        5,
+        5,
+        5,
+        5
+      ],
+      "radius_blocker_ok": true,
+      "rejection_counts": {
+        "column_pair_cap": 13,
+        "row_pair_cap": 68,
+        "two_overlap_crossing": 137
+      },
+      "vertex_circle_status_counts": {
+        "self_edge": 1
+      }
+    },
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_RICH_QUOTIENT_PILOT_ONLY",
+  "summary": {
+    "cycle_edge_count": 0,
+    "first_self_edge_row": 0,
+    "max_rich_class_size": 5,
+    "n": 9,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "rich_class_count": 9,
+    "rich_class_sizes": [
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5,
+      5
+    ],
+    "self_edge_conflict_count": 193,
+    "strict_edge_count": 225,
+    "vertex_circle_status": "self_edge"
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -149,9 +149,13 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_radius_blocker_rich_projection_pilot.py --check --assert-expected --json`
    expands one synthetic size-five class at each center to all exact
    four-subsets and leaves one vertex-circle-obstructed incidence survivor.
-   This is still finite packet evidence only; the next widening is full
-   richer-than-exact-four quotient semantics, or a bridge lemma making such a
-   projection sound.
+   The full rich-class quotient pilot
+   `python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --check --assert-expected --json`
+   checks the same synthetic size-five family without choosing four-subsets:
+   it generates `225` strict edges and is blocked by `193` self-edge
+   conflicts. This is still finite packet evidence only; the next widening is
+   quantifying full richer-than-exact-four quotient replay over generated
+   radius-blocker rich-class packets.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-rich-projection-pilot.md`](n9-radius-blocker-rich-projection-pilot.md):
   bounded size-five richer-class projection pilot; finite packet evidence
   only, not full rich-class quotient replay.
+- [`n9-radius-blocker-rich-quotient-pilot.md`](n9-radius-blocker-rich-quotient-pilot.md):
+  full vertex-circle quotient replay for one synthetic size-five rich-class
+  family; still finite packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-radius-blocker-rich-projection-pilot.md
+++ b/docs/n9-radius-blocker-rich-projection-pilot.md
@@ -50,3 +50,7 @@ reduce to exact-four packets, and it does not classify `n=9`.
 The useful next target is a full rich-class quotient replay, or a bridge lemma
 showing that a suitable four-subset projection is sound for the obstruction
 being used.
+
+The follow-up `docs/n9-radius-blocker-rich-quotient-pilot.md` implements that
+full rich-class quotient replay for this same synthetic size-five family. It
+is still a one-family diagnostic, not a classification.

--- a/docs/n9-radius-blocker-rich-quotient-pilot.md
+++ b/docs/n9-radius-blocker-rich-quotient-pilot.md
@@ -1,0 +1,48 @@
+# n=9 radius-blocker rich-class quotient pilot
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note records a follow-up to
+`docs/n9-radius-blocker-rich-projection-pilot.md`. Instead of projecting each
+synthetic size-five rich class to selected exact four-subsets, it replays the
+vertex-circle quotient using the full rich classes:
+
+- center-to-witness distances are unioned across all witnesses in each rich
+  class;
+- nested-chord strict inequalities are generated from every rich class in its
+  cyclic witness order;
+- the resulting strict graph is checked for self-edges and directed cycles.
+
+This is full vertex-circle quotient replay for one finite rich-class family.
+It is not a classification of richer `n=9` systems and it is not a bridge
+proof.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_rich_quotient_pilot.json
+```
+
+Regenerate and verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --check --assert-expected
+```
+
+For the nine stored size-five classes, the full rich-class quotient has `225`
+strict vertex-circle edges. It is obstructed immediately by `193` self-edge
+conflicts; the first recorded conflict is in row `0`.
+
+## Boundary
+
+This closes one limitation of the projection pilot: the replay no longer
+forgets equality information inside the selected size-five classes. It still
+checks only one synthetic rich-class family, so it does not prove the adaptive
+radius-blocker bridge, `n=9`, or Erdos Problem #97.
+
+The useful next target is to quantify this full rich-class quotient replay
+over a generated family of radius-blocker rich-class packets rather than one
+stored pilot family.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -577,8 +577,11 @@ condition that the surviving multi-block family does not automatically satisfy:
 - the bounded richer-class projection pilot recorded in
   `docs/n9-radius-blocker-rich-projection-pilot.md`, which expands one
   synthetic size-five class at each center to exact four-subset row options.
-  This is finite packet evidence only; the next review target is full
-  richer-than-exact-four quotient semantics or a sound projection bridge.
+- the full rich-class quotient replay pilot recorded in
+  `docs/n9-radius-blocker-rich-quotient-pilot.md`, which checks the same
+  synthetic size-five family without choosing four-subsets. This is finite
+  packet evidence only; the next review target is quantifying that replay over
+  generated radius-blocker rich-class packets.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2939,6 +2939,40 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_rich_quotient_pilot
+    path: data/certificates/n9_radius_blocker_rich_quotient_pilot.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_rich_quotient_pilot.py
+    command: python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_rich_quotient_pilot.py
+    check_command: python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Full rich-class vertex-circle quotient replay for one bounded n=9 synthetic size-five radius-blocker family; checks the full class equalities and nested-chord inequalities without choosing exact four-subsets, but this is not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_rich_quotient_pilot.v1
+      status: N9_RADIUS_BLOCKER_RICH_QUOTIENT_PILOT_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.rich_class_count: 9
+      summary.max_rich_class_size: 5
+      summary.vertex_circle_status: self_edge
+      summary.strict_edge_count: 225
+      summary.self_edge_conflict_count: 193
+      source_projection_pilot.path: data/certificates/n9_radius_blocker_rich_projection_pilot.json
+      provenance.command: python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - arbitrary rich-class systems are classified
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_rich_quotient_pilot.py
+++ b/scripts/check_n9_radius_blocker_rich_quotient_pilot.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Check full rich-class vertex-circle replay on the n=9 size-five pilot.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.radius_blocker_packets import TRUST  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    RichClassRow,
+    replay_vertex_circle_rich_quotient,
+    result_to_json,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_rich_quotient_pilot.v1"
+STATUS = "N9_RADIUS_BLOCKER_RICH_QUOTIENT_PILOT_ONLY"
+DEFAULT_SOURCE = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_rich_projection_pilot.json"
+)
+DEFAULT_OUT = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_rich_quotient_pilot.json"
+)
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "rich_class_count": 9,
+    "max_rich_class_size": 5,
+    "vertex_circle_status": "self_edge",
+    "strict_edge_count": 225,
+    "self_edge_conflict_count": 193,
+    "cycle_edge_count": 0,
+    "first_self_edge_row": 0,
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_projection_payload(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise AssertionError("projection pilot artifact is not an object")
+    return payload
+
+
+def rich_rows_from_payload(payload: Mapping[str, object]) -> list[RichClassRow]:
+    raw_classes = payload.get("projected_rich_classes")
+    if not isinstance(raw_classes, list):
+        raise AssertionError("projection pilot has no rich classes")
+    rows: list[RichClassRow] = []
+    for center, center_classes in enumerate(raw_classes):
+        if not isinstance(center_classes, list) or len(center_classes) != 1:
+            raise AssertionError(f"center {center} does not have one rich class")
+        rich_class = center_classes[0]
+        if not isinstance(rich_class, list):
+            raise AssertionError(f"center {center} rich class is not a list")
+        rows.append(
+            RichClassRow(
+                center=center,
+                witnesses=tuple(int(label) for label in rich_class),
+            )
+        )
+    return rows
+
+
+def order_from_payload(payload: Mapping[str, object]) -> list[int]:
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("projection pilot has no summary")
+    order = summary.get("order")
+    if not isinstance(order, list):
+        raise AssertionError("projection pilot summary has no order")
+    return [int(label) for label in order]
+
+
+def build_payload(source: Path = DEFAULT_SOURCE) -> dict[str, object]:
+    """Build the deterministic full rich-class quotient pilot payload."""
+
+    projection = load_projection_payload(source)
+    rich_rows = rich_rows_from_payload(projection)
+    order = order_from_payload(projection)
+    n = len(order)
+    replay = replay_vertex_circle_rich_quotient(n, order, rich_rows)
+    class_sizes = [len(row.witnesses) for row in rich_rows]
+    self_edge_rows = Counter(edge.row for edge in replay.self_edge_conflicts)
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Full rich-class vertex-circle quotient replay for the bounded "
+            "n=9 synthetic size-five radius-blocker pilot. It checks this "
+            "one finite rich-class family without choosing exact four-subsets, "
+            "but it is not a proof of n=9, not a proof of the adaptive "
+            "blocker bridge, and not a counterexample."
+        ),
+        "summary": {
+            "n": n,
+            "order": order,
+            "rich_class_count": len(rich_rows),
+            "rich_class_sizes": class_sizes,
+            "max_rich_class_size": max(class_sizes),
+            "vertex_circle_status": replay.status,
+            "strict_edge_count": replay.strict_edge_count,
+            "self_edge_conflict_count": len(replay.self_edge_conflicts),
+            "cycle_edge_count": len(replay.cycle_edges),
+            "first_self_edge_row": (
+                replay.self_edge_conflicts[0].row
+                if replay.self_edge_conflicts
+                else None
+            ),
+        },
+        "source_projection_pilot": {
+            "path": source.relative_to(ROOT).as_posix(),
+            "schema": projection.get("schema"),
+            "status": projection.get("status"),
+            "trust": projection.get("trust"),
+            "sha256": sha256_file(source),
+            "summary": projection.get("summary"),
+        },
+        "rich_rows": [
+            {
+                "center": row.center,
+                "witnesses": list(row.witnesses),
+            }
+            for row in rich_rows
+        ],
+        "self_edge_rows": {
+            str(row): int(self_edge_rows[row]) for row in sorted(self_edge_rows)
+        },
+        "replay": result_to_json(replay),
+        "interpretation_warnings": [
+            "This checks one synthetic size-five rich-class family only.",
+            "It is full quotient replay for that family, not a classification of n=9.",
+            "It does not prove the adaptive radius-blocker bridge.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_rich_quotient_pilot.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_rich_quotient_pilot.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_rich_projection_pilot.json",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable full rich-class quotient pilot counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker full rich-class quotient pilot")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"rich classes: {summary['rich_class_count']}")
+    print(f"status: {summary['vertex_circle_status']}")
+    print(f"strict edges: {summary['strict_edge_count']}")
+    print(f"self-edge conflicts: {summary['self_edge_conflict_count']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.source)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1423,6 +1423,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_rich_quotient_pilot",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_rich_quotient_pilot.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Full rich-class vertex-circle quotient replay for one bounded "
+            "n=9 synthetic size-five radius-blocker family; checks the full "
+            "class equalities and nested-chord inequalities without choosing "
+            "exact four-subsets, but this is not a proof of Erdos Problem "
+            "#97 and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/src/erdos97/vertex_circle_quotient_replay.py
+++ b/src/erdos97/vertex_circle_quotient_replay.py
@@ -23,6 +23,12 @@ class SelectedRow:
 
 
 @dataclass(frozen=True)
+class RichClassRow:
+    center: int
+    witnesses: tuple[int, ...]
+
+
+@dataclass(frozen=True)
 class StrictInequality:
     row: int
     witness_order: tuple[int, ...]
@@ -211,6 +217,42 @@ def replay_vertex_circle_quotient(
     )
 
 
+def replay_vertex_circle_rich_quotient(
+    n: int,
+    order: Sequence[int],
+    rows: Sequence[RichClassRow],
+) -> QuotientReplayResult:
+    """Check the vertex-circle quotient graph for supplied rich classes.
+
+    Each row represents one exact distance class at ``center`` with at least
+    four witnesses.  The quotient unions all center-witness distances inside
+    the class and adds nested-chord inequalities from the full witness set.
+    """
+
+    order_tuple = tuple(int(label) for label in order)
+    _validate_order(n, order_tuple)
+    _validate_rich_rows(n, rows)
+    uf = _distance_class_union_find(n, rows)
+    strict_edges = _strict_inequalities(n, order_tuple, rows, uf)
+    self_edges = tuple(edge for edge in strict_edges if edge.outer_class == edge.inner_class)
+    cycle_edges = () if self_edges else tuple(_find_strict_cycle(strict_edges))
+    if self_edges:
+        status = "self_edge"
+    elif cycle_edges:
+        status = "strict_cycle"
+    else:
+        status = "ok"
+    return QuotientReplayResult(
+        n=n,
+        order=order_tuple,
+        selected_row_count=len(rows),
+        strict_edge_count=len(strict_edges),
+        status=status,
+        self_edge_conflicts=self_edges,
+        cycle_edges=cycle_edges,
+    )
+
+
 def result_to_json(result: QuotientReplayResult) -> dict[str, Any]:
     """Return a JSON-safe replay result."""
     return {
@@ -289,7 +331,26 @@ def _validate_rows(n: int, rows: Sequence[SelectedRow]) -> None:
             raise ValueError(f"row {row.center} has witness out of range: {bad[0]}")
 
 
-def _distance_class_union_find(n: int, rows: Sequence[SelectedRow]) -> UnionFind:
+def _validate_rich_rows(n: int, rows: Sequence[RichClassRow]) -> None:
+    for index, row in enumerate(rows):
+        if row.center < 0 or row.center >= n:
+            raise ValueError(f"rich row center out of range: {row.center}")
+        witnesses = set(row.witnesses)
+        if len(witnesses) != len(row.witnesses):
+            raise ValueError(f"rich row {index} has repeated witnesses")
+        if len(witnesses) < 4:
+            raise ValueError(f"rich row {index} has fewer than four witnesses")
+        if row.center in witnesses:
+            raise ValueError(f"rich row {index} includes its own center")
+        bad = [label for label in witnesses if label < 0 or label >= n]
+        if bad:
+            raise ValueError(f"rich row {index} has witness out of range: {bad[0]}")
+
+
+def _distance_class_union_find(
+    n: int,
+    rows: Sequence[SelectedRow | RichClassRow],
+) -> UnionFind:
     uf = UnionFind(_all_pairs(n))
     for row in rows:
         base = pair(row.center, row.witnesses[0])
@@ -301,7 +362,7 @@ def _distance_class_union_find(n: int, rows: Sequence[SelectedRow]) -> UnionFind
 def _strict_inequalities(
     n: int,
     order: Sequence[int],
-    rows: Sequence[SelectedRow],
+    rows: Sequence[SelectedRow | RichClassRow],
     uf: UnionFind,
 ) -> list[StrictInequality]:
     positions = {label: idx for idx, label in enumerate(order)}
@@ -310,10 +371,11 @@ def _strict_inequalities(
         witnesses = tuple(
             sorted(row.witnesses, key=lambda witness: (positions[witness] - positions[row.center]) % n)
         )
-        for outer_start in range(4):
-            for outer_end in range(outer_start + 1, 4):
-                for inner_start in range(4):
-                    for inner_end in range(inner_start + 1, 4):
+        witness_count = len(witnesses)
+        for outer_start in range(witness_count):
+            for outer_end in range(outer_start + 1, witness_count):
+                for inner_start in range(witness_count):
+                    for inner_end in range(inner_start + 1, witness_count):
                         if (outer_start, outer_end) == (inner_start, inner_end):
                             continue
                         contains = (

--- a/tests/test_n9_radius_blocker_rich_quotient_pilot.py
+++ b/tests/test_n9_radius_blocker_rich_quotient_pilot.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_radius_blocker_rich_quotient_pilot import (  # noqa: E402
+    DEFAULT_OUT,
+    assert_expected_payload,
+    build_payload,
+)
+
+
+def test_n9_radius_blocker_rich_quotient_pilot_matches_expected() -> None:
+    payload = build_payload()
+
+    assert_expected_payload(payload)
+
+
+def test_n9_radius_blocker_rich_quotient_pilot_artifact_is_current() -> None:
+    checked_in = json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))
+
+    assert checked_in == build_payload()

--- a/tests/test_vertex_circle_quotient_replay.py
+++ b/tests/test_vertex_circle_quotient_replay.py
@@ -7,14 +7,19 @@ from pathlib import Path
 from erdos97.search import built_in_patterns
 from erdos97.vertex_circle_order_filter import vertex_circle_order_obstruction
 from erdos97.vertex_circle_quotient_replay import (
+    RichClassRow,
     parse_selected_rows,
     replay_local_core_bundle,
+    replay_vertex_circle_rich_quotient,
     replay_vertex_circle_quotient,
 )
 
 
 ROOT = Path(__file__).resolve().parents[1]
 LOCAL_CORES = ROOT / "data" / "certificates" / "n9_vertex_circle_local_cores.json"
+RICH_PROJECTION_PILOT = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_rich_projection_pilot.json"
+)
 
 P18_CROSSING_COMPATIBLE_ORDER = [
     0,
@@ -119,6 +124,45 @@ def test_full_pattern_replay_matches_existing_vertex_circle_filter() -> None:
     assert replay.status == "strict_cycle"
     assert replay.strict_edge_count == existing.strict_edge_count == 162
     assert len(replay.cycle_edges) == len(existing.cycle_edges)
+
+
+def test_rich_quotient_matches_exact_four_selected_rows() -> None:
+    pattern = built_in_patterns()["P18_parity_balanced"]
+    rows = parse_selected_rows(pattern.S)
+    rich_rows = [
+        RichClassRow(center=row.center, witnesses=row.witnesses)
+        for row in rows
+    ]
+
+    selected_replay = replay_vertex_circle_quotient(
+        len(pattern.S),
+        P18_CROSSING_COMPATIBLE_ORDER,
+        rows,
+    )
+    rich_replay = replay_vertex_circle_rich_quotient(
+        len(pattern.S),
+        P18_CROSSING_COMPATIBLE_ORDER,
+        rich_rows,
+    )
+
+    assert rich_replay.status == selected_replay.status == "strict_cycle"
+    assert rich_replay.strict_edge_count == selected_replay.strict_edge_count
+    assert len(rich_replay.cycle_edges) == len(selected_replay.cycle_edges)
+
+
+def test_rich_quotient_obstructs_size_five_projection_pilot_classes() -> None:
+    payload = json.loads(RICH_PROJECTION_PILOT.read_text(encoding="utf-8"))
+    rich_rows = [
+        RichClassRow(center=center, witnesses=tuple(center_classes[0]))
+        for center, center_classes in enumerate(payload["projected_rich_classes"])
+    ]
+
+    replay = replay_vertex_circle_rich_quotient(9, payload["summary"]["order"], rich_rows)
+
+    assert replay.status == "self_edge"
+    assert replay.strict_edge_count == 225
+    assert replay.self_edge_conflicts
+    assert replay.self_edge_conflicts[0].row == 0
 
 
 def test_replay_allows_known_c19_vertex_circle_survivor_order() -> None:


### PR DESCRIPTION
## Summary

- add `RichClassRow` and full rich-class vertex-circle quotient replay, which unions all center-to-witness distances in each rich class and generates nested-chord inequalities over the full witness set
- add a checked n=9 rich-class quotient pilot for the size-five radius-blocker family introduced in #550
- document the new full-quotient boundary in README/STATE/RESULTS/backlog/review docs and add provenance/audit metadata

## Scope

This checks one finite synthetic size-five rich-class family without choosing exact four-subsets. It does not classify arbitrary n=9 rich-class systems, prove n=9, prove the adaptive blocker bridge, update official/global status, or claim a counterexample.

## Validation

- `python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --check --assert-expected --json`
- `python -m pytest tests/test_vertex_circle_quotient_replay.py tests/test_n9_radius_blocker_rich_quotient_pilot.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1052 passed, 299 deselected`)
- replay-heavy artifact checks: rich projection pilot, full exact-four radius-blocker packet, n9 vertex-circle exhaustive, and n9 radius-blocker shape sweep all passed

`make verify-artifacts` remains unavailable in this Windows shell because `make` is not installed; direct artifact commands were used instead.