### PR TITLE
[codex] Add n9 regular tournament Kalmanson audit

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -754,6 +754,17 @@ theorem, and the row-Ptolemy certificates are fixed supplied-order obstructions
 only. See `docs/n9-incidence-frontier.md` and
 `scripts/check_n9_incidence_frontier.py`.
 
+The exact no-reciprocal `n=9` regular-tournament audit in
+`scripts/check_n9_regular_tournament_kalmanson.py` enumerates all `3,230,080`
+labelled regular tournaments on cyclic labels `0,1,...,8`. In this subcase,
+every unordered pair is selected in exactly one direction. Substituting the row
+radius variables into strict Kalmanson inequalities gives a strongly connected
+strict-implication graph for every tournament, hence a strict cycle
+obstruction. This proves only that any `n=9` selected-witness candidate must
+have at least one reciprocal selected pair. It is not an `n=9` proof and does
+not promote the review-pending exhaustive vertex-circle checker. See
+`docs/n9-regular-tournament-kalmanson-audit.md`.
+
 ### Review-pending exhaustive n=9 vertex-circle check
 
 Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -335,6 +335,30 @@ The current replay kills the displayed `n=10` quotient-level survivor and one
 audit only; it is not an `n=10` exclusion and does not change the global
 problem status.
 
+### n=9 no-reciprocal regular-tournament obstruction
+
+Status: `EXACT_N9_NO_RECIPROCAL_SUBCASE_AUDIT`.
+
+For `n=9`, a selected-witness system with no reciprocal selected pair must
+select every unordered pair in exactly one direction: there are `9 * 4 = 36`
+directed selections and `binom(9,2) = 36` unordered pairs. Hence this subcase is
+exactly the labelled regular tournament subcase, with each row selecting four
+out-neighbors.
+
+The checker `scripts/check_n9_regular_tournament_kalmanson.py` enumerates all
+`3,230,080` labelled regular tournaments on cyclic labels `0,1,...,8`. For each
+tournament, it substitutes the selected row-radius variables into the strict
+Kalmanson inequalities for the fixed cyclic order and records every one-term
+cancellation as a strict implication `rho_a < rho_b`. Every enumerated
+tournament has a strongly connected implication graph, so in particular every
+one has a strict implication cycle and is impossible in a strict convex
+realization.
+
+This proves only that an `n=9` selected-witness candidate must contain at least
+one reciprocal selected pair. It is not an `n=9` proof, not a promotion of the
+review-pending exhaustive `n=9` vertex-circle checker, and not a global status
+update. See `docs/n9-regular-tournament-kalmanson-audit.md`.
+
 ### Diameter-lens local lemmas
 
 The proof note `docs/diameter-lens-local-lemmas.md` records four local facts

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,10 @@ put detailed reconciliation in the canonical synthesis.
   fixed-pattern audit extracting `K4-e` stretch relations and combining them
   with Kalmanson inequalities; kills only the displayed `n=10` quotient-level
   survivor and one diagnostic pattern, not an `n=10` exclusion.
+- [`n9-regular-tournament-kalmanson-audit.md`](n9-regular-tournament-kalmanson-audit.md):
+  exact fixed-order audit showing that every `n=9` selected-witness system with
+  no reciprocal selected pair is obstructed by strict Kalmanson implication
+  cycles; a subcase branch cut only, not an `n=9` proof.
 - [`ellipse-model-case.md`](ellipse-model-case.md): restricted exact lemma
   showing that finite point sets on a Euclidean ellipse cannot be
   counterexamples; a failed search family, not a global bridge.

