### PR TITLE
[codex] Add rich-class radius-blocker quotient sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For radius-blocker packet diagnostics, including the full exact-four
   natural-order `n=9` blocker `{0,1,2,3}` packet, the natural-order
   four-blocker shape sweep, its order-reduction crosswalk, a bounded
-  richer-class projection pilot, and a full rich-class quotient replay pilot,
+  richer-class projection pilot, a full rich-class quotient replay pilot, and
+  a generated rich-class quotient sweep,
   read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
@@ -80,7 +81,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-radius-blocker-rich-projection-pilot.md`](docs/n9-radius-blocker-rich-projection-pilot.md)
   and
-  [`docs/n9-radius-blocker-rich-quotient-pilot.md`](docs/n9-radius-blocker-rich-quotient-pilot.md).
+  [`docs/n9-radius-blocker-rich-quotient-pilot.md`](docs/n9-radius-blocker-rich-quotient-pilot.md)
+  and
+  [`docs/n9-radius-blocker-rich-quotient-sweep.md`](docs/n9-radius-blocker-rich-quotient-sweep.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -309,6 +309,18 @@ full class. The resulting quotient has `225` strict edges and is obstructed by
 `scripts/check_n9_radius_blocker_rich_quotient_pilot.py`, and
 `data/certificates/n9_radius_blocker_rich_quotient_pilot.json`.
 
+A generated rich-class quotient sweep widens that full replay to `20`
+synthetic size-five packets, one stored self-edge example and one stored
+strict-cycle example for each of the `10` natural-order four-blocker shapes.
+The sweep checks `180` size-five rich classes and `4,500` strict edges; all
+`20` packets are quotient-obstructed by self-edges, with `3,533` total
+self-edge conflicts. This remains generated finite packet evidence only, not
+arbitrary rich-class classification, not an `n=9` theorem, not a bridge proof,
+and not a counterexample. See
+`docs/n9-radius-blocker-rich-quotient-sweep.md`,
+`scripts/check_n9_radius_blocker_rich_quotient_sweep.py`, and
+`data/certificates/n9_radius_blocker_rich_quotient_sweep.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -198,6 +198,15 @@ full class. The resulting quotient has `225` strict edges and is obstructed by
 `n=9` proof or bridge proof. See
 `docs/n9-radius-blocker-rich-quotient-pilot.md`.
 
