### PR TITLE
[codex] Add rich-extension radius-blocker neighborhood sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ This repository is a public research log and reproducibility workspace for Erdő
 - For radius-blocker packet diagnostics, including the full exact-four
   natural-order `n=9` blocker `{0,1,2,3}` packet, the natural-order
   four-blocker shape sweep, its order-reduction crosswalk, a bounded
-  richer-class projection pilot, a full rich-class quotient replay pilot, and
-  a generated rich-class quotient sweep,
+  richer-class projection pilot, a full rich-class quotient replay pilot, a
+  generated rich-class quotient sweep, and a bounded rich-extension
+  neighborhood sweep,
   read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
@@ -83,7 +84,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-radius-blocker-rich-quotient-pilot.md`](docs/n9-radius-blocker-rich-quotient-pilot.md)
   and
-  [`docs/n9-radius-blocker-rich-quotient-sweep.md`](docs/n9-radius-blocker-rich-quotient-sweep.md).
+  [`docs/n9-radius-blocker-rich-quotient-sweep.md`](docs/n9-radius-blocker-rich-quotient-sweep.md)
+  and
+  [`docs/n9-radius-blocker-rich-extension-neighborhood.md`](docs/n9-radius-blocker-rich-extension-neighborhood.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -321,6 +321,19 @@ and not a counterexample. See
 `scripts/check_n9_radius_blocker_rich_quotient_sweep.py`, and
 `data/certificates/n9_radius_blocker_rich_quotient_sweep.json`.
 
+A bounded rich-extension neighborhood sweep varies the added labels in that
+generated baseline. It enumerates every radius-blocker-preserving
+Hamming-distance `1` or `2` replacement around the `20` baseline packets,
+checking `5,996` variants, `53,964` size-five rich classes, and `1,349,100`
+strict edges. All `5,996` variants are quotient-obstructed by self-edges, with
+`1,017,368` total self-edge conflicts. This remains finite neighborhood
+evidence only, not the full extension-product catalogue, not arbitrary
+rich-class classification, not an `n=9` theorem, not a bridge proof, and not a
+counterexample. See
+`docs/n9-radius-blocker-rich-extension-neighborhood.md`,
+`scripts/check_n9_radius_blocker_rich_extension_neighborhood.py`, and
+`data/certificates/n9_radius_blocker_rich_extension_neighborhood.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -207,6 +207,15 @@ finite packet evidence only, not arbitrary rich-class classification, not an
 `n=9` proof, and not a bridge proof. See
 `docs/n9-radius-blocker-rich-quotient-sweep.md`.
 
