### PR TITLE
Add n9 all-five rich support obstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   richer-class projection pilot, a full rich-class quotient replay pilot, a
   generated rich-class quotient sweep, a bounded rich-extension neighborhood
   sweep, a one-packet full rich-extension product pilot, and an all-packet
-  generated rich-extension product sweep,
+  generated rich-extension product sweep, plus the generator-independent
+  all-five-rich support obstruction,
   read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
@@ -91,7 +92,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-radius-blocker-rich-extension-product-pilot.md`](docs/n9-radius-blocker-rich-extension-product-pilot.md)
   and
-  [`docs/n9-radius-blocker-rich-extension-product-sweep.md`](docs/n9-radius-blocker-rich-extension-product-sweep.md).
+  [`docs/n9-radius-blocker-rich-extension-product-sweep.md`](docs/n9-radius-blocker-rich-extension-product-sweep.md)
+  and
+  [`docs/n9-all-five-rich-support-obstruction.md`](docs/n9-all-five-rich-support-obstruction.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -360,6 +360,20 @@ counterexample. See
 `scripts/check_n9_radius_blocker_rich_extension_product_sweep.py`, and
 `data/certificates/n9_radius_blocker_rich_extension_product_sweep.json`.
 
+A generator-independent all-five-rich support obstruction now checks the
+subcase where every center of a nonagon has some rich distance class of size at
+least five. The checker enumerates the full `56^9 =
+5,416,169,448,144,896` size-five support assignment space by exact
+backtracking under only the two-circle row-pair cap and radical-axis crossing
+for two-overlaps. It visits `136` assignment nodes, reaches maximum depth `2`,
+and leaves `0` complete assignments. This is a repo-local support subcase
+only: it does not enumerate mixed exact-four/size-five catalogues, does not
+prove `n=9`, does not prove the adaptive radius-blocker bridge, and is not a
+counterexample. See
+`docs/n9-all-five-rich-support-obstruction.md`,
+`scripts/check_n9_all_five_rich_support_obstruction.py`, and
+`data/certificates/n9_all_five_rich_support_obstruction.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -234,6 +234,17 @@ quotient self-edges, with `467,149,054` total self-edge conflicts across
 only, not an arbitrary rich-class classification, not an `n=9` proof, and not
 a bridge proof. See `docs/n9-radius-blocker-rich-extension-product-sweep.md`.
 