--- a/docs/n9-regular-tournament-kalmanson-audit.md
+++ b/docs/n9-regular-tournament-kalmanson-audit.md
@@ -1,0 +1,86 @@
+# n=9 Regular-Tournament Kalmanson Audit
+
+Status: `EXACT_N9_NO_RECIPROCAL_SUBCASE_AUDIT`.
+
+This note records a narrow exact subcase audit for selected-witness systems on
+nine cyclically ordered labels. It does not prove `n=9`, does not prove Erdos
+Problem #97, and does not change the repository source-of-truth status. The
+review-pending exhaustive `n=9` vertex-circle checker remains the stronger
+finite-case artifact.
+
+Replay:
+
+```bash
+python scripts/check_n9_regular_tournament_kalmanson.py --assert-expected --json
+```
+
+The full replay enumerates `3,230,080` labelled regular tournaments and checks
+`252` strict Kalmanson inequalities per cyclic order.
+
+## Subcase
+
+Consider a selected-witness system on cyclic labels `0,1,...,8` in which no
+unordered pair is selected in both directions. Since each of the nine rows has
+four selected witnesses, there are `9 * 4 = 36` directed selections. This equals
+the number of unordered pairs `binom(9,2)`. Therefore every unordered pair is
+selected in exactly one direction, and the selected incidence data is exactly a
+labelled regular tournament: every vertex has outdegree `4`.
+
+For such a tournament, let `rho_i` denote the selected row radius at center
+`i`. If the unordered pair `{a,b}` is selected by `a`, then its ordinary
+distance is represented by `rho_a`; if it is selected by `b`, it is represented
+by `rho_b`.
+
+## Strict Kalmanson Implications
+
+For cyclic labels `i < j < k < l`, strict convexity gives the two strict
+Kalmanson inequalities
+
+```text
+d_ij + d_kl < d_ik + d_jl,
+d_il + d_jk < d_ik + d_jl.
+```
+
+After substituting row-radius variables from the tournament orientation, some
+inequalities have one equal row variable on both sides. Cancelling that common
+term gives a strict implication
+
+```text
+rho_a < rho_b.
+```
+
+The checker builds the directed implication graph on the nine row-radius
+variables. Any directed cycle is impossible, since it would imply
+`rho_i < rho_i` after summing strict inequalities.
+
+## Checked Result
+
+The replay reports:
+
+```json
+{
+  "acyclic_implication_failures": 0,
+  "checked_all": true,
+  "kalmanson_inequalities": 252,
+  "n": 9,
+  "status": "EXACT_N9_NO_RECIPROCAL_SUBCASE_AUDIT",
+  "strong_connectivity_failures": 0,
+  "target_outdegree": 4,
+  "total_regular_tournaments": 3230080
+}
+```
+
+In fact, every enumerated regular tournament has a strongly connected strict
+implication graph, which is stronger than merely having a directed cycle.
+
+Consequently, under the fixed cyclic order on the nine labels, every
+no-reciprocal selected-witness system is obstructed by strict Kalmanson
+inequalities. Equivalently, any genuine `n=9` selected-witness candidate must
+contain at least one reciprocal selected pair.
+
+## Scope
+
+This is not a full `n=9` obstruction. The reciprocal-pair cases remain outside
+this audit and require the existing selected-distance quotient,
+vertex-circle, same-distance clique, `K4-e`, or other exact filters. The result
+is best used as a cheap exact branch cut before heavier `n=9` frontier tools.

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -280,6 +280,16 @@ row. Both certificates are valid, but the earlier three-common-witness
 rejection means this pattern should be used as a template for certificate
 coverage, not as a survivor of all cheap filters.
 
+Follow-up exact audit: `scripts/check_n9_regular_tournament_kalmanson.py`
+widens the strict-Kalmanson check from this cyclic tournament to all
+`3,230,080` labelled regular tournaments on nine cyclic labels. Since a
+no-reciprocal `n=9` selected-witness system selects every unordered pair in
+exactly one direction, this closes the whole no-reciprocal subcase under the
+fixed cyclic order: every tournament has a strict Kalmanson implication cycle.
+This is still only a branch cut. The reciprocal-pair cases remain outside the
+audit and require the ordinary selected-distance quotient, vertex-circle,
+same-distance clique, `K4-e`, or related exact filters.
+
 Kalmanson-feasible but circle-impossible block pattern:
 
 Another useful `n=9` audit pattern shows why endpoint-poor branches need

