### PR TITLE
[codex] Add Pro output triage and parabola model case

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1011,6 +1011,28 @@ If all vertices lie on one circle, then no vertex has more than two other
 vertices at any one distance. A second circle centered at the vertex intersects
 the common circumcircle in at most two points.[^syn]
 
+### Parabola model case
+
+Status: `LEMMA` / `FAILED_SEARCH_FAMILY`.
+
+No finite point set on a nondegenerate affine parabola can be a counterexample
+to Erdos Problem #97. More precisely, for
+
+```text
+gamma(t) = p0 + u*t + v*t^2
+```
+
+with `u,v` linearly independent, and for any finite set of distinct parameters
+`T`, each endpoint parameter gives a good vertex. If `M = max T`, then a
+positive-radius equation centered at `gamma(M)` is a quartic polynomial in the
+parameter. Since it is negative at `M` and tends to `+infinity` as
+`t -> +infinity`, it has a root outside the parameter interval. Four available
+witness parameters below `M` would then give five distinct real roots of a
+quartic, impossible. See `docs/parabola-model-case.md`.
+
+This is a restricted exact obstruction only. It does not imply that arbitrary
+strictly convex polygons reduce to parabolic configurations.
+
 ### Paraboloid lift
 
 Lifting `p=(x,y)` to `(x,y,x^2+y^2)`, four vertices are equidistant from

--- a/docs/gpt-pro-followup-triage-2026-05-18.md
+++ b/docs/gpt-pro-followup-triage-2026-05-18.md
@@ -1,0 +1,87 @@
+# GPT Pro Follow-Up Triage, 2026-05-18
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the GPT Pro output batch supplied on 2026-05-18. It does not
+promote any finite-case result, alter the source-of-truth status, or replace
+the checked repository artifacts. The repository still claims no general proof
+and no counterexample for Erdos Problem #97.
+
+## Decision
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this batch.
+
+Useful material to keep:
+
+- the compact `n=9` recheck as corroborating audit evidence for the existing
+  review-pending vertex-circle checker counts;
+- the parabola model-case theorem as a standalone restricted lemma;
+- the reminder that the next useful `n=9` artifact is a compact replay
+  certificate for the 184 terminal assignments.
+
+## `n=9` Recheck
+
+The supplied dependency-free recheck reproduced the existing repository counts
+for the review-pending exhaustive `n=9` vertex-circle checker:
+
+```text
+main search with vertex-circle pruning:
+  row0 choices: 70
+  nodes visited: 16752
+  full assignments: 0
+  partial self-edge prunes: 11271
+  partial strict-cycle prunes: 11011
+
+cross-check without vertex-circle pruning:
+  row0 choices: 70
+  nodes visited: 100817
+  full assignments before terminal replay: 184
+  terminal self-edge obstructions: 158
+  terminal strict-cycle obstructions: 26
+```
+
+These counts match `scripts/check_n9_vertex_circle_exhaustive.py
+--assert-expected --json`.
+
+Triage: useful as an independent audit signal, but not a new proof object. The
+script duplicates the current search logic at a compact scale; it does not
+store the 184 terminal assignments, self-edge paths, or strict-cycle
+certificates as replayable input data. Keep the `n=9` claim review-pending.
+
+Recommended next artifact: a small certificate/replay format that treats the
+184 post-incidence frontier assignments as input and stores, for each
+assignment, a minimal selected-distance equality chain plus a self-edge or
+directed strict cycle.
+
+## Parabola Notes
+
+Several files in the batch gave variants of a parabolic no-go theorem. The
+cleanest formulation is now recorded in `docs/parabola-model-case.md`:
+
+```text
+A finite point set on a nondegenerate affine parabola has an endpoint vertex
+with at most three other points at any positive Euclidean distance.
+```
+
+The endpoint proof is preferable to the longer Vieta/moment variants because it
+is shorter and covers the affine parabola parameterization directly: a positive
+radius equation at an endpoint is quartic, and one root is forced outside the
+finite parameter interval, leaving at most three available vertex parameters.
+
+Triage: valid restricted lemma / failed search family. It is not a proof of
+Erdos Problem #97 and not evidence for an arbitrary-polygon bridge.
+
+## Material Not Imported
+
+The duplicate narrative result notes are not imported. Their useful content is
+covered by the two entries above.
+
+Do not import or promote formulations that suggest a general polygon can be
+reduced to the parabolic case by affine or projective transformations. Such
+maps do not preserve Euclidean centered equal-distance relations.
+
+Do not import the `n=9` recheck as a replacement for the existing
+review-pending checker. It is best used as corroborating provenance until a
+replayable terminal-certificate artifact exists.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`turn-inequality-lemma.md`](turn-inequality-lemma.md): proof-facing note for
   the candidate exterior-turn inequalities used in the review-pending `n=9`
   turn-frontier replay.
+- [`parabola-model-case.md`](parabola-model-case.md): restricted exact lemma
+  showing that finite point sets on a nondegenerate affine parabola cannot be
+  counterexamples; a failed search family, not a global bridge.
 - [`relation-skeleton-catalog.md`](relation-skeleton-catalog.md):
   review-pending relation-skeleton extraction for the focused T01-T09
   self-edge and T10-T12 strict-cycle vertex-circle quotient motifs;
