### PR TITLE
[codex] harden exact obstruction guardrails

### DIFF
--- a/scripts/analyze_n8_fragile_covers.py
+++ b/scripts/analyze_n8_fragile_covers.py
@@ -72,9 +72,17 @@ def main() -> int:
     data = analyze_survivors(args.survivors)
 
     if args.check:
-        assert data["survivor_classes"] == 15
-        assert data["all_survivors_admit_incidence_fragile_cover"] is True
-        assert data["min_cover_size_distribution"] == EXPECTED_MIN_COVER_DISTRIBUTION
+        if data["survivor_classes"] != 15:
+            raise AssertionError(
+                f"expected 15 survivor classes, got {data['survivor_classes']!r}"
+            )
+        if data["all_survivors_admit_incidence_fragile_cover"] is not True:
+            raise AssertionError("expected all survivors to admit incidence fragile covers")
+        if data["min_cover_size_distribution"] != EXPECTED_MIN_COVER_DISTRIBUTION:
+            raise AssertionError(
+                "unexpected min cover size distribution: "
+                f"{data['min_cover_size_distribution']!r}"
+            )
 
     if args.write_artifact:
         args.write_artifact.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/check_two_orbit_radius_propagation.py
+++ b/scripts/check_two_orbit_radius_propagation.py
@@ -30,7 +30,8 @@ from erdos97.two_orbit_radius_propagation import (  # noqa: E402
 def _is_zero(value: object) -> bool:
     import sympy as sp
 
-    return sp.simplify(value) == 0
+    simplified = sp.simplify(value)
+    return simplified == 0 or simplified.equals(0) is True
 
 
 def _is_positive(value: object) -> bool:
@@ -41,7 +42,7 @@ def _is_positive(value: object) -> bool:
         return True
     if simplified.is_positive is False:
         return False
-    return bool(sp.N(simplified, 80) > 0)
+    return False
 
 
 def assert_expected(t: int, *, verify_all_rows: bool) -> None:

--- a/src/erdos97/bridge_lemma_frontier.py
+++ b/src/erdos97/bridge_lemma_frontier.py
@@ -37,6 +37,7 @@ EXPECTED_N9_TOTAL = 184
 EXPECTED_N9_EAR = 182
 EXPECTED_N9_NON_EAR_INDICES = [81, 151]
 EXPECTED_N9_STATUS_COUNTS = {"self_edge": 158, "strict_cycle": 26}
+VERTEX_CIRCLE_OBSTRUCTION_STATUSES = frozenset({"self_edge", "strict_cycle"})
 EXPECTED_CROSS_TAB = {
     "ear|ok": 0,
     "ear|self_edge": 158,
@@ -335,6 +336,11 @@ def build_payload(
             record["circulant_offsets"] = offsets
         n9_records.append(record)
         if not ear.exists:
+            if status not in VERTEX_CIRCLE_OBSTRUCTION_STATUSES:
+                raise ValueError(
+                    "non-ear n=9 proof target lacks an exact vertex-circle "
+                    f"obstruction status: assignment {index}, status {status!r}"
+                )
             proof_targets.append(
                 {
                     "target_id": f"n9-assignment-{index}",
@@ -463,3 +469,31 @@ def assert_expected_payload(payload: Mapping[str, object]) -> None:
             raise AssertionError("proof-mining target is malformed")
         if target.get("exact_obstructions") in (None, []):
             raise AssertionError(f"target lacks obstruction status: {target.get('target_id')!r}")
+        if target.get("n") == 9:
+            vertex_status = target.get("vertex_circle_status")
+            if vertex_status not in VERTEX_CIRCLE_OBSTRUCTION_STATUSES:
+                raise AssertionError(
+                    "n=9 proof-mining target lacks exact vertex-circle "
+                    f"obstruction status: {target.get('target_id')!r}"
+                )
+            exact_obstructions = target.get("exact_obstructions")
+            if not isinstance(exact_obstructions, list):
+                raise AssertionError(
+                    f"target obstruction list is malformed: {target.get('target_id')!r}"
+                )
+            expected_method = f"vertex_circle_{vertex_status}"
+            for obstruction in exact_obstructions:
+                if not isinstance(obstruction, Mapping):
+                    raise AssertionError(
+                        f"target obstruction is malformed: {target.get('target_id')!r}"
+                    )
+                if obstruction.get("method") != expected_method:
+                    raise AssertionError(
+                        "n=9 proof-mining target has mismatched vertex-circle "
+                        f"method: {target.get('target_id')!r}"
+                    )
+                if obstruction.get("status") != "EXACT_OBSTRUCTION_REVIEW_PENDING":
+                    raise AssertionError(
+                        "n=9 proof-mining target has unexpected obstruction "
+                        f"status: {target.get('target_id')!r}"
+                    )

--- a/src/erdos97/interval_verify.py
+++ b/src/erdos97/interval_verify.py
@@ -221,7 +221,7 @@ def exact_verification(points: list[list[Fraction]], S: Pattern) -> dict[str, An
         for j in range(i + 1, n)
     )
     convexity_certified = bool(margins) and min(margins) > 0
-    distance_equalities_certified = all(residual == 0 for residual in residuals)
+    distance_equalities_certified = bool(residuals) and all(residual == 0 for residual in residuals)
     accepted = convexity_certified and distance_equalities_certified and min_pair > 0
     return {
         "exact_mode": True,

--- a/src/erdos97/n7_fano.py
+++ b/src/erdos97/n7_fano.py
@@ -490,7 +490,7 @@ def enumeration_data() -> dict[str, object]:
             "all_pattern_cycle_type_counts": dict(sorted(all_cycle_type_counts.items())),
             "dihedral_class_cycle_type_counts": dict(sorted(class_cycle_type_counts.items())),
             "classes_with_odd_perpendicularity_cycle": odd_cycle_classes,
-            "all_classes_obstructed": odd_cycle_classes == len(classes),
+            "all_classes_obstructed": bool(classes) and odd_cycle_classes == len(classes),
         },
         "conclusion": "No n=7 witness pattern satisfying the two-circle cap can be geometrically realized.",
         "representatives": dihedral_class_records(),

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -910,8 +910,12 @@ def z3_incidence_search(n: int, max_pair_common: int = 2, balance_indegree: bool
         anchor = {n // 5, 2 * n // 5, 3 * n // 5, 4 * n // 5}
         for j in range(n):
             s.add(X[0][j] == (j in anchor and j != 0))
-    if s.check() != z3.sat:
+    check = s.check()
+    if check == z3.unsat:
         return None
+    if check != z3.sat:
+        reason = s.reason_unknown() if check == z3.unknown else "unexpected solver status"
+        raise RuntimeError(f"z3 incidence search returned {check}: {reason}")
     m = s.model()
     return [[j for j in range(n) if bool(m.evaluate(X[i][j]))] for i in range(n)]
 

--- a/src/erdos97/stuck_motif_search.py
+++ b/src/erdos97/stuck_motif_search.py
@@ -144,6 +144,14 @@ def _candidate_rejection(
     return None
 
 
+def _non_sat_status(z3_status: object, *, checked: int, z3_module: object) -> str | None:
+    if z3_status == z3_module.sat:
+        return None
+    if z3_status == z3_module.unsat:
+        return "UNSAT" if checked == 0 else "EXHAUSTED"
+    return "UNKNOWN"
+
+
 def _analysis_payload(
     name: str,
     rows: Pattern,
@@ -230,8 +238,8 @@ def mine_stuck_motif(config: MotifSearchConfig) -> MotifSearchResult:
     rejected_examples: list[dict[str, object]] = []
     while checked < config.max_models:
         check = solver.check()
-        if check != z3.sat:
-            status = "UNSAT" if checked == 0 else "EXHAUSTED"
+        status = _non_sat_status(check, checked=checked, z3_module=z3)
+        if status is not None:
             return MotifSearchResult(
                 config=config,
                 status=status,

--- a/src/erdos97/stuck_motif_sweep.py
+++ b/src/erdos97/stuck_motif_sweep.py
@@ -174,6 +174,7 @@ def sweep_stuck_motifs(config: SweepConfig) -> dict[str, object]:
             "exhausted": sum(1 for item in items if item["status"] == "EXHAUSTED"),
             "model_limit": sum(1 for item in items if item["status"] == "MODEL_LIMIT"),
             "unsat": sum(1 for item in items if item["status"] == "UNSAT"),
+            "unknown": sum(1 for item in items if item["status"] == "UNKNOWN"),
         },
         "semantics": (
             "Bounded search diagnostics only. FOUND motifs are fixed-selection "

--- a/src/erdos97/two_orbit_radius_propagation.py
+++ b/src/erdos97/two_orbit_radius_propagation.py
@@ -687,4 +687,4 @@ def _is_positive(value: object) -> bool:
         return True
     if simplified.is_positive is False:
         return False
-    return bool(sp.N(simplified, 80) > 0)
+    return False

--- a/tests/test_interval_verify.py
+++ b/tests/test_interval_verify.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from fractions import Fraction
 from pathlib import Path
 
 import numpy as np
 
-from erdos97.interval_verify import verify_interval_json
+from erdos97.interval_verify import exact_verification, verify_interval_json
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -81,6 +82,23 @@ def test_exact_coordinates_do_not_require_float_coordinates(tmp_path: Path) -> N
     assert result["ok"] is False
     assert result["failure_mode"] == "exact_algebraic_rejected"
     assert result["claim_strength"] == "EXACT_OR_ALGEBRAIC_INPUT_REJECTED"
+
+
+def test_exact_verification_does_not_certify_empty_residual_list() -> None:
+    points = [
+        [Fraction(0), Fraction(0)],
+        [Fraction(2), Fraction(0)],
+        [Fraction(3), Fraction(1)],
+        [Fraction(1), Fraction(3)],
+        [Fraction(-1), Fraction(1)],
+    ]
+    rows = [[(i + 1) % len(points)] for i in range(len(points))]
+
+    result = exact_verification(points, rows)
+
+    assert result["convexity_certified"] is True
+    assert result["distance_equalities_certified"] is False
+    assert result["failure_mode"] == "exact_algebraic_rejected"
 
 
 def test_convex_float_without_equalities_is_not_certified(tmp_path: Path) -> None:

--- a/tests/test_n7_fano.py
+++ b/tests/test_n7_fano.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import erdos97.n7_fano as n7
 from erdos97.n7_fano import (
     all_pointed_fano_complements,
     analyze_n7_witness_pattern,
@@ -40,6 +41,16 @@ def test_finite_n7_fano_enumeration_counts() -> None:
     assert summary["all_pattern_cycle_type_counts"] == {"7+7+7": 720}
     assert summary["classes_with_odd_perpendicularity_cycle"] == 54
     assert summary["all_classes_obstructed"] is True
+
+
+def test_empty_n7_dihedral_class_list_is_not_obstructed(monkeypatch) -> None:
+    monkeypatch.setattr(n7, "pointed_fano_dihedral_classes", lambda: [])
+
+    data = n7.enumeration_data()
+
+    assert data["counts"]["dihedral_classes"] == 0
+    assert data["counts"]["classes_with_odd_perpendicularity_cycle"] == 0
+    assert data["counts"]["all_classes_obstructed"] is False
 
 
 def test_every_labelled_pattern_has_odd_perpendicularity_cycles() -> None:

--- a/tests/test_search_hygiene.py
+++ b/tests/test_search_hygiene.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -20,3 +23,39 @@ def test_softplus_large_positive_values_do_not_overflow() -> None:
 def test_z3_incidence_search_rejects_too_small_n_before_importing_z3() -> None:
     with pytest.raises(ValueError, match="requires n >= 5"):
         z3_incidence_search(4)
+
+
+def test_z3_incidence_search_reports_unknown(monkeypatch) -> None:
+    class FakeVar:
+        def __init__(self, name: str):
+            self.name = name
+
+        def __eq__(self, other: object) -> tuple[str, object, object]:  # type: ignore[override]
+            return ("eq", self, other)
+
+    class FakeSolver:
+        def add(self, *_constraints: object) -> None:
+            return None
+
+        def check(self) -> str:
+            return "unknown"
+
+        def reason_unknown(self) -> str:
+            return "timeout"
+
+    fake_z3 = SimpleNamespace(
+        sat="sat",
+        unsat="unsat",
+        unknown="unknown",
+        Bool=lambda name: FakeVar(name),
+        Not=lambda value: ("not", value),
+        PbEq=lambda terms, value: ("pbeq", terms, value),
+        PbLe=lambda terms, value: ("pble", terms, value),
+        PbGe=lambda terms, value: ("pbge", terms, value),
+        And=lambda *values: ("and", values),
+        Solver=FakeSolver,
+    )
+    monkeypatch.setitem(sys.modules, "z3", fake_z3)
+
+    with pytest.raises(RuntimeError, match="unknown: timeout"):
+        z3_incidence_search(5)

--- a/tests/test_soundness_guardrails.py
+++ b/tests/test_soundness_guardrails.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.bridge_lemma_frontier import (
+    EXPECTED_CROSS_TAB,
+    EXPECTED_N8_EAR,
+    EXPECTED_N8_NON_EAR_IDS,
+    EXPECTED_N8_TOTAL,
+    EXPECTED_N9_EAR,
+    EXPECTED_N9_NON_EAR_INDICES,
+    EXPECTED_N9_STATUS_COUNTS,
+    EXPECTED_N9_TOTAL,
+    SCHEMA,
+    STATUS,
+    assert_expected_payload,
+)
+
+
+def _expected_summary() -> dict[str, object]:
+    return {
+        "n8_total": EXPECTED_N8_TOTAL,
+        "n8_ear_orderable": EXPECTED_N8_EAR,
+        "n8_non_ear_orderable": EXPECTED_N8_TOTAL - EXPECTED_N8_EAR,
+        "n8_non_ear_ids": EXPECTED_N8_NON_EAR_IDS,
+        "n9_total": EXPECTED_N9_TOTAL,
+        "n9_ear_orderable": EXPECTED_N9_EAR,
+        "n9_non_ear_orderable": EXPECTED_N9_TOTAL - EXPECTED_N9_EAR,
+        "n9_non_ear_indices": EXPECTED_N9_NON_EAR_INDICES,
+        "n9_vertex_circle_status_counts": EXPECTED_N9_STATUS_COUNTS,
+        "n9_cross_tabulation": EXPECTED_CROSS_TAB,
+        "proof_mining_target_count": 6,
+    }
+
+
+def _n9_target(index: int, vertex_status: str = "strict_cycle") -> dict[str, object]:
+    return {
+        "target_id": f"n9-assignment-{index}",
+        "n": 9,
+        "vertex_circle_status": vertex_status,
+        "exact_obstructions": [
+            {
+                "method": f"vertex_circle_{vertex_status}",
+                "status": "EXACT_OBSTRUCTION_REVIEW_PENDING",
+            }
+        ],
+    }
+
+
+def test_bridge_frontier_rejects_n9_ok_as_exact_obstruction() -> None:
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "summary": _expected_summary(),
+        "proof_mining_targets": [_n9_target(index) for index in range(6)],
+    }
+    payload["proof_mining_targets"][0] = _n9_target(0, vertex_status="ok")
+
+    with pytest.raises(AssertionError, match="lacks exact vertex-circle obstruction"):
+        assert_expected_payload(payload)

--- a/tests/test_stuck_motif_search.py
+++ b/tests/test_stuck_motif_search.py
@@ -4,6 +4,7 @@ import pytest
 
 from erdos97.stuck_motif_search import (
     MotifSearchConfig,
+    _non_sat_status,
     mine_stuck_motif,
     search_result_to_json,
 )
@@ -65,3 +66,14 @@ def test_mine_stuck_motif_can_require_no_forward_ear_order() -> None:
 def test_motif_search_rejects_invalid_stuck_size() -> None:
     with pytest.raises(ValueError, match="stuck_size"):
         mine_stuck_motif(MotifSearchConfig(n=9, stuck_size=3))
+
+
+def test_motif_search_status_keeps_unknown_separate_from_unsat() -> None:
+    class FakeZ3:
+        sat = "sat"
+        unsat = "unsat"
+
+    assert _non_sat_status("sat", checked=0, z3_module=FakeZ3) is None
+    assert _non_sat_status("unsat", checked=0, z3_module=FakeZ3) == "UNSAT"
+    assert _non_sat_status("unsat", checked=3, z3_module=FakeZ3) == "EXHAUSTED"
+    assert _non_sat_status("unknown", checked=0, z3_module=FakeZ3) == "UNKNOWN"

--- a/tests/test_two_orbit_radius_propagation.py
+++ b/tests/test_two_orbit_radius_propagation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sympy as sp
 
 from erdos97.two_orbit_radius_propagation import (
+    _is_positive,
     alternating_decagon_crossing_search,
     alternating_two_radius_family_summary,
     alternating_two_radius_family_to_json,
@@ -34,6 +35,12 @@ def test_forced_ratio_violates_convexity_threshold() -> None:
         assert sp.N(summary.turn_at_b, 50) < 0
         assert sp.N(summary.turn_at_a, 50) > 0
         assert summary.forced_concave
+
+
+def test_exact_positivity_helper_does_not_use_numeric_fallback() -> None:
+    x = sp.Symbol("x", real=True)
+
+    assert _is_positive(x) is False
 
 
 def test_explicit_selected_distances_for_t2_are_exactly_equal() -> None:


### PR DESCRIPTION
## Summary

This PR hardens several exact-checking and review-pending diagnostic paths so they fail closed instead of silently accepting ambiguous states.

## What changed

- Reject n=9 bridge proof-mining targets whose vertex-circle status is not an exact obstruction (`self_edge` or `strict_cycle`).
- Prevent empty/vacuous checks from certifying n=7 class obstruction or exact distance equalities.
- Keep Z3 `unknown` separate from `unsat` in incidence and stuck-motif searches.
- Count `UNKNOWN` stuck-motif sweep results explicitly now that the search can surface that state.
- Remove numeric positivity fallback from exact two-orbit radius propagation checks.
- Replace one runtime-strippable artifact-validation `assert` cluster with explicit exceptions.
- Add focused regression tests for the new fail-closed behavior.

## Claim boundary

No mathematical claim is promoted. The global problem remains falsifiable/open, and the local finite-case claim scope remains unchanged.

## Local validation

Clean worktree based on `origin/main` plus this single commit:

- `python scripts/check_text_clean.py` — passed
- `python scripts/check_status_consistency.py` — passed
- `python scripts/check_artifact_provenance.py` — passed
- `git diff --check HEAD` — passed
- `python -m ruff check .` — passed
- `python -m pytest tests/test_soundness_guardrails.py tests/test_n7_fano.py tests/test_interval_verify.py tests/test_stuck_motif_search.py tests/test_stuck_motif_sweep.py tests/test_search_hygiene.py tests/test_two_orbit_radius_propagation.py -q` — 39 passed
- `python scripts/check_bridge_lemma_frontier.py --check --assert-expected` — passed
- `python scripts/check_two_orbit_radius_propagation.py --assert-expected --verify-all-rows` — passed
- `python scripts/check_two_orbit_radius_propagation.py --alternating-family --assert-alternating-family --m-max 12` — passed
- `python -m pytest -q` — 1091 passed, 306 deselected

## Notes

The main checkout had unrelated dirty research artifacts. This PR branch was rebuilt in a separate clean worktree from current `origin/main`, then the guardrail commit was cherry-picked so the compare contains exactly one commit and the intended file set.