### PR TITLE
[codex] Add rich-extension product pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   natural-order `n=9` blocker `{0,1,2,3}` packet, the natural-order
   four-blocker shape sweep, its order-reduction crosswalk, a bounded
   richer-class projection pilot, a full rich-class quotient replay pilot, a
-  generated rich-class quotient sweep, and a bounded rich-extension
-  neighborhood sweep,
+  generated rich-class quotient sweep, a bounded rich-extension neighborhood
+  sweep, and a one-packet full rich-extension product pilot,
   read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
@@ -86,7 +86,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-radius-blocker-rich-quotient-sweep.md`](docs/n9-radius-blocker-rich-quotient-sweep.md)
   and
-  [`docs/n9-radius-blocker-rich-extension-neighborhood.md`](docs/n9-radius-blocker-rich-extension-neighborhood.md).
+  [`docs/n9-radius-blocker-rich-extension-neighborhood.md`](docs/n9-radius-blocker-rich-extension-neighborhood.md)
+  and
+  [`docs/n9-radius-blocker-rich-extension-product-pilot.md`](docs/n9-radius-blocker-rich-extension-product-pilot.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -334,6 +334,20 @@ counterexample. See
 `scripts/check_n9_radius_blocker_rich_extension_neighborhood.py`, and
 `data/certificates/n9_radius_blocker_rich_extension_neighborhood.json`.
 
+A one-packet rich-extension product pilot then exhausts the first maximum-size
+source packet in the generated family:
+`n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0`.
+It checks all `196,608` radius-blocker-preserving size-five extension variants
+for that packet, `1,769,472` size-five rich classes, and `44,236,800` strict
+edges. All variants are quotient-obstructed by self-edges, with `33,895,908`
+total self-edge conflicts. This remains finite packet evidence only, not the
+full product over all `20` generated packets, not arbitrary rich-class
+classification, not an `n=9` theorem, not a bridge proof, and not a
+counterexample. See
+`docs/n9-radius-blocker-rich-extension-product-pilot.md`,
+`scripts/check_n9_radius_blocker_rich_extension_product_pilot.py`, and
+`data/certificates/n9_radius_blocker_rich_extension_product_pilot.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -216,6 +216,16 @@ strict edges. This remains finite neighborhood evidence only, not a full
 rich-class catalogue, not an `n=9` proof, and not a bridge proof. See
 `docs/n9-radius-blocker-rich-extension-neighborhood.md`.
 
