### PR TITLE
Add n9 mixed rich frontier crosswalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ This repository is a public research log and reproducibility workspace for Erdő
   generated rich-class quotient sweep, a bounded rich-extension neighborhood
   sweep, a one-packet full rich-extension product pilot, and an all-packet
   generated rich-extension product sweep, plus the generator-independent
-  all-five-rich support obstruction and mixed rich-support reduction,
+  all-five-rich support obstruction, mixed rich-support reduction, and the
+  mixed-support-to-frontier crosswalk,
   read
   [`docs/radius-blocker-vertex-circle-pilot.md`](docs/radius-blocker-vertex-circle-pilot.md)
   and
@@ -96,7 +97,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/n9-all-five-rich-support-obstruction.md`](docs/n9-all-five-rich-support-obstruction.md).
   For the follow-up mixed four/five support reduction, read
-  [`docs/n9-mixed-rich-support-reduction.md`](docs/n9-mixed-rich-support-reduction.md).
+  [`docs/n9-mixed-rich-support-reduction.md`](docs/n9-mixed-rich-support-reduction.md)
+  and
+  [`docs/n9-mixed-rich-frontier-crosswalk.md`](docs/n9-mixed-rich-frontier-crosswalk.md).
 - For the stored geometric gates and fixed-order widenings on the block-6
   fragile-cover negative control, read
   [`docs/block6-fragile-vertex-circle-extension-audit.md`](docs/block6-fragile-vertex-circle-extension-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -388,6 +388,18 @@ does not prove `n=9`, and is not a counterexample. See
 `scripts/check_n9_mixed_rich_support_reduction.py`, and
 `data/certificates/n9_mixed_rich_support_reduction.json`.
 
+A companion crosswalk now checks that those `184` terminal mixed-support
+assignments are exactly the stored `184` pre-vertex-circle exact-four frontier
+assignments as a labelled row set. The two generators order six assignments
+differently, but their sorted row-set SHA-256 digest agrees:
+`dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55`. The
+matched stored frontier statuses are `158` self-edges and `26` strict cycles.
+This is support-to-frontier bookkeeping only: it does not prove the
+review-pending exact-four exhaustive checker, prove `n=9`, or give a
+counterexample. See `docs/n9-mixed-rich-frontier-crosswalk.md`,
+`scripts/check_n9_mixed_rich_frontier_crosswalk.py`, and
+`data/certificates/n9_mixed_rich_frontier_crosswalk.json`.
+
 The companion bootstrap / vertex-circle overlay joins the two tight
 non-ear-orderable `n=9` crosswalk rows to the review-pending strict-cycle
 certificate chain by selected-row signature. Both land on the same `T12/F16`

--- a/STATE.md
+++ b/STATE.md
@@ -256,6 +256,15 @@ frontier before vertex-circle replay. This still does not independently prove
 the review-pending exact-four exhaustive checker, prove `n=9`, or give a
 counterexample. See `docs/n9-mixed-rich-support-reduction.md`.
 
+A mixed-rich/frontier crosswalk now checks that those `184` terminal
+mixed-support assignments are exactly the stored `184` exact-four
+pre-vertex-circle frontier assignments as a labelled row set. The brancher
+sequences differ at six positions, but the sorted row-set digest agrees, and
+the matched stored statuses are `158` self-edges and `26` strict cycles. This
+is support-to-frontier bookkeeping only; it still does not prove the
+review-pending exact-four exhaustive checker, prove `n=9`, or give a
+counterexample. See `docs/n9-mixed-rich-frontier-crosswalk.md`.
+
 A second bootstrap-core diagnostic overlays the two tight non-ear-orderable
 `n=9` crosswalk rows with the review-pending vertex-circle strict-cycle chain.
 Both rows join by selected-row signature to the same `T12/F16` strict-cycle

--- a/data/certificates/n9_mixed_rich_frontier_crosswalk.json
+++ b/data/certificates/n9_mixed_rich_frontier_crosswalk.json
@@ -1,0 +1,100 @@
+{
+  "claim_scope": "Crosswalk from the generator-independent n=9 mixed four/five rich-support reduction to the stored exact-four vertex-circle frontier. It reruns the mixed support search, collects the 184 all-exact-four terminal support assignments, and checks that their labelled row set is exactly the stored 184 pre-vertex-circle frontier assignments. It does not prove the exact-four vertex-circle exhaustive checker, does not prove filter soundness, strict-edge geometry, selected-distance quotient soundness, n=9, Erdos Problem #97, a counterexample, or any official/global status update.",
+  "interpretation": "A passed crosswalk says the 184 terminal assignments from the mixed four/five rich-support reduction are exactly the stored 184 exact-four pre-vertex-circle frontier assignments as a labelled set. This is a support-to-frontier landing check only.",
+  "mixed_rich_frontier_crosswalk": {
+    "all_collected_supports_exact_four": true,
+    "collected_mixed_assignment_count": 184,
+    "example_mismatches": [],
+    "extra_in_frontier_count": 0,
+    "frontier_assignment_count": 184,
+    "frontier_sequence_rows_sha256": "d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01",
+    "frontier_sorted_rows_sha256": "dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55",
+    "frontier_unique_assignment_count": 184,
+    "matched_frontier_status_counts": {
+      "self_edge": 158,
+      "strict_cycle": 26
+    },
+    "missing_from_frontier_count": 0,
+    "mixed_sequence_rows_sha256": "42df5855afd69904a94408342d6f4194cc36732ee79df67349da4c7e1b67faa2",
+    "mixed_sorted_rows_sha256": "dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55",
+    "mixed_source_assignment_count": 184,
+    "mixed_source_counts_match_collected": true,
+    "mixed_unique_assignment_count": 184,
+    "n": 9,
+    "search_center_choice_counts": {
+      "0": 1,
+      "1": 892,
+      "2": 3979,
+      "3": 8892,
+      "4": 11200,
+      "5": 8868,
+      "6": 6538,
+      "7": 4590,
+      "8": 4084
+    },
+    "search_dead_end_count": 58791,
+    "search_node_depth_counts": {
+      "0": 126,
+      "1": 2520,
+      "2": 11327,
+      "3": 28368,
+      "4": 33043,
+      "5": 21158,
+      "6": 9088,
+      "7": 2204,
+      "8": 184
+    },
+    "search_nodes_visited": 108018,
+    "search_rule": "mixed_support_minimum_remaining_options",
+    "sequence_matches": false,
+    "sequence_mismatch_count": 6,
+    "sequence_mismatch_positions_sample": [
+      106,
+      107,
+      108,
+      109,
+      134,
+      135
+    ],
+    "set_matches": true,
+    "support_sizes": [
+      4,
+      5
+    ]
+  },
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_mixed_rich_frontier_crosswalk.py --write --assert-expected",
+    "generator": "scripts/check_n9_mixed_rich_frontier_crosswalk.py",
+    "sources": [
+      "data/certificates/n9_mixed_rich_support_reduction.json",
+      "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+      "scripts/check_n9_mixed_rich_support_reduction.py"
+    ]
+  },
+  "schema": "erdos97.n9_mixed_rich_frontier_crosswalk.v1",
+  "source_artifacts": {
+    "frontier_motif_classification": {
+      "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+      "schema": "erdos97.n9_vertex_circle_frontier_motif_classification.v1",
+      "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": null
+    },
+    "mixed_support_reduction": {
+      "path": "data/certificates/n9_mixed_rich_support_reduction.json",
+      "schema": "erdos97.n9_mixed_rich_support_reduction.v1",
+      "status": "N9_MIXED_RICH_SUPPORT_REDUCTION_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC",
+      "type": null
+    }
+  },
+  "status": "REVIEW_PENDING_MIXED_RICH_FRONTIER_CROSSWALK",
+  "support_sizes": [
+    4,
+    5
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": [],
+  "validation_status": "passed"
+}

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -518,6 +518,16 @@ prove the review-pending exact-four vertex-circle exhaustive checker, does not
 prove `n=9`, does not prove Erdos Problem #97, and does not provide a
 counterexample. See `docs/n9-mixed-rich-support-reduction.md`.
 
+The companion crosswalk
+`python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json`
+checks that the `184` terminal mixed-support assignments are exactly the
+stored `184` exact-four pre-vertex-circle frontier assignments as a labelled
+set. The mixed and frontier sequences differ at six positions, but the sorted
+row-set digest matches and the stored frontier statuses are `158` self-edges
+and `26` strict cycles. This remains support-to-frontier bookkeeping only; it
+does not prove the exact-four checker, `n=9`, Erdos Problem #97, or a
+counterexample. See `docs/n9-mixed-rich-frontier-crosswalk.md`.
+
 ### Bootstrap-core closure rank and weighted capacity
 
 Status: `LEMMA` / bridge fork.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -186,10 +186,14 @@ Use this queue when no more specific issue is selected.
    The mixed rich-support reduction
    `python scripts/check_n9_mixed_rich_support_reduction.py --check --assert-expected --json`
    now runs that four/five support catalogue with witness-pair capacity and
-   leaves exactly the `184` all-exact-four assignments. The next useful PR is
-   therefore no longer another size-five catalogue; it should either audit the
-   exact-four vertex-circle frontier or replace pieces of that review-pending
-   pipeline with reusable local lemmas.
+   leaves exactly the `184` all-exact-four assignments. The mixed/frontier
+   crosswalk
+   `python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json`
+   checks that those `184` terminal assignments are exactly the stored
+   pre-vertex-circle frontier as a labelled row set. The next useful PR is
+   therefore no longer another size-five catalogue or landing crosswalk; it
+   should audit the exact-four vertex-circle frontier itself or replace pieces
+   of that review-pending pipeline with reusable local lemmas.
    The stored crossing-order sample
    `data/certificates/block6_terminal_crossing_vertex_circle_sample.json`
    now checks two deterministic terminal-extension windows across all of

--- a/docs/n9-mixed-rich-frontier-crosswalk.md
+++ b/docs/n9-mixed-rich-frontier-crosswalk.md
@@ -1,0 +1,60 @@
+# n=9 mixed rich-support frontier crosswalk
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / support-to-frontier crosswalk. No
+general proof of Erdos Problem #97 is claimed. No counterexample is claimed.
+
+This note joins two checked artifacts:
+
+- `data/certificates/n9_mixed_rich_support_reduction.json`;
+- `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
+
+The mixed rich-support reduction enumerates every four- or five-witness
+support at every center of the natural-order nonagon and leaves `184` complete
+assignments, all exact-four. The crosswalk reruns that mixed support search,
+collects those terminal exact-four row systems, and compares them as labelled
+row sets with the stored pre-vertex-circle frontier.
+
+## Checked Result
+
+The checked artifact is:
+
+```text
+data/certificates/n9_mixed_rich_frontier_crosswalk.json
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json
+```
+
+The crosswalk records:
+
+```text
+mixed terminal assignments:     184
+stored frontier assignments:    184
+set equality:                   true
+sequence equality:              false
+sequence mismatch positions:    106, 107, 108, 109, 134, 135
+matched frontier status counts: 158 self_edge, 26 strict_cycle
+sorted row-set SHA-256:         dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55
+```
+
+The sequence mismatch is harmless provenance: the mixed-support brancher and
+the stored frontier classifier order six assignments differently, but the
+labelled row set is identical.
+
+## Consequence
+
+Repo-locally, the mixed rich-support reduction now lands exactly on the stored
+`184` exact-four pre-vertex-circle frontier, not merely on another collection
+with the same cardinality. This removes one bookkeeping gap between the
+four/five support catalogue and the existing exact-four vertex-circle review
+pipeline.
+
+## Boundary
+
+This crosswalk does not independently prove the exact-four vertex-circle
+exhaustive checker. It does not prove filter soundness, strict-edge geometry,
+selected-distance quotient soundness, `n=9`, the adaptive radius-blocker
+bridge, or Erdos Problem #97. It is not a counterexample.