+The generator-independent all-five-rich support catalogue leaves the generated
+radius-blocker packets entirely. It enumerates every choice of one size-five
+support at each center of a natural-order nonagon: `56^9 =
+5,416,169,448,144,896` raw assignments. Using only the two-circle row-pair cap
+and the radical-axis crossing rule for two-overlaps, the exact backtracking
+search visits `136` assignment nodes and finds `0` complete assignments. This
+repo-local subcase says any `n=9` selected-witness counterexample must have at
+least one center whose available rich classes are exact-four-only; it is still
+not an `n=9` proof, not the adaptive blocker bridge, and not a counterexample.
+See `docs/n9-all-five-rich-support-obstruction.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_all_five_rich_support_obstruction.json
+++ b/data/certificates/n9_all_five_rich_support_obstruction.json
@@ -1,0 +1,678 @@
+{
+  "claim_scope": "Generator-independent n=9 all-five-rich support catalogue. It enumerates every choice of one size-five support at each center in the natural cyclic order and applies only the two-circle row-pair cap plus the radical-axis crossing rule for two-overlaps. The checked catalogue has no complete support assignment. Repo-locally, this rules out the subcase where every center has some rich distance class of size at least five, but it does not handle mixed exact-four/size-five catalogues, does not prove n=9, does not prove Erdos Problem #97, and is not a counterexample.",
+  "filters": [
+    {
+      "meaning": "Two distinct distance circles can share at most two witness vertices.",
+      "name": "row_pair_cap"
+    },
+    {
+      "meaning": "When two centers share exactly two witnesses in their rich classes, the center chord and shared-witness chord must cross in the cyclic order.",
+      "name": "two_overlap_crossing"
+    }
+  ],
+  "interpretation_warnings": [
+    "This is a generator-independent size-five support subcase only.",
+    "It does not enumerate mixed exact-four and size-five rich catalogues.",
+    "It does not use or prove the adaptive radius-blocker bridge.",
+    "No general proof and no counterexample are claimed."
+  ],
+  "pair_catalog": {
+    "candidate_count_total": 112896,
+    "center_pair_count": 36,
+    "compatible_count_by_cyclic_gap": {
+      "1": {
+        "140": 9
+      },
+      "2": {
+        "440": 9
+      },
+      "3": {
+        "640": 9
+      },
+      "4": {
+        "740": 9
+      }
+    },
+    "compatible_count_distribution": {
+      "140": 9,
+      "440": 9,
+      "640": 9,
+      "740": 9
+    },
+    "compatible_count_total": 17640,
+    "example_rejections": {
+      "row_pair_cap": {
+        "centers": [
+          0,
+          1
+        ],
+        "intersection": [
+          2,
+          3,
+          4,
+          5
+        ],
+        "left_support": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "right_support": [
+          0,
+          2,
+          3,
+          4,
+          5
+        ]
+      },
+      "two_overlap_crossing": {
+        "centers": [
+          0,
+          1
+        ],
+        "intersection": [
+          2,
+          3
+        ],
+        "left_support": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "right_support": [
+          0,
+          2,
+          3,
+          6,
+          7
+        ]
+      }
+    },
+    "records": [
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          1
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          2
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          3
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          4
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          5
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          6
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          7
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          0,
+          8
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          2
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          3
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          4
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          5
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          6
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          7
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          1,
+          8
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          2,
+          3
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          2,
+          4
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          2,
+          5
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          2,
+          6
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          2,
+          7
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          2,
+          8
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          3,
+          4
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          3,
+          5
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          3,
+          6
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          3,
+          7
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          3,
+          8
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          4,
+          5
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          4,
+          6
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          4,
+          7
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          4,
+          8
+        ],
+        "compatible_count": 740,
+        "cyclic_gap": 4,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 450
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          5,
+          6
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          5,
+          7
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          5,
+          8
+        ],
+        "compatible_count": 640,
+        "cyclic_gap": 3,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 550
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          6,
+          7
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          6,
+          8
+        ],
+        "compatible_count": 440,
+        "cyclic_gap": 2,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 750
+        }
+      },
+      {
+        "candidate_count": 3136,
+        "centers": [
+          7,
+          8
+        ],
+        "compatible_count": 140,
+        "cyclic_gap": 1,
+        "rejection_counts": {
+          "row_pair_cap": 1946,
+          "two_overlap_crossing": 1050
+        }
+      }
+    ],
+    "rejection_counts": {
+      "row_pair_cap": 70056,
+      "two_overlap_crossing": 25200
+    }
+  },
+  "provenance": {
+    "command": "python scripts/check_n9_all_five_rich_support_obstruction.py --write --assert-expected",
+    "generator": "scripts/check_n9_all_five_rich_support_obstruction.py",
+    "sources": [
+      "src/erdos97/incidence_filters.py",
+      "docs/claims.md#radical-axis-crossing--bisection"
+    ]
+  },
+  "schema": "erdos97.n9_all_five_rich_support_obstruction.v1",
+  "search": {
+    "aborted": false,
+    "center_choice_counts": {
+      "0": 1,
+      "1": 20
+    },
+    "complete_assignments": 0,
+    "dead_end_count": 116,
+    "evaluation_rejection_counts": {
+      "row_pair_cap": 5976,
+      "two_overlap_crossing": 1560
+    },
+    "first_dead_end": {
+      "assigned_supports": {
+        "0": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ]
+      },
+      "depth": 1,
+      "next_center": 6,
+      "rejection_counts": {
+        "row_pair_cap": 46,
+        "two_overlap_crossing": 10
+      }
+    },
+    "max_depth": 2,
+    "node_depth_counts": {
+      "0": 56,
+      "1": 80
+    },
+    "nodes_visited": 136
+  },
+  "status": "N9_ALL_FIVE_RICH_SUPPORT_OBSTRUCTION_ONLY",
+  "summary": {
+    "center_count": 9,
+    "center_pair_candidate_count_total": 112896,
+    "center_pair_compatible_count_distribution": {
+      "140": 9,
+      "440": 9,
+      "640": 9,
+      "740": 9
+    },
+    "center_pair_count": 36,
+    "center_pair_rejection_counts": {
+      "row_pair_cap": 70056,
+      "two_overlap_crossing": 25200
+    },
+    "compatible_center_pair_count_total": 17640,
+    "debug_max_nodes": null,
+    "n": 9,
+    "no_pair_filter_survivors": true,
+    "option_counts": [
+      56,
+      56,
+      56,
+      56,
+      56,
+      56,
+      56,
+      56,
+      56
+    ],
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "raw_assignment_upper_bound": 5416169448144896,
+    "search_aborted": false,
+    "search_center_choice_counts": {
+      "0": 1,
+      "1": 20
+    },
+    "search_complete_assignments": 0,
+    "search_dead_end_count": 116,
+    "search_max_depth": 2,
+    "search_node_depth_counts": {
+      "0": 56,
+      "1": 80
+    },
+    "search_nodes_visited": 136,
+    "support_size": 5
+  },
+  "support_rule": {
+    "rule": "For each center, enumerate all five-subsets of the other eight labels. These supports are not generated from stored selected-row packets.",
+    "subcase_reduction": "If a genuine nonagon counterexample had a rich class of size at least five at every center, choosing any five witnesses inside each such class would give a complete support assignment satisfying the checked pair filters.",
+    "support_size": 5
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -471,6 +471,29 @@ rule out radius-blockers using strict convexity, fragile-cover geometry, and
 the current exact obstruction stack, or construct an exact blocker escape
 mechanism. See `docs/adaptive-radius-blocker-bridge.md`.
 
+### n=9 all-five-rich support obstruction
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / generator-independent finite support
+catalogue.
+
+In a strict convex nonagon with cyclic order `0,1,2,3,4,5,6,7,8`, suppose
+each center has some rich distance class containing at least five witnesses.
+Choosing any five witnesses from each such class gives one size-five support
+at each center. The checked support catalogue enumerates all `56^9` such
+choices and applies only the two-circle row-pair cap and radical-axis crossing
+rule for two-overlaps.
+
+The checker finds no complete assignment satisfying those necessary filters:
+the deterministic backtracking search visits `136` assignment nodes, reaches
+maximum depth `2`, and has `0` complete assignments. Check it with
+`python scripts/check_n9_all_five_rich_support_obstruction.py --check --assert-expected --json`.
+
+Repo-locally, this rules out the all-centers-size-at-least-five subcase for
+`n=9`. It does not enumerate mixed exact-four/size-five rich catalogues, does
+not prove `n=9`, does not prove the adaptive radius-blocker bridge, does not
+prove Erdos Problem #97, and does not provide a counterexample. See
+`docs/n9-all-five-rich-support-obstruction.md`.
+
 ### Bootstrap-core closure rank and weighted capacity
 
 Status: `LEMMA` / bridge fork.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -176,6 +176,13 @@ Use this queue when no more specific issue is selected.
    should be a principled rich-class bridge hypothesis or a
    generator-independent catalogue rather than more product replay over the
    same generated packet family.
+   The generator-independent all-five-rich support obstruction
+   `python scripts/check_n9_all_five_rich_support_obstruction.py --check --assert-expected --json`
+   now closes the full `56^9` size-five support assignment space under only
+   the two-circle row-pair cap and radical-axis crossing filters. This rules
+   out the all-centers-size-at-least-five support subcase repo-locally, but
+   the next rich-class widening is still the mixed exact-four/size-five
+   catalogue or a bridge hypothesis forcing the exact-four-only center.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/n9-all-five-rich-support-obstruction.md
+++ b/docs/n9-all-five-rich-support-obstruction.md
@@ -1,0 +1,67 @@
+# n=9 all-five-rich support obstruction
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / generator-independent finite support
+catalogue. No general proof of Erdos Problem #97 is claimed. No
+counterexample is claimed.
+
+This note records a support-level subcase that is independent of the generated
+radius-blocker packets. Work in the cyclic order `0,1,2,3,4,5,6,7,8`. For
+each center, enumerate every five-subset of the other eight labels. A complete
+assignment would choose one such size-five support at each center.
+
+The checker applies only two exact necessary filters:
+
+- two distinct distance circles share at most two witness vertices;
+- if two centers share exactly two witnesses, the center chord and the
+  shared-witness chord must cross in the cyclic order.
+
+These are the same circle-intersection and radical-axis crossing conditions
+recorded in `docs/claims.md`.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_all_five_rich_support_obstruction.json
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_all_five_rich_support_obstruction.py --check --assert-expected --json
+```
+
+There are `56` possible size-five supports at each of the `9` centers, for
+`5,416,169,448,144,896` raw assignments. The pair catalogue checks all `36`
+center-pairs and `112,896` support-pairs:
+
+```text
+compatible support-pairs by center gap:
+gap 1: 140 each
+gap 2: 440 each
+gap 3: 640 each
+gap 4: 740 each
+```
+
+The exact backtracking search visits `136` assignment nodes, reaches depth
+`2`, and leaves `0` complete assignments. The closing filters are only the
+row-pair cap and two-overlap crossing rule; no vertex-circle quotient replay
+or generated selected-row packet is used.
+
+## Consequence
+
+Repo-locally, this rules out the subcase where a strict convex nonagon
+counterexample has some rich distance class of size at least five at every
+center. If such a nonagon existed, choosing any five witnesses inside each
+large rich class would give a complete size-five support assignment satisfying
+the checked pair filters.
+
+## Boundary
+
+This does not enumerate mixed exact-four and size-five rich catalogues. It
+does not prove `n=9`, does not prove the adaptive radius-blocker bridge, does
+not prove Erdos Problem #97, and does not provide a counterexample.
+
+The next useful bridge target is the mixed catalogue: at least one center must
+remain exact-four-only in any `n=9` selected-witness counterexample.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -602,6 +602,13 @@ condition that the surviving multi-block family does not automatically satisfy:
   only; the next review target is a principled rich-class bridge hypothesis
   or a generator-independent catalogue, not another copy of the same product
   replay.