+A one-packet rich-extension product pilot now exhausts the first maximum-size
+source packet from that generated family:
+`n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0`.
+It checks all `196,608` radius-blocker-preserving size-five extension variants
+for that packet, and all are obstructed by quotient self-edges, with
+`33,895,908` total self-edge conflicts across `44,236,800` strict edges. This
+is still finite packet evidence only, not the full `20`-packet product, not an
+arbitrary rich-class classification, not an `n=9` proof, and not a bridge
+proof. See `docs/n9-radius-blocker-rich-extension-product-pilot.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_rich_extension_product_pilot.json
+++ b/data/certificates/n9_radius_blocker_rich_extension_product_pilot.json
@@ -1,0 +1,1279 @@
+{
+  "claim_scope": "One-packet n=9 full rich-extension product replay. It selects the first maximum-size source packet from the generated radius-blocker quotient-sweep packet family and replays every radius-blocker-preserving size-five added-label choice for that packet. This is finite packet evidence only: it is not an n=9 proof, not a proof of the adaptive blocker bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This checks the full extension product for one selected source packet only.",
+    "It does not enumerate the full product for all 20 source packets.",
+    "It does not enumerate arbitrary rich-class catalogues.",
+    "It does not prove the adaptive radius-blocker bridge.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "product_rule": {
+    "catalogue": "For each row, enumerate every extra label that preserves the actual radius-blocker condition: inside-blocker centers must stay below three blocker vertices, while outside-blocker centers are unconstrained by blocker intersection.",
+    "variants": "Replay the full Cartesian product of those row extension choices for the selected source packet."
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_rich_extension_product_pilot.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_shape_sweep.json",
+      "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+      "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "schema": "erdos97.n9_radius_blocker_rich_extension_product_pilot.v1",
+  "selected_packet": {
+    "all_variants_obstructed": true,
+    "all_variants_radius_blockers": true,
+    "blocker": [
+      0,
+      1,
+      3,
+      5
+    ],
+    "case_index": 4,
+    "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+    "first_self_edge_row_counts": {
+      "0": 196608
+    },
+    "hamming_distance_counts": {
+      "0": 1,
+      "1": 26,
+      "2": 300,
+      "3": 2016,
+      "4": 8694,
+      "5": 24948,
+      "6": 47628,
+      "7": 58320,
+      "8": 41553,
+      "9": 13122
+    },
+    "max_rich_class_size": 5,
+    "max_self_edge_conflict_count": 225,
+    "min_self_edge_conflict_count": 69,
+    "product_variant_count": 196608,
+    "quotient_status_counts": {
+      "self_edge": 196608
+    },
+    "replayed_variant_count": 196608,
+    "row_alternative_counts": [
+      2,
+      3,
+      3,
+      3,
+      3,
+      3,
+      3,
+      3,
+      3
+    ],
+    "row_extension_catalog": [
+      {
+        "alternative_added_labels": [
+          6,
+          7
+        ],
+        "baseline_added_label": 4,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          1,
+          2,
+          3,
+          4,
+          8
+        ],
+        "candidate_added_labels": [
+          4,
+          6,
+          7
+        ],
+        "center": 0,
+        "inside_blocker_center": true,
+        "source_exact_row": [
+          1,
+          2,
+          3,
+          8
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          5,
+          6,
+          8
+        ],
+        "baseline_added_label": 3,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          0,
+          2,
+          3,
+          4,
+          7
+        ],
+        "candidate_added_labels": [
+          3,
+          5,
+          6,
+          8
+        ],
+        "center": 1,
+        "inside_blocker_center": true,
+        "source_exact_row": [
+          0,
+          2,
+          4,
+          7
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          4,
+          6,
+          8
+        ],
+        "baseline_added_label": 0,
+        "baseline_blocker_intersection_size": 4,
+        "baseline_rich_class": [
+          0,
+          1,
+          3,
+          5,
+          7
+        ],
+        "candidate_added_labels": [
+          0,
+          4,
+          6,
+          8
+        ],
+        "center": 2,
+        "inside_blocker_center": false,
+        "source_exact_row": [
+          1,
+          3,
+          5,
+          7
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          2,
+          5,
+          7
+        ],
+        "baseline_added_label": 0,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          0,
+          1,
+          4,
+          6,
+          8
+        ],
+        "candidate_added_labels": [
+          0,
+          2,
+          5,
+          7
+        ],
+        "center": 3,
+        "inside_blocker_center": true,
+        "source_exact_row": [
+          1,
+          4,
+          6,
+          8
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          1,
+          3,
+          8
+        ],
+        "baseline_added_label": 7,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          0,
+          2,
+          5,
+          6,
+          7
+        ],
+        "candidate_added_labels": [
+          1,
+          3,
+          7,
+          8
+        ],
+        "center": 4,
+        "inside_blocker_center": false,
+        "source_exact_row": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          1,
+          2,
+          8
+        ],
+        "baseline_added_label": 0,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          0,
+          3,
+          4,
+          6,
+          7
+        ],
+        "candidate_added_labels": [
+          0,
+          1,
+          2,
+          8
+        ],
+        "center": 5,
+        "inside_blocker_center": true,
+        "source_exact_row": [
+          3,
+          4,
+          6,
+          7
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          1,
+          3,
+          4
+        ],
+        "baseline_added_label": 0,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          0,
+          2,
+          5,
+          7,
+          8
+        ],
+        "candidate_added_labels": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "center": 6,
+        "inside_blocker_center": false,
+        "source_exact_row": [
+          2,
+          5,
+          7,
+          8
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          1,
+          4,
+          5
+        ],
+        "baseline_added_label": 2,
+        "baseline_blocker_intersection_size": 2,
+        "baseline_rich_class": [
+          0,
+          2,
+          3,
+          6,
+          8
+        ],
+        "candidate_added_labels": [
+          1,
+          2,
+          4,
+          5
+        ],
+        "center": 7,
+        "inside_blocker_center": false,
+        "source_exact_row": [
+          0,
+          3,
+          6,
+          8
+        ]
+      },
+      {
+        "alternative_added_labels": [
+          3,
+          6,
+          7
+        ],
+        "baseline_added_label": 2,
+        "baseline_blocker_intersection_size": 3,
+        "baseline_rich_class": [
+          0,
+          1,
+          2,
+          4,
+          5
+        ],
+        "candidate_added_labels": [
+          2,
+          3,
+          6,
+          7
+        ],
+        "center": 8,
+        "inside_blocker_center": false,
+        "source_exact_row": [
+          0,
+          1,
+          4,
+          5
+        ]
+      }
+    ],
+    "row_option_counts": [
+      3,
+      4,
+      4,
+      4,
+      4,
+      4,
+      4,
+      4,
+      4
+    ],
+    "selection_rule": "first_maximum_full_extension_product_in_source_order",
+    "source_example_index": 0,
+    "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+    "source_selected_rows": [
+      [
+        1,
+        2,
+        3,
+        8
+      ],
+      [
+        0,
+        2,
+        4,
+        7
+      ],
+      [
+        1,
+        3,
+        5,
+        7
+      ],
+      [
+        1,
+        4,
+        6,
+        8
+      ],
+      [
+        0,
+        2,
+        5,
+        6
+      ],
+      [
+        3,
+        4,
+        6,
+        7
+      ],
+      [
+        2,
+        5,
+        7,
+        8
+      ],
+      [
+        0,
+        3,
+        6,
+        8
+      ],
+      [
+        0,
+        1,
+        4,
+        5
+      ]
+    ],
+    "source_status": "self_edge",
+    "total_self_edge_conflict_count": 33895908,
+    "total_strict_edge_count": 44236800,
+    "truncated": false,
+    "variant_max_blocker_intersection_size_counts": {
+      "3": 110592,
+      "4": 86016
+    }
+  },
+  "selection_rule": {
+    "reason": "The full 20-packet extension product has 2,899,968 variants. This pilot exhausts one largest product packet first, using source-artifact order as the stable tie-break.",
+    "rule": "first_maximum_full_extension_product_in_source_order"
+  },
+  "source_product_catalog": {
+    "source_product_records": [
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "case_index": 0,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          3,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 0,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "case_index": 0,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 1,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "case_index": 1,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 2,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "case_index": 1,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 3,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          5
+        ],
+        "case_index": 2,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 4,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          5
+        ],
+        "case_index": 2,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 5,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "case_index": 3,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 6,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "case_index": 3,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 7,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "case_index": 4,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 8,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "case_index": 4,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 9,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "case_index": 5,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 10,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "case_index": 5,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 11,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "case_index": 6,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          2,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          3,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 12,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "case_index": 6,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 13,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "case_index": 7,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 14,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "case_index": 7,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 15,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "case_index": 8,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 16,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "case_index": 8,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 17,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "case_index": 9,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          3,
+          3,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          4,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 18,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "case_index": 9,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          3,
+          2,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          3,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 19,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      }
+    ],
+    "source_product_variant_count_counts": {
+      "110592": 8,
+      "147456": 7,
+      "196608": 5
+    },
+    "source_product_variant_count_total": 2899968
+  },
+  "source_shape_sweep": {
+    "path": "data/certificates/n9_radius_blocker_shape_sweep.json",
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "sha256": "a5291621ebf8a3ef8cc7eb9502933ef768c4da81b314096ffaea68aa96b19100",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "summary": {
+      "all_cases_finished": true,
+      "all_cases_have_radius_blocker": true,
+      "all_dihedral_labelled_blockers_covered": true,
+      "all_incidence_survivors_obstructed": true,
+      "dihedral_orbit_size_counts": {
+        "18": 4,
+        "9": 6
+      },
+      "labelled_blocker_count": 126,
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "shape_count": 10,
+      "total_incidence_survivors": 1358,
+      "total_nodes_visited": 754505,
+      "vertex_circle_status_totals": {
+        "self_edge": 1164,
+        "strict_cycle": 194
+      }
+    },
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_RICH_EXTENSION_PRODUCT_PILOT_ONLY",
+  "summary": {
+    "all_variants_obstructed": true,
+    "all_variants_radius_blockers": true,
+    "first_self_edge_row_counts": {
+      "0": 196608
+    },
+    "hamming_distance_counts": {
+      "0": 1,
+      "1": 26,
+      "2": 300,
+      "3": 2016,
+      "4": 8694,
+      "5": 24948,
+      "6": 47628,
+      "7": 58320,
+      "8": 41553,
+      "9": 13122
+    },
+    "max_rich_class_size": 5,
+    "max_self_edge_conflict_count": 225,
+    "min_self_edge_conflict_count": 69,
+    "n": 9,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "quotient_status_counts": {
+      "self_edge": 196608
+    },
+    "selected_case_index": 4,
+    "selected_case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+    "selected_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+    "selected_product_variant_count": 196608,
+    "selected_row_alternative_count_profile": {
+      "2": 1,
+      "3": 8
+    },
+    "selected_row_option_count_profile": {
+      "3": 1,
+      "4": 8
+    },
+    "selected_source_status": "self_edge",
+    "source_packet_count": 20,
+    "source_product_variant_count_counts": {
+      "110592": 8,
+      "147456": 7,
+      "196608": 5
+    },
+    "source_product_variant_count_total": 2899968,
+    "source_shape_count": 10,
+    "total_self_edge_conflict_count": 33895908,
+    "total_strict_edge_count": 44236800,
+    "variant_count": 196608,
+    "variant_max_blocker_intersection_size_counts": {
+      "3": 110592,
+      "4": 86016
+    },
+    "variant_rich_class_count_total": 1769472
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -163,9 +163,15 @@ Use this queue when no more specific issue is selected.
    varies the added labels by every Hamming-distance `1` or `2`
    radius-blocker-preserving replacement around those packets, checking
    `5,996` variants; all are quotient-obstructed by self-edges. This is still
-   finite neighborhood evidence only; the next widening is the full extension
-   product for a carefully chosen packet or a principled rich-class bridge
-   hypothesis rather than more baseline-neighborhood sampling.
+   finite neighborhood evidence only. The one-packet full rich-extension
+   product pilot
+   `python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected --json`
+   exhausts the first maximum-size generated packet, checking `196,608`
+   variants; all are quotient-obstructed by self-edges. This is still finite
+   packet evidence only. The next widening is another selected-packet product
+   replay, a batched full-product sweep with stronger pruning, or a principled
+   rich-class bridge hypothesis rather than more baseline-neighborhood
+   sampling.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,6 +169,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-rich-extension-neighborhood.md`](n9-radius-blocker-rich-extension-neighborhood.md):
   bounded Hamming-distance neighborhood of size-five rich-class extensions
   around the generated quotient-sweep packets; finite packet evidence only.
