### PR TITLE
[codex] Refine diameter endpoint research note

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -58,6 +58,27 @@ base-apex lemma to count isosceles triangles and then analyzes the equality
 case for octagons. Independent review is still requested before promoting this
 note beyond the repository's local proof-facing ledger.
 
+### Literature-backed shortcut: Dumitrescu isosceles count for n <= 8
+
+Status: `LITERATURE_BACKED_PROOF_NOTE` / `REVIEW_PENDING`.
+
+The proof note `docs/dumitrescu-isosceles-n8-shortcut.md` records a shorter
+external-bound route to the same small-case wall. In the apex-counted
+isosceles convention, Dumitrescu's convex-position bound gives
+
+```text
+Z(P) <= (11 n^2 - 18 n) / 12.
+```
+
+If a strictly convex `n`-gon were 4-bad, every vertex would contribute at
+least `binom(4,2) = 6` equal-leg pairs, so `Z(P) >= 6n`. Combining the two
+inequalities forces `n >= 90/11 > 8`.
+
+This is a compact human-readable shortcut, not an update to the repository
+source-of-truth status. The checked selected-witness artifacts remain the
+repo-local `n <= 8` source until this literature-backed note receives
+independent review.
+
 ### Altman diagonal-order sums
 
 For a strict convex `n`-gon in cyclic order, the sums `U_k` of chord lengths of
