### PR TITLE
[codex] Add n9 local lemma audit path checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 	$(PYTHON) scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -49,6 +49,11 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
    connects the compact 16-skeleton proof-mining catalog to the same
    aggregate/simple-replay family accounting.
+   The local-lemma audit-path checker
+   `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+   runs the focused packet/catalog, focused mini-replay,
+   aggregate/simple-replay, exhaustive/local-lemma, and
+   relation-skeleton/local-lemma handoffs as one review-pending audit path.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -111,6 +111,13 @@ It verifies only that the checked-in artifacts agree on the same
 review-pending `184 = 158 + 26` frontier accounting and the same 16 motif
 families.
 
+The combined local-lemma audit-path command
+`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+checks the focused packet/catalog, focused mini-replay, aggregate/simple
+replay, exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs as
+one review-pending diagnostic chain. It is still bookkeeping only, not packet
+soundness or an `n=9` proof.
+
 The input-data audit command
 `scripts/check_n9_vertex_circle_input_audit.py` treats the checked-in
 exhaustive JSON as stored data:

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -638,6 +638,20 @@ stored local-lemma layer on template ids, family ids, obstruction kind, and
 assignment counts. It remains a packet audit, not a completeness proof for
 `n=9`.
 
+The local-lemma audit-path checker then runs the reviewer-facing handoff as
+one chain. It checks that the focused packet/catalog audit, focused
+mini-replay crosswalk, aggregate/simple replay crosswalk,
+exhaustive/local-lemma crosswalk, and relation-skeleton/local-lemma crosswalk
+all agree on the same 12 templates, 16 families, and 184 assignments:
+
+```bash
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
+```
+
+This is still only a review-pending audit-path diagnostic. It does not prove
+packet soundness, mini-replay soundness, local-lemma completeness, frontier
+coverage, `n=9`, or Erdos Problem #97.
+
 ## Scan summary
 
 The current local-lemma scan covers these review-pending template-packet

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -92,6 +92,7 @@ python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -385,6 +385,11 @@ Next steps:
   `scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
   to compare the 16-entry relation-skeleton catalog with the same
   aggregate/simple-replay local-lemma family accounting;
+- use
+  `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+  to run the focused packet/catalog, focused mini-replay,
+  aggregate/simple-replay, exhaustive/local-lemma, and
+  relation-skeleton/local-lemma handoffs as one review-pending audit path;
 - use the focused mini-replay commands
   `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -112,6 +112,7 @@ python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Check the n=9 vertex-circle local-lemma audit path as one chain."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+SCRIPT_DIR = ROOT / "scripts"
+for path in (SRC, SCRIPT_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_n9_vertex_circle_exhaustive_local_lemma_crosswalk import (  # noqa: E402
+    DEFAULT_CLASSIFICATION,
+    DEFAULT_EXHAUSTIVE,
+    assert_expected_exhaustive_local_lemma_crosswalk,
+    exhaustive_local_lemma_crosswalk_payload,
+)
+from check_n9_vertex_circle_focused_minireplay_crosswalk import (  # noqa: E402
+    assert_expected_focused_minireplay_crosswalk,
+    focused_minireplay_crosswalk_payload,
+)
+from check_n9_vertex_circle_focused_packet_catalog_audit import (  # noqa: E402
+    assert_expected_focused_packet_catalog_audit,
+    focused_packet_catalog_audit_payload,
+)
+from check_n9_vertex_circle_local_lemma_replay_crosswalk import (  # noqa: E402
+    DEFAULT_AGGREGATE,
+    DEFAULT_SIMPLE_REPLAY,
+    assert_expected_replay_crosswalk,
+    crosswalk_payload as local_replay_crosswalk_payload,
+    load_artifact,
+)
+from check_relation_skeleton_local_lemma_crosswalk import (  # noqa: E402
+    DEFAULT_RELATION_SKELETONS,
+    assert_expected_relation_local_crosswalk,
+    crosswalk_payload as relation_local_crosswalk_payload,
+)
+
+SCHEMA = "erdos97.n9_vertex_circle_local_lemma_audit_path.v1"
+STATUS = "REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Cross-artifact audit path for the review-pending n=9 vertex-circle "
+    "local-lemma packets. It joins focused packet/catalog bookkeeping, "
+    "focused mini-replays, aggregate/simple replay accounting, the "
+    "exhaustive/local-lemma count crosswalk, and the relation-skeleton "
+    "crosswalk. It does not prove packet soundness, does not prove "
+    "mini-replay soundness, does not prove local-lemma completeness, does "
+    "not prove frontier coverage, does not prove n=9, is not a "
+    "counterexample, and is not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_local_lemma_audit_path.py "
+        "--check --assert-expected --json"
+    ),
+}
+
+EXPECTED_LAYER_IDS = [
+    "focused_packet_catalog",
+    "focused_minireplay",
+    "aggregate_simple_replay",
+    "exhaustive_local_lemma",
+    "relation_skeleton_local_lemma",
+]
+EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
+
+AssertFn = Callable[[Mapping[str, Any]], None]
+
+
+def default_layer_payloads() -> dict[str, Mapping[str, Any]]:
+    """Build all local-lemma audit layer payloads from checked-in artifacts."""
+
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    exhaustive = load_artifact(DEFAULT_EXHAUSTIVE)
+    classification = load_artifact(DEFAULT_CLASSIFICATION)
+    relation_skeletons = load_artifact(DEFAULT_RELATION_SKELETONS)
+    for name, payload in (
+        ("aggregate", aggregate),
+        ("simple replay", simple_replay),
+        ("exhaustive", exhaustive),
+        ("classification", classification),
+        ("relation skeletons", relation_skeletons),
+    ):
+        if not isinstance(payload, Mapping):
+            raise TypeError(f"{name} artifact top level must be an object")
+
+    return {
+        "focused_packet_catalog": focused_packet_catalog_audit_payload(),
+        "focused_minireplay": focused_minireplay_crosswalk_payload(),
+        "aggregate_simple_replay": local_replay_crosswalk_payload(
+            aggregate,
+            simple_replay,
+        ),
+        "exhaustive_local_lemma": exhaustive_local_lemma_crosswalk_payload(
+            exhaustive,
+            classification,
+            aggregate,
+            simple_replay,
+        ),
+        "relation_skeleton_local_lemma": relation_local_crosswalk_payload(
+            relation_skeletons,
+            aggregate,
+            simple_replay,
+        ),
+    }
+
+
+def local_lemma_audit_path_payload(
+    *,
+    focused_packet_catalog_payload: Mapping[str, Any] | None = None,
+    focused_minireplay_payload: Mapping[str, Any] | None = None,
+    aggregate_simple_replay_payload: Mapping[str, Any] | None = None,
+    exhaustive_local_lemma_payload: Mapping[str, Any] | None = None,
+    relation_skeleton_local_lemma_payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return an audit-path payload tying all local-lemma layers together."""
+
+    provided = {
+        "focused_packet_catalog": focused_packet_catalog_payload,
+        "focused_minireplay": focused_minireplay_payload,
+        "aggregate_simple_replay": aggregate_simple_replay_payload,
+        "exhaustive_local_lemma": exhaustive_local_lemma_payload,
+        "relation_skeleton_local_lemma": relation_skeleton_local_lemma_payload,
+    }
+    layers = default_layer_payloads()
+    for layer_id, payload in provided.items():
+        if payload is not None:
+            layers[layer_id] = payload
+
+    errors: list[str] = []
+    _append_layer_expected_errors(errors, layers)
+    layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
+    coverage = _coverage_summary(layer_summaries, errors)
+
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": 9,
+        "row_size": 4,
+        "audit_path": {
+            "layer_count": len(layer_summaries),
+            "layer_ids": [summary["layer_id"] for summary in layer_summaries],
+            "layers": layer_summaries,
+        },
+        "coverage_summary": coverage,
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "interpretation": (
+            "A passed audit path says the stored review-pending local-lemma "
+            "bookkeeping layers agree on the same 12 templates, 16 families, "
+            "and 184 frontier assignments. It does not review the exhaustive "
+            "brancher and does not certify packet soundness."
+        ),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
+    """Assert stable counts for the combined local-lemma audit path."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"schema mismatch: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"status mismatch: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
+    if payload.get("provenance") != PROVENANCE:
+        raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
+    claim_scope = str(payload.get("claim_scope", ""))
+    for required in (
+        "does not prove packet soundness",
+        "does not prove mini-replay soundness",
+        "does not prove local-lemma completeness",
+        "does not prove frontier coverage",
+        "does not prove n=9",
+        "not a counterexample",
+        "not a global status update",
+    ):
+        if required not in claim_scope:
+            raise AssertionError(f"claim_scope missing {required!r}")
+    if payload.get("validation_status") != "passed":
+        raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+
+    audit_path = payload.get("audit_path")
+    if not isinstance(audit_path, Mapping):
+        raise AssertionError("audit_path must be an object")
+    if audit_path.get("layer_ids") != EXPECTED_LAYER_IDS:
+        raise AssertionError(f"layer ids mismatch: {audit_path.get('layer_ids')!r}")
+
+    coverage = payload.get("coverage_summary")
+    if not isinstance(coverage, Mapping):
+        raise AssertionError("coverage_summary must be an object")
+    expected = {
+        "layer_count": 5,
+        "template_count": 12,
+        "family_count": 16,
+        "assignment_count": 184,
+        "self_edge_family_count": 13,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_family_count": 3,
+        "strict_cycle_assignment_count": 26,
+        "relation_skeleton_count": 16,
+    }
+    for key, value in expected.items():
+        if coverage.get(key) != value:
+            raise AssertionError(
+                f"coverage_summary[{key!r}] mismatch: expected {value}, "
+                f"got {coverage.get(key)!r}"
+            )
+    if coverage.get("template_ids") != EXPECTED_TEMPLATE_IDS:
+        raise AssertionError(f"template ids mismatch: {coverage.get('template_ids')!r}")
+
+
+def _append_layer_expected_errors(
+    errors: list[str],
+    layers: Mapping[str, Mapping[str, Any]],
+) -> None:
+    assert_functions: dict[str, AssertFn] = {
+        "focused_packet_catalog": assert_expected_focused_packet_catalog_audit,
+        "focused_minireplay": assert_expected_focused_minireplay_crosswalk,
+        "aggregate_simple_replay": assert_expected_replay_crosswalk,
+        "exhaustive_local_lemma": assert_expected_exhaustive_local_lemma_crosswalk,
+        "relation_skeleton_local_lemma": assert_expected_relation_local_crosswalk,
+    }
+    for layer_id in EXPECTED_LAYER_IDS:
+        try:
+            assert_functions[layer_id](layers[layer_id])
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"{layer_id} expected-check failed: {exc}")
+
+
+def _layer_summary(
+    layer_id: str,
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    if layer_id == "focused_packet_catalog":
+        summary = _required_mapping(payload, "focused_packet_catalog_audit", layer_id, errors)
+        status_assignment_counts = _int_map(summary.get("status_assignment_counts"))
+        return {
+            "layer_id": layer_id,
+            "schema": payload.get("schema"),
+            "status": payload.get("status"),
+            "trust": payload.get("trust"),
+            "validation_status": payload.get("validation_status"),
+            "template_count": int(summary.get("packet_count", -1)),
+            "template_ids": _string_list(summary.get("template_ids")),
+            "family_count": int(summary.get("covered_family_count", -1)),
+            "assignment_count": int(summary.get("covered_assignment_count", -1)),
+            "self_edge_family_count": _record_family_count(summary, "self_edge"),
+            "self_edge_assignment_count": int(status_assignment_counts.get("self_edge", -1)),
+            "strict_cycle_family_count": _record_family_count(summary, "strict_cycle"),
+            "strict_cycle_assignment_count": int(status_assignment_counts.get("strict_cycle", -1)),
+        }
+    if layer_id == "focused_minireplay":
+        summary = _required_mapping(payload, "focused_minireplay_crosswalk", layer_id, errors)
+        status_assignment_counts = _int_map(summary.get("status_assignment_counts"))
+        return {
+            "layer_id": layer_id,
+            "schema": payload.get("schema"),
+            "status": payload.get("status"),
+            "trust": payload.get("trust"),
+            "validation_status": payload.get("validation_status"),
+            "template_count": int(summary.get("packet_count", -1)),
+            "template_ids": _string_list(summary.get("template_ids")),
+            "family_count": int(summary.get("source_family_count", -1)),
+            "assignment_count": int(summary.get("source_assignment_count", -1)),
+            "self_edge_family_count": _record_family_count(summary, "self_edge"),
+            "self_edge_assignment_count": int(status_assignment_counts.get("self_edge", -1)),
+            "strict_cycle_family_count": _record_family_count(summary, "strict_cycle"),
+            "strict_cycle_assignment_count": int(status_assignment_counts.get("strict_cycle", -1)),
+        }
+    if layer_id == "aggregate_simple_replay":
+        coverage = _required_mapping(payload, "coverage_summary", layer_id, errors)
+        return {
+            "layer_id": layer_id,
+            "schema": payload.get("schema"),
+            "status": payload.get("status"),
+            "trust": payload.get("trust"),
+            "validation_status": payload.get("validation_status"),
+            "template_count": 12,
+            "template_ids": EXPECTED_TEMPLATE_IDS,
+            "family_count": int(coverage.get("matched_family_count", -1)),
+            "assignment_count": int(coverage.get("matched_assignment_count", -1)),
+            "self_edge_family_count": int(coverage.get("self_edge_family_count", -1)),
+            "self_edge_assignment_count": int(coverage.get("self_edge_assignment_count", -1)),
+            "strict_cycle_family_count": int(coverage.get("strict_cycle_family_count", -1)),
+            "strict_cycle_assignment_count": int(coverage.get("strict_cycle_assignment_count", -1)),
+        }
+    if layer_id == "exhaustive_local_lemma":
+        coverage = _required_mapping(payload, "coverage_summary", layer_id, errors)
+        return {
+            "layer_id": layer_id,
+            "schema": payload.get("schema"),
+            "status": payload.get("status"),
+            "trust": payload.get("trust"),
+            "validation_status": payload.get("validation_status"),
+            "template_count": 12,
+            "template_ids": EXPECTED_TEMPLATE_IDS,
+            "family_count": int(coverage.get("family_count", -1)),
+            "assignment_count": int(coverage.get("local_matched_assignment_count", -1)),
+            "self_edge_family_count": 13,
+            "self_edge_assignment_count": int(coverage.get("self_edge_assignment_count", -1)),
+            "strict_cycle_family_count": 3,
+            "strict_cycle_assignment_count": int(coverage.get("strict_cycle_assignment_count", -1)),
+        }
+    if layer_id == "relation_skeleton_local_lemma":
+        coverage = _required_mapping(payload, "coverage_summary", layer_id, errors)
+        return {
+            "layer_id": layer_id,
+            "schema": payload.get("schema"),
+            "status": payload.get("status"),
+            "trust": payload.get("trust"),
+            "validation_status": payload.get("validation_status"),
+            "template_count": 12,
+            "template_ids": EXPECTED_TEMPLATE_IDS,
+            "family_count": int(coverage.get("matched_family_count", -1)),
+            "assignment_count": int(coverage.get("matched_assignment_count", -1)),
+            "self_edge_family_count": int(coverage.get("self_edge_family_count", -1)),
+            "self_edge_assignment_count": int(coverage.get("self_edge_assignment_count", -1)),
+            "strict_cycle_family_count": int(coverage.get("strict_cycle_family_count", -1)),
+            "strict_cycle_assignment_count": int(coverage.get("strict_cycle_assignment_count", -1)),
+            "relation_skeleton_count": int(coverage.get("relation_skeleton_count", -1)),
+        }
+    errors.append(f"unknown layer id: {layer_id}")
+    return {"layer_id": layer_id, "validation_status": "failed"}
+
+
+def _coverage_summary(
+    layer_summaries: list[Mapping[str, Any]],
+    errors: list[str],
+) -> dict[str, Any]:
+    keys = (
+        "template_count",
+        "family_count",
+        "assignment_count",
+        "self_edge_family_count",
+        "self_edge_assignment_count",
+        "strict_cycle_family_count",
+        "strict_cycle_assignment_count",
+    )
+    for key in keys:
+        values = tuple(int(summary.get(key, -1)) for summary in layer_summaries)
+        if len(set(values)) != 1:
+            errors.append(f"{key} mismatch across audit path: {values!r}")
+    template_ids = [summary.get("template_ids") for summary in layer_summaries]
+    if any(ids != EXPECTED_TEMPLATE_IDS for ids in template_ids):
+        errors.append(f"template id mismatch across audit path: {template_ids!r}")
+    for summary in layer_summaries:
+        if summary.get("validation_status") != "passed":
+            errors.append(f"{summary.get('layer_id')} validation_status is not passed")
+
+    relation_summary = layer_summaries[-1]
+    return {
+        "layer_count": len(layer_summaries),
+        "template_count": int(layer_summaries[0].get("template_count", -1)),
+        "template_ids": EXPECTED_TEMPLATE_IDS,
+        "family_count": int(layer_summaries[0].get("family_count", -1)),
+        "assignment_count": int(layer_summaries[0].get("assignment_count", -1)),
+        "self_edge_family_count": int(layer_summaries[0].get("self_edge_family_count", -1)),
+        "self_edge_assignment_count": int(layer_summaries[0].get("self_edge_assignment_count", -1)),
+        "strict_cycle_family_count": int(layer_summaries[0].get("strict_cycle_family_count", -1)),
+        "strict_cycle_assignment_count": int(layer_summaries[0].get("strict_cycle_assignment_count", -1)),
+        "relation_skeleton_count": int(relation_summary.get("relation_skeleton_count", -1)),
+    }
+
+
+def _required_mapping(
+    payload: Mapping[str, Any],
+    key: str,
+    layer_id: str,
+    errors: list[str],
+) -> Mapping[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        errors.append(f"{layer_id}: {key} must be an object")
+        return {}
+    return value
+
+
+def _int_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): int(item) for key, item in value.items()}
+
+
+def _record_family_count(summary: Mapping[str, Any], status: str) -> int:
+    records = summary.get("packet_records", summary.get("records"))
+    if not isinstance(records, list):
+        return -1
+    family_ids: set[str] = set()
+    for record in records:
+        if not isinstance(record, Mapping) or record.get("status") != status:
+            continue
+        family_ids.update(_string_list(record.get("family_ids")))
+    return len(family_ids)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def summary_lines(payload: Mapping[str, Any]) -> list[str]:
+    coverage = payload["coverage_summary"]
+    return [
+        f"schema: {payload['schema']}",
+        f"status: {payload['status']}",
+        f"validation: {payload['validation_status']}",
+        f"layers: {coverage['layer_count']}",
+        f"templates: {coverage['template_count']}",
+        f"families: {coverage['family_count']}",
+        f"assignments: {coverage['assignment_count']}",
+        (
+            "self-edge: "
+            f"{coverage['self_edge_family_count']} families, "
+            f"{coverage['self_edge_assignment_count']} assignments"
+        ),
+        (
+            "strict-cycle: "
+            f"{coverage['strict_cycle_family_count']} families, "
+            f"{coverage['strict_cycle_assignment_count']} assignments"
+        ),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate the audit path")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = local_lemma_audit_path_payload()
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        payload = {
+            "schema": SCHEMA,
+            "status": STATUS,
+            "trust": TRUST,
+            "claim_scope": CLAIM_SCOPE,
+            "validation_status": "failed",
+            "validation_errors": [str(exc)],
+            "provenance": dict(PROVENANCE),
+        }
+
+    if args.assert_expected:
+        assert_expected_local_lemma_audit_path(payload)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif payload.get("validation_status") == "passed":
+        print("n=9 vertex-circle local-lemma audit path")
+        for line in summary_lines(payload):
+            print(line)
+        print("OK: local-lemma audit path checks passed")
+    else:
+        print("FAILED: local-lemma audit path", file=sys.stderr)
+        for error in payload.get("validation_errors", []):
+            print(f"- {error}", file=sys.stderr)
+
+    if args.check and payload.get("validation_status") != "passed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1031,6 +1031,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_vertex_circle_local_lemma_audit_path",
+        command=(
+            "python",
+            "scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Combined audit path for focused n=9 local-lemma packets, "
+            "mini-replays, aggregate/simple replay, exhaustive/local-lemma "
+            "counts, and relation skeletons; not packet soundness, proof of "
+            "n=9, counterexample, or independent review completion."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_t11_strict_cycle_lemma_packet",
         command=(
             "python",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
+    EXPECTED_LAYER_IDS,
+    assert_expected_local_lemma_audit_path,
+    local_lemma_audit_path_payload,
+)
+from scripts.check_n9_vertex_circle_local_lemma_replay_crosswalk import (
+    DEFAULT_AGGREGATE,
+    DEFAULT_SIMPLE_REPLAY,
+    crosswalk_payload as local_replay_crosswalk_payload,
+    load_artifact,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_local_lemma_audit_path_counts_and_scope() -> None:
+    payload = local_lemma_audit_path_payload()
+
+    assert_expected_local_lemma_audit_path(payload)
+    assert payload["validation_status"] == "passed"
+    assert payload["audit_path"]["layer_ids"] == EXPECTED_LAYER_IDS
+    assert payload["coverage_summary"] == {
+        "layer_count": 5,
+        "template_count": 12,
+        "template_ids": [f"T{index:02d}" for index in range(1, 13)],
+        "family_count": 16,
+        "assignment_count": 184,
+        "self_edge_family_count": 13,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_family_count": 3,
+        "strict_cycle_assignment_count": 26,
+        "relation_skeleton_count": 16,
+    }
+    assert "does not prove packet soundness" in payload["claim_scope"]
+    assert "does not prove n=9" in payload["claim_scope"]
+    assert "not a counterexample" in payload["claim_scope"]
+    assert "not a global status update" in payload["claim_scope"]
+
+
+def test_local_lemma_audit_path_layer_summaries() -> None:
+    payload = local_lemma_audit_path_payload()
+    by_layer = {item["layer_id"]: item for item in payload["audit_path"]["layers"]}
+
+    assert by_layer["focused_packet_catalog"]["template_count"] == 12
+    assert by_layer["focused_minireplay"]["assignment_count"] == 184
+    assert by_layer["aggregate_simple_replay"]["family_count"] == 16
+    assert by_layer["exhaustive_local_lemma"]["strict_cycle_assignment_count"] == 26
+    assert by_layer["relation_skeleton_local_lemma"]["relation_skeleton_count"] == 16
+
+
+def test_local_lemma_audit_path_rejects_local_replay_drift() -> None:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    tampered["coverage_summary"]["matched_assignment_count"] = 183
+
+    payload = local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
+
+    assert payload["validation_status"] == "failed"
+    assert any(
+        "aggregate_simple_replay expected-check failed" in error
+        for error in payload["validation_errors"]
+    )
+    assert (
+        "assignment_count mismatch across audit path: (184, 184, 183, 184, 184)"
+        in payload["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    parsed = json.loads(result.stdout)
+    assert parsed["validation_status"] == "passed"
+    assert parsed["coverage_summary"]["assignment_count"] == 184
+    assert parsed["coverage_summary"]["relation_skeleton_count"] == 16

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -587,6 +587,25 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_n9_vertex_circle_local_lemma_audit_path.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_relation_skeleton_local_lemma_crosswalk.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_local_lemma_audit_path.py "
+        "--check --assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_local_lemma_audit_path.py "
+        "--check --assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py "
+        "--check --assert-expected --json"
+    )
+    assert (
         "python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py "
         "--check --assert-expected --json"
         in command_texts


### PR DESCRIPTION
## Summary

- Add `scripts/check_n9_vertex_circle_local_lemma_audit_path.py`, a combined reviewer-facing audit that ties together the focused packet/catalog audit, focused mini-replay crosswalk, aggregate/simple replay crosswalk, exhaustive/local-lemma crosswalk, and relation-skeleton/local-lemma crosswalk.
- Register the checker in the n=9 review/audit command lists and add tests for stable counts, scope wording, drift detection, and CLI JSON output.
- Document the checker as review-pending audit-path bookkeeping only.

## Verification

Task-specific audit commands:

```bash
python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py tests/test_run_artifact_audit.py -q
```

Fast tier:

```bash
make verify-fast  # attempted; make is unavailable in this PowerShell environment
python scripts/check_text_clean.py
python scripts/check_status_consistency.py
python scripts/check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

`python -m pytest -q` passed on rerun with `1075 passed, 299 deselected`.

## Trust-label scope

- Trust label: `REVIEW_PENDING_DIAGNOSTIC`.
- Scope: cross-artifact audit-path bookkeeping for stored `n=9` vertex-circle local-lemma packets and related review-pending ledgers.

## Non-overclaiming notes

- This does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97.
- This is not a counterexample and does not change the official/global falsifiable/open status.
- The repo-local source-of-truth strongest result remains the machine-checked `n <= 8` selected-witness artifact pending independent review.