+A bounded rich-extension neighborhood sweep now varies the added labels in
+those `20` generated packets. It checks the baseline plus every Hamming-distance
+`1` or `2` replacement by radius-blocker-preserving size-five extensions,
+covering `5,996` variants. All `5,996` variants are obstructed by quotient
+self-edges, with `1,017,368` total self-edge conflicts across `1,349,100`
+strict edges. This remains finite neighborhood evidence only, not a full
+rich-class catalogue, not an `n=9` proof, and not a bridge proof. See
+`docs/n9-radius-blocker-rich-extension-neighborhood.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_rich_extension_neighborhood.json
+++ b/data/certificates/n9_radius_blocker_rich_extension_neighborhood.json
@@ -1,0 +1,7394 @@
+{
+  "claim_scope": "Bounded n=9 rich-extension neighborhood replay. Starting from the 20 stored shape-sweep obstruction examples, it builds the baseline synthetic size-five rich classes and replays every radius-blocker-preserving one-row or two-row added-label change. This is finite catalogue evidence only: it is not an n=9 proof, not a proof of the adaptive blocker bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This checks only a Hamming-distance <= 2 extension neighborhood.",
+    "It does not enumerate the full Cartesian product of size-five extensions.",
+    "It does not enumerate arbitrary rich-class catalogues.",
+    "It does not prove the adaptive radius-blocker bridge.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "neighborhood_rule": {
+    "baseline": "Use the deterministic baseline added label from the generated rich-class quotient sweep for each exact-four source row.",
+    "catalogue": "For each row, enumerate every extra label that preserves the actual radius-blocker condition: inside-blocker centers must stay below three blocker vertices, while outside-blocker centers are unconstrained by blocker intersection.",
+    "variants": "Replay the baseline and every Hamming-distance 1 or 2 replacement of baseline added labels by alternative catalogue labels. This is not the full Cartesian product of all row extension choices."
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_shape_sweep.json",
+      "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "schema": "erdos97.n9_radius_blocker_rich_extension_neighborhood.v1",
+  "source_packets": [
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "case_index": 0,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 215,
+      "min_self_edge_conflict_count": 119,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            6
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            3,
+            4,
+            6
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 7,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            2,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            8
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            6
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            6
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            5
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 51779,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "2": 128,
+        "3": 152
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "case_index": 0,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 203,
+      "min_self_edge_conflict_count": 87,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            5,
+            6
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            3,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 46812,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 66,
+        "4": 214
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "case_index": 1,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 214,
+      "min_self_edge_conflict_count": 129,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            4,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            5,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            5,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            6
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 50870,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 69,
+        "4": 234
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "case_index": 1,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 204,
+      "min_self_edge_conflict_count": 88,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            6
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            7,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            2,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            8
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            6
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            6
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 47936,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 66,
+        "4": 214
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "case_index": 2,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 136,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            4
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 46702,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 9,
+        "4": 271
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "case_index": 2,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 192,
+      "min_self_edge_conflict_count": 90,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            0,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            4,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            2,
+            4
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            6
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 46742,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 69,
+        "4": 234
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "case_index": 3,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 220,
+      "min_self_edge_conflict_count": 150,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 53119,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 258,
+        "4": 22
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "case_index": 3,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 183,
+      "min_self_edge_conflict_count": 84,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            6,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 44002,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 9,
+        "4": 294
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 1,
+        "3": 8
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "case_index": 4,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 327
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 221,
+      "min_self_edge_conflict_count": 162,
+      "quotient_status_counts": {
+        "self_edge": 327
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 7,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 63081,
+      "total_strict_edge_count": 73575,
+      "variant_count": 327,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 69,
+        "4": 258
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "case_index": 4,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 215,
+      "min_self_edge_conflict_count": 118,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            5,
+            6
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            3,
+            5,
+            6
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            7,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            6,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            5,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            8
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            6
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            6
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 55555,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 69,
+        "4": 234
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "case_index": 5,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 216,
+      "min_self_edge_conflict_count": 149,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            6,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 7,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 55429,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 69,
+        "4": 234
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 1,
+        "3": 8
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "case_index": 5,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 327
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 203,
+      "min_self_edge_conflict_count": 92,
+      "quotient_status_counts": {
+        "self_edge": 327
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            5
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 52758,
+      "total_strict_edge_count": 73575,
+      "variant_count": 327,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 9,
+        "4": 318
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "case_index": 6,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 219,
+      "min_self_edge_conflict_count": 138,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 49406,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 66,
+        "4": 214
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 1,
+        "3": 8
+      },
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "case_index": 6,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 327
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 191,
+      "min_self_edge_conflict_count": 107,
+      "quotient_status_counts": {
+        "self_edge": 327
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            3,
+            4
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 50079,
+      "total_strict_edge_count": 73575,
+      "variant_count": 327,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 9,
+        "4": 318
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "case_index": 7,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 213,
+      "min_self_edge_conflict_count": 145,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            5,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 55337,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "4": 303
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "case_index": 7,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 189,
+      "min_self_edge_conflict_count": 82,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            6,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            4,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            3,
+            4
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 40855,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 258,
+        "4": 22
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 2,
+        "3": 7
+      },
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "case_index": 8,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 303
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 208,
+      "min_self_edge_conflict_count": 139,
+      "quotient_status_counts": {
+        "self_edge": 303
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 52711,
+      "total_strict_edge_count": 68175,
+      "variant_count": 303,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 66,
+        "4": 237
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 1,
+        "3": 8
+      },
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "case_index": 8,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 327
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 198,
+      "min_self_edge_conflict_count": 94,
+      "quotient_status_counts": {
+        "self_edge": 327
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 51742,
+      "total_strict_edge_count": 73575,
+      "variant_count": 327,
+      "variant_max_blocker_intersection_size_counts": {
+        "4": 327
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 1,
+        "3": 8
+      },
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "case_index": 9,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 327
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 219,
+      "min_self_edge_conflict_count": 129,
+      "quotient_status_counts": {
+        "self_edge": 327
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            6,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            5,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            5,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            6
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 55234,
+      "total_strict_edge_count": 73575,
+      "variant_count": 327,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 9,
+        "4": 318
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "alternative_count_profile": {
+        "2": 3,
+        "3": 6
+      },
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "case_index": 9,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 280
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 202,
+      "min_self_edge_conflict_count": 95,
+      "quotient_status_counts": {
+        "self_edge": 280
+      },
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            6,
+            7
+          ],
+          "center": 1,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            6,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            5,
+            6
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            3,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "source_example_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 47219,
+      "total_strict_edge_count": 63000,
+      "variant_count": 280,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 237,
+        "4": 43
+      }
+    }
+  ],
+  "source_shape_sweep": {
+    "path": "data/certificates/n9_radius_blocker_shape_sweep.json",
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "sha256": "a5291621ebf8a3ef8cc7eb9502933ef768c4da81b314096ffaea68aa96b19100",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "summary": {
+      "all_cases_finished": true,
+      "all_cases_have_radius_blocker": true,
+      "all_dihedral_labelled_blockers_covered": true,
+      "all_incidence_survivors_obstructed": true,
+      "dihedral_orbit_size_counts": {
+        "18": 4,
+        "9": 6
+      },
+      "labelled_blocker_count": 126,
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "shape_count": 10,
+      "total_incidence_survivors": 1358,
+      "total_nodes_visited": 754505,
+      "vertex_circle_status_totals": {
+        "self_edge": 1164,
+        "strict_cycle": 194
+      }
+    },
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_RICH_EXTENSION_NEIGHBORHOOD_ONLY",
+  "summary": {
+    "all_variants_obstructed": true,
+    "all_variants_radius_blockers": true,
+    "first_self_edge_row_counts": {
+      "0": 5996
+    },
+    "hamming_distance_counts": {
+      "0": 20,
+      "1": 497,
+      "2": 5479
+    },
+    "max_rich_class_size": 5,
+    "max_self_edge_conflict_count": 221,
+    "min_self_edge_conflict_count": 82,
+    "n": 9,
+    "neighborhood_radius": 2,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "quotient_status_counts": {
+      "self_edge": 5996
+    },
+    "source_packet_count": 20,
+    "source_row_alternative_count_profile": {
+      "2": 43,
+      "3": 137
+    },
+    "source_shape_count": 10,
+    "source_status_counts": {
+      "self_edge": 10,
+      "strict_cycle": 10
+    },
+    "source_variant_count_counts": {
+      "280": 8,
+      "303": 7,
+      "327": 5
+    },
+    "total_self_edge_conflict_count": 1017368,
+    "total_strict_edge_count": 1349100,
+    "variant_count": 5996,
+    "variant_max_blocker_intersection_size_counts": {
+      "2": 128,
+      "3": 1559,
+      "4": 4309
+    },
+    "variant_rich_class_count_total": 53964
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -158,9 +158,14 @@ Use this queue when no more specific issue is selected.
    repeats the full replay over `20` size-five packets derived from the stored
    self-edge and strict-cycle obstruction examples for all `10` four-blocker
    shapes; all `20` are quotient-obstructed by self-edges. This is still
-   finite packet evidence only; the next widening is a principled
-   rich-class catalogue or bridge hypothesis rather than synthetic examples
-   generated from stored exact-four obstructions.
+   finite packet evidence only. The bounded rich-extension neighborhood
+   `python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --check --assert-expected --json`
+   varies the added labels by every Hamming-distance `1` or `2`
+   radius-blocker-preserving replacement around those packets, checking
+   `5,996` variants; all are quotient-obstructed by self-edges. This is still
+   finite neighborhood evidence only; the next widening is the full extension
+   product for a carefully chosen packet or a principled rich-class bridge
+   hypothesis rather than more baseline-neighborhood sampling.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-rich-quotient-sweep.md`](n9-radius-blocker-rich-quotient-sweep.md):
   generated full rich-class quotient replay over the stored shape-sweep
   obstruction examples; finite packet evidence only.