+A generated rich-class quotient sweep now repeats the same full replay over
+`20` synthetic size-five packets derived from the stored self-edge and
+strict-cycle obstruction examples for the `10` natural-order four-blocker
+shapes. All `20` generated packets are obstructed by quotient self-edges, with
+`3,533` total self-edge conflicts across `4,500` strict edges. This remains
+finite packet evidence only, not arbitrary rich-class classification, not an
+`n=9` proof, and not a bridge proof. See
+`docs/n9-radius-blocker-rich-quotient-sweep.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_rich_quotient_sweep.json
+++ b/data/certificates/n9_radius_blocker_rich_quotient_sweep.json
@@ -1,0 +1,5764 @@
+{
+  "claim_scope": "Bounded n=9 full rich-class quotient sweep. It enlarges each stored shape-sweep obstruction example to one synthetic size-five rich class per center, preserving the actual radius-blocker condition, and replays the full rich quotient. This is finite packet evidence only: it is not an n=9 proof, not a proof of the adaptive blocker bridge, and not a counterexample.",
+  "expansion_rule": {
+    "preference": "Among labels preserving the actual blocker condition, choose the first label that also keeps the class below three blocker vertices when such a label exists; otherwise choose the first actual-condition-preserving label.",
+    "radius_blocker_boundary": "When the row center is inside the blocker, the added label must keep the rich class below three blocker vertices. For centers outside the blocker, the radius-blocker definition does not constrain blocker intersection.",
+    "rule": "For each stored exact-four source row, add one deterministic extra label to make a size-five rich class."
+  },
+  "interpretation_warnings": [
+    "This checks only synthetic size-five packets generated from stored examples.",
+    "It does not enumerate arbitrary rich-class catalogues.",
+    "It does not prove the adaptive radius-blocker bridge.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "packets": [
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "case_index": 0,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 7,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            4
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ]
+        },
+        "self_edge_conflict_count": 193,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "case_index": 0,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 4,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            3,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            4
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 178,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "case_index": 1,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            4,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 4,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 173,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "case_index": 1,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            2,
+            3,
+            4,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 4,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            5,
+            6
+          ]
+        },
+        "self_edge_conflict_count": 168,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "case_index": 2,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 4,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 5,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 4,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 163,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "case_index": 2,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            4,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            3,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 4,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 156,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "case_index": 3,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            3,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 3,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 200,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "case_index": 3,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 4,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 4,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            5
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 151,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "case_index": 4,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 7,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 3,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 207,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "case_index": 4,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            4
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ]
+        },
+        "self_edge_conflict_count": 192,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "case_index": 5,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 7,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 6,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 4,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 188,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "case_index": 5,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 4,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 175,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "case_index": 6,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 177,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "case_index": 6,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            4,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 4,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 155,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "case_index": 7,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            3,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 4,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 190,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "case_index": 7,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 3,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 6,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            4,
+            5,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 148,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "case_index": 8,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 6,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 3,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 176,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "case_index": 8,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 4,
+          "center": 2,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 6,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            3,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 170,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    },
+    {
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "case_index": 9,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 4,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            3,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 4,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 6,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 4,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:self_edge:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 184,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_status": "self_edge"
+    },
+    {
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "case_index": 9,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "expansion_records": [
+        {
+          "added_label": 3,
+          "blocker_intersection_size": 2,
+          "center": 0,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 1,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            2,
+            3,
+            5,
+            8
+          ],
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "added_label": 5,
+          "blocker_intersection_size": 2,
+          "center": 2,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            3,
+            4,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 3,
+          "inside_blocker_center": false,
+          "rich_class": [
+            1,
+            2,
+            4,
+            5,
+            7
+          ],
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 2,
+          "center": 4,
+          "inside_blocker_center": true,
+          "rich_class": [
+            1,
+            2,
+            3,
+            6,
+            8
+          ],
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 3,
+          "center": 5,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "added_label": 0,
+          "blocker_intersection_size": 1,
+          "center": 6,
+          "inside_blocker_center": true,
+          "rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "added_label": 1,
+          "blocker_intersection_size": 3,
+          "center": 7,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "added_label": 2,
+          "blocker_intersection_size": 2,
+          "center": 8,
+          "inside_blocker_center": false,
+          "rich_class": [
+            0,
+            1,
+            2,
+            3,
+            7
+          ],
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:strict_cycle:0",
+      "radius_blocker_ok": true,
+      "replay_summary": {
+        "cycle_edge_count": 0,
+        "first_self_edge": {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            1,
+            2
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            3
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ]
+        },
+        "self_edge_conflict_count": 189,
+        "strict_edge_count": 225,
+        "vertex_circle_status": "self_edge"
+      },
+      "source_example_index": 0,
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle"
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_shape_sweep.json",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "schema": "erdos97.n9_radius_blocker_rich_quotient_sweep.v1",
+  "source_shape_sweep": {
+    "path": "data/certificates/n9_radius_blocker_shape_sweep.json",
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "sha256": "a5291621ebf8a3ef8cc7eb9502933ef768c4da81b314096ffaea68aa96b19100",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "summary": {
+      "all_cases_finished": true,
+      "all_cases_have_radius_blocker": true,
+      "all_dihedral_labelled_blockers_covered": true,
+      "all_incidence_survivors_obstructed": true,
+      "dihedral_orbit_size_counts": {
+        "18": 4,
+        "9": 6
+      },
+      "labelled_blocker_count": 126,
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "shape_count": 10,
+      "total_incidence_survivors": 1358,
+      "total_nodes_visited": 754505,
+      "vertex_circle_status_totals": {
+        "self_edge": 1164,
+        "strict_cycle": 194
+      }
+    },
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_RICH_QUOTIENT_SWEEP_ONLY",
+  "summary": {
+    "all_packets_obstructed": true,
+    "all_packets_radius_blockers": true,
+    "first_self_edge_row_counts": {
+      "0": 20
+    },
+    "max_rich_class_size": 5,
+    "max_self_edge_conflict_count": 207,
+    "min_self_edge_conflict_count": 148,
+    "n": 9,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "packet_count": 20,
+    "packet_max_blocker_intersection_size_counts": {
+      "2": 1,
+      "3": 3,
+      "4": 16
+    },
+    "quotient_status_counts": {
+      "self_edge": 20
+    },
+    "rich_class_count_total": 180,
+    "source_shape_count": 10,
+    "source_status_counts": {
+      "self_edge": 10,
+      "strict_cycle": 10
+    },
+    "total_self_edge_conflict_count": 3533,
+    "total_strict_edge_count": 4500
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -153,9 +153,14 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --check --assert-expected --json`
    checks the same synthetic size-five family without choosing four-subsets:
    it generates `225` strict edges and is blocked by `193` self-edge
