### PR TITLE
[codex] Add rich-extension product sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   four-blocker shape sweep, its order-reduction crosswalk, a bounded
   richer-class projection pilot, a full rich-class quotient replay pilot, a
   generated rich-class quotient sweep, a bounded rich-extension neighborhood
-  sweep, and a one-packet full rich-extension product pilot,
+  sweep, a one-packet full rich-extension product pilot, and an all-packet
+  generated rich-extension product sweep,
   read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
@@ -88,7 +89,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-radius-blocker-rich-extension-neighborhood.md`](docs/n9-radius-blocker-rich-extension-neighborhood.md)
   and
-  [`docs/n9-radius-blocker-rich-extension-product-pilot.md`](docs/n9-radius-blocker-rich-extension-product-pilot.md).
+  [`docs/n9-radius-blocker-rich-extension-product-pilot.md`](docs/n9-radius-blocker-rich-extension-product-pilot.md)
+  and
+  [`docs/n9-radius-blocker-rich-extension-product-sweep.md`](docs/n9-radius-blocker-rich-extension-product-sweep.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -348,6 +348,18 @@ counterexample. See
 `scripts/check_n9_radius_blocker_rich_extension_product_pilot.py`, and
 `data/certificates/n9_radius_blocker_rich_extension_product_pilot.json`.
 
+An all-packet generated rich-extension product sweep now exhausts the full
+extension product over all `20` generated source packets. It checks
+`2,899,968` radius-blocker-preserving size-five variants, `26,099,712`
+size-five rich classes, and `652,492,800` strict edges. All variants are
+quotient-obstructed by self-edges, with `467,149,054` total self-edge
+conflicts. This remains finite generated-packet evidence only, not arbitrary
+rich-class classification, not an `n=9` theorem, not a bridge proof, and not a
+counterexample. See
+`docs/n9-radius-blocker-rich-extension-product-sweep.md`,
+`scripts/check_n9_radius_blocker_rich_extension_product_sweep.py`, and
+`data/certificates/n9_radius_blocker_rich_extension_product_sweep.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -226,6 +226,14 @@ is still finite packet evidence only, not the full `20`-packet product, not an
 arbitrary rich-class classification, not an `n=9` proof, and not a bridge
 proof. See `docs/n9-radius-blocker-rich-extension-product-pilot.md`.
 