+- [`n9-radius-blocker-rich-extension-neighborhood.md`](n9-radius-blocker-rich-extension-neighborhood.md):
+  bounded Hamming-distance neighborhood of size-five rich-class extensions
+  around the generated quotient-sweep packets; finite packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-radius-blocker-rich-extension-neighborhood.md
+++ b/docs/n9-radius-blocker-rich-extension-neighborhood.md
@@ -1,0 +1,55 @@
+# n=9 radius-blocker rich-extension neighborhood
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note widens `docs/n9-radius-blocker-rich-quotient-sweep.md` by replacing
+the single deterministic added label in the generated size-five rich classes.
+For each of the `20` stored shape-sweep obstruction examples, the checker first
+builds the deterministic baseline packet, then enumerates every added-label
+variant at Hamming distance `1` or `2` from that baseline.
+
+The row catalogue contains every extra label that preserves the actual
+radius-blocker condition: if a row center is inside the blocker, the enlarged
+rich class must still contain fewer than three blocker vertices. For centers
+outside the blocker, blocker intersection is recorded but is not constrained
+by the radius-blocker definition.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_rich_extension_neighborhood.json
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --check --assert-expected --json
+```
+
+The neighborhood has `5,996` radius-blocker-preserving variants:
+
+```text
+distance 0:    20
+distance 1:   497
+distance 2: 5,479
+```
+
+All `5,996` variants are obstructed by quotient self-edges. The replay checks
+`53,964` size-five rich classes and `1,349,100` strict vertex-circle edges,
+with `1,017,368` total self-edge conflicts. The first self-edge row is row `0`
+in every variant.
+
+## Boundary
+
+This is a Hamming-distance `<= 2` neighborhood around the generated baseline
+packets, not the full Cartesian product of every size-five row extension and
+not an enumeration of arbitrary rich-class catalogues. It does not prove that
+all radius-blockers are impossible, does not prove `n=9`, does not prove the
+adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
+
+The next useful widening is either the full extension-product catalogue for a
+carefully chosen small packet, or a genuine minimal/rich-class bridge
+hypothesis that narrows which richer catalogues must be checked.

--- a/docs/n9-radius-blocker-rich-quotient-sweep.md
+++ b/docs/n9-radius-blocker-rich-quotient-sweep.md
@@ -42,6 +42,8 @@ enumeration of arbitrary rich-class catalogues. It does not prove that all
 radius-blockers are impossible, does not prove `n=9`, does not prove the
 adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
 
-The next useful widening is to generate richer packets from a principled
-rich-class catalogue or bridge hypothesis, rather than from the two stored
-obstruction examples per exact-four blocker shape.
+The follow-up `docs/n9-radius-blocker-rich-extension-neighborhood.md` checks a
+bounded Hamming-distance neighborhood of size-five extension choices around
+these generated packets. The next wider target is still the full extension
+product for a carefully chosen packet or a genuine minimal/rich-class bridge
+hypothesis.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -585,9 +585,14 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/n9-radius-blocker-rich-quotient-sweep.md`, which quantifies that
   replay over `20` synthetic size-five packets derived from the stored
   self-edge and strict-cycle obstruction examples for all `10` four-blocker