+- [`n9-radius-blocker-rich-extension-product-pilot.md`](n9-radius-blocker-rich-extension-product-pilot.md):
+  full extension-product replay for one maximum-size generated packet; finite
+  packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-radius-blocker-rich-extension-neighborhood.md
+++ b/docs/n9-radius-blocker-rich-extension-neighborhood.md
@@ -50,6 +50,9 @@ not an enumeration of arbitrary rich-class catalogues. It does not prove that
 all radius-blockers are impossible, does not prove `n=9`, does not prove the
 adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
 
-The next useful widening is either the full extension-product catalogue for a
-carefully chosen small packet, or a genuine minimal/rich-class bridge
-hypothesis that narrows which richer catalogues must be checked.
+The follow-up `docs/n9-radius-blocker-rich-extension-product-pilot.md` exhausts
+the full extension-product catalogue for one maximum-size generated packet.
+The next useful widening is either another selected-packet product replay, a
+batched full-product sweep with stronger pruning, or a genuine
+minimal/rich-class bridge hypothesis that narrows which richer catalogues must
+be checked.

--- a/docs/n9-radius-blocker-rich-extension-product-pilot.md
+++ b/docs/n9-radius-blocker-rich-extension-product-pilot.md
@@ -1,0 +1,69 @@
+# n=9 radius-blocker rich-extension product pilot
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite packet diagnostic. No general
+proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note widens `docs/n9-radius-blocker-rich-extension-neighborhood.md` for
+one generated source packet. The full `20`-packet extension product has
+`2,899,968` variants, so this pilot chooses the first maximum-size source
+packet in stable source-artifact order and exhausts that packet first.
+
+The selected packet is:
+
+```text
+n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0
+```
+
+Its row option counts are:
+
+```text
+[3,4,4,4,4,4,4,4,4]
+```
+
+This gives `196,608` radius-blocker-preserving size-five extension variants.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_rich_extension_product_pilot.json
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected --json
+```
+
+All `196,608` variants are obstructed by quotient self-edges. The replay checks
+`1,769,472` size-five rich classes and `44,236,800` strict vertex-circle edges,
+with `33,895,908` total self-edge conflicts. The first self-edge row is row
+`0` in every variant.
+
+The Hamming-distance distribution from the baseline packet is:
+
+```text
+distance 0:      1
+distance 1:     26
+distance 2:    300
+distance 3:  2,016
+distance 4:  8,694
+distance 5: 24,948
+distance 6: 47,628
+distance 7: 58,320
+distance 8: 41,553
+distance 9: 13,122
+```
+
+## Boundary
+
+This is a full Cartesian product only for one selected source packet. It does
+not enumerate the full product for all `20` generated packets, does not
+enumerate arbitrary rich-class catalogues, does not prove that all
+radius-blockers are impossible, does not prove `n=9`, does not prove the
+adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
+
+The next useful widening is another selected-packet product replay, a batched
+full-product sweep with stronger pruning, or a genuine minimal/rich-class
+bridge hypothesis that narrows which richer catalogues must be checked.

--- a/docs/n9-radius-blocker-rich-quotient-sweep.md
+++ b/docs/n9-radius-blocker-rich-quotient-sweep.md
@@ -44,6 +44,8 @@ adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
 
 The follow-up `docs/n9-radius-blocker-rich-extension-neighborhood.md` checks a
 bounded Hamming-distance neighborhood of size-five extension choices around
-these generated packets. The next wider target is still the full extension
-product for a carefully chosen packet or a genuine minimal/rich-class bridge
-hypothesis.
+these generated packets, and
+`docs/n9-radius-blocker-rich-extension-product-pilot.md` exhausts one
+maximum-size packet's full extension product. The next wider target is another
+selected-packet product replay, a batched product sweep with stronger pruning,
+or a genuine minimal/rich-class bridge hypothesis.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -590,9 +590,14 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/n9-radius-blocker-rich-extension-neighborhood.md`, which varies the
   added labels around those `20` packets by every Hamming-distance `1` or `2`
   radius-blocker-preserving replacement and checks `5,996` quotient-obstructed