@@ -442,6 +445,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt-pro-followup-triage-2026-05-11.md`](gpt-pro-followup-triage-2026-05-11.md):
   triage of later GPT Pro follow-up notes; provenance and task-selection
   guidance only.
+- [`gpt-pro-followup-triage-2026-05-18.md`](gpt-pro-followup-triage-2026-05-18.md):
+  triage of the May 18 GPT Pro output batch; records the compact `n=9`
+  recheck as corroborating audit evidence and promotes only the scoped
+  parabola model-case note.
 - [`n9-base-apex-frontier.md`](n9-base-apex-frontier.md): corrected exploratory
   slack ledger for the first `n=9` base-apex workstream; not a proof.
 - [`repo-roadmap.md`](repo-roadmap.md): staged repository plan.

--- a/docs/parabola-model-case.md
+++ b/docs/parabola-model-case.md
@@ -1,0 +1,93 @@
+# Parabola Model Case
+
+Status: `LEMMA` / `FAILED_SEARCH_FAMILY`.
+
+This note records a restricted exact obstruction. It does not prove Erdos
+Problem #97, does not produce a counterexample, and does not change the
+repository source-of-truth status. It only rules out one natural algebraic
+search family: finite vertex sets lying on one nondegenerate affine parabola.
+
+## Statement
+
+Let
+
+```text
+gamma(t) = p0 + u*t + v*t^2
+```
+
+where `p0,u,v` are planar vectors and `u,v` are linearly independent. For a
+finite set `T` of distinct real parameters, set
+
+```text
+P_T = { gamma(t) : t in T }.
+```
+
+Then an endpoint parameter of `T` gives a good vertex. More precisely, if
+`M = max T`, then `gamma(M)` has at most three other points of `P_T` at any one
+positive Euclidean distance. The same holds for `m = min T`.
+
+Consequently no finite point set on a nondegenerate affine parabola can be a
+counterexample to Erdos Problem #97.
+
+## Proof
+
+It is enough to prove the claim for the right endpoint `M = max T`. The left
+endpoint is identical after reversing the parameter.
+
+For a fixed positive squared radius `rho > 0`, define
+
+```text
+F(t) = ||gamma(t) - gamma(M)||^2 - rho.
+```
+
+Since
+
+```text
+gamma(t) - gamma(M) = u*(t-M) + v*(t^2-M^2),
+```
+
+the function `F(t)` is a real polynomial of degree four. Its leading
+coefficient is `||v||^2`, which is positive because `v != 0`. Also
+
+```text
+F(M) = -rho < 0,
+```
+
+while `F(t) -> +infinity` as `t -> +infinity`. By continuity, there is at
+least one real root `t_+ > M`.
+
+Now suppose that `gamma(M)` had four other vertices of `P_T` at the same
+positive squared distance `rho`. Their parameters would be four distinct
+numbers
+
+```text
+t1,t2,t3,t4 in T \ {M}.
+```
+
+Because `M` is the maximum parameter, all four satisfy `tk < M`. They are four
+distinct roots of `F(t)`. Together with the root `t_+ > M`, this gives five
+distinct real roots of a degree-four polynomial, impossible.
+
+Thus every positive radius centered at `gamma(M)` contains at most three other
+points of `P_T`, so `E(gamma(M)) <= 3`.
+
+## Convexity Check
+
+The curve `gamma(t)` is an invertible affine image of the standard parabola
+`(t,t^2)`. Finite sets of distinct points on the standard parabola are in
+strictly convex position when ordered by increasing parameter: no three are
+collinear, and every listed point is an extreme point of the convex hull.
+Invertible affine maps preserve strict convex position. Hence this is a
+genuine strictly convex polygon subcase, not only an algebraic point-set
+calculation.
+
+## Scope
+
+This obstruction is useful as a negative control for parabolic construction
+attempts. It is not a bridge to the full problem. A general strictly convex
+polygon need not lie on any affine parabola, and non-Euclidean affine or
+projective transformations do not preserve the centered equal-distance
+property.
+
+The proof also allows the selected radius to vary with the center. It is not a
+common-radius reduction.


### PR DESCRIPTION
## Summary

- Add a standalone `docs/parabola-model-case.md` proof note for the restricted affine-parabola no-go family.
- Add `docs/gpt-pro-followup-triage-2026-05-18.md` to triage the supplied GPT Pro batch, keeping the `n=9` recheck review-pending and non-promoting.
- Link the new note from `docs/claims.md` and `docs/index.md` without changing README, STATE, RESULTS, or metadata source-of-truth status.

## Scope

This PR does not claim a general proof of Erdos Problem #97 and does not claim a counterexample. The parabola note is scoped as `LEMMA` / `FAILED_SEARCH_FAMILY`; the `n=9` material remains corroborating audit evidence for the existing review-pending checker.

## Checks

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (1071 passed, 299 deselected)