--- a/docs/n9-mixed-rich-support-reduction.md
+++ b/docs/n9-mixed-rich-support-reduction.md
@@ -51,6 +51,23 @@ Thus the generator-independent mixed support catalogue collapses to the same
 all-exact-four frontier size already used by the review-pending `n=9`
 vertex-circle pipeline.
 
+The companion crosswalk
+`data/certificates/n9_mixed_rich_frontier_crosswalk.json` checks the stronger
+bookkeeping statement: the `184` terminal mixed-support assignments are
+exactly the stored `184` pre-vertex-circle frontier assignments as a labelled
+row set. The two generators order six assignments differently, but their
+sorted row-set digest is identical:
+
+```text
+dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55
+```
+
+Verify it with:
+
+```bash
+python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json
+```
+
 ## Consequence
 
 Repo-locally, this rules out any size-at-least-five rich distance class in an

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -178,6 +178,20 @@ is stored-frontier coverage bookkeeping against the current brancher, not
 filter soundness, strict-edge geometry, quotient soundness, or a completed
 `n=9` review.
 
+The mixed-rich/frontier crosswalk checks that the newer four/five support
+catalogue lands on this same exact-four frontier:
+
+```bash
+python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json
+```
+
+It reruns the mixed support search and compares its `184` all-exact-four
+terminal assignments with the stored motif-classification rows as a labelled
+set. The brancher sequences differ in six positions, but the sorted row-set
+digest matches. This is support-to-frontier bookkeeping only, not a proof of
+the mixed support reduction, filter soundness, strict-edge geometry, quotient
+soundness, or a completed `n=9` review.
+
 The dihedral-orbit audit command checks stored motif-family orbit bookkeeping:
 
 ```bash

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -613,7 +613,10 @@ condition that the surviving multi-block family does not automatically satisfy:
   `docs/n9-mixed-rich-support-reduction.md`, which closes the four/five
   support catalogue under the same pair/crossing filters plus witness-pair
   capacity. It leaves exactly `184` complete assignments and all are
-  all-exact-four, so the next review target is the exact-four frontier or a
+  all-exact-four. The mixed/frontier crosswalk recorded in
+  `docs/n9-mixed-rich-frontier-crosswalk.md` checks that those `184` terminal
+  assignments are exactly the stored pre-vertex-circle frontier as a labelled
+  row set, so the next review target is the exact-four frontier itself or a
   smaller reusable replacement for the review-pending vertex-circle pipeline.
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -333,6 +333,11 @@ local_repo:
       artifact: "data/certificates/n9_mixed_rich_support_reduction.json"
       verifier: "scripts/check_n9_mixed_rich_support_reduction.py"
       claim_scope: "repo-local finite support reduction only; enumerates the full 126^9 four/five support assignment space under row-pair cap, two-overlap crossing, and witness-pair capacity filters and leaves 184 complete all-exact-four assignments with zero size-five support assignments, but does not independently prove the exact-four vertex-circle exhaustive checker, prove n=9, prove Erdos #97, or give a counterexample"
+    - pattern: "n9_mixed_rich_frontier_crosswalk"
+      status: "mixed rich-support to exact-four frontier crosswalk"
+      artifact: "data/certificates/n9_mixed_rich_frontier_crosswalk.json"
+      verifier: "scripts/check_n9_mixed_rich_frontier_crosswalk.py"
+      claim_scope: "repo-local support-to-frontier bookkeeping only; checks that the 184 terminal mixed rich-support assignments equal the stored 184 pre-vertex-circle exact-four frontier assignments as a labelled row set, but does not prove the exact-four vertex-circle exhaustive checker, prove n=9, prove Erdos #97, or give a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3253,6 +3253,57 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: n9_mixed_rich_frontier_crosswalk
+    path: data/certificates/n9_mixed_rich_frontier_crosswalk.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n9_mixed_rich_frontier_crosswalk.py
+    command: python scripts/check_n9_mixed_rich_frontier_crosswalk.py --write --assert-expected
+    checker: scripts/check_n9_mixed_rich_frontier_crosswalk.py
+    check_command: python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Crosswalk from the n=9 mixed four/five support reduction to the stored exact-four vertex-circle frontier; support-to-frontier bookkeeping only, not an independent proof of the exact-four vertex-circle exhaustive checker, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_mixed_rich_frontier_crosswalk.v1
+      status: REVIEW_PENDING_MIXED_RICH_FRONTIER_CROSSWALK
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      n: 9
+      support_sizes:
+        - 4
+        - 5
+      mixed_rich_frontier_crosswalk.search_nodes_visited: 108018
+      mixed_rich_frontier_crosswalk.search_dead_end_count: 58791
+      mixed_rich_frontier_crosswalk.mixed_source_assignment_count: 184
+      mixed_rich_frontier_crosswalk.collected_mixed_assignment_count: 184
+      mixed_rich_frontier_crosswalk.frontier_assignment_count: 184
+      mixed_rich_frontier_crosswalk.mixed_unique_assignment_count: 184
+      mixed_rich_frontier_crosswalk.frontier_unique_assignment_count: 184
+      mixed_rich_frontier_crosswalk.all_collected_supports_exact_four: true
+      mixed_rich_frontier_crosswalk.mixed_source_counts_match_collected: true
+      mixed_rich_frontier_crosswalk.sequence_matches: false
+      mixed_rich_frontier_crosswalk.sequence_mismatch_count: 6
+      mixed_rich_frontier_crosswalk.set_matches: true
+      mixed_rich_frontier_crosswalk.missing_from_frontier_count: 0
+      mixed_rich_frontier_crosswalk.extra_in_frontier_count: 0
+      mixed_rich_frontier_crosswalk.matched_frontier_status_counts.self_edge: 158
+      mixed_rich_frontier_crosswalk.matched_frontier_status_counts.strict_cycle: 26
+      mixed_rich_frontier_crosswalk.mixed_sequence_rows_sha256: 42df5855afd69904a94408342d6f4194cc36732ee79df67349da4c7e1b67faa2
+      mixed_rich_frontier_crosswalk.frontier_sequence_rows_sha256: d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01
+      mixed_rich_frontier_crosswalk.mixed_sorted_rows_sha256: dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55
+      mixed_rich_frontier_crosswalk.frontier_sorted_rows_sha256: dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55
+      validation_status: passed
+      provenance.command: python scripts/check_n9_mixed_rich_frontier_crosswalk.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - exact-four vertex-circle exhaustive checker is independently proved
+      - adaptive blocker bridge is proved
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+      - general proof of Erdos Problem #97
+
   - id: block6_fragile_vertex_circle_extension_audit
     path: data/certificates/block6_fragile_vertex_circle_extension_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_n9_mixed_rich_frontier_crosswalk.py
+++ b/scripts/check_n9_mixed_rich_frontier_crosswalk.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Crosswalk the n=9 mixed rich-support reduction to the exact-four frontier.
+
+This is a finite support/frontier diagnostic only. It proves no general
+theorem about Erdos Problem #97 and supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+SCRIPTS = ROOT / "scripts"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from erdos97.path_display import display_path  # noqa: E402
+
+import check_n9_mixed_rich_support_reduction as mixed  # noqa: E402
+
+SCHEMA = "erdos97.n9_mixed_rich_frontier_crosswalk.v1"
+STATUS = "REVIEW_PENDING_MIXED_RICH_FRONTIER_CROSSWALK"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_mixed_rich_frontier_crosswalk.json"
+DEFAULT_MIXED = ROOT / "data" / "certificates" / "n9_mixed_rich_support_reduction.json"
+DEFAULT_FRONTIER = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_vertex_circle_frontier_motif_classification.json"
+)
+CLAIM_SCOPE = (
+    "Crosswalk from the generator-independent n=9 mixed four/five rich-support "
+    "reduction to the stored exact-four vertex-circle frontier. It reruns the "
+    "mixed support search, collects the 184 all-exact-four terminal support "
+    "assignments, and checks that their labelled row set is exactly the stored "
+    "184 pre-vertex-circle frontier assignments. It does not prove the "
+    "exact-four vertex-circle exhaustive checker, does not prove filter "
+    "soundness, strict-edge geometry, selected-distance quotient soundness, "
+    "n=9, Erdos Problem #97, a counterexample, or any official/global status "
+    "update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_mixed_rich_frontier_crosswalk.py",
+    "command": (
+        "python scripts/check_n9_mixed_rich_frontier_crosswalk.py "
+        "--write --assert-expected"
+    ),
+    "sources": [
+        "data/certificates/n9_mixed_rich_support_reduction.json",
+        "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+        "scripts/check_n9_mixed_rich_support_reduction.py",
+    ],
+}
+
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "support_sizes": [4, 5],
+    "search_nodes_visited": 108018,
+    "search_dead_end_count": 58791,
+    "mixed_source_assignment_count": 184,
+    "collected_mixed_assignment_count": 184,
+    "frontier_assignment_count": 184,
+    "mixed_unique_assignment_count": 184,
+    "frontier_unique_assignment_count": 184,
+    "all_collected_supports_exact_four": True,
+    "mixed_source_counts_match_collected": True,
+    "sequence_matches": False,
+    "sequence_mismatch_count": 6,
+    "set_matches": True,
+    "missing_from_frontier_count": 0,
+    "extra_in_frontier_count": 0,
+    "matched_frontier_status_counts": {"self_edge": 158, "strict_cycle": 26},
+    "mixed_sequence_rows_sha256": "42df5855afd69904a94408342d6f4194cc36732ee79df67349da4c7e1b67faa2",
+    "frontier_sequence_rows_sha256": "d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01",
+    "mixed_sorted_rows_sha256": "dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55",
+    "frontier_sorted_rows_sha256": "dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55",
+    "sequence_mismatch_positions_sample": [106, 107, 108, 109, 134, 135],
+}
+
+Rows = tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True)
+class CollectedMixedFrontier:
+    rows: tuple[Rows, ...]
+    nodes_visited: int
+    dead_end_count: int
+    center_choice_counts: Mapping[int, int]
+    node_depth_counts: Mapping[int, int]
+
+
+def load_json(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def mixed_frontier_crosswalk_payload(
+    *,
+    mixed_path: Path = DEFAULT_MIXED,
+    frontier_path: Path = DEFAULT_FRONTIER,
+) -> dict[str, Any]:
+    """Return the mixed-rich-to-exact-four-frontier crosswalk payload."""
+
+    errors: list[str] = []
+    mixed_source = load_json(mixed_path)
+    frontier_source = load_json(frontier_path)
+    collected = collect_mixed_terminal_rows()
+    stored = stored_frontier_rows(frontier_source)
+    summary = crosswalk_summary(mixed_source, collected, stored)
+    audit_summary(summary, errors)
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": mixed.N,
+        "support_sizes": list(mixed.SUPPORT_SIZES),
+        "mixed_rich_frontier_crosswalk": summary,
+        "source_artifacts": {
+            "mixed_support_reduction": source_metadata(mixed_path, mixed_source),
+            "frontier_motif_classification": source_metadata(
+                frontier_path,
+                frontier_source,
+            ),
+        },
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "interpretation": (
+            "A passed crosswalk says the 184 terminal assignments from the "
+            "mixed four/five rich-support reduction are exactly the stored "
+            "184 exact-four pre-vertex-circle frontier assignments as a "
+            "labelled set. This is a support-to-frontier landing check only."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def collect_mixed_terminal_rows() -> CollectedMixedFrontier:
+    """Collect all terminal row systems from the mixed support search."""
+
+    catalogue = mixed.prepare_support_catalogue(mixed.N, mixed.ORDER)
+    n = len(catalogue.options)
+    assigned: dict[int, int] = {}
+    pair_counts = [0] * len(mixed.pair_indices(n))
+    terminal_rows: list[Rows] = []
+    center_choice_counts: Counter[int] = Counter()
+    node_depth_counts: Counter[int] = Counter()
+    nodes_visited = 0
+    dead_end_count = 0
+
+    def add_support(center: int, support_index: int) -> None:
+        for pair_id in catalogue.pair_ids[center][support_index]:
+            pair_counts[pair_id] += 1
+
+    def remove_support(center: int, support_index: int) -> None:
+        for pair_id in catalogue.pair_ids[center][support_index]:
+            pair_counts[pair_id] -= 1
+
+    def choose_center() -> tuple[int | None, list[int]]:
+        best_center: int | None = None
+        best_options: list[int] = []
+        for center in range(n):
+            if center in assigned:
+                continue
+            viable, _rejections = mixed.viable_support_indices(
+                catalogue,
+                assigned,
+                pair_counts,
+                center,
+            )
+            if best_center is None or len(viable) < len(best_options):
+                best_center = center
+                best_options = viable
+            if not viable:
+                break
+        return best_center, best_options
+
+    def search() -> None:
+        nonlocal dead_end_count
+        nonlocal nodes_visited
+
+        depth = len(assigned)
+        if depth == n:
+            terminal_rows.append(
+                tuple(catalogue.options[center][assigned[center]] for center in range(n))
+            )
+            return
+        center, center_options = choose_center()
+        if center is None:
+            return
+        if not center_options:
+            dead_end_count += 1
+            return
+
+        center_choice_counts[center] += 1
+        node_depth_counts[depth] += len(center_options)
+        for support_index in center_options:
+            nodes_visited += 1
+            assigned[center] = support_index
+            add_support(center, support_index)
+            search()
+            remove_support(center, support_index)
+            del assigned[center]
+
+    search()
+    return CollectedMixedFrontier(
+        rows=tuple(terminal_rows),
+        nodes_visited=nodes_visited,
+        dead_end_count=dead_end_count,
+        center_choice_counts=dict(sorted(center_choice_counts.items())),
+        node_depth_counts=dict(sorted(node_depth_counts.items())),
+    )
+
+
+def stored_frontier_rows(frontier_source: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return stored frontier rows and status labels."""
+
+    assignments = frontier_source.get("assignments")
+    if not isinstance(assignments, list):
+        raise ValueError("frontier artifact must contain an assignments list")
+    out: list[dict[str, Any]] = []
+    for index, assignment in enumerate(assignments, start=1):
+        if not isinstance(assignment, Mapping):
+            raise ValueError(f"frontier assignment {index} is not an object")
+        out.append(
+            {
+                "assignment_id": str(assignment.get("assignment_id", f"A{index:03d}")),
+                "rows": rows_from_selected_rows(assignment.get("selected_rows")),
+                "status": str(assignment.get("status")),
+            }
+        )
+    return out
+
+
+def rows_from_selected_rows(raw_rows: Any) -> Rows:
+    """Return witness rows ordered by center from compact selected rows."""
+
+    if not isinstance(raw_rows, list):
+        raise ValueError("selected_rows must be a list")
+    rows: list[tuple[int, ...] | None] = [None] * mixed.N
+    for raw_row in raw_rows:
+        if not isinstance(raw_row, list) or len(raw_row) != 5:
+            raise ValueError(f"bad selected row: {raw_row!r}")
+        center = int(raw_row[0])
+        witnesses = tuple(int(label) for label in raw_row[1:])
+        if center < 0 or center >= mixed.N:
+            raise ValueError(f"bad row center: {center!r}")
+        if len(witnesses) != 4 or len(set(witnesses)) != 4 or center in witnesses:
+            raise ValueError(f"bad witness row for center {center}: {witnesses!r}")
+        rows[center] = witnesses
+    if any(row is None for row in rows):
+        raise ValueError("stored assignment does not cover every center")
+    return tuple(row for row in rows if row is not None)
+
+
+def crosswalk_summary(
+    mixed_source: Mapping[str, Any],
+    collected: CollectedMixedFrontier,
+    stored: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return the stable crosswalk summary."""
+
+    mixed_rows = list(collected.rows)
+    frontier_rows = [record["rows"] for record in stored]
+    mixed_set = set(mixed_rows)
+    frontier_set = set(frontier_rows)
+    missing = sorted(mixed_set - frontier_set)
+    extra = sorted(frontier_set - mixed_set)
+    sequence_mismatches = [
+        index
+        for index, (left, right) in enumerate(zip(mixed_rows, frontier_rows), start=1)
+        if left != right
+    ]
+    status_by_rows = {record["rows"]: str(record["status"]) for record in stored}
+    matched_status_counts = Counter(status_by_rows[rows] for rows in mixed_set & frontier_set)
+    source_summary = mixed_source.get("summary", {})
+    if not isinstance(source_summary, Mapping):
+        source_summary = {}
+
+    return {
+        "n": mixed.N,
+        "support_sizes": list(mixed.SUPPORT_SIZES),
+        "search_rule": "mixed_support_minimum_remaining_options",
+        "search_nodes_visited": int(collected.nodes_visited),
+        "search_dead_end_count": int(collected.dead_end_count),
+        "search_center_choice_counts": mixed.counter_to_json(
+            collected.center_choice_counts,
+        ),
+        "search_node_depth_counts": mixed.counter_to_json(collected.node_depth_counts),
+        "mixed_source_assignment_count": source_summary.get(
+            "search_complete_assignments",
+        ),
+        "collected_mixed_assignment_count": len(mixed_rows),
+        "frontier_assignment_count": len(frontier_rows),
+        "mixed_unique_assignment_count": len(mixed_set),
+        "frontier_unique_assignment_count": len(frontier_set),
+        "all_collected_supports_exact_four": all(
+            len(row) == 4 for rows in mixed_rows for row in rows
+        ),
+        "mixed_source_counts_match_collected": (
+            source_summary.get("search_complete_assignments") == len(mixed_rows)
+            and source_summary.get("search_nodes_visited") == collected.nodes_visited
+            and source_summary.get("search_dead_end_count") == collected.dead_end_count
+        ),
+        "sequence_matches": mixed_rows == frontier_rows,
+        "sequence_mismatch_count": len(sequence_mismatches),
+        "set_matches": mixed_set == frontier_set,
+        "missing_from_frontier_count": len(missing),
+        "extra_in_frontier_count": len(extra),
+        "matched_frontier_status_counts": dict(sorted(matched_status_counts.items())),
+        "mixed_sequence_rows_sha256": rows_digest(mixed_rows),
+        "frontier_sequence_rows_sha256": rows_digest(frontier_rows),
+        "mixed_sorted_rows_sha256": rows_digest(sorted(mixed_rows)),
+        "frontier_sorted_rows_sha256": rows_digest(sorted(frontier_rows)),
+        "sequence_mismatch_positions_sample": sequence_mismatches[:10],
+        "example_mismatches": example_mismatches(missing, extra),
+    }
+
+
+def rows_digest(rows_list: Sequence[Rows]) -> str:
+    """Return the stable digest convention used by frontier crosswalks."""
+
+    payload = [[list(row) for row in rows] for rows in rows_list]
+    text = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def example_mismatches(
+    missing: Sequence[Rows],
+    extra: Sequence[Rows],
+) -> list[dict[str, Any]]:
+    """Return a small mismatch sample for failed crosswalks."""
+
+    examples: list[dict[str, Any]] = []
+    for kind, rows_list in (
+        ("missing_from_frontier", missing),
+        ("extra_in_frontier", extra),
+    ):
+        for rows in rows_list[:3]:
+            examples.append({"kind": kind, "rows": [list(row) for row in rows]})
+    return examples
+
+
+def audit_summary(summary: Mapping[str, Any], errors: list[str]) -> None:
+    """Collect validation errors from the crosswalk summary."""
+
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            errors.append(f"{key}: {summary.get(key)!r} != {expected!r}")
+    if summary.get("example_mismatches") != []:
+        errors.append(f"unexpected mismatch examples: {summary.get('example_mismatches')!r}")
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    """Assert the expected mixed-rich-to-frontier crosswalk."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not prove the exact-four vertex-circle exhaustive checker",
+        "does not prove filter soundness",
+        "strict-edge geometry",
+        "selected-distance quotient soundness",
+        "n=9",
+        "Erdos Problem #97",
+        "counterexample",
+        "official/global status update",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+    if payload.get("validation_status") != "passed":
+        raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+    summary = payload.get("mixed_rich_frontier_crosswalk")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("mixed_rich_frontier_crosswalk missing")
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: {summary.get(key)!r} != {expected!r}")
+    if summary.get("example_mismatches") != []:
+        raise AssertionError(f"unexpected mismatch examples: {summary['example_mismatches']!r}")
+
+
+def source_metadata(path: Path, payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return compact metadata for a source artifact."""
+
+    return {
+        "path": display_path(path, ROOT),
+        "schema": payload.get("schema"),
+        "type": payload.get("type"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+    }
+
+
+def compare_artifact(payload: Mapping[str, Any], path: Path) -> None:
+    checked = load_json(path)
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {display_path(path, ROOT)}")
+
+
+def print_summary(payload: Mapping[str, Any]) -> None:
+    summary = payload["mixed_rich_frontier_crosswalk"]
+    assert isinstance(summary, Mapping)
+    print("n=9 mixed rich-support to frontier crosswalk")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"mixed terminals: {summary['collected_mixed_assignment_count']}")
+    print(f"frontier assignments: {summary['frontier_assignment_count']}")
+    print(f"set matches: {summary['set_matches']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--mixed", type=Path, default=DEFAULT_MIXED)
+    parser.add_argument("--frontier", type=Path, default=DEFAULT_FRONTIER)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = mixed_frontier_crosswalk_payload(
+        mixed_path=args.mixed,
+        frontier_path=args.frontier,
+    )
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1537,6 +1537,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_mixed_rich_frontier_crosswalk",
+        command=(
+            "python",
+            "scripts/check_n9_mixed_rich_frontier_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Crosswalk from the n=9 mixed four/five support reduction to the "
+            "stored exact-four vertex-circle frontier; support-to-frontier "
+            "bookkeeping only, not an independent proof of the exact-four "
+            "vertex-circle exhaustive checker, not a proof of Erdos Problem "
+            "#97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_core_crosswalk",
         command=(
             "python",

--- a/tests/test_n9_mixed_rich_frontier_crosswalk.py
+++ b/tests/test_n9_mixed_rich_frontier_crosswalk.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from scripts.check_n9_mixed_rich_frontier_crosswalk import (
+    EXPECTED_SUMMARY,
+    assert_expected_payload,
+    mixed_frontier_crosswalk_payload,
+)
+
+
+def test_n9_mixed_rich_frontier_crosswalk_payload() -> None:
+    payload = mixed_frontier_crosswalk_payload()
+
+    assert_expected_payload(payload)
+    assert payload["validation_status"] == "passed"
+    summary = payload["mixed_rich_frontier_crosswalk"]
+    assert summary["set_matches"] is True
+    assert summary["sequence_matches"] is False
+    assert summary["sequence_mismatch_count"] == 6
+    assert summary["matched_frontier_status_counts"] == {
+        "self_edge": 158,
+        "strict_cycle": 26,
+    }
+    assert summary["mixed_sorted_rows_sha256"] == EXPECTED_SUMMARY[
+        "mixed_sorted_rows_sha256"
+    ]
+    assert summary["frontier_sorted_rows_sha256"] == EXPECTED_SUMMARY[
+        "frontier_sorted_rows_sha256"
+    ]
+    assert "does not prove the exact-four vertex-circle exhaustive checker" in payload[
+        "claim_scope"
+    ]
+    assert "counterexample" in payload["claim_scope"]


### PR DESCRIPTION
## Summary
- add a checked crosswalk from the mixed four/five rich-support reduction to the stored exact-four vertex-circle frontier
- rerun the mixed support terminal search and confirm its 184 all-exact-four assignments match the stored 184 frontier assignments as a labelled set
- document the sequence-order mismatch, status counts, provenance metadata, and audit wiring

## Scope
This is support-to-frontier bookkeeping only. It does not independently prove the exact-four vertex-circle exhaustive checker, filter soundness, strict-edge geometry, selected-distance quotient soundness, n=9, Erdos Problem #97, or a counterexample.

## Verification
- python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json
- python -m ruff check scripts/check_n9_mixed_rich_frontier_crosswalk.py tests/test_n9_mixed_rich_frontier_crosswalk.py
- python -m pytest tests/test_n9_mixed_rich_frontier_crosswalk.py -q
- python scripts/check_text_clean.py
- python scripts/check_status_consistency.py
- python scripts/check_status_consistency.py --max-official-status-age-days 90
- python scripts/check_artifact_provenance.py
- git diff --check
- python -m ruff check .
- python -m pytest tests/test_n9_mixed_rich_frontier_crosswalk.py tests/test_run_artifact_audit.py -q
- python -m pytest -q (1071 passed, 299 deselected)

Note: local `make verify-artifacts` was not available in this Windows shell because `make` is not installed; the new artifact's raw checker above was run directly.