-  variants. This is still finite neighborhood evidence only; the next review
-  target is the full extension product for a carefully chosen packet or a
-  principled rich-class bridge hypothesis.
+  variants. This is still finite neighborhood evidence only.
+- the one-packet full rich-extension product pilot recorded in
+  `docs/n9-radius-blocker-rich-extension-product-pilot.md`, which exhausts
+  `196,608` radius-blocker-preserving size-five variants for the first
+  maximum-size generated packet. This is still finite packet evidence only;
+  the next review target is another selected-packet product replay, a batched
+  product sweep with stronger pruning, or a principled rich-class bridge
+  hypothesis.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3055,6 +3055,52 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_rich_extension_product_pilot
+    path: data/certificates/n9_radius_blocker_rich_extension_product_pilot.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_rich_extension_product_pilot.py
+    command: python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_rich_extension_product_pilot.py
+    check_command: python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: One-packet n=9 full rich-extension product replay for the first maximum-size generated radius-blocker packet, checking 196,608 size-five variants; finite packet evidence only, not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_rich_extension_product_pilot.v1
+      status: N9_RADIUS_BLOCKER_RICH_EXTENSION_PRODUCT_PILOT_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.source_shape_count: 10
+      summary.source_packet_count: 20
+      summary.source_product_variant_count_total: 2899968
+      summary.source_product_variant_count_counts.196608: 5
+      summary.selected_packet_id: n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0
+      summary.selected_product_variant_count: 196608
+      summary.variant_count: 196608
+      summary.hamming_distance_counts.9: 13122
+      summary.variant_rich_class_count_total: 1769472
+      summary.max_rich_class_size: 5
+      summary.all_variants_radius_blockers: true
+      summary.quotient_status_counts.self_edge: 196608
+      summary.all_variants_obstructed: true
+      summary.total_strict_edge_count: 44236800
+      summary.total_self_edge_conflict_count: 33895908
+      summary.variant_max_blocker_intersection_size_counts.4: 86016
+      source_shape_sweep.path: data/certificates/n9_radius_blocker_shape_sweep.json
+      provenance.command: python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - all 20 extension products are enumerated
+      - arbitrary rich-class systems are classified
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_rich_extension_product_pilot.py
+++ b/scripts/check_n9_radius_blocker_rich_extension_product_pilot.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Check a full rich-extension product for one n=9 blocker packet.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from itertools import product
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from check_n9_radius_blocker_rich_extension_neighborhood import (  # noqa: E402
+    extension_catalog,
+    rich_classes_for_blocker,
+    rich_rows_from_added_labels,
+)
+from check_n9_radius_blocker_rich_quotient_sweep import (  # noqa: E402
+    DEFAULT_SOURCE,
+    N,
+    ORDER,
+    counter_to_json,
+    load_shape_sweep,
+    sha256_file,
+    source_examples,
+)
+from erdos97.adaptive_blockers import is_radius_blocker  # noqa: E402
+from erdos97.radius_blocker_packets import TRUST  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    replay_vertex_circle_rich_quotient,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_rich_extension_product_pilot.v1"
+STATUS = "N9_RADIUS_BLOCKER_RICH_EXTENSION_PRODUCT_PILOT_ONLY"
+DEFAULT_OUT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_radius_blocker_rich_extension_product_pilot.json"
+)
+SELECTION_RULE = "first_maximum_full_extension_product_in_source_order"
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "source_shape_count": 10,
+    "source_packet_count": 20,
+    "source_product_variant_count_total": 2899968,
+    "source_product_variant_count_counts": {
+        "110592": 8,
+        "147456": 7,
+        "196608": 5,
+    },
+    "selected_packet_id": (
+        "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:"
+        "self_edge:0"
+    ),
+    "selected_case_index": 4,
+    "selected_case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+    "selected_source_status": "self_edge",
+    "selected_product_variant_count": 196608,
+    "selected_row_option_count_profile": {"3": 1, "4": 8},
+    "selected_row_alternative_count_profile": {"2": 1, "3": 8},
+    "variant_count": 196608,
+    "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300,
+        "3": 2016,
+        "4": 8694,
+        "5": 24948,
+        "6": 47628,
+        "7": 58320,
+        "8": 41553,
+        "9": 13122,
+    },
+    "variant_rich_class_count_total": 1769472,
+    "max_rich_class_size": 5,
+    "all_variants_radius_blockers": True,
+    "quotient_status_counts": {"self_edge": 196608},
+    "all_variants_obstructed": True,
+    "total_strict_edge_count": 44236800,
+    "total_self_edge_conflict_count": 33895908,
+    "min_self_edge_conflict_count": 69,
+    "max_self_edge_conflict_count": 225,
+    "first_self_edge_row_counts": {"0": 196608},
+    "variant_max_blocker_intersection_size_counts": {"3": 110592, "4": 86016},
+}
+
+
+def packet_id(source: Mapping[str, object]) -> str:
+    return (
+        f"{source['case_name']}:{source['source_status']}:"
+        f"{source['source_example_index']}"
+    )
+
+
+def option_lists(
+    baseline: Sequence[int],
+    alternatives: Sequence[Sequence[int]],
+) -> list[tuple[int, ...]]:
+    return [
+        (int(base), *(int(label) for label in labels))
+        for base, labels in zip(baseline, alternatives, strict=True)
+    ]
+
+
+def product_variant_count(options: Sequence[Sequence[int]]) -> int:
+    return math.prod(len(option) for option in options)
+
+
+def iter_full_product_added_label_variants(
+    baseline: Sequence[int],
+    alternatives: Sequence[Sequence[int]],
+) -> Iterable[tuple[int, tuple[int, ...]]]:
+    """Yield every full-product added-label variant and baseline distance."""
+
+    baseline_tuple = tuple(int(label) for label in baseline)
+    for added_labels in product(*option_lists(baseline, alternatives)):
+        added_tuple = tuple(int(label) for label in added_labels)
+        distance = sum(
+            1
+            for base_label, added_label in zip(
+                baseline_tuple, added_tuple, strict=True
+            )
+            if base_label != added_label
+        )
+        yield distance, added_tuple
+
+
+def source_product_records(
+    sources: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for index, source in enumerate(sources):
+        selected_rows = source["source_selected_rows"]
+        if not isinstance(selected_rows, list):
+            raise AssertionError("source selected rows are missing")
+        baseline, alternatives, _catalog_records = extension_catalog(
+            selected_rows, source["blocker"]
+        )
+        options = option_lists(baseline, alternatives)
+        records.append(
+            {
+                "source_order_index": index,
+                "source_packet_id": packet_id(source),
+                "case_index": int(source["case_index"]),
+                "case_name": str(source["case_name"]),
+                "source_status": str(source["source_status"]),
+                "source_example_index": int(source["source_example_index"]),
+                "blocker": [int(label) for label in source["blocker"]],
+                "row_option_counts": [len(option) for option in options],
+                "row_alternative_counts": [len(labels) for labels in alternatives],
+                "product_variant_count": product_variant_count(options),
+            }
+        )
+    return records
+
+
+def select_source_record(
+    sources: Sequence[Mapping[str, object]],
+) -> tuple[Mapping[str, object], dict[str, object]]:
+    product_records = source_product_records(sources)
+    selected_product = max(
+        int(record["product_variant_count"]) for record in product_records
+    )
+    selected_record = next(
+        record
+        for record in product_records
+        if int(record["product_variant_count"]) == selected_product
+    )
+    return sources[int(selected_record["source_order_index"])], selected_record
+
+
+def build_source_product_summary(
+    product_records: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    variant_counts: Counter[int] = Counter()
+    total = 0
+    for record in product_records:
+        count = int(record["product_variant_count"])
+        variant_counts[count] += 1
+        total += count
+    return {
+        "source_product_variant_count_total": total,
+        "source_product_variant_count_counts": counter_to_json(variant_counts),
+        "source_product_records": list(product_records),
+    }
+
+
+def build_selected_packet_record(
+    source: Mapping[str, object],
+    product_record: Mapping[str, object],
+    *,
+    max_variants: int | None = None,
+) -> dict[str, object]:
+    selected_rows = source["source_selected_rows"]
+    if not isinstance(selected_rows, list):
+        raise AssertionError("source selected rows are missing")
+    rows = [[int(label) for label in row] for row in selected_rows]
+    blocker = [int(label) for label in source["blocker"]]
+    blocker_set = set(blocker)
+    baseline, alternatives, catalog_records = extension_catalog(rows, blocker)
+
+    hamming_distance_counts: Counter[int] = Counter()
+    quotient_status_counts: Counter[str] = Counter()
+    first_self_edge_rows: Counter[int | None] = Counter()
+    max_blocker_intersections: Counter[int] = Counter()
+    self_edge_counts: list[int] = []
+    total_strict_edges = 0
+    all_radius_blockers = True
+    variant_count = 0
+    max_rich_class_size = 0
+    seen_variants: set[tuple[int, ...]] = set()
+
+    for distance, added_labels in iter_full_product_added_label_variants(
+        baseline, alternatives
+    ):
+        if max_variants is not None and variant_count >= max_variants:
+            break
+        if added_labels in seen_variants:
+            raise AssertionError("duplicate full-product variant")
+        seen_variants.add(added_labels)
+        rich_rows = rich_rows_from_added_labels(rows, added_labels)
+        all_radius_blockers = all_radius_blockers and is_radius_blocker(
+            rich_classes_for_blocker(rich_rows), blocker
+        )
+        replay = replay_vertex_circle_rich_quotient(N, ORDER, rich_rows)
+        hamming_distance_counts[distance] += 1
+        quotient_status_counts[str(replay.status)] += 1
+        total_strict_edges += int(replay.strict_edge_count)
+        self_edge_counts.append(len(replay.self_edge_conflicts))
+        first_self_edge_rows[
+            int(replay.self_edge_conflicts[0].row)
+            if replay.self_edge_conflicts
+            else None
+        ] += 1
+        max_blocker_intersections[
+            max(len(set(row.witnesses) & blocker_set) for row in rich_rows)
+        ] += 1
+        max_rich_class_size = max(
+            max_rich_class_size,
+            max(len(row.witnesses) for row in rich_rows),
+        )
+        variant_count += 1
+
+    first_self_edge_json = counter_to_json(first_self_edge_rows)
+    first_self_edge_json.pop("None", None)
+
+    return {
+        "source_packet_id": str(product_record["source_packet_id"]),
+        "selection_rule": SELECTION_RULE,
+        "case_index": int(source["case_index"]),
+        "case_name": str(source["case_name"]),
+        "blocker": blocker,
+        "source_status": str(source["source_status"]),
+        "source_example_index": int(source["source_example_index"]),
+        "source_selected_rows": rows,
+        "row_extension_catalog": catalog_records,
+        "row_option_counts": list(product_record["row_option_counts"]),
+        "row_alternative_counts": list(product_record["row_alternative_counts"]),
+        "product_variant_count": int(product_record["product_variant_count"]),
+        "replayed_variant_count": variant_count,
+        "truncated": max_variants is not None
+        and variant_count < int(product_record["product_variant_count"]),
+        "hamming_distance_counts": counter_to_json(hamming_distance_counts),
+        "all_variants_radius_blockers": all_radius_blockers,
+        "quotient_status_counts": counter_to_json(quotient_status_counts),
+        "all_variants_obstructed": quotient_status_counts.get("ok", 0) == 0,
+        "total_strict_edge_count": total_strict_edges,
+        "total_self_edge_conflict_count": sum(self_edge_counts),
+        "min_self_edge_conflict_count": min(self_edge_counts),
+        "max_self_edge_conflict_count": max(self_edge_counts),
+        "first_self_edge_row_counts": first_self_edge_json,
+        "variant_max_blocker_intersection_size_counts": counter_to_json(
+            max_blocker_intersections
+        ),
+        "max_rich_class_size": max_rich_class_size,
+    }
+
+
+def build_summary(
+    product_records: Sequence[Mapping[str, object]],
+    selected_packet: Mapping[str, object],
+    source_shape_count: int,
+) -> dict[str, object]:
+    source_product_summary = build_source_product_summary(product_records)
+    row_option_profile = Counter(int(count) for count in selected_packet["row_option_counts"])
+    row_alternative_profile = Counter(
+        int(count) for count in selected_packet["row_alternative_counts"]
+    )
+    return {
+        "n": N,
+        "order": ORDER,
+        "source_shape_count": source_shape_count,
+        "source_packet_count": len(product_records),
+        "source_product_variant_count_total": source_product_summary[
+            "source_product_variant_count_total"
+        ],
+        "source_product_variant_count_counts": source_product_summary[
+            "source_product_variant_count_counts"
+        ],
+        "selected_packet_id": selected_packet["source_packet_id"],
+        "selected_case_index": selected_packet["case_index"],
+        "selected_case_name": selected_packet["case_name"],
+        "selected_source_status": selected_packet["source_status"],
+        "selected_product_variant_count": selected_packet["product_variant_count"],
+        "selected_row_option_count_profile": counter_to_json(row_option_profile),
+        "selected_row_alternative_count_profile": counter_to_json(
+            row_alternative_profile
+        ),
+        "variant_count": selected_packet["replayed_variant_count"],
+        "hamming_distance_counts": selected_packet["hamming_distance_counts"],
+        "variant_rich_class_count_total": selected_packet["replayed_variant_count"]
+        * N,
+        "max_rich_class_size": selected_packet["max_rich_class_size"],
+        "all_variants_radius_blockers": selected_packet[
+            "all_variants_radius_blockers"
+        ],
+        "quotient_status_counts": selected_packet["quotient_status_counts"],
+        "all_variants_obstructed": selected_packet["all_variants_obstructed"],
+        "total_strict_edge_count": selected_packet["total_strict_edge_count"],
+        "total_self_edge_conflict_count": selected_packet[
+            "total_self_edge_conflict_count"
+        ],
+        "min_self_edge_conflict_count": selected_packet[
+            "min_self_edge_conflict_count"
+        ],
+        "max_self_edge_conflict_count": selected_packet[
+            "max_self_edge_conflict_count"
+        ],
+        "first_self_edge_row_counts": selected_packet["first_self_edge_row_counts"],
+        "variant_max_blocker_intersection_size_counts": selected_packet[
+            "variant_max_blocker_intersection_size_counts"
+        ],
+    }
+
+
+def build_payload(
+    source: Path = DEFAULT_SOURCE,
+    *,
+    max_variants: int | None = None,
+) -> dict[str, object]:
+    shape_sweep = load_shape_sweep(source)
+    sources = source_examples(shape_sweep)
+    product_records = source_product_records(sources)
+    selected_source, selected_product_record = select_source_record(sources)
+    selected_packet = build_selected_packet_record(
+        selected_source,
+        selected_product_record,
+        max_variants=max_variants,
+    )
+    cases = shape_sweep.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "One-packet n=9 full rich-extension product replay. It selects "
+            "the first maximum-size source packet from the generated "
+            "radius-blocker quotient-sweep packet family and replays every "
+            "radius-blocker-preserving size-five added-label choice for that "
+            "packet. This is finite packet evidence only: it is not an n=9 "
+            "proof, not a proof of the adaptive blocker bridge, and not a "
+            "counterexample."
+        ),
+        "summary": build_summary(product_records, selected_packet, len(cases)),
+        "source_shape_sweep": {
+            "path": source.relative_to(ROOT).as_posix(),
+            "schema": shape_sweep.get("schema"),
+            "status": shape_sweep.get("status"),
+            "trust": shape_sweep.get("trust"),
+            "sha256": sha256_file(source),
+            "summary": shape_sweep.get("summary"),
+        },
+        "source_product_catalog": build_source_product_summary(product_records),
+        "selection_rule": {
+            "rule": SELECTION_RULE,
+            "reason": (
+                "The full 20-packet extension product has 2,899,968 variants. "
+                "This pilot exhausts one largest product packet first, using "
+                "source-artifact order as the stable tie-break."
+            ),
+        },
+        "product_rule": {
+            "catalogue": (
+                "For each row, enumerate every extra label that preserves the "
+                "actual radius-blocker condition: inside-blocker centers must "
+                "stay below three blocker vertices, while outside-blocker "
+                "centers are unconstrained by blocker intersection."
+            ),
+            "variants": (
+                "Replay the full Cartesian product of those row extension "
+                "choices for the selected source packet."
+            ),
+        },
+        "selected_packet": selected_packet,
+        "interpretation_warnings": [
+            "This checks the full extension product for one selected source packet only.",
+            "It does not enumerate the full product for all 20 source packets.",
+            "It does not enumerate arbitrary rich-class catalogues.",
+            "It does not prove the adaptive radius-blocker bridge.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_rich_extension_product_pilot.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_shape_sweep.json",
+                "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+                "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    selected_packet = payload.get("selected_packet")
+    if not isinstance(selected_packet, Mapping):
+        raise AssertionError("selected packet record is missing")
+    if selected_packet.get("truncated"):
+        raise AssertionError("expected payload must not be truncated")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker rich-extension product pilot")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"selected packet: {summary['selected_packet_id']}")
+    print(f"variants: {summary['variant_count']}")
+    print(f"quotient statuses: {summary['quotient_status_counts']}")
+    print(f"self-edge conflicts: {summary['total_self_edge_conflict_count']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument(
+        "--max-variants",
+        type=int,
+        default=None,
+        help="debug/testing limit; do not use for checked artifacts",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args.source, max_variants=args.max_variants)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1473,6 +1473,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_rich_extension_product_pilot",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_rich_extension_product_pilot.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "One-packet full rich-extension product replay for the first "
+            "maximum-size generated n=9 radius-blocker packet; finite packet "
+            "evidence only, not the full 20-packet product, not a proof of "
+            "Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/tests/test_n9_radius_blocker_rich_extension_product_pilot.py
+++ b/tests/test_n9_radius_blocker_rich_extension_product_pilot.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_radius_blocker_rich_extension_product_pilot import (  # noqa: E402
+    build_payload,
+    iter_full_product_added_label_variants,
+    select_source_record,
+    source_product_records,
+)
+from check_n9_radius_blocker_rich_quotient_sweep import (  # noqa: E402
+    DEFAULT_SOURCE,
+    load_shape_sweep,
+    source_examples,
+)
+
+
+def test_n9_radius_blocker_rich_extension_product_selects_first_maximum() -> None:
+    shape_sweep = load_shape_sweep(DEFAULT_SOURCE)
+    sources = source_examples(shape_sweep)
+    records = source_product_records(sources)
+    _selected_source, selected_record = select_source_record(sources)
+
+    assert sum(int(record["product_variant_count"]) for record in records) == 2899968
+    assert Counter(int(record["product_variant_count"]) for record in records) == {
+        110592: 8,
+        147456: 7,
+        196608: 5,
+    }
+    assert (
+        selected_record["source_packet_id"]
+        == "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0"
+    )
+    assert selected_record["product_variant_count"] == 196608
+    assert selected_record["row_option_counts"] == [3, 4, 4, 4, 4, 4, 4, 4, 4]
+
+
+def test_n9_radius_blocker_rich_extension_product_variant_iterator() -> None:
+    variants = list(
+        iter_full_product_added_label_variants(
+            baseline=[10, 20, 30],
+            alternatives=[[11, 12], [], [31]],
+        )
+    )
+
+    assert len(variants) == 6
+    assert variants[0] == (0, (10, 20, 30))
+    assert variants[-1] == (2, (12, 20, 31))
+    assert Counter(distance for distance, _labels in variants) == {
+        0: 1,
+        1: 3,
+        2: 2,
+    }
+
+
+def test_n9_radius_blocker_rich_extension_product_limited_replay_smoke() -> None:
+    payload = build_payload(max_variants=4)
+    summary = payload["summary"]
+    selected_packet = payload["selected_packet"]
+
+    assert summary["selected_packet_id"] == (
+        "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0"
+    )
+    assert summary["variant_count"] == 4
+    assert summary["quotient_status_counts"] == {"self_edge": 4}
+    assert selected_packet["truncated"] is True


### PR DESCRIPTION
## Summary

Adds a one-packet n=9 rich-extension product pilot for the generated radius-blocker packet family.

The new checker computes the full extension-product sizes for all 20 generated source packets, selects the first maximum-size packet by stable source-artifact order, and replays every radius-blocker-preserving size-five added-label choice for that packet. The selected packet is `n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0`, with row option counts `[3,4,4,4,4,4,4,4,4]` and `196,608` full-product variants. All variants are quotient-obstructed by self-edges.

## Scope / Non-claim

This is finite packet evidence only. It does not enumerate the full product for all 20 generated packets, does not enumerate arbitrary rich-class catalogues, does not prove the adaptive radius-blocker bridge, does not prove n=9, does not prove Erdos Problem #97, and does not supply a counterexample.

## Validation

- `python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --write`
- `python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected`
- `python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected --json`
- `python -m ruff check scripts/check_n9_radius_blocker_rich_extension_product_pilot.py tests/test_n9_radius_blocker_rich_extension_product_pilot.py`
- `python -m pytest tests/test_n9_radius_blocker_rich_extension_product_pilot.py -q`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_status_consistency.py --max-official-status-age-days 90`
- `python scripts/check_text_clean.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (1059 passed, 299 deselected)
- `python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --check --assert-expected`
- `python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected`
- `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected`

`make verify-artifacts` could not be run in this PowerShell shell because `make` is not installed.