+The follow-up all-packet generated-product sweep exhausts the full extension
+product over all `20` generated source packets, checking `2,899,968`
+radius-blocker-preserving size-five variants. All variants are obstructed by
+quotient self-edges, with `467,149,054` total self-edge conflicts across
+`652,492,800` strict edges. This is still finite generated-packet evidence
+only, not an arbitrary rich-class classification, not an `n=9` proof, and not
+a bridge proof. See `docs/n9-radius-blocker-rich-extension-product-sweep.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_radius_blocker_rich_extension_product_sweep.json
+++ b/data/certificates/n9_radius_blocker_rich_extension_product_sweep.json
@@ -1,0 +1,8719 @@
+{
+  "claim_scope": "All-packet n=9 full rich-extension product replay over the 20 generated radius-blocker quotient-sweep source packets. It replays every radius-blocker-preserving size-five added-label choice for those generated packets. This is finite generated packet evidence only: it is not an n=9 proof, not a proof of the adaptive blocker bridge, and not a counterexample.",
+  "debug_limits": {
+    "max_packets": null,
+    "max_variants_per_packet": null
+  },
+  "interpretation_warnings": [
+    "This checks only generated size-five packets derived from stored examples.",
+    "It does not enumerate arbitrary rich-class catalogues.",
+    "It does not prove the adaptive radius-blocker bridge.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "product_rule": {
+    "catalogue": "For each row, enumerate every extra label that preserves the actual radius-blocker condition: inside-blocker centers must stay below three blocker vertices, while outside-blocker centers are unconstrained by blocker intersection.",
+    "variants": "Replay the full Cartesian product of those row extension choices for every generated source packet."
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --write --assert-expected",
+    "generator": "scripts/check_n9_radius_blocker_rich_extension_product_sweep.py",
+    "sources": [
+      "data/certificates/n9_radius_blocker_shape_sweep.json",
+      "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+      "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+      "scripts/check_n9_radius_blocker_rich_extension_product_pilot.py",
+      "src/erdos97/adaptive_blockers.py",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "schema": "erdos97.n9_radius_blocker_rich_extension_product_sweep.v1",
+  "source_packets": [
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "case_index": 0,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 89,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        3,
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            6
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            3,
+            4,
+            6
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 7,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            2,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            8
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            6
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            6
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            5
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        4,
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 0,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          6
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          0,
+          1,
+          5,
+          6
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 19742932,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "2": 6912,
+        "3": 103680
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "case_index": 0,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 51,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            5,
+            6
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            3,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 1,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 16378418,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 27648
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "case_index": 1,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 81,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            4,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            5,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            5,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            6
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 2,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 23699984,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 36864
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        4
+      ],
+      "case_index": 1,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 78,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            6
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            7,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            2,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            8
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            6
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            6
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 3,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 20094996,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 27648
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "case_index": 2,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 215,
+      "min_self_edge_conflict_count": 77,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            4
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 4,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 19093070,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 62208,
+        "4": 48384
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "case_index": 2,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 51,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            0,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            4,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            2,
+            4
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            6
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 5,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 22170219,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 36864
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "case_index": 3,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 69,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 6,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 19470228,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 27648
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        4
+      ],
+      "case_index": 3,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 60,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            6,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 7,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 20948800,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 64512
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "case_index": 4,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 196608
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300,
+        "3": 2016,
+        "4": 8694,
+        "5": 24948,
+        "6": 47628,
+        "7": 58320,
+        "8": 41553,
+        "9": 13122
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 69,
+      "product_variant_count": 196608,
+      "quotient_status_counts": {
+        "self_edge": 196608
+      },
+      "replayed_variant_count": 196608,
+      "row_alternative_counts": [
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 7,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 8,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 33895908,
+      "total_strict_edge_count": 44236800,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 86016
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "case_index": 4,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 91,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        2,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            5,
+            6
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            3,
+            5,
+            6
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            7
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            7,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            6,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            5,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            8
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            6
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            6
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 9,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ],
+        [
+          1,
+          3,
+          5,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          7
+        ],
+        [
+          0,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 26730145,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 36864
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "case_index": 5,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 79,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        2,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            6,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 7,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 10,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 25506876,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 36864
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        6
+      ],
+      "case_index": 5,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 196608
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300,
+        "3": 2016,
+        "4": 8694,
+        "5": 24948,
+        "6": 47628,
+        "7": 58320,
+        "8": 41553,
+        "9": 13122
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 51,
+      "product_variant_count": 196608,
+      "quotient_status_counts": {
+        "self_edge": 196608
+      },
+      "replayed_variant_count": 196608,
+      "row_alternative_counts": [
+        3,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            5
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        4,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 11,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 29148286,
+      "total_strict_edge_count": 44236800,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 86016
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "case_index": 6,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 69,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        2,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        3,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 12,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 19563120,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 27648
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        3,
+        7
+      ],
+      "case_index": 6,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 196608
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300,
+        "3": 2016,
+        "4": 8694,
+        "5": 24948,
+        "6": 47628,
+        "7": 58320,
+        "8": 41553,
+        "9": 13122
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 60,
+      "product_variant_count": 196608,
+      "quotient_status_counts": {
+        "self_edge": 196608
+      },
+      "replayed_variant_count": 196608,
+      "row_alternative_counts": [
+        3,
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            3,
+            4
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        4,
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 13,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 28241014,
+      "total_strict_edge_count": 44236800,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 86016
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "case_index": 7,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 69,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        3,
+        2,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            5,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        4,
+        3,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 14,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 25601224,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "4": 147456
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "case_index": 7,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 51,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        2,
+        3,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            6,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            6,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 6,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            4,
+            5,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            3,
+            4
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            5
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            4,
+            5
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        3,
+        4,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 15,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 16353470,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 27648
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "case_index": 8,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 147456
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 25,
+        "2": 277,
+        "3": 1785,
+        "4": 7371,
+        "5": 20223,
+        "6": 36855,
+        "7": 43011,
+        "8": 29160,
+        "9": 8748
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 69,
+      "product_variant_count": 147456,
+      "quotient_status_counts": {
+        "self_edge": 147456
+      },
+      "replayed_variant_count": 147456,
+      "row_alternative_counts": [
+        3,
+        2,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            6,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            5,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            4,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            7,
+            8
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            1,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            2,
+            3,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            3,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            2,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            6,
+            7
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            5
+          ]
+        }
+      ],
+      "row_option_counts": [
+        4,
+        3,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 16,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          7
+        ],
+        [
+          1,
+          4,
+          6,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          3,
+          4,
+          6,
+          7
+        ],
+        [
+          2,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          5
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 25735580,
+      "total_strict_edge_count": 33177600,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 82944,
+        "4": 64512
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        1,
+        4,
+        6
+      ],
+      "case_index": 8,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 196608
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300,
+        "3": 2016,
+        "4": 8694,
+        "5": 24948,
+        "6": 47628,
+        "7": 58320,
+        "8": 41553,
+        "9": 13122
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 51,
+      "product_variant_count": 196608,
+      "quotient_status_counts": {
+        "self_edge": 196608
+      },
+      "replayed_variant_count": 196608,
+      "row_alternative_counts": [
+        2,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            6,
+            7,
+            8
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            5
+          ],
+          "candidate_added_labels": [
+            4,
+            6,
+            7,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            2,
+            3,
+            5
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            2,
+            7
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            5,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            2,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            3,
+            5,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            6,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            4,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            6,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            4,
+            5
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            5
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            4,
+            5
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            4,
+            5
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 17,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          2,
+          3,
+          5
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          3,
+          5,
+          6,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          6,
+          8
+        ],
+        [
+          1,
+          3,
+          6,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 28269476,
+      "total_strict_edge_count": 44236800,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "4": 196608
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "case_index": 9,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 196608
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 26,
+        "2": 300,
+        "3": 2016,
+        "4": 8694,
+        "5": 24948,
+        "6": 47628,
+        "7": 58320,
+        "8": 41553,
+        "9": 13122
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 225,
+      "min_self_edge_conflict_count": 81,
+      "product_variant_count": 196608,
+      "quotient_status_counts": {
+        "self_edge": 196608
+      },
+      "replayed_variant_count": 196608,
+      "row_alternative_counts": [
+        3,
+        3,
+        3,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            6,
+            7
+          ],
+          "baseline_added_label": 4,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            4,
+            5,
+            6,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            6,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            3,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            5,
+            6,
+            8
+          ],
+          "center": 1,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            4,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            7,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            0,
+            4,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            6,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            7
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            1,
+            3,
+            8
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            2,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            5,
+            8
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 4,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            4,
+            6
+          ],
+          "candidate_added_labels": [
+            2,
+            3,
+            5,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            6
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        4,
+        4,
+        4,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 18,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:self_edge:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          3,
+          8
+        ],
+        [
+          0,
+          3,
+          4,
+          7
+        ],
+        [
+          1,
+          3,
+          5,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          8
+        ],
+        [
+          0,
+          3,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          1,
+          4,
+          6
+        ],
+        [
+          0,
+          2,
+          5,
+          7
+        ]
+      ],
+      "source_status": "self_edge",
+      "total_self_edge_conflict_count": 30074112,
+      "total_strict_edge_count": 44236800,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 110592,
+        "4": 86016
+      }
+    },
+    {
+      "all_variants_obstructed": true,
+      "all_variants_radius_blockers": true,
+      "blocker": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "case_index": 9,
+      "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+      "first_self_edge_row_counts": {
+        "0": 110592
+      },
+      "hamming_distance_counts": {
+        "0": 1,
+        "1": 24,
+        "2": 255,
+        "3": 1574,
+        "4": 6219,
+        "5": 16308,
+        "6": 28377,
+        "7": 31590,
+        "8": 20412,
+        "9": 5832
+      },
+      "max_rich_class_size": 5,
+      "max_self_edge_conflict_count": 205,
+      "min_self_edge_conflict_count": 63,
+      "product_variant_count": 110592,
+      "quotient_status_counts": {
+        "self_edge": 110592
+      },
+      "replayed_variant_count": 110592,
+      "row_alternative_counts": [
+        2,
+        3,
+        2,
+        3,
+        2,
+        3,
+        3,
+        3,
+        3
+      ],
+      "row_extension_catalog": [
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 3,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            4,
+            8
+          ],
+          "candidate_added_labels": [
+            3,
+            5,
+            7
+          ],
+          "center": 0,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            6,
+            7
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            2,
+            3,
+            5,
+            8
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            6,
+            7
+          ],
+          "center": 1,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            3,
+            5,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            7,
+            8
+          ],
+          "baseline_added_label": 5,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            3,
+            4,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            5,
+            7,
+            8
+          ],
+          "center": 2,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            3,
+            4,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            0,
+            6,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            4,
+            5,
+            7
+          ],
+          "candidate_added_labels": [
+            0,
+            1,
+            6,
+            8
+          ],
+          "center": 3,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            2,
+            4,
+            5,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            5,
+            7
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            1,
+            2,
+            3,
+            6,
+            8
+          ],
+          "candidate_added_labels": [
+            1,
+            5,
+            7
+          ],
+          "center": 4,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            4,
+            6,
+            7
+          ],
+          "candidate_added_labels": [
+            1,
+            2,
+            3,
+            8
+          ],
+          "center": 5,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            2,
+            3,
+            4
+          ],
+          "baseline_added_label": 0,
+          "baseline_blocker_intersection_size": 1,
+          "baseline_rich_class": [
+            0,
+            1,
+            5,
+            7,
+            8
+          ],
+          "candidate_added_labels": [
+            0,
+            2,
+            3,
+            4
+          ],
+          "center": 6,
+          "inside_blocker_center": true,
+          "source_exact_row": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            3,
+            4,
+            8
+          ],
+          "baseline_added_label": 1,
+          "baseline_blocker_intersection_size": 3,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            5,
+            6
+          ],
+          "candidate_added_labels": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "center": 7,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            2,
+            5,
+            6
+          ]
+        },
+        {
+          "alternative_added_labels": [
+            4,
+            5,
+            6
+          ],
+          "baseline_added_label": 2,
+          "baseline_blocker_intersection_size": 2,
+          "baseline_rich_class": [
+            0,
+            1,
+            2,
+            3,
+            7
+          ],
+          "candidate_added_labels": [
+            2,
+            4,
+            5,
+            6
+          ],
+          "center": 8,
+          "inside_blocker_center": false,
+          "source_exact_row": [
+            0,
+            1,
+            3,
+            7
+          ]
+        }
+      ],
+      "row_option_counts": [
+        3,
+        4,
+        3,
+        4,
+        3,
+        4,
+        4,
+        4,
+        4
+      ],
+      "source_example_index": 0,
+      "source_order_index": 19,
+      "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:strict_cycle:0",
+      "source_selected_rows": [
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          0,
+          3,
+          5,
+          8
+        ],
+        [
+          1,
+          3,
+          4,
+          6
+        ],
+        [
+          2,
+          4,
+          5,
+          7
+        ],
+        [
+          2,
+          3,
+          6,
+          8
+        ],
+        [
+          0,
+          4,
+          6,
+          7
+        ],
+        [
+          1,
+          5,
+          7,
+          8
+        ],
+        [
+          0,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          3,
+          7
+        ]
+      ],
+      "source_status": "strict_cycle",
+      "total_self_edge_conflict_count": 16431196,
+      "total_strict_edge_count": 24883200,
+      "truncated": false,
+      "variant_max_blocker_intersection_size_counts": {
+        "3": 62208,
+        "4": 48384
+      }
+    }
+  ],
+  "source_product_catalog": {
+    "source_product_records": [
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "case_index": 0,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          3,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 0,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "case_index": 0,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 1,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0123_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "case_index": 1,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 2,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          4
+        ],
+        "case_index": 1,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 3,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0124_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          5
+        ],
+        "case_index": 2,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 4,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          2,
+          5
+        ],
+        "case_index": 2,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 5,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0125_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "case_index": 3,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 6,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "case_index": 3,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 7,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0134_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "case_index": 4,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 8,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "case_index": 4,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 9,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0135_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "case_index": 5,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 10,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "case_index": 5,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 11,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0136_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "case_index": 6,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          2,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          3,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 12,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "case_index": 6,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 13,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0137_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "case_index": 7,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 14,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "case_index": 7,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          2,
+          3,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          3,
+          4,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 15,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0145_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "case_index": 8,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+        "product_variant_count": 147456,
+        "row_alternative_counts": [
+          3,
+          2,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          3,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 16,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "case_index": 8,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          2,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 17,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0146_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      },
+      {
+        "blocker": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "case_index": 9,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+        "product_variant_count": 196608,
+        "row_alternative_counts": [
+          3,
+          3,
+          3,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          4,
+          4,
+          4,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 18,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:self_edge:0",
+        "source_status": "self_edge"
+      },
+      {
+        "blocker": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "case_index": 9,
+        "case_name": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order",
+        "product_variant_count": 110592,
+        "row_alternative_counts": [
+          2,
+          3,
+          2,
+          3,
+          2,
+          3,
+          3,
+          3,
+          3
+        ],
+        "row_option_counts": [
+          3,
+          4,
+          3,
+          4,
+          3,
+          4,
+          4,
+          4,
+          4
+        ],
+        "source_example_index": 0,
+        "source_order_index": 19,
+        "source_packet_id": "n9_full_exact_four_radius_blocker_shape_U0246_natural_order:strict_cycle:0",
+        "source_status": "strict_cycle"
+      }
+    ],
+    "source_product_variant_count_counts": {
+      "110592": 8,
+      "147456": 7,
+      "196608": 5
+    },
+    "source_product_variant_count_total": 2899968
+  },
+  "source_shape_sweep": {
+    "path": "data/certificates/n9_radius_blocker_shape_sweep.json",
+    "schema": "erdos97.radius_blocker_vertex_circle_packet.v1",
+    "sha256": "a5291621ebf8a3ef8cc7eb9502933ef768c4da81b314096ffaea68aa96b19100",
+    "status": "RADIUS_BLOCKER_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+    "summary": {
+      "all_cases_finished": true,
+      "all_cases_have_radius_blocker": true,
+      "all_dihedral_labelled_blockers_covered": true,
+      "all_incidence_survivors_obstructed": true,
+      "dihedral_orbit_size_counts": {
+        "18": 4,
+        "9": 6
+      },
+      "labelled_blocker_count": 126,
+      "n": 9,
+      "order": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "shape_count": 10,
+      "total_incidence_survivors": 1358,
+      "total_nodes_visited": 754505,
+      "vertex_circle_status_totals": {
+        "self_edge": 1164,
+        "strict_cycle": 194
+      }
+    },
+    "trust": "REVIEW_PENDING_DIAGNOSTIC"
+  },
+  "status": "N9_RADIUS_BLOCKER_RICH_EXTENSION_PRODUCT_SWEEP_ONLY",
+  "summary": {
+    "all_variants_obstructed": true,
+    "all_variants_radius_blockers": true,
+    "first_self_edge_row_counts": {
+      "0": 2899968
+    },
+    "hamming_distance_counts": {
+      "0": 20,
+      "1": 497,
+      "2": 5479,
+      "3": 35167,
+      "4": 144819,
+      "5": 396765,
+      "6": 723141,
+      "7": 845397,
+      "8": 575181,
+      "9": 173502
+    },
+    "max_rich_class_size": 5,
+    "max_self_edge_conflict_count": 225,
+    "min_self_edge_conflict_count": 51,
+    "n": 9,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "quotient_status_counts": {
+      "self_edge": 2899968
+    },
+    "source_packet_count": 20,
+    "source_product_variant_count_counts": {
+      "110592": 8,
+      "147456": 7,
+      "196608": 5
+    },
+    "source_product_variant_count_total": 2899968,
+    "source_row_alternative_count_profile": {
+      "2": 43,
+      "3": 137
+    },
+    "source_row_option_count_profile": {
+      "3": 43,
+      "4": 137
+    },
+    "source_shape_count": 10,
+    "source_status_counts": {
+      "self_edge": 10,
+      "strict_cycle": 10
+    },
+    "total_self_edge_conflict_count": 467149054,
+    "total_strict_edge_count": 652492800,
+    "variant_count": 2899968,
+    "variant_max_blocker_intersection_size_counts": {
+      "2": 6912,
+      "3": 1693440,
+      "4": 1199616
+    },
+    "variant_rich_class_count_total": 26099712
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -168,10 +168,14 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected --json`
    exhausts the first maximum-size generated packet, checking `196,608`
    variants; all are quotient-obstructed by self-edges. This is still finite