@@ -279,6 +300,37 @@ In any selected-witness counterexample, for distinct centers `a,b`,
 ```
 
 Otherwise two distinct Euclidean circles would share at least three points.[^small]
+
+### Same-distance K4 obstruction
+
+After exact same-distance quotienting, one ordinary distance class cannot
+contain all six edges of a `K_4` on four distinct vertices. Four planar points
+cannot be pairwise equidistant at one positive distance: three would form an
+equilateral triangle, and the only planar point equidistant from all three is
+the circumcenter, whose distance to the vertices is smaller than the side
+length.
+
+This is a fixed-pattern or quotient-class obstruction only. It becomes
+available after selected-distance equalities, reciprocal selected-edge
+components, or another exact mechanism has proved that all six ordinary pairs
+belong to one distance class.
+
+### Diameter-lens local lemmas
+
+The proof note `docs/diameter-lens-local-lemmas.md` records four local facts
+for a global diameter pair `{A,B}`:
+
+```text
+diameter-circle pinching,
+mutual selected-diameter overlap <= 1,
+double-boundary seven-vertex lower bound,
+|R(theta)-L(phi)| <= D iff theta*phi >= 0.
+```
+
+It also records the seven-point lens-cap negative control showing that the
+double-boundary same-side and seven-vertex lemmas are sharp but do not by
+themselves contradict strict convexity. Any endpoint-reduction proof must use
+the other 4-bad witness rows or another exact certificate.
 
 ### Radical-axis crossing / bisection
 

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -315,6 +315,26 @@ available after selected-distance equalities, reciprocal selected-edge
 components, or another exact mechanism has proved that all six ordinary pairs
 belong to one distance class.
 
+### Same-distance K4-e stretch obstruction
+
+If an exact ordinary distance class contains exactly five of the six edges on
+four distinct vertices, then the missing edge has length `sqrt(3)` times the
+common class length. The proof is the two-equilateral-triangles picture: the
+five equal edges force two equilateral triangles sharing the edge opposite the
+missing pair, and distinct planar vertices put the two missing-edge endpoints
+on opposite sides of that shared edge.
+
+The checker `scripts/check_k4e_kalmanson_stretch_audit.py` uses this relation
+only after exact selected-distance quotienting, and only inside fixed patterns
+and fixed cyclic orders. It represents coefficients in `Q(sqrt(3))` exactly
+and then tests whether a substituted Kalmanson inequality has positive
+left-minus-right coefficient for all positive quotient class lengths.
+
+The current replay kills the displayed `n=10` quotient-level survivor and one
+`n=9` diagnostic pattern. This is a filter improvement and a fixed-pattern
+audit only; it is not an `n=10` exclusion and does not change the global
+problem status.
+
 ### Diameter-lens local lemmas
 
 The proof note `docs/diameter-lens-local-lemmas.md` records four local facts

--- a/docs/diameter-lens-local-lemmas.md
+++ b/docs/diameter-lens-local-lemmas.md
@@ -1,0 +1,201 @@
+# Diameter-Lens Local Lemmas
+
+Status: `LOCAL_LEMMA_NOTE` / `REVIEW_PENDING`.
+
+This note extracts local diameter geometry from the 2026-05-19 research batch.
+It is not a proof of Erdos Problem #97 and does not claim that the diameter
+endpoint reduction is closed. Its main point is the opposite: the endpoint
+lemmas are useful, but the double-boundary package alone is sharp and
+geometrically realizable.
+
+Throughout, `S_v` denotes a chosen selected 4-witness row, not the full rich
+distance class at `v`.
+
+## Setup
+
+Let `{A,B}` be a global diameter pair of length `D`, normalized as
+
+```text
+A = (-D/2, 0),  B = (D/2, 0).
+```
+
+Every vertex lies in the lens
+
+```text
+B(A,D) cap B(B,D).
+```
+
+For boundary witnesses on the two diameter circles, write
+
+```text
+R(theta) = A + D (cos theta, sin theta),
+L(phi)   = B + D (-cos phi, sin phi).
+```
+
+The selected-diameter lemmas use angles in `[-pi/3, pi/3]` after the pinching
+lemma below.
+
+## Lemma 1: Diameter-Circle Pinching
+
+If `B in S_A`, then the selected radius at `A` is `D`, so every selected
+witness in `S_A` lies on `C(A,D)`. For two witnesses with angular separation
+`Delta` around `A`,
+
+```text
+|xy| = 2D sin(Delta/2).
+```
+
+Since `D` is the global diameter, `|xy| <= D`, so `Delta <= pi/3`. Thus the
+selected diameter witnesses from `A` lie in a closed angular interval of width
+at most `pi/3`. The same statement holds at `B`.
+
+## Lemma 2: Mutual Selected-Diameter Overlap
+
+If `B in S_A` and `A in S_B`, then the non-endpoint selected witness overlap
+has size at most one:
+
+```text
+|(S_A cap S_B) \ {A,B}| <= 1.
+```
+
+A common non-endpoint witness lies in `C(A,D) cap C(B,D)`, which consists of
+the two equilateral apexes over `AB`. Those two apexes are distance
+`sqrt(3)D > D` apart, so both cannot occur in a diameter-`D` point set.
+
+## Lemma 3: Seven-Vertex Lower Bound
+
+If both endpoint rows select the diameter radius and contain the opposite
+endpoint, then
+
+```text
+|{A,B} union S_A union S_B| >= 7.
+```
+
+Indeed, each endpoint row contributes the other endpoint and three
+non-endpoint witnesses, and Lemma 2 allows at most one non-endpoint overlap:
+
+```text
+2 + (3 + 3 - 1) = 7.
+```
+
+## Lemma 4: Same-Side Constraint
+
+For `theta, phi in [-pi/3, pi/3]`,
+
+```text
+|R(theta) - L(phi)| <= D  iff  theta*phi >= 0.
+```
+
+After dividing by `D^2`,
+
+```text
+|R(theta)-L(phi)|^2 / D^2
+  = (cos theta + cos phi - 1)^2 + (sin theta - sin phi)^2
+  = 3 + 2 cos(theta+phi) - 2 cos theta - 2 cos phi.
+```
+
+Thus `|R(theta)-L(phi)| <= D` is equivalent to
+
+```text
+1 + cos(theta+phi) <= cos theta + cos phi.
+```
+
+Using sum-to-product and the positivity of `cos((theta+phi)/2)` on the stated
+range, this becomes
+
+```text
+cos((theta+phi)/2) <= cos((theta-phi)/2),
+```
+
+which is equivalent on this interval to
+
+```text
+|theta+phi| >= |theta-phi|,
+```
+
+and hence to `theta*phi >= 0`.
+
+## Sharp Negative Control
+
+The double-boundary same-side and seven-vertex lemmas do not themselves force
+a contradiction.
+
+Normalize `D = 1`, `A = (-1/2,0)`, `B = (1/2,0)`. For
+`0 < alpha < beta < pi/3`, set
+
+```text
+L(t) = B + (-cos t, sin t),
+R(t) = A + ( cos t, sin t),
+E    = L(pi/3) = R(pi/3).
+```
+
+The seven points
+
+```text
+A, L(alpha), L(beta), E, R(beta), R(alpha), B
+```
+
+in cyclic order form a strictly convex diameter-lens cap. The endpoint rows
+
+```text
+S_A = {B, R(alpha), R(beta), E},
+S_B = {A, L(alpha), L(beta), E}
+```
+
+both select the diameter radius, have exactly one non-endpoint common witness
+`E`, and attain the seven-vertex lower bound. Same-arc distances are chords of
+angular width less than `pi/3`, and cross-arc distances are controlled by the
+same-side lemma, so all pairwise distances are at most `1`.
+
+This skeleton is not 4-bad. It only disproves the local reading that endpoint
+geometry plus strict convexity already gives a contradiction. A proof must use
+the witness rows at the boundary witnesses or another exact certificate.
+
+## Full-Class Branching Caution
+
+A missing selected edge is not evidence of diameter-poorness. For a diameter
+pair `{v,u}`, define the full diameter class
+
+```text
+M_v(u) = {x != v : |vx| = |vu|}.
+```
+
+If `|M_v(u)| >= 4`, a selected row can be chosen at the diameter radius and can
+be chosen to include `u`; this is a full-class branch. If `|M_v(u)| <= 3`,
+then every selected row at `v` has radius strictly smaller than the diameter,
+and any linear certificate for this branch must preserve that strictness.
+
+The poor-endpoint branch does not automatically imply angular pinching. If the
+selected radius is at most `D/2`, every chord of the selected circle already
+has length at most `D`.
+
+## Boundary-Witness Isolation
+
+This review-pending local lemma is a possible finite-pruning ingredient.
+
+Let `D = 1`, `A = (0,0)`, `B = (1,0)`, and
+
+```text
+K^+ = B(A,1) cap B(B,1) cap {y >= 0}.
+```
+
+If `R(theta) = (cos theta, sin theta)` with `0 < theta < pi/3`, and
+`X in K^+` satisfies
+
+```text
+|X - R(theta)| = 1,
+```
+
+then `X = A`.
+
+The boundary check is elementary: on `AB`, equality forces the segment
+parameter to be `0`; on the same right arc, all chord gaps are strictly less
+than `pi/3`; and on the opposite left arc, the same-side formula gives equality
+only at the endpoint angle `0`. The squared distance to `R(theta)` is convex,
+so no interior point of the convex half-lens can have a larger value than the
+boundary maximum.
+
+Consequence: if a noncommon upper right-arc witness `R` reciprocates the
+selected edge `A <-> R`, then `R`'s selected radius is the diameter, and its
+other three diameter witnesses must lie below the line `AB`. This is not a
+standalone obstruction and does not apply to the common equilateral apex.

--- a/docs/dumitrescu-isosceles-n8-shortcut.md
+++ b/docs/dumitrescu-isosceles-n8-shortcut.md
@@ -1,0 +1,93 @@
+# Dumitrescu Isosceles Shortcut For n <= 8
+
+Status: `LITERATURE_BACKED_PROOF_NOTE` / `REVIEW_PENDING`.
+
+This note records a short literature-backed route to the same small-case wall
+as the repository's machine-checked selected-witness artifacts. It does not
+change the source-of-truth status: no general proof and no counterexample are
+claimed, and the repo-local `n <= 8` result remains grounded in the checked
+finite-case pipeline until independent review promotes any paper-style proof.
+
+## Counting Convention
+
+For a finite strictly convex point set `P`, let
+
+```text
+Z(P) = sum_{p in P} sum_delta binom(m_p(delta), 2),
+```
+
+where `m_p(delta)` is the number of other vertices at distance `delta` from
+`p`. Equivalently, `Z(P)` counts unordered equal-leg pairs at an apex `p`.
+With this convention an equilateral triangle is counted three times, once for
+each possible apex. This is the same apex-counted convention used by
+Nivasch--Pach--Pinchasi--Zerbib and by Dumitrescu's isosceles-triangle bound.
+
+Dumitrescu's convex-position bound is
+
+```text
+Z(P) <= (11 n^2 - 18 n) / 12.
+```
+
+The exact expression is the only external input in this shortcut.
+
+## Shortcut
+
+Suppose `P` is 4-bad: every vertex has at least four other vertices at one
+common distance. Then each apex contributes at least
+
+```text
+binom(4,2) = 6
+```
+
+apex-counted isosceles triangles, so
+
+```text
+Z(P) >= 6n.
+```
+
+Combining with Dumitrescu's upper bound gives
+
+```text
+6n <= (11 n^2 - 18 n) / 12.
+```
+
+For `n > 0`, this is equivalent to
+
+```text
+72n <= 11 n^2 - 18n,
+90n <= 11 n^2,
+n >= 90/11 > 8.
+```
+
+Therefore no strictly convex 4-bad polygon exists with `n <= 8`.
+
+## n = 9 Slack
+
+For `n = 9`, Dumitrescu's bound gives
+
+```text
+Z(P) <= (11*9^2 - 18*9) / 12 = 729/12 = 60.75.
+```
+
+Since `Z(P)` is integral, `Z(P) <= 60`. The 4-bad lower bound gives only
+`Z(P) >= 54`, leaving slack `6`. Thus this shortcut stops exactly before the
+`n = 9` frontier and does not promote any `n = 9` artifact.
+
+## Review Notes
+
+- This note is independent of the selected-witness enumeration, but it uses an
+  external literature bound and should be reviewed against the cited counting
+  convention before being treated as a paper-style proof.
+- It does not update `README.md`, `STATE.md`, `RESULTS.md`, or
+  `metadata/erdos97.yaml`.
+- It is consistent with the repository's existing `n <= 8` artifacts and gives
+  a compact human-readable shortcut, not a new global claim.
+
+## References
+
+- A. Dumitrescu, "On Distinct Distances from a Vertex of a Convex Polygon."
+  Accessible copy:
+  <https://www.academia.edu/118624932/On_Distinct_Distances_from_a_Vertex_of_a_Convex_Polygon>.
+- G. Nivasch, J. Pach, R. Pinchasi, and S. Zerbib, "The number of distinct
+  distances from a vertex of a convex polygon." Accessible JoCG copy:
+  <https://jocg.org/index.php/jocg/article/download/2937/2631/7290>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,10 @@ put detailed reconciliation in the canonical synthesis.
   diameter-pair lemmas, the seven-point lens-cap negative control, and the
   selected/full-rich-class branching caution; review-pending local geometry
   only.
+- [`k4e-kalmanson-stretch-audit.md`](k4e-kalmanson-stretch-audit.md): exact
+  fixed-pattern audit extracting `K4-e` stretch relations and combining them
+  with Kalmanson inequalities; kills only the displayed `n=10` quotient-level
+  survivor and one diagnostic pattern, not an `n=10` exclusion.
 - [`ellipse-model-case.md`](ellipse-model-case.md): restricted exact lemma
   showing that finite point sets on a Euclidean ellipse cannot be
   counterexamples; a failed search family, not a global bridge.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,14 @@ put detailed reconciliation in the canonical synthesis.
 - [`turn-inequality-lemma.md`](turn-inequality-lemma.md): proof-facing note for
   the candidate exterior-turn inequalities used in the review-pending `n=9`
   turn-frontier replay.
+- [`dumitrescu-isosceles-n8-shortcut.md`](dumitrescu-isosceles-n8-shortcut.md):
+  literature-backed review note giving the short apex-isosceles count that
+  rules out 4-bad convex polygons with `n <= 8`; not a source-of-truth status
+  update.
+- [`diameter-lens-local-lemmas.md`](diameter-lens-local-lemmas.md): local
+  diameter-pair lemmas, the seven-point lens-cap negative control, and the
+  selected/full-rich-class branching caution; review-pending local geometry
+  only.
 - [`ellipse-model-case.md`](ellipse-model-case.md): restricted exact lemma
   showing that finite point sets on a Euclidean ellipse cannot be
   counterexamples; a failed search family, not a global bridge.

--- a/docs/k4e-kalmanson-stretch-audit.md
+++ b/docs/k4e-kalmanson-stretch-audit.md
@@ -1,0 +1,124 @@
+# K4-e Kalmanson Stretch Audit
+
+Status: `EXACT_FIXED_PATTERN_AUDIT`; review-pending as a reusable filter.
+
+This note records a narrow exact audit layer for selected-distance quotients.
+It does not prove or disprove Erdos Problem #97, does not exclude `n=10`, and
+does not change the repository status. It kills only the displayed
+quotient-level `n=10` survivor pattern and one `n=9` diagnostic pattern under
+their stated fixed cyclic orders.
+
+Replay:
+
+```bash
+python scripts/check_k4e_kalmanson_stretch_audit.py --assert-expected
+```
+
+## Lemma
+
+Let one exact ordinary distance class of a planar point set contain exactly
+five of the six edges on four distinct vertices. Then the missing edge has
+length `sqrt(3)` times the common class length.
+
+Indeed, if the missing edge is `{c,d}`, then the five equal edges include two
+equilateral triangles sharing the edge `{a,b}`. The two possible third
+vertices for an equilateral triangle on `{a,b}` are on opposite sides of the
+line `ab` unless they coincide. Since the vertices are distinct, `c` and `d`
+are the opposite equilateral apexes, and therefore `|cd| = sqrt(3) |ab|`.
+
+Thus a `K4-e` found inside a selected-distance quotient class `Q` gives an
+exact stretch relation
+
+```text
+rho(target missing-edge class) = sqrt(3) rho(Q).
+```
+
+The checker substitutes one such relation at a time into the ordinary strict
+Kalmanson inequalities for a fixed cyclic order. Coefficients are represented
+exactly in `Q(sqrt(3))`, so the audit uses no floating point arithmetic.
+
+## Displayed n=10 Survivor
+
+The displayed pattern has selected rows:
+
+```text
+S_0 = {1,4,5,8}
+S_1 = {2,3,6,9}
+S_2 = {0,1,3,4}
+S_3 = {1,2,5,6}
+S_4 = {0,3,5,7}
+S_5 = {0,4,6,8}
+S_6 = {2,4,7,9}
+S_7 = {3,5,8,9}
+S_8 = {1,6,7,9}
+S_9 = {0,2,7,8}
+```
+
+Selected-distance quotienting gives four nontrivial classes:
+
+```text
+Q01 size 9: 01 04 05 08 34 45 47 56 58
+Q02 size 9: 02 12 13 16 19 23 24 35 36
+Q09 size 9: 09 18 29 37 57 68 78 79 89
+Q26 size 4: 26 46 67 69
+```
+
+There is no same-distance `K4` and no same-distance codegree-3 obstruction in
+these classes. The checker extracts two `K4-e` stretch relations:
+
+```text
+Q48 = sqrt3 * Q01 from quad (0,4,5,8), missing 48
+Q26 = sqrt3 * Q02 from quad (1,2,3,6), missing 26
+```
+
+The second relation is decisive. Since `46` is in `Q26`,
+`d46 = sqrt(3) rho(Q02)`. The Kalmanson inequality on cyclic quadruple
+`0 < 1 < 4 < 6` is
+
+```text
+d01 + d46 <= d04 + d16.
+```
+
+Substitution gives
+
+```text
+rho(Q01) + sqrt(3) rho(Q02) <= rho(Q01) + rho(Q02),
+```
+
+or
+
+```text
+(sqrt(3) - 1) rho(Q02) <= 0,
+```
+
+which is impossible because `rho(Q02) > 0`.
+
+The replay finds two additional Kalmanson contradictions from the same stretch
+relation:
+
+```text
+(2,3,4,6): d23 + d46 <= d24 + d36
+(3,4,6,7): d34 + d67 <= d36 + d47
+```
+
+Both reduce to the same positive coefficient
+`(sqrt(3) - 1) rho(Q02)`.
+
+## Methodological Role
+
+This audit retires the displayed `n=10` quotient-level survivor only. It
+supports adding a `K4-e` stretch layer before heavier midpoint, EDM-rank, or
+Farkas machinery:
+
+```text
+row-overlap / crossing / parity
+-> selected-distance quotient
+-> K4 and codegree-3 checks
+-> K4-e extraction
+-> symbolic Kalmanson-stretch check
+-> midpoint / EDM / Farkas checks
+```
+
+The result is a filter improvement, not an `n=10` exclusion. The next search
+loop should rerun with this layer enabled and report the next survivor, if any,
+under the same non-overclaiming rules.

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -109,6 +109,26 @@ Exact packet spec:
 - optional derived angular-span certificate for the four witnesses around
   `v`.
 
+Full-class diameter branching caution:
+
+A selected row is only a chosen rich 4-subset. Therefore `u notin S_v` is not
+the same statement as "`v` is diameter-poor" for the diameter pair `{v,u}`. A
+certificate-grade diameter branch should be phrased using the full diameter
+class
+
+```text
+M_v(u) = {x != v : |vx| = |vu|}.
+```
+
+If `|M_v(u)| >= 4`, a proof search may choose or add a selected row at `v`
+that contains `u`, but this is a full-class branch, not a fact about an
+arbitrary preselected row. If `|M_v(u)| <= 3`, then every valid selected row at
+`v` has radius strictly smaller than `|vu|`, so a linear or Kalmanson/Farkas
+certificate must represent strictness explicitly. The poor-endpoint branch
+does not automatically give angular pinching: for a selected radius
+`r <= |vu|/2`, the global diameter bound gives no pairwise chord restriction
+among witnesses on the selected circle.
+
 Double-boundary endpoint negative control:
 
 The endpoint-only double-boundary package should not be treated as a
@@ -163,6 +183,37 @@ diameter line. The symmetric statement holds for noncommon left-arc witnesses
 and for the lower half-lens. This is only a finite-pruning ingredient: it does
 not cover the common equilateral apex, it requires the reciprocal selected
 edge, and it does not by itself rule out a full 4-bad completion.
+
+Selected tournament audit pattern:
+
+The cyclic tournament pattern
+
+```text
+S_i = {i+1, i+2, i+3, i+4} mod 9
+```
+
+is useful as an endpoint-logic stress test because every unordered pair is
+selected in exactly one direction. It has no reciprocal selected edges, and a
+candidate diameter edge is selected by exactly one endpoint. It should not be
+treated as a true frontier survivor, however. Adjacent rows share three
+witnesses, for example `S_0 cap S_1 = {2,3,4}`, so the elementary two-circle
+cap already rejects the pattern: two distinct selected circles cannot share
+three distinct witness vertices.
+
+There is also an independent Kalmanson audit. Let `x_i` be the common distance
+in row `i`. For the cyclic quadruple `(i, i+2, i+4, i+6)`, the Kalmanson
+inequality
+
+```text
+d_{i,i+2} + d_{i+4,i+6} <= d_{i,i+4} + d_{i+2,i+6}
+```
+
+becomes `x_i + x_{i+4} <= x_i + x_{i+2}`, hence `x_{j+2} <= x_j` for every
+`j mod 9`. Since adding `2` cycles through all residues modulo `9`, all `x_i`
+are equal. Because every unordered pair appears in exactly one selected row,
+this would make all pair distances equal, impossible for more than three
+planar points. This makes the pattern a good regression example for global
+certificates, not a counterexample candidate.
 
 This packet cannot be applied directly to the stored 184 `n=9` frontier
 assignments unless a separate metric diameter certificate identifies a

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -228,20 +228,23 @@ witnesses, for example `S_0 cap S_1 = {2,3,4}`, so the elementary two-circle
 cap already rejects the pattern: two distinct selected circles cannot share
 three distinct witness vertices.
 
-There is also an independent Kalmanson audit. Let `x_i` be the common distance
-in row `i`. For the cyclic quadruple `(i, i+2, i+4, i+6)`, the Kalmanson
-inequality
+There is also an independent strict Kalmanson audit. Let `x_i` be the common
+distance in row `i`. For four consecutive convex vertices
+`(i, i+1, i+2, i+3)`, the diagonals cross. If `O` is their intersection, then
+strict triangle inequality in the two boundary triangles gives
 
 ```text
