### PR TITLE
[codex] Harden T10 strict-cycle packet

### DIFF
--- a/data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
+++ b/data/certificates/n9_vertex_circle_t10_strict_cycle_lemma_packet.json
@@ -276,6 +276,62 @@
         "cycle_closure_statement": "Each strict edge's inner pair is identified with the next strict edge's outer pair, closing a directed two-edge strict cycle in the selected-distance quotient.",
         "hypothesis_scope": "Natural cyclic order on labels 0..8 plus the four listed selected rows; no claim is made about other n=9 templates.",
         "packet_name": "T10/F12 strict-cycle local lemma packet",
+        "quotient_cycle_classes": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            0,
+            1
+          ]
+        ],
+        "quotient_strict_edges": [
+          {
+            "cycle_step": 0,
+            "from_class": [
+              0,
+              1
+            ],
+            "raw_inner_pair": [
+              0,
+              3
+            ],
+            "raw_outer_pair": [
+              0,
+              6
+            ],
+            "row": 8,
+            "to_class": [
+              0,
+              3
+            ]
+          },
+          {
+            "cycle_step": 1,
+            "from_class": [
+              0,
+              3
+            ],
+            "raw_inner_pair": [
+              0,
+              1
+            ],
+            "raw_outer_pair": [
+              1,
+              6
+            ],
+            "row": 3,
+            "to_class": [
+              0,
+              1
+            ]
+          }
+        ],
         "review_status": "review_pending",
         "selected_distance_equalities": [
           {
@@ -319,6 +375,44 @@
                 ],
                 "row": 0
               }
+            ]
+          }
+        ],
+        "selected_row_hypotheses": [
+          {
+            "center": 0,
+            "witnesses": [
+              1,
+              2,
+              5,
+              6
+            ]
+          },
+          {
+            "center": 3,
+            "witnesses": [
+              0,
+              1,
+              4,
+              6
+            ]
+          },
+          {
+            "center": 6,
+            "witnesses": [
+              1,
+              3,
+              4,
+              7
+            ]
+          },
+          {
+            "center": 8,
+            "witnesses": [
+              0,
+              3,
+              6,
+              7
             ]
           }
         ],