-   packet evidence only. The next widening is another selected-packet product
-   replay, a batched full-product sweep with stronger pruning, or a principled
-   rich-class bridge hypothesis rather than more baseline-neighborhood
-   sampling.
+   packet evidence only. The all-packet generated product sweep
+   `python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --check --assert-expected --json`
+   exhausts the full Cartesian product over all `20` generated source packets,
+   checking `2,899,968` variants; all are quotient-obstructed by self-edges.
+   This is still finite generated-packet evidence only. The next widening
+   should be a principled rich-class bridge hypothesis or a
+   generator-independent catalogue rather than more product replay over the
+   same generated packet family.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,6 +172,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-radius-blocker-rich-extension-product-pilot.md`](n9-radius-blocker-rich-extension-product-pilot.md):
   full extension-product replay for one maximum-size generated packet; finite
   packet evidence only.
+- [`n9-radius-blocker-rich-extension-product-sweep.md`](n9-radius-blocker-rich-extension-product-sweep.md):
+  full extension-product replay over all 20 generated source packets; finite
+  generated-packet evidence only.
 - [`bootstrap-core-bridge.md`](bootstrap-core-bridge.md): rich-triple closure
   rank, bootstrap cores, private halos, and weighted cyclic capacity.
 - [`bootstrap-core-crosswalk.md`](bootstrap-core-crosswalk.md): checked

--- a/docs/n9-radius-blocker-rich-extension-product-pilot.md
+++ b/docs/n9-radius-blocker-rich-extension-product-pilot.md
@@ -58,12 +58,10 @@ distance 9: 13,122
 
 ## Boundary
 
-This is a full Cartesian product only for one selected source packet. It does
-not enumerate the full product for all `20` generated packets, does not
-enumerate arbitrary rich-class catalogues, does not prove that all
-radius-blockers are impossible, does not prove `n=9`, does not prove the
-adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
+This is a full Cartesian product only for one selected source packet. The
+follow-up all-packet generated-product sweep is recorded in
+`docs/n9-radius-blocker-rich-extension-product-sweep.md`.
 
-The next useful widening is another selected-packet product replay, a batched
-full-product sweep with stronger pruning, or a genuine minimal/rich-class
-bridge hypothesis that narrows which richer catalogues must be checked.
+Neither packet enumerates arbitrary rich-class catalogues, proves that all
+radius-blockers are impossible, proves `n=9`, proves the adaptive
+radius-blocker bridge, or proves Erdos Problem #97.

--- a/docs/n9-radius-blocker-rich-extension-product-sweep.md
+++ b/docs/n9-radius-blocker-rich-extension-product-sweep.md
@@ -1,0 +1,66 @@
+# n=9 radius-blocker rich-extension product sweep
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite generated-packet diagnostic. No
+general proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note widens the one-packet replay in
+`docs/n9-radius-blocker-rich-extension-product-pilot.md` to all `20` generated
+source packets from `docs/n9-radius-blocker-rich-quotient-sweep.md`. For each
+source packet, the checker enumerates the full Cartesian product of
+radius-blocker-preserving added labels, turning every exact-four row into a
+synthetic size-five rich class.
+
+The full generated product contains `2,899,968` variants. The source packet
+product sizes are:
+
+```text
+110,592 variants: 8 packets
+147,456 variants: 7 packets
+196,608 variants: 5 packets
+```
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_radius_blocker_rich_extension_product_sweep.json
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --check --assert-expected --json
+```
+
+All `2,899,968` variants are obstructed by quotient self-edges. The replay
+checks `26,099,712` size-five rich classes and `652,492,800` strict
+vertex-circle edges, with `467,149,054` total self-edge conflicts. The first
+self-edge row is row `0` in every variant.
+
+The Hamming-distance distribution from the baseline packets is:
+
+```text
+distance 0:      20
+distance 1:     497
+distance 2:   5,479
+distance 3:  35,167
+distance 4: 144,819
+distance 5: 396,765
+distance 6: 723,141
+distance 7: 845,397
+distance 8: 575,181
+distance 9: 173,502
+```
+
+## Boundary
+
+This exhausts the full extension product only for the `20` generated source
+packets. It does not enumerate arbitrary rich-class catalogues, does not prove
+that all radius-blockers are impossible, does not prove `n=9`, does not prove
+the adaptive radius-blocker bridge, and does not prove Erdos Problem #97.
+
+The next useful step is no longer another copy of the same generated-packet
+product. It is a principled minimal/rich-class bridge hypothesis or a checker
+that leaves this generated packet family and reaches arbitrary rich-class
+catalogues.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -595,9 +595,13 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/n9-radius-blocker-rich-extension-product-pilot.md`, which exhausts
   `196,608` radius-blocker-preserving size-five variants for the first
   maximum-size generated packet. This is still finite packet evidence only;
-  the next review target is another selected-packet product replay, a batched
-  product sweep with stronger pruning, or a principled rich-class bridge
-  hypothesis.
+- the all-packet generated rich-extension product sweep recorded in
+  `docs/n9-radius-blocker-rich-extension-product-sweep.md`, which exhausts
+  `2,899,968` radius-blocker-preserving size-five variants over the `20`
+  generated source packets. This is still finite generated-packet evidence
+  only; the next review target is a principled rich-class bridge hypothesis
+  or a generator-independent catalogue, not another copy of the same product
+  replay.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -318,6 +318,11 @@ local_repo:
       artifact: "data/certificates/bootstrap_t12_151_singleton_support_audit.json"
       verifier: "scripts/check_bootstrap_t12_151_singleton_support_audit.py"
       claim_scope: "proof-mining diagnostic only; enumerates singleton-support activation rows for source 151 rows 5 and 8 and finds no non-original target-row survivor in the fixed source-151 neighborhood or one-row-drop relaxation, but does not prove singleton support existence, row forcing, n=9, or the bridge"
+    - pattern: "n9_radius_blocker_rich_extension_product_sweep"
+      status: "all-packet generated rich-extension product sweep"
+      artifact: "data/certificates/n9_radius_blocker_rich_extension_product_sweep.json"
+      verifier: "scripts/check_n9_radius_blocker_rich_extension_product_sweep.py"
+      claim_scope: "finite generated-packet proof-mining diagnostic only; exhausts 2899968 radius-blocker-preserving size-five variants over 20 generated source packets and finds all quotient-obstructed by self-edges, but does not classify arbitrary rich-class catalogues, prove n=9, prove the adaptive blocker bridge, prove Erdos #97, or give a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3101,6 +3101,50 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_radius_blocker_rich_extension_product_sweep
+    path: data/certificates/n9_radius_blocker_rich_extension_product_sweep.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_radius_blocker_rich_extension_product_sweep.py
+    command: python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --write --assert-expected
+    checker: scripts/check_n9_radius_blocker_rich_extension_product_sweep.py
+    check_command: python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: All-packet n=9 full rich-extension product replay over 20 generated radius-blocker source packets, checking 2,899,968 size-five variants; finite generated-packet evidence only, not a proof of Erdos Problem #97 and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_radius_blocker_rich_extension_product_sweep.v1
+      status: N9_RADIUS_BLOCKER_RICH_EXTENSION_PRODUCT_SWEEP_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.source_shape_count: 10
+      summary.source_packet_count: 20
+      summary.source_product_variant_count_total: 2899968
+      summary.source_product_variant_count_counts.196608: 5
+      summary.variant_count: 2899968
+      summary.hamming_distance_counts.9: 173502
+      summary.variant_rich_class_count_total: 26099712
+      summary.max_rich_class_size: 5
+      summary.all_variants_radius_blockers: true
+      summary.quotient_status_counts.self_edge: 2899968
+      summary.all_variants_obstructed: true
+      summary.total_strict_edge_count: 652492800
+      summary.total_self_edge_conflict_count: 467149054
+      summary.first_self_edge_row_counts.0: 2899968
+      summary.variant_max_blocker_intersection_size_counts.4: 1199616
+      source_shape_sweep.path: data/certificates/n9_radius_blocker_shape_sweep.json
+      provenance.command: python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --write --assert-expected
+    forbidden_claims:
+      - adaptive blocker bridge is proved
+      - n=9 is proved
+      - arbitrary rich-class systems are classified
+      - all radius-blockers are impossible
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_radius_blocker_rich_extension_product_sweep.py
+++ b/scripts/check_n9_radius_blocker_rich_extension_product_sweep.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Check the full rich-extension product over all n=9 blocker packets.
+
+This is a finite bridge diagnostic only. It proves no general theorem about
+Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from check_n9_radius_blocker_rich_extension_neighborhood import (  # noqa: E402
+    extension_catalog,
+    rich_classes_for_blocker,
+    rich_rows_from_added_labels,
+)
+from check_n9_radius_blocker_rich_extension_product_pilot import (  # noqa: E402
+    build_source_product_summary,
+    iter_full_product_added_label_variants,
+    source_product_records,
+)
+from check_n9_radius_blocker_rich_quotient_sweep import (  # noqa: E402
+    DEFAULT_SOURCE,
+    N,
+    ORDER,
+    counter_to_json,
+    load_shape_sweep,
+    sha256_file,
+    source_examples,
+)
+from erdos97.adaptive_blockers import is_radius_blocker  # noqa: E402
+from erdos97.radius_blocker_packets import TRUST  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    replay_vertex_circle_rich_quotient,
+)
+
+SCHEMA = "erdos97.n9_radius_blocker_rich_extension_product_sweep.v1"
+STATUS = "N9_RADIUS_BLOCKER_RICH_EXTENSION_PRODUCT_SWEEP_ONLY"
+DEFAULT_OUT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_radius_blocker_rich_extension_product_sweep.json"
+)
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "source_shape_count": 10,
+    "source_packet_count": 20,
+    "source_status_counts": {"self_edge": 10, "strict_cycle": 10},
+    "source_product_variant_count_total": 2899968,
+    "source_product_variant_count_counts": {
+        "110592": 8,
+        "147456": 7,
+        "196608": 5,
+    },
+    "source_row_option_count_profile": {"3": 43, "4": 137},
+    "source_row_alternative_count_profile": {"2": 43, "3": 137},
+    "variant_count": 2899968,
+    "hamming_distance_counts": {
+        "0": 20,
+        "1": 497,
+        "2": 5479,
+        "3": 35167,
+        "4": 144819,
+        "5": 396765,
+        "6": 723141,
+        "7": 845397,
+        "8": 575181,
+        "9": 173502,
+    },
+    "variant_rich_class_count_total": 26099712,
+    "max_rich_class_size": 5,
+    "all_variants_radius_blockers": True,
+    "quotient_status_counts": {"self_edge": 2899968},
+    "all_variants_obstructed": True,
+    "total_strict_edge_count": 652492800,
+    "total_self_edge_conflict_count": 467149054,
+    "min_self_edge_conflict_count": 51,
+    "max_self_edge_conflict_count": 225,
+    "first_self_edge_row_counts": {"0": 2899968},
+    "variant_max_blocker_intersection_size_counts": {
+        "2": 6912,
+        "3": 1693440,
+        "4": 1199616,
+    },
+}
+
+
+def build_source_packet_record(
+    source: Mapping[str, object],
+    product_record: Mapping[str, object],
+    *,
+    max_variants_per_packet: int | None = None,
+) -> dict[str, object]:
+    selected_rows = source["source_selected_rows"]
+    if not isinstance(selected_rows, list):
+        raise AssertionError("source selected rows are missing")
+    rows = [[int(label) for label in row] for row in selected_rows]
+    blocker = [int(label) for label in source["blocker"]]
+    blocker_set = set(blocker)
+    baseline, alternatives, catalog_records = extension_catalog(rows, blocker)
+
+    hamming_distance_counts: Counter[int] = Counter()
+    quotient_status_counts: Counter[str] = Counter()
+    first_self_edge_rows: Counter[int | None] = Counter()
+    max_blocker_intersections: Counter[int] = Counter()
+    self_edge_counts: list[int] = []
+    total_strict_edges = 0
+    all_radius_blockers = True
+    variant_count = 0
+    max_rich_class_size = 0
+    seen_variants: set[tuple[int, ...]] = set()
+
+    for distance, added_labels in iter_full_product_added_label_variants(
+        baseline, alternatives
+    ):
+        if (
+            max_variants_per_packet is not None
+            and variant_count >= max_variants_per_packet
+        ):
+            break
+        if added_labels in seen_variants:
+            raise AssertionError("duplicate full-product variant")
+        seen_variants.add(added_labels)
+
+        rich_rows = rich_rows_from_added_labels(rows, added_labels)
+        all_radius_blockers = all_radius_blockers and is_radius_blocker(
+            rich_classes_for_blocker(rich_rows), blocker
+        )
+        replay = replay_vertex_circle_rich_quotient(N, ORDER, rich_rows)
+
+        hamming_distance_counts[distance] += 1
+        quotient_status_counts[str(replay.status)] += 1
+        total_strict_edges += int(replay.strict_edge_count)
+        self_edge_counts.append(len(replay.self_edge_conflicts))
+        first_self_edge_rows[
+            int(replay.self_edge_conflicts[0].row)
+            if replay.self_edge_conflicts
+            else None
+        ] += 1
+        max_blocker_intersections[
+            max(len(set(row.witnesses) & blocker_set) for row in rich_rows)
+        ] += 1
+        max_rich_class_size = max(
+            max_rich_class_size,
+            max(len(row.witnesses) for row in rich_rows),
+        )
+        variant_count += 1
+
+    first_self_edge_json = counter_to_json(first_self_edge_rows)
+    first_self_edge_json.pop("None", None)
+
+    return {
+        "source_packet_id": str(product_record["source_packet_id"]),
+        "source_order_index": int(product_record["source_order_index"]),
+        "case_index": int(source["case_index"]),
+        "case_name": str(source["case_name"]),
+        "blocker": blocker,
+        "source_status": str(source["source_status"]),
+        "source_example_index": int(source["source_example_index"]),
+        "source_selected_rows": rows,
+        "row_extension_catalog": catalog_records,
+        "row_option_counts": list(product_record["row_option_counts"]),
+        "row_alternative_counts": list(product_record["row_alternative_counts"]),
+        "product_variant_count": int(product_record["product_variant_count"]),
+        "replayed_variant_count": variant_count,
+        "truncated": max_variants_per_packet is not None
+        and variant_count < int(product_record["product_variant_count"]),
+        "hamming_distance_counts": counter_to_json(hamming_distance_counts),
+        "all_variants_radius_blockers": all_radius_blockers,
+        "quotient_status_counts": counter_to_json(quotient_status_counts),
+        "all_variants_obstructed": quotient_status_counts.get("ok", 0) == 0,
+        "total_strict_edge_count": total_strict_edges,
+        "total_self_edge_conflict_count": sum(self_edge_counts),
+        "min_self_edge_conflict_count": min(self_edge_counts),
+        "max_self_edge_conflict_count": max(self_edge_counts),
+        "first_self_edge_row_counts": first_self_edge_json,
+        "variant_max_blocker_intersection_size_counts": counter_to_json(
+            max_blocker_intersections
+        ),
+        "max_rich_class_size": max_rich_class_size,
+    }
+
+
+def build_summary(
+    records: Sequence[Mapping[str, object]],
+    product_records: Sequence[Mapping[str, object]],
+    source_shape_count: int,
+) -> dict[str, object]:
+    source_product_summary = build_source_product_summary(product_records)
+    source_status_counts: Counter[str] = Counter()
+    option_count_profile: Counter[int] = Counter()
+    alternative_count_profile: Counter[int] = Counter()
+    hamming_distance_counts: Counter[str] = Counter()
+    quotient_status_counts: Counter[str] = Counter()
+    first_self_edge_rows: Counter[str] = Counter()
+    max_blocker_intersections: Counter[str] = Counter()
+    variant_count = 0
+    strict_edge_count = 0
+    self_edge_total = 0
+    self_edge_min: int | None = None
+    self_edge_max = 0
+    max_rich_class_size = 0
+
+    for product_record in product_records:
+        source_status_counts[str(product_record["source_status"])] += 1
+        for count in product_record["row_option_counts"]:
+            option_count_profile[int(count)] += 1
+        for count in product_record["row_alternative_counts"]:
+            alternative_count_profile[int(count)] += 1
+
+    for record in records:
+        record_variant_count = int(record["replayed_variant_count"])
+        variant_count += record_variant_count
+        strict_edge_count += int(record["total_strict_edge_count"])
+        self_edge_total += int(record["total_self_edge_conflict_count"])
+        record_min = int(record["min_self_edge_conflict_count"])
+        record_max = int(record["max_self_edge_conflict_count"])
+        self_edge_min = record_min if self_edge_min is None else min(
+            self_edge_min, record_min
+        )
+        self_edge_max = max(self_edge_max, record_max)
+        max_rich_class_size = max(
+            max_rich_class_size, int(record["max_rich_class_size"])
+        )
+        for key, value in record["hamming_distance_counts"].items():
+            hamming_distance_counts[str(key)] += int(value)
+        for key, value in record["quotient_status_counts"].items():
+            quotient_status_counts[str(key)] += int(value)
+        for key, value in record["first_self_edge_row_counts"].items():
+            first_self_edge_rows[str(key)] += int(value)
+        for key, value in record["variant_max_blocker_intersection_size_counts"].items():
+            max_blocker_intersections[str(key)] += int(value)
+
+    return {
+        "n": N,
+        "order": ORDER,
+        "source_shape_count": source_shape_count,
+        "source_packet_count": len(product_records),
+        "source_status_counts": counter_to_json(source_status_counts),
+        "source_product_variant_count_total": source_product_summary[
+            "source_product_variant_count_total"
+        ],
+        "source_product_variant_count_counts": source_product_summary[
+            "source_product_variant_count_counts"
+        ],
+        "source_row_option_count_profile": counter_to_json(option_count_profile),
+        "source_row_alternative_count_profile": counter_to_json(
+            alternative_count_profile
+        ),
+        "variant_count": variant_count,
+        "hamming_distance_counts": counter_to_json(hamming_distance_counts),
+        "variant_rich_class_count_total": variant_count * N,
+        "max_rich_class_size": max_rich_class_size,
+        "all_variants_radius_blockers": all(
+            bool(record["all_variants_radius_blockers"]) for record in records
+        ),
+        "quotient_status_counts": counter_to_json(quotient_status_counts),
+        "all_variants_obstructed": quotient_status_counts.get("ok", 0) == 0,
+        "total_strict_edge_count": strict_edge_count,
+        "total_self_edge_conflict_count": self_edge_total,
+        "min_self_edge_conflict_count": self_edge_min,
+        "max_self_edge_conflict_count": self_edge_max,
+        "first_self_edge_row_counts": counter_to_json(first_self_edge_rows),
+        "variant_max_blocker_intersection_size_counts": counter_to_json(
+            max_blocker_intersections
+        ),
+    }
+
+
+def build_payload(
+    source: Path = DEFAULT_SOURCE,
+    *,
+    max_packets: int | None = None,
+    max_variants_per_packet: int | None = None,
+) -> dict[str, object]:
+    shape_sweep = load_shape_sweep(source)
+    sources = source_examples(shape_sweep)
+    product_records = source_product_records(sources)
+    replay_sources = sources if max_packets is None else sources[:max_packets]
+    replay_product_records = (
+        product_records if max_packets is None else product_records[:max_packets]
+    )
+    records = [
+        build_source_packet_record(
+            source_record,
+            product_record,
+            max_variants_per_packet=max_variants_per_packet,
+        )
+        for source_record, product_record in zip(
+            replay_sources, replay_product_records, strict=True
+        )
+    ]
+    cases = shape_sweep.get("cases")
+    if not isinstance(cases, list):
+        raise AssertionError("shape sweep artifact has no cases list")
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "All-packet n=9 full rich-extension product replay over the 20 "
+            "generated radius-blocker quotient-sweep source packets. It "
+            "replays every radius-blocker-preserving size-five added-label "
+            "choice for those generated packets. This is finite generated "
+            "packet evidence only: it is not an n=9 proof, not a proof of the "
+            "adaptive blocker bridge, and not a counterexample."
+        ),
+        "summary": build_summary(records, product_records, len(cases)),
+        "source_shape_sweep": {
+            "path": source.relative_to(ROOT).as_posix(),
+            "schema": shape_sweep.get("schema"),
+            "status": shape_sweep.get("status"),
+            "trust": shape_sweep.get("trust"),
+            "sha256": sha256_file(source),
+            "summary": shape_sweep.get("summary"),
+        },
+        "source_product_catalog": build_source_product_summary(product_records),
+        "product_rule": {
+            "catalogue": (
+                "For each row, enumerate every extra label that preserves the "
+                "actual radius-blocker condition: inside-blocker centers must "
+                "stay below three blocker vertices, while outside-blocker "
+                "centers are unconstrained by blocker intersection."
+            ),
+            "variants": (
+                "Replay the full Cartesian product of those row extension "
+                "choices for every generated source packet."
+            ),
+        },
+        "debug_limits": {
+            "max_packets": max_packets,
+            "max_variants_per_packet": max_variants_per_packet,
+        },
+        "source_packets": records,
+        "interpretation_warnings": [
+            "This checks only generated size-five packets derived from stored examples.",
+            "It does not enumerate arbitrary rich-class catalogues.",
+            "It does not prove the adaptive radius-blocker bridge.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_radius_blocker_rich_extension_product_sweep.py",
+            "command": (
+                "python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "data/certificates/n9_radius_blocker_shape_sweep.json",
+                "scripts/check_n9_radius_blocker_rich_quotient_sweep.py",
+                "scripts/check_n9_radius_blocker_rich_extension_neighborhood.py",
+                "scripts/check_n9_radius_blocker_rich_extension_product_pilot.py",
+                "src/erdos97/adaptive_blockers.py",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    if payload.get("debug_limits") != {
+        "max_packets": None,
+        "max_variants_per_packet": None,
+    }:
+        raise AssertionError("expected payload must not use debug limits")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    source_packets = payload.get("source_packets")
+    if not isinstance(source_packets, list):
+        raise AssertionError("source packet records are missing")
+    if len(source_packets) != EXPECTED_SUMMARY["source_packet_count"]:
+        raise AssertionError("unexpected packet count")
+    packet_ids = [packet["source_packet_id"] for packet in source_packets]
+    if len(packet_ids) != len(set(packet_ids)):
+        raise AssertionError("source packet IDs are not unique")
+    if any(packet.get("truncated") for packet in source_packets):
+        raise AssertionError("expected payload must not be truncated")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 radius-blocker rich-extension product sweep")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"source packets: {summary['source_packet_count']}")
+    print(f"variants: {summary['variant_count']}")
+    print(f"quotient statuses: {summary['quotient_status_counts']}")
+    print(f"self-edge conflicts: {summary['total_self_edge_conflict_count']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument(
+        "--max-packets",
+        type=int,
+        default=None,
+        help="debug/testing packet limit; do not use for checked artifacts",
+    )
+    parser.add_argument(
+        "--max-variants-per-packet",
+        type=int,
+        default=None,
+        help="debug/testing per-packet limit; do not use for checked artifacts",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(
+        args.source,
+        max_packets=args.max_packets,
+        max_variants_per_packet=args.max_variants_per_packet,
+    )
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1489,6 +1489,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_radius_blocker_rich_extension_product_sweep",
+        command=(
+            "python",
+            "scripts/check_n9_radius_blocker_rich_extension_product_sweep.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "All-packet full rich-extension product replay over the 20 "
+            "generated n=9 radius-blocker source packets; finite generated-"
+            "packet evidence only, not arbitrary rich-class classification, "
+            "not a proof of Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/tests/test_n9_radius_blocker_rich_extension_product_sweep.py
+++ b/tests/test_n9_radius_blocker_rich_extension_product_sweep.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_radius_blocker_rich_extension_product_sweep import (  # noqa: E402
+    build_payload,
+)
+from check_n9_radius_blocker_rich_extension_product_pilot import (  # noqa: E402
+    source_product_records,
+)
+from check_n9_radius_blocker_rich_quotient_sweep import (  # noqa: E402
+    DEFAULT_SOURCE,
+    load_shape_sweep,
+    source_examples,
+)
+
+
+def test_n9_radius_blocker_rich_extension_product_sweep_catalog_counts() -> None:
+    shape_sweep = load_shape_sweep(DEFAULT_SOURCE)
+    sources = source_examples(shape_sweep)
+    records = source_product_records(sources)
+
+    assert len(records) == 20
+    assert Counter(record["source_status"] for record in records) == {
+        "self_edge": 10,
+        "strict_cycle": 10,
+    }
+    assert sum(int(record["product_variant_count"]) for record in records) == 2899968
+    assert Counter(int(record["product_variant_count"]) for record in records) == {
+        110592: 8,
+        147456: 7,
+        196608: 5,
+    }
+    assert Counter(
+        count for record in records for count in record["row_option_counts"]
+    ) == {3: 43, 4: 137}
+
+
+def test_n9_radius_blocker_rich_extension_product_sweep_limited_replay() -> None:
+    payload = build_payload(max_packets=2, max_variants_per_packet=3)
+    summary = payload["summary"]
+
+    assert payload["debug_limits"] == {
+        "max_packets": 2,
+        "max_variants_per_packet": 3,
+    }
+    assert len(payload["source_packets"]) == 2
+    assert summary["variant_count"] == 6
+    assert summary["quotient_status_counts"] == {"self_edge": 6}
+    assert summary["all_variants_obstructed"] is True
+    assert all(packet["truncated"] is True for packet in payload["source_packets"])


### PR DESCRIPTION
## Summary

- adds an all-packet generated rich-extension product checker for the n=9 radius-blocker packet line
- writes the checked artifact for all 20 generated source packets: 2,899,968 size-five variants, all quotient-obstructed by self-edges
- updates provenance, audit registration, docs, and lightweight tests while preserving the no-proof/no-counterexample boundary

## Claim Scope

This is finite generated-packet evidence only. It does not enumerate arbitrary rich-class catalogues, does not prove n=9, does not prove the adaptive blocker bridge, does not prove Erdos Problem #97, and does not claim a counterexample.

## Validation

- `python scripts/check_n9_radius_blocker_rich_extension_product_sweep.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_status_consistency.py --max-official-status-age-days 90`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_radius_blocker_rich_extension_product_pilot.py --check --assert-expected`
- `python scripts/check_n9_radius_blocker_rich_extension_neighborhood.py --check --assert-expected`
- `python scripts/check_n9_radius_blocker_rich_quotient_sweep.py --check --assert-expected`
- `python scripts/check_n9_radius_blocker_shape_sweep.py --check --assert-expected`

`make verify-artifacts` could not run in this PowerShell environment because `make` is not installed; the relevant artifact commands above were run directly.