-  shapes. This is still generated finite packet evidence only; the next review
-  target is a principled rich-class catalogue or bridge hypothesis rather than
-  examples generated from stored exact-four obstructions.
+  shapes. This is still generated finite packet evidence only.
+- the bounded rich-extension neighborhood recorded in
+  `docs/n9-radius-blocker-rich-extension-neighborhood.md`, which varies the
+  added labels around those `20` packets by every Hamming-distance `1` or `2`
+  radius-blocker-preserving replacement and checks `5,996` quotient-obstructed
+  variants. This is still finite neighborhood evidence only; the next review
+  target is the full extension product for a carefully chosen packet or a
+  principled rich-class bridge hypothesis.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3012,6 +3012,49 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_rich_extension_neighborhood
+    path: data/certificates/n9_radius_blocker_rich_extension_neighborhood.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_rich_extension_neighborhood.py
+    command: python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_rich_extension_neighborhood.py
+    check_command: python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Bounded n=9 rich-extension neighborhood replay for 5,996 Hamming-distance <= 2 size-five variants around the generated radius-blocker quotient-sweep packets; finite neighborhood evidence only, not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_rich_extension_neighborhood.v1
+      status: N9_RADIUS_BLOCKER_RICH_EXTENSION_NEIGHBORHOOD_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.source_shape_count: 10
+      summary.source_packet_count: 20
+      summary.neighborhood_radius: 2
+      summary.variant_count: 5996
+      summary.hamming_distance_counts.2: 5479
+      summary.variant_rich_class_count_total: 53964
+      summary.max_rich_class_size: 5
+      summary.all_variants_radius_blockers: true
+      summary.quotient_status_counts.self_edge: 5996
+      summary.all_variants_obstructed: true
+      summary.total_strict_edge_count: 1349100
+      summary.total_self_edge_conflict_count: 1017368
+      summary.variant_max_blocker_intersection_size_counts.4: 4309
+      source_shape_sweep.path: data/certificates/n9_radius_blocker_shape_sweep.json
+      provenance.command: python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - full extension product is enumerated
+      - arbitrary rich-class systems are classified
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_rich_extension_neighborhood.py
+++ b/scripts/check_n9_radius_blocker_rich_extension_neighborhood.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Check a bounded rich-extension neighborhood for n=9 blocker packets.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from check_n9_radius_blocker_rich_quotient_sweep import (  # noqa: E402
+    DEFAULT_SOURCE,
+    N,
+    ORDER,
+    choose_extra_label,
+    counter_to_json,
+    extra_label_candidates,
+    load_shape_sweep,
+    sha256_file,
+    source_examples,
+)
+from erdos97.adaptive_blockers import is_radius_blocker  # noqa: E402
+from erdos97.radius_blocker_packets import TRUST  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    RichClassRow,
+    replay_vertex_circle_rich_quotient,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_rich_extension_neighborhood.v1"
+STATUS = "N9_RADIUS_BLOCKER_RICH_EXTENSION_NEIGHBORHOOD_ONLY"
+DEFAULT_OUT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_radius_blocker_rich_extension_neighborhood.json"
+)
+NEIGHBORHOOD_RADIUS = 2
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "source_shape_count": 10,
+    "source_packet_count": 20,
+    "neighborhood_radius": 2,
+    "variant_count": 5996,
+    "source_status_counts": {"self_edge": 10, "strict_cycle": 10},
+    "source_variant_count_counts": {"280": 8, "303": 7, "327": 5},
+    "hamming_distance_counts": {"0": 20, "1": 497, "2": 5479},
+    "source_row_alternative_count_profile": {"2": 43, "3": 137},
+    "variant_rich_class_count_total": 53964,
+    "max_rich_class_size": 5,
+    "all_variants_radius_blockers": True,
+    "quotient_status_counts": {"self_edge": 5996},
+    "all_variants_obstructed": True,
+    "total_strict_edge_count": 1349100,
+    "total_self_edge_conflict_count": 1017368,
+    "min_self_edge_conflict_count": 82,
+    "max_self_edge_conflict_count": 221,
+    "first_self_edge_row_counts": {"0": 5996},
+    "variant_max_blocker_intersection_size_counts": {
+        "2": 128,
+        "3": 1559,
+        "4": 4309,
+    },
+}
+
+
+def rich_classes_for_blocker(
+    rows: Sequence[RichClassRow],
+) -> tuple[tuple[tuple[int, ...], ...], ...]:
+    return tuple((row.witnesses,) for row in rows)
+
+
+def extension_catalog(
+    selected_rows: Sequence[Sequence[int]],
+    blocker: Sequence[int],
+) -> tuple[list[int], list[list[int]], list[dict[str, object]]]:
+    baseline: list[int] = []
+    alternatives: list[list[int]] = []
+    records: list[dict[str, object]] = []
+    blocker_set = set(int(label) for label in blocker)
+    for center, row in enumerate(selected_rows):
+        row_list = [int(label) for label in row]
+        candidates = extra_label_candidates(center, row_list, blocker)
+        baseline_label = choose_extra_label(center, row_list, blocker)
+        alternative_labels = [label for label in candidates if label != baseline_label]
+        baseline.append(baseline_label)
+        alternatives.append(alternative_labels)
+        baseline_class = tuple(sorted(set(row_list) | {baseline_label}))
+        records.append(
+            {
+                "center": center,
+                "source_exact_row": row_list,
+                "candidate_added_labels": candidates,
+                "baseline_added_label": baseline_label,
+                "alternative_added_labels": alternative_labels,
+                "baseline_rich_class": list(baseline_class),
+                "baseline_blocker_intersection_size": len(
+                    set(baseline_class) & blocker_set
+                ),
+                "inside_blocker_center": center in blocker_set,
+            }
+        )
+    return baseline, alternatives, records
+
+
+def iter_added_label_variants(
+    baseline: Sequence[int],
+    alternatives: Sequence[Sequence[int]],
+    radius: int = NEIGHBORHOOD_RADIUS,
+) -> Iterable[tuple[int, tuple[int, ...], tuple[int, ...]]]:
+    """Yield baseline plus all one- and two-row extension changes."""
+
+    baseline_tuple = tuple(int(label) for label in baseline)
+    yield 0, (), baseline_tuple
+    if radius < 1:
+        return
+    for center, labels in enumerate(alternatives):
+        for label in labels:
+            variant = list(baseline_tuple)
+            variant[center] = int(label)
+            yield 1, (center,), tuple(variant)
+    if radius < 2:
+        return
+    for left, right in combinations(range(N), 2):
+        for left_label in alternatives[left]:
+            for right_label in alternatives[right]:
+                variant = list(baseline_tuple)
+                variant[left] = int(left_label)
+                variant[right] = int(right_label)
+                yield 2, (left, right), tuple(variant)
+
+
+def rich_rows_from_added_labels(
+    selected_rows: Sequence[Sequence[int]],
+    added_labels: Sequence[int],
+) -> list[RichClassRow]:
+    rich_rows: list[RichClassRow] = []
+    for center, row in enumerate(selected_rows):
+        row_set = set(int(label) for label in row)
+        row_set.add(int(added_labels[center]))
+        rich_rows.append(RichClassRow(center=center, witnesses=tuple(sorted(row_set))))
+    return rich_rows
+
+
+def build_source_packet_record(source: Mapping[str, object]) -> dict[str, object]:
+    selected_rows = source["source_selected_rows"]
+    if not isinstance(selected_rows, list):
+        raise AssertionError("source selected rows are missing")
+    rows = [[int(label) for label in row] for row in selected_rows]
+    blocker = [int(label) for label in source["blocker"]]
+    blocker_set = set(blocker)
+    baseline, alternatives, catalog_records = extension_catalog(rows, blocker)
+
+    hamming_distance_counts: Counter[int] = Counter()
+    quotient_status_counts: Counter[str] = Counter()
+    first_self_edge_rows: Counter[int | None] = Counter()
+    max_blocker_intersections: Counter[int] = Counter()
+    self_edge_counts: list[int] = []
+    total_strict_edges = 0
+    all_radius_blockers = True
+    variant_count = 0
+    max_rich_class_size = 0
+
+    seen_variants: set[tuple[int, ...]] = set()
+    for distance, _changed_centers, added_labels in iter_added_label_variants(
+        baseline, alternatives
+    ):
+        if added_labels in seen_variants:
+            raise AssertionError("duplicate extension-neighborhood variant")
+        seen_variants.add(added_labels)
+        rich_rows = rich_rows_from_added_labels(rows, added_labels)
+        all_radius_blockers = all_radius_blockers and is_radius_blocker(
+            rich_classes_for_blocker(rich_rows), blocker
+        )
+        replay = replay_vertex_circle_rich_quotient(N, ORDER, rich_rows)
+        hamming_distance_counts[distance] += 1
+        quotient_status_counts[str(replay.status)] += 1
+        total_strict_edges += int(replay.strict_edge_count)
+        self_edge_counts.append(len(replay.self_edge_conflicts))
+        first_self_edge_rows[
+            int(replay.self_edge_conflicts[0].row)
+            if replay.self_edge_conflicts
+            else None
+        ] += 1
+        max_blocker_intersections[
+            max(len(set(row.witnesses) & blocker_set) for row in rich_rows)
+        ] += 1
+        max_rich_class_size = max(
+            max_rich_class_size,
+            max(len(row.witnesses) for row in rich_rows),
+        )
+        variant_count += 1
+
+    return {
+        "source_packet_id": (
+            f"{source['case_name']}:{source['source_status']}:"
+            f"{source['source_example_index']}"
+        ),
+        "case_index": source["case_index"],
+        "case_name": source["case_name"],
+        "blocker": blocker,
+        "source_status": source["source_status"],
+        "source_example_index": source["source_example_index"],
+        "source_selected_rows": rows,
+        "row_extension_catalog": catalog_records,
+        "alternative_count_profile": counter_to_json(
+            Counter(len(labels) for labels in alternatives)
+        ),
+        "variant_count": variant_count,
+        "hamming_distance_counts": counter_to_json(hamming_distance_counts),
+        "all_variants_radius_blockers": all_radius_blockers,
+        "quotient_status_counts": counter_to_json(quotient_status_counts),
+        "all_variants_obstructed": quotient_status_counts.get("ok", 0) == 0,
+        "total_strict_edge_count": total_strict_edges,
+        "total_self_edge_conflict_count": sum(self_edge_counts),
+        "min_self_edge_conflict_count": min(self_edge_counts),
+        "max_self_edge_conflict_count": max(self_edge_counts),
+        "first_self_edge_row_counts": counter_to_json(first_self_edge_rows),
+        "variant_max_blocker_intersection_size_counts": counter_to_json(
+            max_blocker_intersections
+        ),
+        "max_rich_class_size": max_rich_class_size,
+    }
+
+
+def build_summary(
+    records: Sequence[Mapping[str, object]],
+    source_shape_count: int,
+) -> dict[str, object]:
+    source_status_counts: Counter[str] = Counter()
+    source_variant_count_counts: Counter[int] = Counter()
+    hamming_distance_counts: Counter[str] = Counter()
+    alternative_count_profile: Counter[str] = Counter()
+    quotient_status_counts: Counter[str] = Counter()
+    first_self_edge_rows: Counter[str] = Counter()
+    max_blocker_intersections: Counter[str] = Counter()
+    variant_count = 0
+    strict_edge_count = 0
+    self_edge_total = 0
+    self_edge_min: int | None = None
+    self_edge_max = 0
+    max_rich_class_size = 0
+
+    for record in records:
+        source_status_counts[str(record["source_status"])] += 1
+        record_variant_count = int(record["variant_count"])
+        source_variant_count_counts[record_variant_count] += 1
+        variant_count += record_variant_count
+        strict_edge_count += int(record["total_strict_edge_count"])
+        self_edge_total += int(record["total_self_edge_conflict_count"])
+        record_min = int(record["min_self_edge_conflict_count"])
+        record_max = int(record["max_self_edge_conflict_count"])
+        self_edge_min = record_min if self_edge_min is None else min(self_edge_min, record_min)
+        self_edge_max = max(self_edge_max, record_max)
+        max_rich_class_size = max(max_rich_class_size, int(record["max_rich_class_size"]))
+        for key, value in record["hamming_distance_counts"].items():
+            hamming_distance_counts[str(key)] += int(value)
+        for key, value in record["alternative_count_profile"].items():
+            alternative_count_profile[str(key)] += int(value)
+        for key, value in record["quotient_status_counts"].items():
+            quotient_status_counts[str(key)] += int(value)
+        for key, value in record["first_self_edge_row_counts"].items():
+            first_self_edge_rows[str(key)] += int(value)
+        for key, value in record["variant_max_blocker_intersection_size_counts"].items():
+            max_blocker_intersections[str(key)] += int(value)
+
+    return {
+        "n": N,
+        "order": ORDER,
+        "source_shape_count": source_shape_count,
+        "source_packet_count": len(records),
+        "neighborhood_radius": NEIGHBORHOOD_RADIUS,
+        "variant_count": variant_count,
+        "source_status_counts": counter_to_json(source_status_counts),
+        "source_variant_count_counts": counter_to_json(source_variant_count_counts),
+        "hamming_distance_counts": counter_to_json(hamming_distance_counts),
+        "source_row_alternative_count_profile": counter_to_json(
+            alternative_count_profile
+        ),
+        "variant_rich_class_count_total": variant_count * N,
+        "max_rich_class_size": max_rich_class_size,
+        "all_variants_radius_blockers": all(
+            bool(record["all_variants_radius_blockers"]) for record in records
+        ),
+        "quotient_status_counts": counter_to_json(quotient_status_counts),
+        "all_variants_obstructed": quotient_status_counts.get("ok", 0) == 0,
+        "total_strict_edge_count": strict_edge_count,
+        "total_self_edge_conflict_count": self_edge_total,
+        "min_self_edge_conflict_count": self_edge_min,
+        "max_self_edge_conflict_count": self_edge_max,
+        "first_self_edge_row_counts": counter_to_json(first_self_edge_rows),
+        "variant_max_blocker_intersection_size_counts": counter_to_json(
+            max_blocker_intersections
+        ),
+    }
+
+
+def build_payload(source: Path = DEFAULT_SOURCE) -> dict[str, object]:
+    shape_sweep = load_shape_sweep(source)
+    sources = source_examples(shape_sweep)
+    records = [build_source_packet_record(source_record) for source_record in sources]
+    cases = shape_sweep.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Bounded n=9 rich-extension neighborhood replay. Starting from "
+            "the 20 stored shape-sweep obstruction examples, it builds the "
+            "baseline synthetic size-five rich classes and replays every "
+            "radius-blocker-preserving one-row or two-row added-label change. "
+            "This is finite catalogue evidence only: it is not an n=9 proof, "
+            "not a proof of the adaptive blocker bridge, and not a "
+            "counterexample."
+        ),
+        "summary": build_summary(records, len(cases)),
+        "source_shape_sweep": {
+            "path": source.relative_to(ROOT).as_posix(),
+            "schema": shape_sweep.get("schema"),
+            "status": shape_sweep.get("status"),
+            "trust": shape_sweep.get("trust"),
+            "sha256": sha256_file(source),
+            "summary": shape_sweep.get("summary"),
+        },
+        "neighborhood_rule": {
+            "baseline": (
+                "Use the deterministic baseline added label from the generated "
+                "rich-class quotient sweep for each exact-four source row."
+            ),
+            "catalogue": (
+                "For each row, enumerate every extra label that preserves the "
+                "actual radius-blocker condition: inside-blocker centers must "
+                "stay below three blocker vertices, while outside-blocker "
+                "centers are unconstrained by blocker intersection."
+            ),
+            "variants": (
+                "Replay the baseline and every Hamming-distance 1 or 2 "
+                "replacement of baseline added labels by alternative catalogue "
+                "labels. This is not the full Cartesian product of all row "
+                "extension choices."
+            ),
+        },
+        "source_packets": records,
+        "interpretation_warnings": [
+            "This checks only a Hamming-distance <= 2 extension neighborhood.",
+            "It does not enumerate the full Cartesian product of size-five extensions.",
+            "It does not enumerate arbitrary rich-class catalogues.",
+            "It does not prove the adaptive radius-blocker bridge.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_shape_sweep.json",
+                "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    source_packets = payload.get("source_packets")
+    if not isinstance(source_packets, list):
+        raise AssertionError("source packet records are missing")
+    packet_ids = [packet["source_packet_id"] for packet in source_packets]
+    if len(packet_ids) != len(set(packet_ids)):
+        raise AssertionError("source packet IDs are not unique")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker rich-extension neighborhood")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"variants: {summary['variant_count']}")
+    print(f"hamming distances: {summary['hamming_distance_counts']}")
+    print(f"quotient statuses: {summary['quotient_status_counts']}")
+    print(f"self-edge conflicts: {summary['total_self_edge_conflict_count']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.source)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1456,6 +1456,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_rich_extension_neighborhood",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Bounded n=9 rich-extension neighborhood replay for 5,996 "
+            "Hamming-distance <= 2 size-five variants around the generated "
+            "radius-blocker quotient-sweep packets; finite neighborhood "
+            "evidence only, not a proof of Erdos Problem #97 and not a "
+            "counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/tests/test_n9_radius_blocker_rich_extension_neighborhood.py
+++ b/tests/test_n9_radius_blocker_rich_extension_neighborhood.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_radius_blocker_rich_extension_neighborhood import (  # noqa: E402
+    DEFAULT_OUT,
+    assert_expected_payload,
+    build_payload,
+)
+
+
+def test_n9_radius_blocker_rich_extension_neighborhood_matches_expected() -> None:
+    payload = build_payload()
+
+    assert_expected_payload(payload)
+
+
+def test_n9_radius_blocker_rich_extension_neighborhood_artifact_is_current() -> None:
+    checked_in = json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))
+
+    assert checked_in == build_payload()