-   conflicts. This is still finite packet evidence only; the next widening is
-   quantifying full richer-than-exact-four quotient replay over generated
-   radius-blocker rich-class packets.
+   conflicts. The generated rich-class quotient sweep
+   `python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected --json`
+   repeats the full replay over `20` size-five packets derived from the stored
+   self-edge and strict-cycle obstruction examples for all `10` four-blocker
+   shapes; all `20` are quotient-obstructed by self-edges. This is still
+   finite packet evidence only; the next widening is a principled
+   rich-class catalogue or bridge hypothesis rather than synthetic examples
+   generated from stored exact-four obstructions.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,6 +163,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-rich-quotient-pilot.md`](n9-radius-blocker-rich-quotient-pilot.md):
   full vertex-circle quotient replay for one synthetic size-five rich-class
   family; still finite packet evidence only.
+- [`n9-radius-blocker-rich-quotient-sweep.md`](n9-radius-blocker-rich-quotient-sweep.md):
+  generated full rich-class quotient replay over the stored shape-sweep
+  obstruction examples; finite packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-radius-blocker-rich-quotient-pilot.md
+++ b/docs/n9-radius-blocker-rich-quotient-pilot.md
@@ -43,6 +43,6 @@ forgets equality information inside the selected size-five classes. It still
 checks only one synthetic rich-class family, so it does not prove the adaptive
 radius-blocker bridge, `n=9`, or Erdos Problem #97.
 
-The useful next target is to quantify this full rich-class quotient replay
-over a generated family of radius-blocker rich-class packets rather than one
-stored pilot family.
+The follow-up `docs/n9-radius-blocker-rich-quotient-sweep.md` quantifies this
+full rich-class quotient replay over generated size-five packets derived from
+the stored shape-sweep obstruction examples.

--- a/docs/n9-radius-blocker-rich-quotient-sweep.md
+++ b/docs/n9-radius-blocker-rich-quotient-sweep.md
@@ -1,0 +1,47 @@
+# n=9 radius-blocker rich-class quotient sweep
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note widens `docs/n9-radius-blocker-rich-quotient-pilot.md` from one
+synthetic size-five rich-class family to a generated packet family. The input is
+the stored natural-order `n=9` radius-blocker shape sweep. For each of the `10`
+four-blocker shapes, the sweep takes the stored self-edge obstruction example
+and the stored strict-cycle obstruction example, then enlarges every exact
+four-row to one synthetic size-five rich class.
+
+The enlargement rule preserves the actual radius-blocker condition: if a row
+center is inside the blocker, the enlarged rich class must still contain fewer
+than three blocker vertices. For centers outside the blocker, blocker
+intersection is recorded but is not constrained by the radius-blocker
+definition.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_rich_quotient_sweep.json
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected --json
+```
+
+The sweep checks `20` generated packets, with `180` total size-five rich
+classes. Each packet has `225` full rich-class strict vertex-circle edges.
+All `20` packets are obstructed by quotient self-edges, for `3,533` total
+self-edge conflicts. The first self-edge row is row `0` in every packet.
+
+## Boundary
+
+This is full rich-class quotient replay for generated examples, not an
+enumeration of arbitrary rich-class catalogues. It does not prove that all
+radius-blockers are impossible, does not prove `n=9`, does not prove the
+adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
+
+The next useful widening is to generate richer packets from a principled
+rich-class catalogue or bridge hypothesis, rather than from the two stored
+obstruction examples per exact-four blocker shape.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -580,8 +580,14 @@ condition that the surviving multi-block family does not automatically satisfy:
 - the full rich-class quotient replay pilot recorded in
   `docs/n9-radius-blocker-rich-quotient-pilot.md`, which checks the same
   synthetic size-five family without choosing four-subsets. This is finite