--- a/scripts/check_n9_regular_tournament_kalmanson.py
+++ b/scripts/check_n9_regular_tournament_kalmanson.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Audit no-reciprocal n=9 selected-row patterns by strict Kalmanson implications."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable
+
+N = 9
+TARGET_OUTDEGREE = 4
+EXPECTED_REGULAR_TOURNAMENTS = 3_230_080
+
+Edge = tuple[int, int]
+Rows = tuple[tuple[int, ...], ...]
+
+
+def edge(i: int, j: int) -> Edge:
+    return (i, j) if i < j else (j, i)
+
+
+def build_edges(n: int = N) -> tuple[Edge, ...]:
+    return tuple((i, j) for i in range(n) for j in range(i + 1, n))
+
+
+EDGES = build_edges()
+EDGE_INDEX = {e: index for index, e in enumerate(EDGES)}
+
+
+def build_kalmanson_inequalities(n: int = N) -> tuple[tuple[int, int, int, int], ...]:
+    inequalities: list[tuple[int, int, int, int]] = []
+    for i, j, k, m in combinations(range(n), 4):
+        inequalities.append(
+            (
+                EDGE_INDEX[edge(i, j)],
+                EDGE_INDEX[edge(k, m)],
+                EDGE_INDEX[edge(i, k)],
+                EDGE_INDEX[edge(j, m)],
+            )
+        )
+        inequalities.append(
+            (
+                EDGE_INDEX[edge(i, m)],
+                EDGE_INDEX[edge(j, k)],
+                EDGE_INDEX[edge(i, k)],
+                EDGE_INDEX[edge(j, m)],
+            )
+        )
+    return tuple(inequalities)
+
+
+KALMANSON_INEQUALITIES = build_kalmanson_inequalities()
+
+
+def build_remaining_incidence(n: int = N) -> tuple[tuple[int, ...], ...]:
+    remaining: list[list[int]] = [[0] * n for _ in range(len(EDGES) + 1)]
+    for index in range(len(EDGES) - 1, -1, -1):
+        remaining[index][:] = remaining[index + 1][:]
+        u, v = EDGES[index]
+        remaining[index][u] += 1
+        remaining[index][v] += 1
+    return tuple(tuple(row) for row in remaining)
+
+
+REMAINING_INCIDENCE = build_remaining_incidence()
+
+
+def selected_rows_from_tails(tails: Iterable[int]) -> Rows:
+    rows: list[list[int]] = [[] for _ in range(N)]
+    for (u, v), tail in zip(EDGES, tails):
+        if tail == u:
+            rows[u].append(v)
+        elif tail == v:
+            rows[v].append(u)
+        else:
+            raise ValueError(f"tail {tail} is not incident to edge {(u, v)}")
+    return tuple(tuple(row) for row in rows)
+
+
+def tails_from_selected_rows(rows: Rows) -> tuple[int, ...]:
+    if len(rows) != N:
+        raise ValueError(f"expected {N} rows")
+    row_sets = [set(row) for row in rows]
+    tails: list[int] = []
+    for u, v in EDGES:
+        u_selects_v = v in row_sets[u]
+        v_selects_u = u in row_sets[v]
+        if u_selects_v == v_selects_u:
+            raise ValueError(f"edge {(u, v)} is not selected in exactly one direction")
+        tails.append(u if u_selects_v else v)
+    return tuple(tails)
+
+
+def add_implication(adj: list[int], source: int, target: int) -> None:
+    adj[source] |= 1 << target
+
+
+def strict_implication_graph(tails: tuple[int, ...]) -> tuple[int, ...]:
+    """Return row-variable implications forced by one-term Kalmanson cancellation."""
+
+    adj = [0] * N
+    for left_a, left_b, right_a, right_b in KALMANSON_INEQUALITIES:
+        la = tails[left_a]
+        lb = tails[left_b]
+        ra = tails[right_a]
+        rb = tails[right_b]
+        if la == ra:
+            add_implication(adj, lb, rb)
+        if la == rb:
+            add_implication(adj, lb, ra)
+        if lb == ra:
+            add_implication(adj, la, rb)
+        if lb == rb:
+            add_implication(adj, la, ra)
+    return tuple(adj)
+
+
+def transitive_closure(adj: tuple[int, ...], *, include_self: bool = True) -> tuple[int, ...]:
+    reach = [
+        row | ((1 << index) if include_self else 0)
+        for index, row in enumerate(adj)
+    ]
+    for k in range(N):
+        bit = 1 << k
+        kth = reach[k]
+        for i in range(N):
+            if reach[i] & bit:
+                reach[i] |= kth
+    return tuple(reach)
+
+
+def is_strongly_connected(adj: tuple[int, ...]) -> bool:
+    all_mask = (1 << N) - 1
+    return all(row == all_mask for row in transitive_closure(adj))
+
+
+def has_strict_cycle(adj: tuple[int, ...]) -> bool:
+    closure = transitive_closure(adj, include_self=False)
+    return any(closure[index] & (1 << index) for index in range(N))
+
+
+@dataclass(frozen=True)
+class RegularTournamentAudit:
+    total_regular_tournaments: int
+    strong_connectivity_failures: int
+    acyclic_implication_failures: int
+    first_strong_failure_rows: Rows | None
+    first_acyclic_failure_rows: Rows | None
+    checked_all: bool
+
+
+def audit_regular_tournaments(limit: int | None = None) -> RegularTournamentAudit:
+    tails = [-1] * len(EDGES)
+    outdegree = [0] * N
+    total = 0
+    strong_failures = 0
+    acyclic_failures = 0
+    first_strong_failure: Rows | None = None
+    first_acyclic_failure: Rows | None = None
+
+    def feasible(next_index: int) -> bool:
+        remaining = REMAINING_INCIDENCE[next_index]
+        for vertex in range(N):
+            degree = outdegree[vertex]
+            if degree > TARGET_OUTDEGREE:
+                return False
+            if degree + remaining[vertex] < TARGET_OUTDEGREE:
+                return False
+        return True
+
+    def recurse(index: int) -> None:
+        nonlocal total, strong_failures, acyclic_failures
+        nonlocal first_strong_failure, first_acyclic_failure
+
+        if limit is not None and total >= limit:
+            return
+        if index == len(EDGES):
+            total += 1
+            frozen_tails = tuple(tails)
+            adj = strict_implication_graph(frozen_tails)
+            rows = None
+            if not is_strongly_connected(adj):
+                strong_failures += 1
+                if first_strong_failure is None:
+                    rows = selected_rows_from_tails(frozen_tails)
+                    first_strong_failure = rows
+            if not has_strict_cycle(adj):
+                acyclic_failures += 1
+                if first_acyclic_failure is None:
+                    if rows is None:
+                        rows = selected_rows_from_tails(frozen_tails)
+                    first_acyclic_failure = rows
+            return
+
+        u, v = EDGES[index]
+
+        tails[index] = u
+        outdegree[u] += 1
+        if feasible(index + 1):
+            recurse(index + 1)
+        outdegree[u] -= 1
+
+        tails[index] = v
+        outdegree[v] += 1
+        if feasible(index + 1):
+            recurse(index + 1)
+        outdegree[v] -= 1
+
+        tails[index] = -1
+
+    recurse(0)
+    return RegularTournamentAudit(
+        total_regular_tournaments=total,
+        strong_connectivity_failures=strong_failures,
+        acyclic_implication_failures=acyclic_failures,
+        first_strong_failure_rows=first_strong_failure,
+        first_acyclic_failure_rows=first_acyclic_failure,
+        checked_all=limit is None or total < limit,
+    )
+
+
+def rows_json(rows: Rows | None) -> list[list[int]] | None:
+    if rows is None:
+        return None
+    return [list(row) for row in rows]
+
+
+def audit_json(audit: RegularTournamentAudit) -> dict[str, object]:
+    return {
+        "status": "EXACT_N9_NO_RECIPROCAL_SUBCASE_AUDIT",
+        "claim_scope": (
+            "For n=9 selected-witness systems with no reciprocal selected pair, "
+            "the selected graph is a labelled regular tournament. This audit "
+            "checks those tournament patterns only under the fixed cyclic order."
+        ),
+        "n": N,
+        "target_outdegree": TARGET_OUTDEGREE,
+        "kalmanson_inequalities": len(KALMANSON_INEQUALITIES),
+        "total_regular_tournaments": audit.total_regular_tournaments,
+        "strong_connectivity_failures": audit.strong_connectivity_failures,
+        "acyclic_implication_failures": audit.acyclic_implication_failures,
+        "first_strong_failure_rows": rows_json(audit.first_strong_failure_rows),
+        "first_acyclic_failure_rows": rows_json(audit.first_acyclic_failure_rows),
+        "checked_all": audit.checked_all,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    audit = audit_regular_tournaments(limit=args.limit)
+    if args.assert_expected:
+        if args.limit is not None:
+            raise AssertionError("--assert-expected requires a full audit without --limit")
+        if audit.total_regular_tournaments != EXPECTED_REGULAR_TOURNAMENTS:
+            raise AssertionError(
+                f"expected {EXPECTED_REGULAR_TOURNAMENTS} regular tournaments, "
+                f"got {audit.total_regular_tournaments}"
+            )
+        if audit.strong_connectivity_failures != 0:
+            raise AssertionError("expected zero strong-connectivity failures")
+        if audit.acyclic_implication_failures != 0:
+            raise AssertionError("expected zero acyclic-implication failures")
+
+    if args.json:
+        print(json.dumps(audit_json(audit), indent=2, sort_keys=True))
+    else:
+        print("n=9 regular-tournament Kalmanson audit")
+        print(f"regular tournaments checked: {audit.total_regular_tournaments}")
+        print(f"Kalmanson inequalities per order: {len(KALMANSON_INEQUALITIES)}")
+        print(f"strong-connectivity failures: {audit.strong_connectivity_failures}")
+        print(f"acyclic-implication failures: {audit.acyclic_implication_failures}")
+        if args.assert_expected:
+            print("OK: all no-reciprocal n=9 regular tournaments are Kalmanson-obstructed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_n9_regular_tournament_kalmanson.py
+++ b/tests/test_n9_regular_tournament_kalmanson.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.check_n9_regular_tournament_kalmanson import (
+    N,
+    audit_regular_tournaments,
+    has_strict_cycle,
+    is_strongly_connected,
+    strict_implication_graph,
+    tails_from_selected_rows,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cyclic_regular_tournament_has_kalmanson_cycle() -> None:
+    rows = tuple(
+        tuple((center + step) % N for step in (1, 2, 3, 4))
+        for center in range(N)
+    )
+    tails = tails_from_selected_rows(rows)
+    graph = strict_implication_graph(tails)
+
+    assert has_strict_cycle(graph)
+    assert is_strongly_connected(graph)
+
+
+def test_limited_regular_tournament_audit() -> None:
+    audit = audit_regular_tournaments(limit=250)
+
+    assert audit.total_regular_tournaments == 250
+    assert audit.strong_connectivity_failures == 0
+    assert audit.acyclic_implication_failures == 0
+    assert audit.first_strong_failure_rows is None
+    assert audit.first_acyclic_failure_rows is None
+    assert audit.checked_all is False
+
+
+def test_regular_tournament_audit_cli_limited_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_regular_tournament_kalmanson.py",
+            "--limit",
+            "25",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert '"total_regular_tournaments": 25' in result.stdout
+    assert '"strong_connectivity_failures": 0' in result.stdout
+    assert '"acyclic_implication_failures": 0' in result.stdout


### PR DESCRIPTION
## Summary

- Adds `scripts/check_n9_regular_tournament_kalmanson.py`, an exact checker for the `n=9` no-reciprocal selected-witness subcase.
- Documents the subcase in `docs/n9-regular-tournament-kalmanson-audit.md` and links it from the claims/results/index/research-direction ledgers.
- Adds focused tests for the cyclic regular tournament, limited enumeration, and JSON CLI output.

## Result

The checker enumerates all `3,230,080` labelled regular tournaments on cyclic labels `0,1,...,8`. For each one, strict Kalmanson inequalities produce a row-radius implication graph with a strict cycle; in fact every graph is strongly connected.

## Non-overclaiming note

This is only an exact branch cut for the no-reciprocal `n=9` subcase. It does not prove `n=9`, does not prove Erdos Problem #97, does not produce a counterexample, and does not promote the review-pending exhaustive `n=9` vertex-circle checker.

## Verification

- `python scripts/check_text_clean.py` -> passed
- `python scripts/check_status_consistency.py` -> passed
- `python scripts/check_artifact_provenance.py` -> passed
- `git diff --check` -> passed
- `python -m ruff check .` -> passed
- `python scripts/check_n9_regular_tournament_kalmanson.py --assert-expected --json` -> `total_regular_tournaments=3230080`, `strong_connectivity_failures=0`, `acyclic_implication_failures=0`
- `python -m pytest -q` -> `1098 passed, 306 deselected`

## Follow-up tasks

- Use this as a cheap prefilter before heavier `n=9` reciprocal-pair search branches.
- Continue proof-mining in the reciprocal selected-pair cases using selected-distance quotient, vertex-circle, same-distance clique, `K4-e`, and related exact filters.