--- a/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
@@ -116,6 +116,13 @@ The two quotient inequalities (2) and (4) form the directed strict cycle
 [0,6] > [1,6] > [0,6].
 ```
 
+Using the packet's canonical selected-distance quotient representatives, this
+is the two-class cycle:
+
+```text
+[0,1] > [0,3] > [0,1].
+```
+
 Equivalently, after quotienting ordinary pair distances by the selected-row
 equalities, the strict quotient graph has a directed two-edge cycle. No
 Euclidean strictly convex realization satisfying the stated local hypotheses

--- a/scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+++ b/scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
@@ -206,6 +206,38 @@ def _family_packets_by_id(payload: dict[str, Any], errors: list[str]) -> dict[st
     return {family_id: by_id[family_id] for family_id in EXPECTED_FAMILY_IDS if family_id in by_id}
 
 
+def _expected_selected_row_hypotheses() -> list[dict[str, Any]]:
+    return [
+        {
+            "center": int(row[0]),
+            "witnesses": [int(value) for value in row[1:]],
+        }
+        for row in EXPECTED_CORE_SELECTED_ROWS
+    ]
+
+
+def _expected_quotient_strict_edges() -> list[dict[str, Any]]:
+    return [
+        {
+            "cycle_step": index,
+            "row": int(step["strict_inequality"]["row"]),
+            "raw_outer_pair": step["strict_inequality"]["outer_pair"],
+            "raw_inner_pair": step["strict_inequality"]["inner_pair"],
+            "from_class": step["strict_inequality"]["outer_class"],
+            "to_class": step["strict_inequality"]["inner_class"],
+        }
+        for index, step in enumerate(EXPECTED_CYCLE_STEPS)
+    ]
+
+
+def _expected_quotient_cycle_classes() -> list[list[int]]:
+    cycle = [list(EXPECTED_CYCLE_STEPS[0]["strict_inequality"]["outer_class"])]
+    cycle.extend(
+        list(step["strict_inequality"]["inner_class"]) for step in EXPECTED_CYCLE_STEPS
+    )
+    return cycle
+
+
 def _validate_local_lemma(packet: dict[str, Any], errors: list[str]) -> None:
     lemma = packet.get("local_lemma")
     if not isinstance(lemma, dict):
@@ -249,6 +281,24 @@ def _validate_local_lemma(packet: dict[str, Any], errors: list[str]) -> None:
         errors.append("F12 local_lemma contradiction must mention a directed strict cycle")
     if "reflexive strict edge" in contradiction or "self-edge" in contradiction:
         errors.append("F12 local_lemma contradiction must not describe a self-edge")
+    expect_equal(
+        errors,
+        "F12 local_lemma selected_row_hypotheses",
+        lemma.get("selected_row_hypotheses"),
+        _expected_selected_row_hypotheses(),
+    )
+    expect_equal(
+        errors,
+        "F12 local_lemma quotient_strict_edges",
+        lemma.get("quotient_strict_edges"),
+        _expected_quotient_strict_edges(),
+    )
+    expect_equal(
+        errors,
+        "F12 local_lemma quotient_cycle_classes",
+        lemma.get("quotient_cycle_classes"),
+        _expected_quotient_cycle_classes(),
+    )
 
 
 def _expected_cycle_pair_chain(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/erdos97/n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+++ b/src/erdos97/n9_vertex_circle_t10_strict_cycle_lemma_packet.py
@@ -481,7 +481,40 @@ def _cycle_pair_chain(steps: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
-def _family_local_lemma(steps: Sequence[dict[str, Any]]) -> dict[str, Any]:
+def _selected_row_hypotheses(rows: Sequence[Sequence[int]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "center": int(row[0]),
+            "witnesses": [int(value) for value in row[1:]],
+        }
+        for row in rows
+    ]
+
+
+def _quotient_strict_edges(steps: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "cycle_step": index,
+            "row": int(step["strict_inequality"]["row"]),
+            "raw_outer_pair": step["strict_inequality"]["outer_pair"],
+            "raw_inner_pair": step["strict_inequality"]["inner_pair"],
+            "from_class": step["strict_inequality"]["outer_class"],
+            "to_class": step["strict_inequality"]["inner_class"],
+        }
+        for index, step in enumerate(steps)
+    ]
+
+
+def _quotient_cycle_classes(steps: Sequence[dict[str, Any]]) -> list[list[int]]:
+    cycle = [list(steps[0]["strict_inequality"]["outer_class"])]
+    cycle.extend(list(step["strict_inequality"]["inner_class"]) for step in steps)
+    return cycle
+
+
+def _family_local_lemma(
+    rows: Sequence[Sequence[int]],
+    steps: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
     return {
         "packet_name": "T10/F12 strict-cycle local lemma packet",
         "review_status": "review_pending",
@@ -489,6 +522,7 @@ def _family_local_lemma(steps: Sequence[dict[str, Any]]) -> dict[str, Any]:
             "Natural cyclic order on labels 0..8 plus the four listed selected "
             "rows; no claim is made about other n=9 templates."
         ),
+        "selected_row_hypotheses": _selected_row_hypotheses(rows),
         "strict_inequality_statements": [
             (
                 f"Step {index}: row {step['strict_inequality']['row']} has "
@@ -505,6 +539,8 @@ def _family_local_lemma(steps: Sequence[dict[str, Any]]) -> dict[str, Any]:
             }
             for index, step in enumerate(steps)
         ],
+        "quotient_strict_edges": _quotient_strict_edges(steps),
+        "quotient_cycle_classes": _quotient_cycle_classes(steps),
         "cycle_closure_statement": (
             "Each strict edge's inner pair is identified with the next strict "
             "edge's outer pair, closing a directed two-edge strict cycle in the "
@@ -555,7 +591,7 @@ def _family_packet(family: dict[str, Any]) -> dict[str, Any]:
         "core_selected_rows": rows,
         "cycle_steps": steps,
         "cycle_pair_chain": _cycle_pair_chain(steps),
-        "local_lemma": _family_local_lemma(steps),
+        "local_lemma": _family_local_lemma(rows, steps),
         "replay": {
             "status": replay["status"],
             "selected_row_count": replay["selected_row_count"],
@@ -702,6 +738,9 @@ def assert_expected_t10_strict_cycle_lemma_packet(payload: Mapping[str, Any]) ->
     expected_pair_chain = _cycle_pair_chain(EXPECTED_CYCLE_STEPS)
     if packet["cycle_pair_chain"] != expected_pair_chain:
         raise AssertionError("F12 cycle pair chain mismatch")
+    expected_selected_rows = _selected_row_hypotheses(EXPECTED_CORE_SELECTED_ROWS)
+    expected_quotient_edges = _quotient_strict_edges(EXPECTED_CYCLE_STEPS)
+    expected_quotient_cycle = _quotient_cycle_classes(EXPECTED_CYCLE_STEPS)
 
     replay = packet["replay"]
     if replay["status"] != "strict_cycle":
@@ -746,6 +785,12 @@ def assert_expected_t10_strict_cycle_lemma_packet(payload: Mapping[str, Any]) ->
         raise AssertionError("F12 local lemma must describe a directed strict cycle")
     if "reflexive strict edge" in contradiction or "self-edge" in contradiction:
         raise AssertionError("F12 local lemma must not describe a self-edge conflict")
+    if lemma["selected_row_hypotheses"] != expected_selected_rows:
+        raise AssertionError("F12 local lemma selected rows mismatch")
+    if lemma["quotient_strict_edges"] != expected_quotient_edges:
+        raise AssertionError("F12 local lemma quotient strict edges mismatch")
+    if lemma["quotient_cycle_classes"] != expected_quotient_cycle:
+        raise AssertionError("F12 local lemma quotient cycle mismatch")
 
     if "No proof of the n=9 case is claimed." not in payload.get("interpretation", []):
         raise AssertionError("interpretation must preserve the no-proof statement")

--- a/tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
+++ b/tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py
@@ -98,6 +98,35 @@ def test_t10_strict_cycle_lemma_packet_records_expected_directed_cycle() -> None
     ]
     assert packet["local_lemma"]["review_status"] == "review_pending"  # type: ignore[index]
     assert "four listed selected rows" in packet["local_lemma"]["hypothesis_scope"]  # type: ignore[index]
+    assert packet["local_lemma"]["selected_row_hypotheses"] == [  # type: ignore[index]
+        {"center": 0, "witnesses": [1, 2, 5, 6]},
+        {"center": 3, "witnesses": [0, 1, 4, 6]},
+        {"center": 6, "witnesses": [1, 3, 4, 7]},
+        {"center": 8, "witnesses": [0, 3, 6, 7]},
+    ]
+    assert packet["local_lemma"]["quotient_strict_edges"] == [  # type: ignore[index]
+        {
+            "cycle_step": 0,
+            "row": 8,
+            "raw_outer_pair": [0, 6],
+            "raw_inner_pair": [0, 3],
+            "from_class": [0, 1],
+            "to_class": [0, 3],
+        },
+        {
+            "cycle_step": 1,
+            "row": 3,
+            "raw_outer_pair": [1, 6],
+            "raw_inner_pair": [0, 1],
+            "from_class": [0, 3],
+            "to_class": [0, 1],
+        },
+    ]
+    assert packet["local_lemma"]["quotient_cycle_classes"] == [  # type: ignore[index]
+        [0, 1],
+        [0, 3],
+        [0, 1],
+    ]
     assert "directed strict cycle" in packet["local_lemma"]["contradiction"]  # type: ignore[index]
     assert "self-edge" not in packet["local_lemma"]["contradiction"]  # type: ignore[index]
     assert packet["replay"]["status"] == "strict_cycle"  # type: ignore[index]
@@ -212,6 +241,16 @@ def test_t10_strict_cycle_lemma_packet_rejects_self_edge_copy_error() -> None:
 
     assert any("must mention a directed strict cycle" in error for error in errors)
     assert any("must not include primary_self_edge_conflict" in error for error in errors)
+
+
+def test_t10_strict_cycle_lemma_packet_rejects_tampered_quotient_cycle() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    packet = _f12(payload)
+    packet["local_lemma"]["quotient_cycle_classes"][1] = [1, 6]  # type: ignore[index]
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("quotient_cycle_classes mismatch" in error for error in errors)
 
 
 def test_t10_strict_cycle_lemma_packet_rejects_missing_family() -> None:


### PR DESCRIPTION
## Summary
- Add explicit selected-row hypotheses, quotient strict edges, and quotient-cycle classes to the T10/F12 strict-cycle local lemma packet.
- Regenerate the T10 packet artifact and update its checker/tests to validate the new proof-facing fields.
- Note the canonical two-class quotient cycle in the T10 local lemma documentation.

## Scope
This remains a review-pending local lemma candidate. It does not promote the n=9 exhaustive checker, claim a counterexample, or update the global Erdos #97 status.

## Validation
- `python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py -q`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`