+- the generator-independent all-five-rich support obstruction recorded in
+  `docs/n9-all-five-rich-support-obstruction.md`, which leaves the generated
+  packet family and closes the full `56^9` size-five support assignment space
+  using only the two-circle row-pair cap and radical-axis crossing filters.
+  This rules out the all-centers-size-at-least-five `n=9` support subcase
+  repo-locally, but it still does not cover mixed exact-four/size-five
+  catalogues, prove `n=9`, or prove the adaptive blocker bridge.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -323,6 +323,11 @@ local_repo:
       artifact: "data/certificates/n9_radius_blocker_rich_extension_product_sweep.json"
       verifier: "scripts/check_n9_radius_blocker_rich_extension_product_sweep.py"
       claim_scope: "finite generated-packet proof-mining diagnostic only; exhausts 2899968 radius-blocker-preserving size-five variants over 20 generated source packets and finds all quotient-obstructed by self-edges, but does not classify arbitrary rich-class catalogues, prove n=9, prove the adaptive blocker bridge, prove Erdos #97, or give a counterexample"
+    - pattern: "n9_all_five_rich_support_obstruction"
+      status: "generator-independent all-five-rich support obstruction"
+      artifact: "data/certificates/n9_all_five_rich_support_obstruction.json"
+      verifier: "scripts/check_n9_all_five_rich_support_obstruction.py"
+      claim_scope: "repo-local finite support subcase only; enumerates the full 56^9 size-five support assignment space under the two-circle row-pair cap and radical-axis crossing filters and finds no complete assignment, but does not enumerate mixed exact-four/size-five rich catalogues, prove n=9, prove the adaptive blocker bridge, prove Erdos #97, or give a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3145,6 +3145,57 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_all_five_rich_support_obstruction
+    path: data/certificates/n9_all_five_rich_support_obstruction.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_all_five_rich_support_obstruction.py
+    command: python scripts/check_n9_all_five_rich_support_obstruction.py --write --assert-expected
+    checker: scripts/check_n9_all_five_rich_support_obstruction.py
+    check_command: python scripts/check_n9_all_five_rich_support_obstruction.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Generator-independent n=9 all-five-rich support obstruction under the two-circle row-pair cap and radical-axis crossing filters; finite support subcase only, not mixed exact-four/size-five catalogue coverage, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_all_five_rich_support_obstruction.v1
+      status: N9_ALL_FIVE_RICH_SUPPORT_OBSTRUCTION_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 9
+      summary.support_size: 5
+      summary.center_count: 9
+      summary.option_counts:
+        - 56
+        - 56
+        - 56
+        - 56
+        - 56
+        - 56
+        - 56
+        - 56
+        - 56
+      summary.raw_assignment_upper_bound: 5416169448144896
+      summary.center_pair_count: 36
+      summary.center_pair_candidate_count_total: 112896
+      summary.compatible_center_pair_count_total: 17640
+      summary.center_pair_rejection_counts.row_pair_cap: 70056
+      summary.center_pair_rejection_counts.two_overlap_crossing: 25200
+      summary.search_nodes_visited: 136
+      summary.search_complete_assignments: 0
+      summary.search_dead_end_count: 116
+      summary.search_max_depth: 2
+      summary.search_aborted: false
+      summary.no_pair_filter_survivors: true
+      provenance.command: python scripts/check_n9_all_five_rich_support_obstruction.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - adaptive blocker bridge is proved
+      - mixed exact-four and size-five catalogues are classified
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_all_five_rich_support_obstruction.py
+++ b/scripts/check_n9_all_five_rich_support_obstruction.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Check the generator-independent n=9 all-five-rich support subcase.
+
+This is a finite support-catalogue diagnostic only. It proves no general
+theorem about Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations
+from math import prod
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.incidence_filters import (  # noqa: E402
+    chords_cross_in_order,
+    normalize_chord,
+)
+from erdos97.radius_blocker_packets import TRUST  # noqa: E402
+
+SCHEMA = "erdos97.n9_all_five_rich_support_obstruction.v1"
+STATUS = "N9_ALL_FIVE_RICH_SUPPORT_OBSTRUCTION_ONLY"
+DEFAULT_OUT = (
+    ROOT / "data" / "certificates" / "n9_all_five_rich_support_obstruction.json"
+)
+N = 9
+ORDER = tuple(range(N))
+SUPPORT_SIZE = 5
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "order": list(range(9)),
+    "support_size": 5,
+    "center_count": 9,
+    "option_counts": [56, 56, 56, 56, 56, 56, 56, 56, 56],
+    "raw_assignment_upper_bound": 5416169448144896,
+    "center_pair_count": 36,
+    "center_pair_candidate_count_total": 112896,
+    "compatible_center_pair_count_total": 17640,
+    "center_pair_compatible_count_distribution": {
+        "140": 9,
+        "440": 9,
+        "640": 9,
+        "740": 9,
+    },
+    "center_pair_rejection_counts": {
+        "row_pair_cap": 70056,
+        "two_overlap_crossing": 25200,
+    },
+    "search_nodes_visited": 136,
+    "search_complete_assignments": 0,
+    "search_dead_end_count": 116,
+    "search_max_depth": 2,
+    "search_aborted": False,
+    "search_center_choice_counts": {"0": 1, "1": 20},
+    "search_node_depth_counts": {"0": 56, "1": 80},
+    "no_pair_filter_survivors": True,
+}
+
+Support = tuple[int, ...]
+SupportOptions = tuple[tuple[Support, ...], ...]
+
+
+@dataclass(frozen=True)
+class SupportSearchResult:
+    nodes_visited: int
+    complete_assignments: int
+    dead_end_count: int
+    max_depth: int
+    aborted: bool
+    center_choice_counts: Mapping[int, int]
+    node_depth_counts: Mapping[int, int]
+    evaluation_rejection_counts: Mapping[str, int]
+    first_dead_end: Mapping[str, object] | None
+
+
+def counter_to_json(counter: Mapping[object, int]) -> dict[str, int]:
+    """Return a stable JSON object for a small counter."""
+
+    return {
+        str(key): int(counter[key])
+        for key in sorted(counter, key=lambda item: str(item))
+    }
+
+
+def support_options_for_center(
+    n: int,
+    center: int,
+    support_size: int = SUPPORT_SIZE,
+) -> tuple[Support, ...]:
+    """Return all labelled supports of ``support_size`` avoiding ``center``."""
+
+    if n <= support_size:
+        raise ValueError(f"support size {support_size} is too large for n={n}")
+    if center < 0 or center >= n:
+        raise ValueError(f"center out of range: {center}")
+    return tuple(
+        tuple(row)
+        for row in combinations(
+            (label for label in range(n) if label != center),
+            support_size,
+        )
+    )
+
+
+def all_support_options(
+    n: int = N,
+    support_size: int = SUPPORT_SIZE,
+) -> SupportOptions:
+    """Return the generator-independent support catalogue for every center."""
+
+    return tuple(
+        support_options_for_center(n, center, support_size)
+        for center in range(n)
+    )
+
+
+def row_pair_rejection(
+    order: Sequence[int],
+    left_center: int,
+    left_support: Sequence[int],
+    right_center: int,
+    right_support: Sequence[int],
+) -> str | None:
+    """Return the first exact row-pair reason rejecting two supports.
+
+    The filters are necessary geometric conditions for two exact distance
+    classes in a strict convex polygon: two distinct circles share at most two
+    points, and a two-overlap forces the source chord and shared-witness chord
+    to cross.
+    """
+
+    if left_center == right_center:
+        raise ValueError("row-pair rejection requires distinct centers")
+    if right_center < left_center:
+        return row_pair_rejection(
+            order,
+            right_center,
+            right_support,
+            left_center,
+            left_support,
+        )
+    intersection = sorted(set(left_support) & set(right_support))
+    if len(intersection) > 2:
+        return "row_pair_cap"
+    if len(intersection) == 2:
+        source = normalize_chord(left_center, right_center)
+        target = normalize_chord(intersection[0], intersection[1])
+        if not chords_cross_in_order(source, target, order):
+            return "two_overlap_crossing"
+    return None
+
+
+def build_pair_catalog(
+    order: Sequence[int],
+    options: SupportOptions,
+) -> dict[str, object]:
+    """Build a compact catalogue of pairwise support compatibility."""
+
+    n = len(options)
+    compatible_counts: Counter[int] = Counter()
+    compatible_by_gap: dict[int, Counter[int]] = {}
+    rejection_counts: Counter[str] = Counter()
+    records: list[dict[str, object]] = []
+    candidate_total = 0
+    compatible_total = 0
+    example_rejections: dict[str, dict[str, object]] = {}
+
+    for left, right in combinations(range(n), 2):
+        pair_compatible = 0
+        pair_rejections: Counter[str] = Counter()
+        for left_support in options[left]:
+            for right_support in options[right]:
+                candidate_total += 1
+                reason = row_pair_rejection(
+                    order,
+                    left,
+                    left_support,
+                    right,
+                    right_support,
+                )
+                if reason is None:
+                    pair_compatible += 1
+                    continue
+                rejection_counts[reason] += 1
+                pair_rejections[reason] += 1
+                if reason not in example_rejections:
+                    example_rejections[reason] = {
+                        "centers": [left, right],
+                        "left_support": list(left_support),
+                        "right_support": list(right_support),
+                        "intersection": sorted(
+                            set(left_support) & set(right_support)
+                        ),
+                    }
+        gap = min((right - left) % n, (left - right) % n)
+        compatible_counts[pair_compatible] += 1
+        compatible_by_gap.setdefault(gap, Counter())[pair_compatible] += 1
+        compatible_total += pair_compatible
+        records.append(
+            {
+                "centers": [left, right],
+                "cyclic_gap": gap,
+                "candidate_count": len(options[left]) * len(options[right]),
+                "compatible_count": pair_compatible,
+                "rejection_counts": counter_to_json(pair_rejections),
+            }
+        )
+
+    return {
+        "center_pair_count": len(records),
+        "candidate_count_total": candidate_total,
+        "compatible_count_total": compatible_total,
+        "compatible_count_distribution": counter_to_json(compatible_counts),
+        "compatible_count_by_cyclic_gap": {
+            str(gap): counter_to_json(counter)
+            for gap, counter in sorted(compatible_by_gap.items())
+        },
+        "rejection_counts": counter_to_json(rejection_counts),
+        "example_rejections": example_rejections,
+        "records": records,
+    }
+
+
+def support_compatible_with_assignment(
+    order: Sequence[int],
+    options: SupportOptions,
+    assigned: Mapping[int, int],
+    center: int,
+    support_index: int,
+) -> str | None:
+    """Return the first row-pair rejection against an assigned partial state."""
+
+    support = options[center][support_index]
+    for other_center in sorted(assigned):
+        other_support = options[other_center][assigned[other_center]]
+        reason = row_pair_rejection(
+            order,
+            other_center,
+            other_support,
+            center,
+            support,
+        )
+        if reason is not None:
+            return reason
+    return None
+
+
+def viable_support_indices(
+    order: Sequence[int],
+    options: SupportOptions,
+    assigned: Mapping[int, int],
+    center: int,
+) -> tuple[list[int], Counter[str]]:
+    """Return viable support indices and rejection counts for one center."""
+
+    viable: list[int] = []
+    rejections: Counter[str] = Counter()
+    for support_index in range(len(options[center])):
+        reason = support_compatible_with_assignment(
+            order,
+            options,
+            assigned,
+            center,
+            support_index,
+        )
+        if reason is None:
+            viable.append(support_index)
+        else:
+            rejections[reason] += 1
+    return viable, rejections
+
+
+def run_support_search(
+    order: Sequence[int],
+    options: SupportOptions,
+    *,
+    max_nodes: int | None = None,
+) -> SupportSearchResult:
+    """Search for a complete all-five-rich support assignment."""
+
+    n = len(options)
+    assigned: dict[int, int] = {}
+    center_choice_counts: Counter[int] = Counter()
+    node_depth_counts: Counter[int] = Counter()
+    evaluation_rejection_counts: Counter[str] = Counter()
+    first_dead_end: dict[str, object] | None = None
+    nodes_visited = 0
+    complete_assignments = 0
+    dead_end_count = 0
+    max_depth = 0
+    aborted = False
+
+    def choose_center() -> tuple[int | None, list[int], Counter[str]]:
+        best_center: int | None = None
+        best_options: list[int] = []
+        best_rejections: Counter[str] = Counter()
+        for center in range(n):
+            if center in assigned:
+                continue
+            viable, rejections = viable_support_indices(
+                order,
+                options,
+                assigned,
+                center,
+            )
+            if best_center is None or len(viable) < len(best_options):
+                best_center = center
+                best_options = viable
+                best_rejections = rejections
+            if not viable:
+                break
+        return best_center, best_options, best_rejections
+
+    def search() -> None:
+        nonlocal aborted
+        nonlocal complete_assignments
+        nonlocal dead_end_count
+        nonlocal first_dead_end
+        nonlocal max_depth
+        nonlocal nodes_visited
+
+        depth = len(assigned)
+        max_depth = max(max_depth, depth)
+        if depth == n:
+            complete_assignments += 1
+            return
+        center, center_options, rejections = choose_center()
+        evaluation_rejection_counts.update(rejections)
+        if center is None:
+            complete_assignments += 1
+            return
+        if not center_options:
+            dead_end_count += 1
+            if first_dead_end is None:
+                first_dead_end = {
+                    "depth": depth,
+                    "next_center": center,
+                    "assigned_supports": {
+                        str(assigned_center): list(
+                            options[assigned_center][support_index]
+                        )
+                        for assigned_center, support_index in sorted(
+                            assigned.items()
+                        )
+                    },
+                    "rejection_counts": counter_to_json(rejections),
+                }
+            return
+
+        center_choice_counts[center] += 1
+        node_depth_counts[depth] += len(center_options)
+        for support_index in center_options:
+            if max_nodes is not None and nodes_visited >= max_nodes:
+                aborted = True
+                return
+            nodes_visited += 1
+            assigned[center] = support_index
+            search()
+            del assigned[center]
+            if aborted:
+                return
+
+    search()
+    return SupportSearchResult(
+        nodes_visited=nodes_visited,
+        complete_assignments=complete_assignments,
+        dead_end_count=dead_end_count,
+        max_depth=max_depth,
+        aborted=aborted,
+        center_choice_counts=dict(sorted(center_choice_counts.items())),
+        node_depth_counts=dict(sorted(node_depth_counts.items())),
+        evaluation_rejection_counts=dict(sorted(evaluation_rejection_counts.items())),
+        first_dead_end=first_dead_end,
+    )
+
+
+def build_summary(
+    pair_catalog: Mapping[str, object],
+    search: SupportSearchResult,
+    options: SupportOptions,
+    *,
+    max_nodes: int | None,
+) -> dict[str, object]:
+    """Return the stable summary block for the support obstruction payload."""
+
+    option_counts = [len(center_options) for center_options in options]
+    return {
+        "n": N,
+        "order": list(ORDER),
+        "support_size": SUPPORT_SIZE,
+        "center_count": len(options),
+        "option_counts": option_counts,
+        "raw_assignment_upper_bound": prod(option_counts),
+        "center_pair_count": pair_catalog["center_pair_count"],
+        "center_pair_candidate_count_total": pair_catalog["candidate_count_total"],
+        "compatible_center_pair_count_total": pair_catalog["compatible_count_total"],
+        "center_pair_compatible_count_distribution": pair_catalog[
+            "compatible_count_distribution"
+        ],
+        "center_pair_rejection_counts": pair_catalog["rejection_counts"],
+        "search_nodes_visited": search.nodes_visited,
+        "search_complete_assignments": search.complete_assignments,
+        "search_dead_end_count": search.dead_end_count,
+        "search_max_depth": search.max_depth,
+        "search_aborted": search.aborted,
+        "search_center_choice_counts": counter_to_json(search.center_choice_counts),
+        "search_node_depth_counts": counter_to_json(search.node_depth_counts),
+        "no_pair_filter_survivors": (
+            search.complete_assignments == 0 and not search.aborted
+        ),
+        "debug_max_nodes": max_nodes,
+    }
+
+
+def build_payload(*, max_nodes: int | None = None) -> dict[str, object]:
+    """Build the generator-independent n=9 all-five-rich payload."""
+
+    options = all_support_options(N, SUPPORT_SIZE)
+    pair_catalog = build_pair_catalog(ORDER, options)
+    search = run_support_search(ORDER, options, max_nodes=max_nodes)
+    summary = build_summary(
+        pair_catalog,
+        search,
+        options,
+        max_nodes=max_nodes,
+    )
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Generator-independent n=9 all-five-rich support catalogue. It "
+            "enumerates every choice of one size-five support at each center "
+            "in the natural cyclic order and applies only the two-circle "
+            "row-pair cap plus the radical-axis crossing rule for "
+            "two-overlaps. The checked catalogue has no complete support "
+            "assignment. Repo-locally, this rules out the subcase where every "
+            "center has some rich distance class of size at least five, but "
+            "it does not handle mixed exact-four/size-five catalogues, does "
+            "not prove n=9, does not prove Erdos Problem #97, and is not a "
+            "counterexample."
+        ),
+        "summary": summary,
+        "pair_catalog": pair_catalog,
+        "search": {
+            "nodes_visited": search.nodes_visited,
+            "complete_assignments": search.complete_assignments,
+            "dead_end_count": search.dead_end_count,
+            "max_depth": search.max_depth,
+            "aborted": search.aborted,
+            "center_choice_counts": counter_to_json(search.center_choice_counts),
+            "node_depth_counts": counter_to_json(search.node_depth_counts),
+            "evaluation_rejection_counts": counter_to_json(
+                search.evaluation_rejection_counts
+            ),
+            "first_dead_end": search.first_dead_end,
+        },
+        "support_rule": {
+            "support_size": SUPPORT_SIZE,
+            "rule": (
+                "For each center, enumerate all five-subsets of the other "
+                "eight labels. These supports are not generated from stored "
+                "selected-row packets."
+            ),
+            "subcase_reduction": (
+                "If a genuine nonagon counterexample had a rich class of "
+                "size at least five at every center, choosing any five "
+                "witnesses inside each such class would give a complete "
+                "support assignment satisfying the checked pair filters."
+            ),
+        },
+        "filters": [
+            {
+                "name": "row_pair_cap",
+                "meaning": (
+                    "Two distinct distance circles can share at most two "
+                    "witness vertices."
+                ),
+            },
+            {
+                "name": "two_overlap_crossing",
+                "meaning": (
+                    "When two centers share exactly two witnesses in their "
+                    "rich classes, the center chord and shared-witness chord "
+                    "must cross in the cyclic order."
+                ),
+            },
+        ],
+        "interpretation_warnings": [
+            "This is a generator-independent size-five support subcase only.",
+            "It does not enumerate mixed exact-four and size-five rich catalogues.",
+            "It does not use or prove the adaptive radius-blocker bridge.",
+            "No general proof and no counterexample are claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n9_all_five_rich_support_obstruction.py",
+            "command": (
+                "python scripts/check_n9_all_five_rich_support_obstruction.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "src/erdos97/incidence_filters.py",
+                "docs/claims.md#radical-axis-crossing--bisection",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable all-five-rich support obstruction counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    if summary.get("debug_max_nodes") is not None:
+        raise AssertionError("expected payload must not use debug limits")
+    pair_catalog = payload.get("pair_catalog")
+    if not isinstance(pair_catalog, Mapping):
+        raise AssertionError("pair catalog is missing")
+    records = pair_catalog.get("records")
+    if not isinstance(records, list) or len(records) != EXPECTED_SUMMARY[
+        "center_pair_count"
+    ]:
+        raise AssertionError("unexpected pair-catalog record count")
+    search = payload.get("search")
+    if not isinstance(search, Mapping):
+        raise AssertionError("search record is missing")
+    if search.get("first_dead_end") is None:
+        raise AssertionError("expected first dead-end certificate")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 all-five-rich support obstruction")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"raw assignments: {summary['raw_assignment_upper_bound']}")
+    print(f"search nodes: {summary['search_nodes_visited']}")
+    print(f"complete assignments: {summary['search_complete_assignments']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument(
+        "--max-nodes",
+        type=int,
+        default=None,
+        help="debug/testing node limit; do not use for checked artifacts",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(max_nodes=args.max_nodes)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1505,6 +1505,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_all_five_rich_support_obstruction",
+        command=(
+            "python",
+            "scripts/check_n9_all_five_rich_support_obstruction.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Generator-independent n=9 all-five-rich support obstruction; "
+            "finite support subcase only, not mixed exact-four/size-five "
+            "catalogue coverage, not a proof of Erdos Problem #97, and not "
+            "a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/tests/test_n9_all_five_rich_support_obstruction.py
+++ b/tests/test_n9_all_five_rich_support_obstruction.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n9_all_five_rich_support_obstruction import (  # noqa: E402
+    DEFAULT_OUT,
+    ORDER,
+    all_support_options,
+    build_pair_catalog,
+    build_payload,
+    row_pair_rejection,
+    run_support_search,
+)
+
+
+def test_n9_all_five_support_options_are_generator_independent() -> None:
+    options = all_support_options()
+
+    assert len(options) == 9
+    assert [len(center_options) for center_options in options] == [56] * 9
+    assert options[0][0] == (1, 2, 3, 4, 5)
+    assert options[0][-1] == (4, 5, 6, 7, 8)
+    assert all(0 not in support for support in options[0])
+
+
+def test_n9_all_five_pair_filter_rejection_reasons() -> None:
+    assert (
+        row_pair_rejection(
+            ORDER,
+            0,
+            (1, 2, 3, 4, 5),
+            1,
+            (0, 2, 3, 4, 5),
+        )
+        == "row_pair_cap"
+    )
+    assert (
+        row_pair_rejection(
+            ORDER,
+            0,
+            (1, 2, 3, 4, 5),
+            1,
+            (0, 2, 3, 6, 7),
+        )
+        == "two_overlap_crossing"
+    )
+    assert (
+        row_pair_rejection(
+            ORDER,
+            0,
+            (1, 2, 3, 4, 5),
+            1,
+            (0, 2, 6, 7, 8),
+        )
+        is None
+    )
+
+
+def test_n9_all_five_pair_catalog_counts() -> None:
+    catalog = build_pair_catalog(ORDER, all_support_options())
+
+    assert catalog["center_pair_count"] == 36
+    assert catalog["candidate_count_total"] == 112896
+    assert catalog["compatible_count_total"] == 17640
+    assert catalog["compatible_count_distribution"] == {
+        "140": 9,
+        "440": 9,
+        "640": 9,
+        "740": 9,
+    }
+    assert catalog["rejection_counts"] == {
+        "row_pair_cap": 70056,
+        "two_overlap_crossing": 25200,
+    }
+
+
+def test_n9_all_five_search_closes_without_vertex_circle_replay() -> None:
+    search = run_support_search(ORDER, all_support_options())
+
+    assert search.nodes_visited == 136
+    assert search.complete_assignments == 0
+    assert search.dead_end_count == 116
+    assert search.max_depth == 2
+    assert not search.aborted
+    assert search.center_choice_counts == {0: 1, 1: 20}
+    assert search.node_depth_counts == {0: 56, 1: 80}
+    assert search.first_dead_end is not None
+    assert search.first_dead_end["next_center"] == 6
+
+
+def test_n9_all_five_payload_matches_checked_artifact() -> None:
+    payload = build_payload()
+
+    assert payload["summary"]["no_pair_filter_survivors"] is True
+    assert payload == json.loads(DEFAULT_OUT.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add a generator-independent n=9 all-five-rich support catalogue checker and stored artifact
- document the repo-local subcase: 56^9 size-five support assignments close under only the two-circle row-pair cap and two-overlap crossing filters
- wire the artifact into claims/docs, metadata, tests, and the artifact audit runner

## Scope
This rules out only the all-centers-size-at-least-five support subcase repo-locally. It does not enumerate mixed exact-four/size-five rich catalogues, does not prove n=9, does not prove the adaptive blocker bridge, does not prove Erdos Problem #97, and is not a counterexample.

## Verification
- python scripts/check_n9_all_five_rich_support_obstruction.py --check --assert-expected --json
- python scripts/check_text_clean.py
- python scripts/check_status_consistency.py
- python scripts/check_status_consistency.py --max-official-status-age-days 90
- python scripts/check_artifact_provenance.py
- git diff --check
- python -m ruff check .
- python -m pytest -q (1066 passed, 299 deselected)