-d_{i,i+2} + d_{i+4,i+6} <= d_{i,i+4} + d_{i+2,i+6}
+d_{i,i+1} + d_{i+2,i+3} < d_{i,i+2} + d_{i+1,i+3}.
 ```
 
-becomes `x_i + x_{i+4} <= x_i + x_{i+2}`, hence `x_{j+2} <= x_j` for every
-`j mod 9`. Since adding `2` cycles through all residues modulo `9`, all `x_i`
-are equal. Because every unordered pair appears in exactly one selected row,
-this would make all pair distances equal, impossible for more than three
-planar points. This makes the pattern a good regression example for global
-certificates, not a counterexample candidate.
+The row equalities turn this into `x_i + x_{i+2} < x_i + x_{i+1}`, hence
+`x_{i+2} < x_{i+1}` for every `i mod 9`, an impossible strict cyclic chain.
+The non-strict LP/Kalmanson version is also useful as a regression: applying
+Kalmanson to `(i, i+2, i+4, i+6)` forces all `x_i` equal, and then every pair
+distance is equal because every unordered pair appears in exactly one selected
+row. Both certificates are valid, but the earlier three-common-witness
+rejection means this pattern should be used as a template for certificate
+coverage, not as a survivor of all cheap filters.
 
 Kalmanson-feasible but circle-impossible block pattern:
 

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -109,11 +109,66 @@ Exact packet spec:
 - optional derived angular-span certificate for the four witnesses around
   `v`.
 
+Double-boundary endpoint negative control:
+
+The endpoint-only double-boundary package should not be treated as a
+contradiction. Normalize a diameter pair to `A = (0,0)`, `B = (1,0)`, and set
+
+```text
+R(theta) = (cos theta, sin theta),
+L(phi) = (1 - cos phi, sin phi).
+```
+
+For `0 < alpha < beta < pi/3`, the seven points
+
+```text
+A, L(alpha), L(beta), R(pi/3), R(beta), R(alpha), B
+```
+
+in cyclic order form a strictly convex diameter-lens anchor. The endpoint rows
+
+```text
+S_A = {B, R(alpha), R(beta), R(pi/3)}
+S_B = {A, L(alpha), L(beta), R(pi/3)}
+```
+
+both select the diameter radius, overlap in the one non-endpoint equilateral
+apex, and attain the seven-vertex lower bound. This anchor is not a 4-bad
+polygon, but it shows that any case-1 proof must use witness rows at the
+boundary witnesses or another exact certificate. Strict convexity plus the
+same-side/seven-vertex package is not enough.
+
+Boundary-witness isolation lemma:
+
+Let
+
+```text
+K^+ = B(A,1) cap B(B,1) cap {y >= 0}.
+```
+
+If `R(theta) = (cos theta, sin theta)` with `0 < theta < pi/3` and
+`X in K^+` satisfies `|X - R(theta)| = 1`, then `X = A`. The boundary check is
+elementary: on the segment `AB`, equality forces the segment parameter to be
+`0`; on the same right arc, all chord gaps are strictly less than `pi/3`; and
+on the left arc, the same-side formula gives equality only when the left angle
+is `0`. Since squared distance to `R(theta)` is convex, no other point of the
+upper half-lens can be a unit-distance neighbor.
+
+Consequent pruning rule:
+
+For a noncommon upper right-arc endpoint witness `R`, a reciprocal selected
+edge `A <-> R` forces `R`'s selected radius to be the diameter. The isolation
+lemma then forces the other three selected witnesses in `S_R` below the
+diameter line. The symmetric statement holds for noncommon left-arc witnesses
+and for the lower half-lens. This is only a finite-pruning ingredient: it does
+not cover the common equilateral apex, it requires the reciprocal selected
+edge, and it does not by itself rule out a full 4-bad completion.
+
 This packet cannot be applied directly to the stored 184 `n=9` frontier
 assignments unless a separate metric diameter certificate identifies a
 diameter pair in each assignment. The next useful artifact would be a
-hand-checkable local lemma note plus one toy exact packet, not a claim about
-the full frontier.
+hand-checkable local lemma note plus one toy exact packet, including the
+boundary-witness isolation check above, not a claim about the full frontier.
 
 ## 3. Fishburn--Reeds k=4 Extension Search
 

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -212,6 +212,40 @@ component:
 if `a in S_b` and `b in S_a`, then `r_a = r_b = |ab|`, so all selected edges
 from centers in that component inherit one ordinary distance class.
 
+Same-distance `K4-e` stretch certificate:
+
+After exact same-distance quotienting, if one ordinary distance class contains
+exactly five of the six edges on four distinct vertices, then the missing edge
+has length `sqrt(3)` times the common class length. This gives an exact
+relation between quotient classes that can be substituted into fixed-order
+Kalmanson inequalities over `Q(sqrt(3))`. The replay script
+`scripts/check_k4e_kalmanson_stretch_audit.py` implements this filter without
+floating point arithmetic.
+
+The displayed `n=10` quotient-level survivor from the GPT review batch is
+retired by this layer. Its selected-distance quotient has nontrivial classes
+
+```text
+Q01: 01 04 05 08 34 45 47 56 58
+Q02: 02 12 13 16 19 23 24 35 36
+Q09: 09 18 29 37 57 68 78 79 89
+Q26: 26 46 67 69
+```
+
+The class `Q02` contains the five edges
+`12, 13, 16, 23, 36` on vertices `{1,2,3,6}`, so the missing edge `26` gives
+`Q26 = sqrt(3) Q02`. Since `46` is also in `Q26`, Kalmanson on cyclic quadruple
+`0 < 1 < 4 < 6` gives
+
+```text
+d01 + d46 <= d04 + d16,
+```
+
+which reduces to `(sqrt(3) - 1) Q02 <= 0`, impossible for positive distances.
+This kills only the displayed fixed pattern/order. It is not an `n=10`
+exclusion; the next search loop should rerun with this filter enabled and
+collect the next survivor, if any.
+
 Selected tournament audit pattern:
 
 The cyclic tournament pattern
@@ -324,8 +358,9 @@ pairs
 
 are all forced into the same distance class. Thus vertices `{0,1,2,7}` form a
 same-distance `K_4`, which cannot occur in the plane. The diagnostic lesson is
-that Kalmanson-feasible endpoint-poor branches may require same-distance clique
-or other vertex-circle certificates, not only Farkas/Kalmanson certificates.
+that Kalmanson-feasible endpoint-poor branches may require same-distance
+clique, `K4-e` stretch, or other vertex-circle certificates, not only
+Farkas/Kalmanson certificates.
 
 This packet cannot be applied directly to the stored 184 `n=9` frontier
 assignments unless a separate metric diameter certificate identifies a

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -199,6 +199,19 @@ Euclidean circles meet in at most two points. This is often stronger than a
 linear Kalmanson check and should be treated as a first-class vertex-circle
 certificate rather than as endpoint geometry.
 
+Same-distance clique certificate:
+
+After exact same-distance quotienting, if one forced ordinary distance class
+contains a `K_4` on four distinct vertices, the pattern is impossible in the
+plane. Four planar points cannot be pairwise equidistant at a positive
+distance: three would form an equilateral triangle, and a fourth point
+equidistant from all three would have to be the triangle's circumcenter, whose
+distance to the vertices is smaller than the side length. In selected-row
+language, a common source for this certificate is a reciprocal selected-edge
+component:
+if `a in S_b` and `b in S_a`, then `r_a = r_b = |ab|`, so all selected edges
+from centers in that component inherit one ordinary distance class.
+
 Selected tournament audit pattern:
 
 The cyclic tournament pattern
@@ -263,6 +276,53 @@ exactly by the common-circle certificate above: for instance
 common witness points. The role of this example is only to separate two
 failure modes: Kalmanson-only endpoint certificates can be feasible while a
 vertex-circle/common-neighbor certificate still kills the selected pattern.
+
+Kalmanson-feasible but same-distance-impossible endpoint pattern:
+
+A stronger `n=9` audit pattern survives the common-circle row-intersection
+certificate and is killed instead by the same-distance clique certificate.
+Use cyclic order `0,1,...,8`, mark `{0,4}` as the diameter candidate, and set
+
+```text
+S_0 = {1,2,3,8}
+S_1 = {0,2,7,8}
+S_2 = {0,5,6,7}
+S_3 = {1,4,5,7}
+S_4 = {2,5,6,8}
+S_5 = {2,3,6,7}
+S_6 = {3,5,7,8}
+S_7 = {0,1,3,4}
+S_8 = {0,1,2,6}
+```
+
+No pair of rows shares more than two witnesses. An exact rational
+pseudo-metric gives a Kalmanson-feasible diameter relaxation:
+
+```text
+d(0,4) = d(0,5) = d(0,6) = d(1,4) = d(1,5) = d(1,6) = 1,
+d(2,3) = d(7,8) = 1/10,
+all other off-diagonal distances = 11/20.
+```
+
+The selected row equalities hold, every distance is at most `d(0,4) = 1`,
+all triangle inequalities hold, and the cyclic Kalmanson inequalities in
+order `0,1,...,8` have exact slacks only in `{0, 9/20, 9/10}`. For the marked
+diameter pair, neither endpoint has a diameter-rich selected row:
+`4 notin S_0` and `0 notin S_4`; in the pseudo-metric the full diameter
+classes are also small, with `N_D(0) = {4,5,6}` and `N_D(4) = {0,1}`.
+
+The pattern is still exactly impossible. Reciprocal selected edges connect
+`0,1,2,3,5,6,7,8` into one forced selected-radius component, and the ordinary
+pairs
+
+```text
+01, 02, 07, 12, 17, 27
+```
+
+are all forced into the same distance class. Thus vertices `{0,1,2,7}` form a
+same-distance `K_4`, which cannot occur in the plane. The diagnostic lesson is
+that Kalmanson-feasible endpoint-poor branches may require same-distance clique
+or other vertex-circle certificates, not only Farkas/Kalmanson certificates.
 
 This packet cannot be applied directly to the stored 184 `n=9` frontier
 assignments unless a separate metric diameter certificate identifies a

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -184,6 +184,21 @@ and for the lower half-lens. This is only a finite-pruning ingredient: it does
 not cover the common equilateral apex, it requires the reciprocal selected
 edge, and it does not by itself rule out a full 4-bad completion.
 
+Common-circle row-intersection certificate:
+
+For any two distinct centers `u != v` in a realizable selected-witness system,
+the selected rows satisfy
+
+```text
+|S_u cap S_v| <= 2.
+```
+
+Every common witness lies on both selected circles `C(u,r_u)` and `C(v,r_v)`.
+Those circles have distinct centers, so they cannot coincide, and two distinct
+Euclidean circles meet in at most two points. This is often stronger than a
+linear Kalmanson check and should be treated as a first-class vertex-circle
+certificate rather than as endpoint geometry.
+
 Selected tournament audit pattern:
 
 The cyclic tournament pattern
@@ -214,6 +229,40 @@ are equal. Because every unordered pair appears in exactly one selected row,
 this would make all pair distances equal, impossible for more than three
 planar points. This makes the pattern a good regression example for global
 certificates, not a counterexample candidate.
+
+Kalmanson-feasible but circle-impossible block pattern:
+
+Another useful `n=9` audit pattern shows why endpoint-poor branches need
+vertex-circle certificates in addition to Kalmanson/Farkas checks. Let
+
+```text
+S_0 = S_1 = S_2 = S_3 = {4,5,6,7},
+S_4 = S_5 = S_6 = S_7 = S_8 = {0,1,2,3}.
+```
+
+Define a rational symmetric distance matrix by:
+
+```text
+d(0,j) = 1                  for j in {1,2,3},
+d(i,j) = 1/2                for i != j in {1,2,3},
+d(h,m) = 19/20              for h in {0,1,2,3}, m in {4,5,6,7},
+d(h,8) = 11/20              for h in {0,1,2,3},
+d(i,j) = 1/2                for i != j in {4,5,6,7,8}.
+```
+
+An exact rational check verifies the selected row equalities, all triangle
+inequalities, diameter inequalities with diameter value `1`, and the two
+Kalmanson inequalities for every cyclic quadruple in order `0,1,...,8`. The
+only diameter pairs are `{0,1}`, `{0,2}`, and `{0,3}`; in this relaxation no
+diameter endpoint has four diameter-distance neighbors, and all selected
+radii at diameter endpoints are strictly below the diameter.
+
+This matrix is not Euclidean evidence. The selected pattern is rejected
+exactly by the common-circle certificate above: for instance
+`S_0 cap S_1 = {4,5,6,7}`, so two distinct selected circles would have four
+common witness points. The role of this example is only to separate two
+failure modes: Kalmanson-only endpoint certificates can be feasible while a
+vertex-circle/common-neighbor certificate still kills the selected pattern.
 
 This packet cannot be applied directly to the stored 184 `n=9` frontier
 assignments unless a separate metric diameter certificate identifies a

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -363,6 +363,52 @@ No prototype is added here because the repository already has extensive
 fixed-pattern and numerical machinery. The value of this direction is a
 carefully scoped pattern generator, not another floating near-miss.
 
+## Counterexample-Oriented Addendum: Convex-Body Boundary Discretization
+
+Trust label: `COUNTEREXAMPLE_SEARCH_SCAFFOLD` plus `NO_FINITE_EVIDENCE`.
+
+The Barany--Roldan-Pensado convex-body examples remain a boundary-intersection
+warning, not a finite-vertex counterexample. Their 15-gon shows that the
+continuous boundary problem can have many centered boundary intersections, but
+those hits may lie in edge interiors rather than at vertices. See
+`docs/literature-risk.md` for the checked anchor and caveats.
+
+The useful new search framing is a finite invariant-set problem. Suppose a
+strictly convex closed curve `Gamma` is split into arcs
+`Gamma_0, ..., Gamma_{m-1}`. For `p in Gamma_i`, suppose an exact or certified
+radius rule gives four continuously selectable boundary-hit branches
+
+```text
+F_{i,1}(p), F_{i,2}(p), F_{i,3}(p), F_{i,4}(p) in Gamma_{i+1}.
+```
+
+A finite selected-vertex counterexample would require a finite set
+`X subset Gamma` closed under all chosen witness branches:
+
+```text
+F_{i,j}(X cap Gamma_i) subset X cap Gamma_{i+1}
+```
+
+for every relevant `i,j`. Thus the continuous body example becomes a finite
+closure problem for branch maps on a convex curve, not an incidence-counting
+claim by itself.
+
+Exactification requirements before this route can produce evidence:
+
+- explicit branch domains and formulas, or interval-certified branch graphs;
+- a finite candidate set `X` with exact or interval-certified closure under the
+  selected branches;
+- strict convexity and distinct-vertex certificates for the finite set;
+- equal-distance verification at each selected center;
+- a proof that every newly added boundary point also has four selected
+  witnesses inside the same finite set.
+
+Negative control: the one-parabola construction family is already ruled out in
+`docs/parabola-model-case.md`. That proof is a restricted exact lemma and
+should not be duplicated here. The convex-body discretization route is only
+interesting if it uses multi-arc closure in a way the one-parabola endpoint
+argument cannot see.
+
 ## 4. Reciprocal-Radial Global Budget
 
 Trust label: `RESEARCH_PACKET`.
@@ -508,5 +554,8 @@ diagnostic, not a proof.
    finite packet needs it.
 3. Open any Fishburn--Reeds `k=4` search as pattern mining with explicit
    exactification gates.
-4. Try a reciprocal-radial summation only after identifying the global index
+4. Treat convex-body discretization as a finite branch-map closure problem;
+   do not promote it without exact finite closure and strict-convexity
+   certificates.
+5. Try a reciprocal-radial summation only after identifying the global index
    set and a negative control that the proposed theorem must avoid.

--- a/scripts/check_k4e_kalmanson_stretch_audit.py
+++ b/scripts/check_k4e_kalmanson_stretch_audit.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""Replay K4-minus-edge stretch certificates against Kalmanson inequalities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from fractions import Fraction
+from itertools import combinations
+from typing import Iterable
+
+Edge = tuple[int, int]
+Rows = dict[int, tuple[int, int, int, int]]
+
+
+def edge(i: int, j: int) -> Edge:
+    return (i, j) if i < j else (j, i)
+
+
+def edge_str(e: Edge) -> str:
+    return f"{e[0]}{e[1]}"
+
+
+@dataclass(frozen=True)
+class QSqrt3:
+    """An exact element of Q(sqrt(3)), represented as a + b sqrt(3)."""
+
+    a: Fraction = Fraction(0)
+    b: Fraction = Fraction(0)
+
+    def __add__(self, other: QSqrt3) -> QSqrt3:
+        return QSqrt3(self.a + other.a, self.b + other.b)
+
+    def __sub__(self, other: QSqrt3) -> QSqrt3:
+        return QSqrt3(self.a - other.a, self.b - other.b)
+
+    def __neg__(self) -> QSqrt3:
+        return QSqrt3(-self.a, -self.b)
+
+    def is_zero(self) -> bool:
+        return self.a == 0 and self.b == 0
+
+    def sign(self) -> int:
+        """Return the exact sign of this element."""
+
+        a, b = self.a, self.b
+        if a == 0 and b == 0:
+            return 0
+        if b == 0:
+            return 1 if a > 0 else -1
+        if a == 0:
+            return 1 if b > 0 else -1
+        if a > 0 and b > 0:
+            return 1
+        if a < 0 and b < 0:
+            return -1
+
+        lhs = a * a
+        rhs = 3 * b * b
+        if a > 0 and b < 0:
+            return 1 if lhs > rhs else -1
+        if a < 0 and b > 0:
+            return 1 if rhs > lhs else -1
+        raise AssertionError("unreachable sign case")
+
+    def text(self) -> str:
+        terms: list[str] = []
+        if self.a:
+            terms.append(str(self.a))
+        if self.b == 1:
+            terms.append("sqrt3")
+        elif self.b == -1:
+            terms.append("-sqrt3")
+        elif self.b:
+            terms.append(f"{self.b}*sqrt3")
+        if not terms:
+            return "0"
+
+        out = terms[0]
+        for term in terms[1:]:
+            if term.startswith("-"):
+                out += " - " + term[1:]
+            else:
+                out += " + " + term
+        return out
+
+
+ONE = QSqrt3(Fraction(1), Fraction(0))
+SQRT3 = QSqrt3(Fraction(0), Fraction(1))
+NEG_ONE = QSqrt3(Fraction(-1), Fraction(0))
+
+
+class DSU:
+    def __init__(self, items: Iterable[Edge]) -> None:
+        self.parent = {x: x for x in items}
+
+    def find(self, x: Edge) -> Edge:
+        parent = self.parent[x]
+        if parent != x:
+            self.parent[x] = self.find(parent)
+        return self.parent[x]
+
+    def union(self, a: Edge, b: Edge) -> None:
+        root_a, root_b = self.find(a), self.find(b)
+        if root_a == root_b:
+            return
+        if root_b < root_a:
+            root_a, root_b = root_b, root_a
+        self.parent[root_b] = root_a
+
+
+def quotient_classes(n: int, rows: Rows) -> tuple[dict[Edge, list[Edge]], dict[Edge, Edge]]:
+    all_edges = [edge(i, j) for i, j in combinations(range(n), 2)]
+    dsu = DSU(all_edges)
+    for i, row in rows.items():
+        row_edges = [edge(i, j) for j in row]
+        if len(row_edges) != 4:
+            raise ValueError(f"row {i} has {len(row_edges)} witnesses, expected 4")
+        base = row_edges[0]
+        for row_edge in row_edges[1:]:
+            dsu.union(base, row_edge)
+
+    classes: dict[Edge, list[Edge]] = {}
+    edge_root: dict[Edge, Edge] = {}
+    for e in all_edges:
+        root = dsu.find(e)
+        edge_root[e] = root
+        classes.setdefault(root, []).append(e)
+    return {root: sorted(edges) for root, edges in classes.items()}, edge_root
+
+
+def class_name(root: Edge) -> str:
+    return "Q" + edge_str(root)
+
+
+def find_k4(n: int, edges: Iterable[Edge]) -> list[tuple[int, int, int, int]]:
+    edge_set = set(edges)
+    hits: list[tuple[int, int, int, int]] = []
+    for quad in combinations(range(n), 4):
+        if all(edge(a, b) in edge_set for a, b in combinations(quad, 2)):
+            hits.append(quad)
+    return hits
+
+
+def find_codegree_ge3(n: int, edges: Iterable[Edge]) -> list[tuple[int, int, tuple[int, ...]]]:
+    edge_set = set(edges)
+    hits: list[tuple[int, int, tuple[int, ...]]] = []
+    for a, b in combinations(range(n), 2):
+        common = tuple(
+            v
+            for v in range(n)
+            if v not in (a, b)
+            and edge(a, v) in edge_set
+            and edge(b, v) in edge_set
+        )
+        if len(common) >= 3:
+            hits.append((a, b, common))
+    return hits
+
+
+@dataclass(frozen=True)
+class K4eRelation:
+    source: Edge
+    target: Edge
+    quad: tuple[int, int, int, int]
+    missing: Edge
+    present: tuple[Edge, ...]
+
+
+def find_k4e_relations(
+    n: int,
+    classes: dict[Edge, list[Edge]],
+    edge_root: dict[Edge, Edge],
+) -> list[K4eRelation]:
+    relations: list[K4eRelation] = []
+    seen: set[tuple[Edge, Edge, tuple[int, int, int, int], Edge]] = set()
+    for root, class_edges in classes.items():
+        edge_set = set(class_edges)
+        if len(edge_set) < 5:
+            continue
+        for quad in combinations(range(n), 4):
+            quad_edges = [edge(a, b) for a, b in combinations(quad, 2)]
+            present = tuple(sorted(e for e in quad_edges if e in edge_set))
+            if len(present) != 5:
+                continue
+            missing = next(e for e in quad_edges if e not in edge_set)
+            target = edge_root[missing]
+            key = (root, target, quad, missing)
+            if target != root and key not in seen:
+                relations.append(K4eRelation(root, target, quad, missing, present))
+                seen.add(key)
+    return relations
+
+
+def expr_for_edge(
+    e: Edge,
+    edge_root: dict[Edge, Edge],
+    rel: K4eRelation,
+) -> dict[Edge, QSqrt3]:
+    root = edge_root[e]
+    if root == rel.target:
+        return {rel.source: SQRT3}
+    return {root: ONE}
+
+
+def add_expr(
+    dst: dict[Edge, QSqrt3],
+    src: dict[Edge, QSqrt3],
+    scale: QSqrt3,
+) -> None:
+    if scale not in (ONE, NEG_ONE):
+        raise ValueError("only +/-1 expression scaling is supported")
+    for key, value in src.items():
+        scaled = value if scale == ONE else -value
+        dst[key] = dst.get(key, QSqrt3()) + scaled
+        if dst[key].is_zero():
+            del dst[key]
+
+
+def diff_for_inequality(
+    lhs: tuple[Edge, Edge],
+    rhs: tuple[Edge, Edge],
+    edge_root: dict[Edge, Edge],
+    rel: K4eRelation,
+) -> dict[Edge, QSqrt3]:
+    diff: dict[Edge, QSqrt3] = {}
+    for e in lhs:
+        add_expr(diff, expr_for_edge(e, edge_root, rel), ONE)
+    for e in rhs:
+        add_expr(diff, expr_for_edge(e, edge_root, rel), NEG_ONE)
+    return diff
+
+
+def positive_contradiction(diff: dict[Edge, QSqrt3]) -> bool:
+    """Return true when LHS - RHS is positive for all positive class lengths."""
+
+    if not diff:
+        return False
+    saw_positive = False
+    for coeff in diff.values():
+        sign = coeff.sign()
+        if sign < 0:
+            return False
+        if sign > 0:
+            saw_positive = True
+    return saw_positive
+
+
+@dataclass(frozen=True)
+class StretchCertificate:
+    rel: K4eRelation
+    quad: tuple[int, int, int, int]
+    kind: str
+    lhs: tuple[Edge, Edge]
+    rhs: tuple[Edge, Edge]
+    diff: dict[Edge, QSqrt3]
+
+
+def kalmanson_stretch_certificates(
+    n: int,
+    edge_root: dict[Edge, Edge],
+    relations: list[K4eRelation],
+) -> list[StretchCertificate]:
+    certs: list[StretchCertificate] = []
+    for rel in relations:
+        for i, j, k, m in combinations(range(n), 4):
+            inequalities = [
+                ("K1", (edge(i, j), edge(k, m)), (edge(i, k), edge(j, m))),
+                ("K2", (edge(i, m), edge(j, k)), (edge(i, k), edge(j, m))),
+            ]
+            for kind, lhs, rhs in inequalities:
+                diff = diff_for_inequality(lhs, rhs, edge_root, rel)
+                if positive_contradiction(diff):
+                    certs.append(StretchCertificate(rel, (i, j, k, m), kind, lhs, rhs, diff))
+    return certs
+
+
+@dataclass(frozen=True)
+class PatternAudit:
+    name: str
+    n: int
+    classes: dict[Edge, list[Edge]]
+    edge_root: dict[Edge, Edge]
+    k4_obstructions: list[tuple[Edge, tuple[int, int, int, int]]]
+    codegree_obstructions: list[tuple[Edge, tuple[int, int, tuple[int, ...]]]]
+    k4e_relations: list[K4eRelation]
+    stretch_certificates: list[StretchCertificate]
+
+
+def audit_pattern(name: str, n: int, rows: Rows) -> PatternAudit:
+    classes, edge_root = quotient_classes(n, rows)
+    k4_obstructions = [
+        (root, quad)
+        for root, edges in classes.items()
+        for quad in find_k4(n, edges)
+    ]
+    codegree_obstructions = [
+        (root, hit)
+        for root, edges in classes.items()
+        for hit in find_codegree_ge3(n, edges)
+    ]
+    relations = find_k4e_relations(n, classes, edge_root)
+    certs = kalmanson_stretch_certificates(n, edge_root, relations)
+    return PatternAudit(
+        name=name,
+        n=n,
+        classes=classes,
+        edge_root=edge_root,
+        k4_obstructions=k4_obstructions,
+        codegree_obstructions=codegree_obstructions,
+        k4e_relations=relations,
+        stretch_certificates=certs,
+    )
+
+
+def format_edges(edges: Iterable[Edge]) -> str:
+    return " ".join(edge_str(e) for e in sorted(edges))
+
+
+def format_expr_terms(
+    terms: tuple[Edge, Edge],
+    edge_root: dict[Edge, Edge],
+    rel: K4eRelation,
+) -> str:
+    pieces: list[str] = []
+    for e in terms:
+        root = edge_root[e]
+        if root == rel.target:
+            pieces.append(f"d{edge_str(e)}=sqrt3*{class_name(rel.source)}")
+        else:
+            pieces.append(f"d{edge_str(e)}={class_name(root)}")
+    return " + ".join(pieces)
+
+
+def format_diff(diff: dict[Edge, QSqrt3]) -> str:
+    if not diff:
+        return "0"
+    return " + ".join(
+        f"({coeff.text()})*{class_name(root)}"
+        for root, coeff in sorted(diff.items())
+    )
+
+
+def render_text(audit: PatternAudit, max_certs: int = 5) -> str:
+    lines: list[str] = [f"=== {audit.name} ==="]
+    nontrivial = [
+        (root, edges)
+        for root, edges in audit.classes.items()
+        if len(edges) > 1
+    ]
+    nontrivial.sort(key=lambda item: (-len(item[1]), item[0]))
+    lines.append(
+        f"n={audit.n}; quotient classes={len(audit.classes)}; "
+        f"nontrivial classes={len(nontrivial)}"
+    )
+    for root, edges in nontrivial:
+        lines.append(f"  {class_name(root)} size {len(edges)}: {format_edges(edges)}")
+
+    lines.append(f"K4 obstructions: {len(audit.k4_obstructions)}")
+    for root, quad in audit.k4_obstructions[:max_certs]:
+        lines.append(f"  {class_name(root)} contains K4 on {quad}")
+
+    lines.append(f"K2,3/codegree>=3 obstructions: {len(audit.codegree_obstructions)}")
+    for root, (a, b, common) in audit.codegree_obstructions[:max_certs]:
+        lines.append(f"  {class_name(root)} vertices {a},{b} share {common}")
+
+    lines.append(f"K4-e relations extracted: {len(audit.k4e_relations)}")
+    for rel in audit.k4e_relations[:max_certs]:
+        lines.append(
+            f"  {class_name(rel.target)} = sqrt3*{class_name(rel.source)} "
+            f"from quad {rel.quad}, missing {edge_str(rel.missing)}, "
+            f"present {format_edges(rel.present)}"
+        )
+
+    lines.append(
+        "K4-e/Kalmanson stretch contradictions: "
+        f"{len(audit.stretch_certificates)}"
+    )
+    for cert in audit.stretch_certificates[:max_certs]:
+        rel = cert.rel
+        lines.append("  CERT")
+        lines.append(
+            f"    relation: {class_name(rel.target)} = sqrt3*"
+            f"{class_name(rel.source)} from K4-e quad {rel.quad} "
+            f"missing {edge_str(rel.missing)}"
+        )
+        lines.append(
+            f"    {cert.kind} on cyclic quad {cert.quad}: "
+            f"d{edge_str(cert.lhs[0])}+d{edge_str(cert.lhs[1])} <= "
+            f"d{edge_str(cert.rhs[0])}+d{edge_str(cert.rhs[1])}"
+        )
+        lines.append(
+            "    LHS substitutions: "
+            f"{format_expr_terms(cert.lhs, audit.edge_root, rel)}"
+        )
+        lines.append(
+            "    RHS substitutions: "
+            f"{format_expr_terms(cert.rhs, audit.edge_root, rel)}"
+        )
+        lines.append(f"    LHS-RHS = {format_diff(cert.diff)} > 0")
+    return "\n".join(lines)
+
+
+def rel_json(rel: K4eRelation) -> dict[str, object]:
+    return {
+        "source": class_name(rel.source),
+        "target": class_name(rel.target),
+        "quad": list(rel.quad),
+        "missing": edge_str(rel.missing),
+        "present": [edge_str(e) for e in rel.present],
+    }
+
+
+def cert_json(cert: StretchCertificate) -> dict[str, object]:
+    rel = cert.rel
+    return {
+        "relation": rel_json(rel),
+        "quad": list(cert.quad),
+        "kind": cert.kind,
+        "lhs": [edge_str(e) for e in cert.lhs],
+        "rhs": [edge_str(e) for e in cert.rhs],
+        "diff": {
+            class_name(root): coeff.text()
+            for root, coeff in sorted(cert.diff.items())
+        },
+    }
+
+
+def audit_json(audit: PatternAudit) -> dict[str, object]:
+    nontrivial = {
+        class_name(root): [edge_str(e) for e in edges]
+        for root, edges in sorted(audit.classes.items())
+        if len(edges) > 1
+    }
+    return {
+        "name": audit.name,
+        "n": audit.n,
+        "status": "EXACT_FIXED_PATTERN_AUDIT",
+        "claim_scope": (
+            "Kills only the listed selected-witness pattern and fixed cyclic "
+            "order; not an n=10 exclusion."
+        ),
+        "quotient_classes": len(audit.classes),
+        "nontrivial_classes": nontrivial,
+        "k4_obstructions": len(audit.k4_obstructions),
+        "codegree_obstructions": len(audit.codegree_obstructions),
+        "k4e_relations": [rel_json(rel) for rel in audit.k4e_relations],
+        "stretch_certificates": [
+            cert_json(cert)
+            for cert in audit.stretch_certificates
+        ],
+    }
+
+
+PATTERNS: dict[str, tuple[int, Rows]] = {
+    "n10_frontier": (
+        10,
+        {
+            0: (1, 4, 5, 8),
+            1: (2, 3, 6, 9),
+            2: (0, 1, 3, 4),
+            3: (1, 2, 5, 6),
+            4: (0, 3, 5, 7),
+            5: (0, 4, 6, 8),
+            6: (2, 4, 7, 9),
+            7: (3, 5, 8, 9),
+            8: (1, 6, 7, 9),
+            9: (0, 2, 7, 8),
+        },
+    ),
+    "case2_diagnostic": (
+        9,
+        {
+            0: (1, 3, 4, 6),
+            1: (3, 6, 7, 8),
+            2: (1, 3, 4, 6),
+            3: (1, 5, 6, 7),
+            4: (2, 3, 7, 8),
+            5: (1, 2, 6, 8),
+            6: (1, 3, 4, 8),
+            7: (1, 2, 3, 5),
+            8: (0, 2, 3, 5),
+        },
+    ),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pattern",
+        choices=sorted(PATTERNS),
+        action="append",
+        help="Pattern to audit. Defaults to all registered patterns.",
+    )
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    names = args.pattern or sorted(PATTERNS)
+    audits = []
+    for name in names:
+        n, rows = PATTERNS[name]
+        audits.append(audit_pattern(name, n, rows))
+
+    if args.assert_expected:
+        expected = {
+            "n10_frontier": (0, 0, 2, 3),
+            "case2_diagnostic": (0, 0, 3, 24),
+        }
+        for audit in audits:
+            want = expected[audit.name]
+            got = (
+                len(audit.k4_obstructions),
+                len(audit.codegree_obstructions),
+                len(audit.k4e_relations),
+                len(audit.stretch_certificates),
+            )
+            if got != want:
+                raise AssertionError(f"{audit.name}: expected {want}, got {got}")
+
+    if args.json:
+        print(json.dumps([audit_json(audit) for audit in audits], indent=2))
+    else:
+        for index, audit in enumerate(audits):
+            if index:
+                print()
+            print(render_text(audit))
+        if args.assert_expected:
+            print("OK: expected K4-e/Kalmanson stretch audit verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_k4e_kalmanson_stretch_audit.py
+++ b/tests/test_k4e_kalmanson_stretch_audit.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+from scripts.check_k4e_kalmanson_stretch_audit import (
+    PATTERNS,
+    QSqrt3,
+    audit_pattern,
+    class_name,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_qsqrt3_signs_are_exact() -> None:
+    assert QSqrt3(Fraction(-1), Fraction(1)).sign() == 1
+    assert QSqrt3(Fraction(2), Fraction(-1)).sign() == 1
+    assert QSqrt3(Fraction(1), Fraction(-1)).sign() == -1
+    assert QSqrt3(Fraction(-2), Fraction(1)).sign() == -1
+
+
+def test_n10_frontier_k4e_kalmanson_certificate() -> None:
+    n, rows = PATTERNS["n10_frontier"]
+    audit = audit_pattern("n10_frontier", n, rows)
+
+    assert len(audit.k4_obstructions) == 0
+    assert len(audit.codegree_obstructions) == 0
+    assert len(audit.k4e_relations) == 2
+    assert len(audit.stretch_certificates) == 3
+
+    first = audit.stretch_certificates[0]
+    assert first.kind == "K1"
+    assert first.quad == (0, 1, 4, 6)
+    assert class_name(first.rel.source) == "Q02"
+    assert class_name(first.rel.target) == "Q26"
+    assert first.diff[first.rel.source] == QSqrt3(Fraction(-1), Fraction(1))
+
+
+def test_case2_diagnostic_k4e_kalmanson_counts() -> None:
+    n, rows = PATTERNS["case2_diagnostic"]
+    audit = audit_pattern("case2_diagnostic", n, rows)
+
+    assert len(audit.k4_obstructions) == 0
+    assert len(audit.codegree_obstructions) == 0
+    assert len(audit.k4e_relations) == 3
+    assert len(audit.stretch_certificates) == 24
+
+
+def test_k4e_kalmanson_stretch_cli() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_k4e_kalmanson_stretch_audit.py",
+            "--pattern",
+            "n10_frontier",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "K4-e relations extracted: 2" in result.stdout
+    assert "K4-e/Kalmanson stretch contradictions: 3" in result.stdout
+    assert "OK: expected K4-e/Kalmanson stretch audit verified" in result.stdout


### PR DESCRIPTION
## Summary

- Add `docs/dumitrescu-isosceles-n8-shortcut.md`, a literature-backed review note for the apex-isosceles shortcut excluding 4-bad strictly convex polygons with `n <= 8`, without changing the repo-local source-of-truth status.
- Add `docs/diameter-lens-local-lemmas.md`, extracting the diameter pinching, overlap, seven-vertex, and same-side lemmas plus the seven-point lens-cap negative control and selected/full-rich-class branching caution.
- Add a double-boundary endpoint negative control to `docs/research-directions-2026-05-19.md`, recording the seven-point diameter-lens anchor as a sharp local evasion of the endpoint-only contradiction mechanism.
- Add the scoped boundary-witness diameter-isolation lemma and its reciprocal-edge pruning consequence.
- Add common-circle and same-distance clique certificates, plus three audit patterns: the corrected `S_i={i+1,i+2,i+3,i+4} mod 9` tournament stress test, a Kalmanson-feasible but circle-impossible `n=9` block pattern, and a Kalmanson-feasible endpoint-poor `n=9` pattern killed only by a same-distance `K_4`.
- Add `docs/k4e-kalmanson-stretch-audit.md`, `scripts/check_k4e_kalmanson_stretch_audit.py`, and tests for an exact `K4-e` stretch + Kalmanson audit. This retires only the displayed `n=10` quotient-level survivor and one diagnostic pattern; it is not an `n=10` exclusion.
- Add a counterexample-oriented convex-body discretization scaffold, treating Barany--Roldan-Pensado boundary examples as finite branch-map closure problems with explicit exactification requirements and no finite evidence.
- Wire the new proof notes into `docs/index.md` and surface the Dumitrescu shortcut, same-distance `K_4`, same-distance `K4-e`, and diameter-lens lemmas in `docs/claims.md` with review/non-overclaiming labels.

## Verification

- `python scripts/check_text_clean.py` - passed
- `python scripts/check_status_consistency.py` - passed
- `python scripts/check_artifact_provenance.py` - passed
- `git diff --check` / `git diff --cached --check` - passed
- `python -m ruff check .` - passed
- `python scripts/check_k4e_kalmanson_stretch_audit.py --assert-expected` - passed
- `python -m pytest -q` - passed: 1085 passed, 305 deselected in 633.23s

## Non-Overclaiming Note

This PR does not update `README.md`, `STATE.md`, `RESULTS.md`, or `metadata/erdos97.yaml`; it does not claim a general proof, a counterexample, promotion of review-pending `n=9`/`n=10` artifacts, or any official/global status change. The Dumitrescu shortcut is recorded as literature-backed and review-pending rather than as a source-of-truth status replacement. The `K4-e` audit kills only registered fixed patterns under fixed cyclic orders.

## Remaining Follow-Ups

- Review the Dumitrescu shortcut against the external counting convention before any paper-style promotion.
- If the boundary-isolation lemma becomes operational, add a small exact checker or toy packet that records the diameter pair, half-lens side, reciprocal selected edge, and forced opposite-side witnesses.
- Keep common-apex cases separate: the boundary-isolation pruning rule is for noncommon interior arc witnesses, not the equilateral apex shared by both endpoint circles.
- Rerun the next `n=10` search loop with the `K4-e` stretch layer enabled before naming any new survivor.
- If the audit patterns become regression fixtures, keep row-intersection, strict/non-strict Kalmanson, equidistant-set, same-distance `K_4`, and `K4-e` stretch rejections as separate checks.
- For convex-body discretization, do not promote the route without an exact finite invariant set, selected branch closure, and strict-convexity certificates.