-  packet evidence only; the next review target is quantifying that replay over
-  generated radius-blocker rich-class packets.
+  packet evidence only.
+- the generated full rich-class quotient sweep recorded in
+  `docs/n9-radius-blocker-rich-quotient-sweep.md`, which quantifies that
+  replay over `20` synthetic size-five packets derived from the stored
+  self-edge and strict-cycle obstruction examples for all `10` four-blocker
+  shapes. This is still generated finite packet evidence only; the next review
+  target is a principled rich-class catalogue or bridge hypothesis rather than
+  examples generated from stored exact-four obstructions.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -2973,6 +2973,45 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_rich_quotient_sweep
+    path: data/certificates/n9_radius_blocker_rich_quotient_sweep.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_rich_quotient_sweep.py
+    command: python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_rich_quotient_sweep.py
+    check_command: python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Generated full rich-class quotient replay for 20 synthetic size-five n=9 radius-blocker packets derived from stored shape-sweep obstruction examples; finite packet evidence only, not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_rich_quotient_sweep.v1
+      status: N9_RADIUS_BLOCKER_RICH_QUOTIENT_SWEEP_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.source_shape_count: 10
+      summary.packet_count: 20
+      summary.rich_class_count_total: 180
+      summary.max_rich_class_size: 5
+      summary.all_packets_radius_blockers: true
+      summary.quotient_status_counts.self_edge: 20
+      summary.all_packets_obstructed: true
+      summary.total_strict_edge_count: 4500
+      summary.total_self_edge_conflict_count: 3533
+      summary.packet_max_blocker_intersection_size_counts.4: 16
+      source_shape_sweep.path: data/certificates/n9_radius_blocker_shape_sweep.json
+      provenance.command: python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - arbitrary rich-class systems are classified
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_rich_quotient_sweep.py
+++ b/scripts/check_n9_radius_blocker_rich_quotient_sweep.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Check full rich-class quotient replay over generated n=9 blocker packets.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.adaptive_blockers import is_radius_blocker  # noqa: E402
+from erdos97.radius_blocker_packets import TRUST  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    RichClassRow,
+    StrictInequality,
+    replay_vertex_circle_rich_quotient,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_rich_quotient_sweep.v1"
+STATUS = "N9_RADIUS_BLOCKER_RICH_QUOTIENT_SWEEP_ONLY"
+DEFAULT_SOURCE = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_shape_sweep.json"
+)
+DEFAULT_OUT = (
+    ROOT / "data" / "certificates" / "n9_radius_blocker_rich_quotient_sweep.json"
+)
+N = 9
+ORDER = list(range(N))
+SOURCE_STATUS_ORDER = ("self_edge", "strict_cycle")
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "source_shape_count": 10,
+    "packet_count": 20,
+    "source_status_counts": {"self_edge": 10, "strict_cycle": 10},
+    "rich_class_count_total": 180,
+    "max_rich_class_size": 5,
+    "all_packets_radius_blockers": True,
+    "quotient_status_counts": {"self_edge": 20},
+    "all_packets_obstructed": True,
+    "total_strict_edge_count": 4500,
+    "total_self_edge_conflict_count": 3533,
+    "min_self_edge_conflict_count": 148,
+    "max_self_edge_conflict_count": 207,
+    "first_self_edge_row_counts": {"0": 20},
+    "packet_max_blocker_intersection_size_counts": {"2": 1, "3": 3, "4": 16},
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_shape_sweep(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise AssertionError("shape sweep artifact is not an object")
+    return payload
+
+
+def ordered_source_statuses(examples: Mapping[str, object]) -> list[str]:
+    """Return stable source statuses, putting known statuses first."""
+
+    known = [status for status in SOURCE_STATUS_ORDER if status in examples]
+    rest = sorted(status for status in examples if status not in SOURCE_STATUS_ORDER)
+    return known + rest
+
+
+def source_examples(payload: Mapping[str, object]) -> list[dict[str, object]]:
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+    records: list[dict[str, object]] = []
+    for case_index, raw_case in enumerate(cases):
+        if not isinstance(raw_case, Mapping):
+            raise AssertionError(f"shape sweep case {case_index} is not an object")
+        examples = raw_case.get("obstruction_examples")
+        if not isinstance(examples, Mapping):
+            raise AssertionError(f"shape sweep case {case_index} has no examples")
+        for status in ordered_source_statuses(examples):
+            raw_examples = examples[status]
+            if not isinstance(raw_examples, list):
+                raise AssertionError(f"examples for {status!r} are not a list")
+            for example_index, raw_example in enumerate(raw_examples):
+                if not isinstance(raw_example, Mapping):
+                    raise AssertionError("source obstruction example is not an object")
+                rows = raw_example.get("selected_rows")
+                if not isinstance(rows, list):
+                    raise AssertionError("source example has no selected rows")
+                records.append(
+                    {
+                        "case_index": case_index,
+                        "case_name": raw_case.get("name"),
+                        "blocker": [int(label) for label in raw_case["blocker"]],
+                        "source_status": status,
+                        "source_example_index": example_index,
+                        "source_selected_rows": [
+                            [int(label) for label in row] for row in rows
+                        ],
+                    }
+                )
+    return records
+
+
+def extra_label_candidates(
+    center: int,
+    row: Sequence[int],
+    blocker: Sequence[int],
+) -> list[int]:
+    row_set = set(int(label) for label in row)
+    blocker_set = set(int(label) for label in blocker)
+    candidates: list[int] = []
+    for label in range(N):
+        if label == center or label in row_set:
+            continue
+        if center in blocker_set and len((row_set | {label}) & blocker_set) >= 3:
+            continue
+        candidates.append(label)
+    return candidates
+
+
+def choose_extra_label(center: int, row: Sequence[int], blocker: Sequence[int]) -> int:
+    """Choose a deterministic size-five extension preserving blocker status.
+
+    The radius-blocker condition only constrains centers inside the blocker.
+    For continuity with the earlier pilot, prefer an added label that also
+    keeps the enlarged class below three blocker vertices when such a label
+    exists.
+    """
+
+    row_set = set(int(label) for label in row)
+    blocker_set = set(int(label) for label in blocker)
+    candidates = extra_label_candidates(center, row, blocker)
+    for label in candidates:
+        if len((row_set | {label}) & blocker_set) <= 2:
+            return label
+    if candidates:
+        return candidates[0]
+    raise AssertionError(f"no safe size-five extension for center {center}")
+
+
+def rich_rows_from_source(
+    selected_rows: Sequence[Sequence[int]],
+    blocker: Sequence[int],
+) -> tuple[list[RichClassRow], list[dict[str, object]]]:
+    blocker_set = set(int(label) for label in blocker)
+    rich_rows: list[RichClassRow] = []
+    expansion_records: list[dict[str, object]] = []
+    for center, row in enumerate(selected_rows):
+        row_list = [int(label) for label in row]
+        added = choose_extra_label(center, row_list, blocker)
+        rich_class = tuple(sorted(set(row_list) | {added}))
+        intersection_size = len(set(rich_class) & blocker_set)
+        rich_rows.append(RichClassRow(center=center, witnesses=rich_class))
+        expansion_records.append(
+            {
+                "center": center,
+                "source_exact_row": row_list,
+                "added_label": added,
+                "rich_class": list(rich_class),
+                "blocker_intersection_size": intersection_size,
+                "inside_blocker_center": center in blocker_set,
+            }
+        )
+    return rich_rows, expansion_records
+
+
+def rich_classes_for_blocker(rows: Sequence[RichClassRow]) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    return tuple((row.witnesses,) for row in rows)
+
+
+def counter_to_json(counter: Counter[object]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter, key=lambda item: str(item))}
+
+
+def strict_inequality_to_json(edge: StrictInequality) -> dict[str, object]:
+    return {
+        "row": edge.row,
+        "witness_order": list(edge.witness_order),
+        "outer_interval": list(edge.outer_interval),
+        "inner_interval": list(edge.inner_interval),
+        "outer_pair": list(edge.outer_pair),
+        "inner_pair": list(edge.inner_pair),
+        "outer_class": list(edge.outer_class),
+        "inner_class": list(edge.inner_class),
+    }
+
+
+def build_packet_record(source: Mapping[str, object]) -> dict[str, object]:
+    blocker = [int(label) for label in source["blocker"]]
+    selected_rows = source["source_selected_rows"]
+    if not isinstance(selected_rows, list):
+        raise AssertionError("source selected rows are missing")
+    rich_rows, expansions = rich_rows_from_source(selected_rows, blocker)
+    radius_blocker_ok = is_radius_blocker(rich_classes_for_blocker(rich_rows), blocker)
+    replay = replay_vertex_circle_rich_quotient(N, ORDER, rich_rows)
+    first_self_edge = (
+        strict_inequality_to_json(replay.self_edge_conflicts[0])
+        if replay.self_edge_conflicts
+        else None
+    )
+
+    return {
+        "packet_id": (
+            f"{source['case_name']}:{source['source_status']}:"
+            f"{source['source_example_index']}"
+        ),
+        "case_index": source["case_index"],
+        "case_name": source["case_name"],
+        "blocker": blocker,
+        "source_status": source["source_status"],
+        "source_example_index": source["source_example_index"],
+        "source_selected_rows": selected_rows,
+        "expansion_records": expansions,
+        "radius_blocker_ok": radius_blocker_ok,
+        "replay_summary": {
+            "vertex_circle_status": replay.status,
+            "strict_edge_count": replay.strict_edge_count,
+            "self_edge_conflict_count": len(replay.self_edge_conflicts),
+            "cycle_edge_count": len(replay.cycle_edges),
+            "first_self_edge": first_self_edge,
+        },
+    }
+
+
+def build_summary(records: Sequence[Mapping[str, object]], source_shape_count: int) -> dict[str, object]:
+    source_status_counts: Counter[str] = Counter()
+    quotient_status_counts: Counter[str] = Counter()
+    first_self_edge_rows: Counter[int | None] = Counter()
+    max_blocker_intersections: Counter[int] = Counter()
+    self_edge_counts: list[int] = []
+    total_strict_edges = 0
+    rich_class_total = 0
+    max_rich_class_size = 0
+
+    for record in records:
+        source_status_counts[str(record["source_status"])] += 1
+        replay_summary = record["replay_summary"]
+        if not isinstance(replay_summary, Mapping):
+            raise AssertionError("packet has no replay summary")
+        quotient_status_counts[str(replay_summary["vertex_circle_status"])] += 1
+        total_strict_edges += int(replay_summary["strict_edge_count"])
+        self_edge_counts.append(int(replay_summary["self_edge_conflict_count"]))
+        first_edge = replay_summary["first_self_edge"]
+        first_self_edge_rows[
+            int(first_edge["row"]) if isinstance(first_edge, Mapping) else None
+        ] += 1
+        expansions = record["expansion_records"]
+        if not isinstance(expansions, list):
+            raise AssertionError("packet has no expansion records")
+        rich_class_total += len(expansions)
+        max_blocker_intersections[
+            max(int(expansion["blocker_intersection_size"]) for expansion in expansions)
+        ] += 1
+        max_rich_class_size = max(
+            max_rich_class_size,
+            max(len(expansion["rich_class"]) for expansion in expansions),
+        )
+
+    return {
+        "n": N,
+        "order": ORDER,
+        "source_shape_count": source_shape_count,
+        "packet_count": len(records),
+        "source_status_counts": counter_to_json(source_status_counts),
+        "rich_class_count_total": rich_class_total,
+        "max_rich_class_size": max_rich_class_size,
+        "all_packets_radius_blockers": all(
+            bool(record["radius_blocker_ok"]) for record in records
+        ),
+        "quotient_status_counts": counter_to_json(quotient_status_counts),
+        "all_packets_obstructed": quotient_status_counts.get("ok", 0) == 0,
+        "total_strict_edge_count": total_strict_edges,
+        "total_self_edge_conflict_count": sum(self_edge_counts),
+        "min_self_edge_conflict_count": min(self_edge_counts),
+        "max_self_edge_conflict_count": max(self_edge_counts),
+        "first_self_edge_row_counts": counter_to_json(first_self_edge_rows),
+        "packet_max_blocker_intersection_size_counts": counter_to_json(
+            max_blocker_intersections
+        ),
+    }
+
+
+def build_payload(source: Path = DEFAULT_SOURCE) -> dict[str, object]:
+    """Build the deterministic full rich-class quotient sweep payload."""
+
+    shape_sweep = load_shape_sweep(source)
+    sources = source_examples(shape_sweep)
+    records = [build_packet_record(source_record) for source_record in sources]
+    cases = shape_sweep.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Bounded n=9 full rich-class quotient sweep. It enlarges each "
+            "stored shape-sweep obstruction example to one synthetic "
+            "size-five rich class per center, preserving the actual "
+            "radius-blocker condition, and replays the full rich quotient. "
+            "This is finite packet evidence only: it is not an n=9 proof, "
+            "not a proof of the adaptive blocker bridge, and not a "
+            "counterexample."
+        ),
+        "summary": build_summary(records, len(cases)),
+        "source_shape_sweep": {
+            "path": source.relative_to(ROOT).as_posix(),
+            "schema": shape_sweep.get("schema"),
+            "status": shape_sweep.get("status"),
+            "trust": shape_sweep.get("trust"),
+            "sha256": sha256_file(source),
+            "summary": shape_sweep.get("summary"),
+        },
+        "expansion_rule": {
+            "rule": (
+                "For each stored exact-four source row, add one deterministic "
+                "extra label to make a size-five rich class."
+            ),
+            "radius_blocker_boundary": (
+                "When the row center is inside the blocker, the added label "
+                "must keep the rich class below three blocker vertices. For "
+                "centers outside the blocker, the radius-blocker definition "
+                "does not constrain blocker intersection."
+            ),
+            "preference": (
+                "Among labels preserving the actual blocker condition, choose "
+                "the first label that also keeps the class below three blocker "
+                "vertices when such a label exists; otherwise choose the "
+                "first actual-condition-preserving label."
+            ),
+        },
+        "packets": records,
+        "interpretation_warnings": [
+            "This checks only synthetic size-five packets generated from stored examples.",
+            "It does not enumerate arbitrary rich-class catalogues.",
+            "It does not prove the adaptive radius-blocker bridge.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_rich_quotient_sweep.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_shape_sweep.json",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable full rich-class quotient sweep counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    packets = payload.get("packets")
+    if not isinstance(packets, list):
+        raise AssertionError("packet records are missing")
+    packet_ids = [packet["packet_id"] for packet in packets]
+    if len(packet_ids) != len(set(packet_ids)):
+        raise AssertionError("packet IDs are not unique")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker full rich-class quotient sweep")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"packets: {summary['packet_count']}")
+    print(f"quotient statuses: {summary['quotient_status_counts']}")
+    print(f"strict edges: {summary['total_strict_edge_count']}")
+    print(f"self-edge conflicts: {summary['total_self_edge_conflict_count']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.source)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1440,6 +1440,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_rich_quotient_sweep",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Generated full rich-class quotient replay for 20 synthetic "
+            "size-five n=9 radius-blocker packets derived from stored "
+            "shape-sweep obstruction examples; finite packet evidence only, "
+            "not a proof of Erdos Problem #97 and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/tests/test_n9_radius_blocker_rich_quotient_sweep.py
+++ b/tests/test_n9_radius_blocker_rich_quotient_sweep.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_radius_blocker_rich_quotient_sweep import (  # noqa: E402
+    DEFAULT_OUT,
+    assert_expected_payload,
+    build_payload,
+)
+
+
+def test_n9_radius_blocker_rich_quotient_sweep_matches_expected() -> None:
+    payload = build_payload()
+
+    assert_expected_payload(payload)
+
+
+def test_n9_radius_blocker_rich_quotient_sweep_artifact_is_current() -> None:
+    checked_in = json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))
+
+    assert checked_in == build_payload()