### PR DESCRIPTION
## Summary

Adds a bounded n=9 rich-extension neighborhood diagnostic around the generated radius-blocker quotient-sweep packets.

The new checker starts from the 20 stored shape-sweep obstruction examples, builds the deterministic size-five rich-class baseline, enumerates every radius-blocker-preserving one-row or two-row added-label replacement around that baseline, and replays the full rich-class vertex-circle quotient. The checked artifact records compact aggregate and per-source-packet counts for 5,996 variants.

## Scope / Non-claim

This is finite neighborhood evidence only. It does not enumerate the full Cartesian product of size-five extensions, does not enumerate arbitrary rich-class catalogues, does not prove the adaptive radius-blocker bridge, does not prove n=9, does not prove Erdos Problem #97, and does not supply a counterexample.

## Validation

- `python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --write --assert-expected`
- `python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_radius_blocker_rich_extension_neighborhood.py -q`
- `python -m ruff check scripts/check_n9_radius_blocker_rich_extension_neighborhood.py tests/test_n9_radius_blocker_rich_extension_neighborhood.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_text_clean.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (1056 passed, 299 deselected)
- `python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected --json`
- `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected`

`make verify-artifacts` could not be run in this PowerShell shell because `make` is not installed. The verbose `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected --json` run emitted the expected JSON but hit the command timeout before returning, so it was rerun without `--json` and passed with a clean exit code.