### PR DESCRIPTION
## Summary

Adds a generated n=9 rich-class radius-blocker quotient sweep over 20 synthetic size-five packets derived from the stored natural-order four-blocker shape-sweep obstruction examples.

The new checker enlarges each stored exact-four self-edge and strict-cycle example to one deterministic size-five rich class per center, preserves the actual radius-blocker condition, replays the full rich-class vertex-circle quotient, and records a compact generated JSON artifact. Documentation, generated-artifact metadata, and the artifact audit list are updated to point at the new finite packet diagnostic.

## Scope / Non-claim

This is finite generated packet evidence only. It does not enumerate arbitrary rich-class catalogues, does not prove the adaptive radius-blocker bridge, does not prove n=9, does not prove Erdos Problem #97, and does not supply a counterexample.

## Validation

- `python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --write --assert-expected`
- `python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_radius_blocker_rich_quotient_sweep.py -q`
- `python -m ruff check scripts/check_n9_radius_blocker_rich_quotient_sweep.py tests/test_n9_radius_blocker_rich_quotient_sweep.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_text_clean.py`
- `git diff --check`
- `python -m ruff check .`
- focused radius-blocker pytest suite: 21 passed
- `python scripts/check_n9_radius_blocker_rich_projection_pilot.py --check --assert-expected --json`
- `python scripts/check_n9_radius_blocker_rich_quotient_pilot.py --check --assert-expected --json`
- `python scripts/check_n9_full_radius_blocker_vertex_circle_packet.py --check --assert-expected --json`
- `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected --json`
- `python -m pytest -q` (1054 passed, 299 deselected)

`make verify-artifacts` could not be run in this PowerShell shell because `make` is not installed, so the relevant raw artifact commands above were run directly.