### PR TITLE
docs: add turn-packing bridge note

### DIFF
--- a/docs/n9-turn-inequality-frontier.md
+++ b/docs/n9-turn-inequality-frontier.md
@@ -5,7 +5,9 @@ Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.
 This note records a replayable check of the latest GPT Pro n=9 route. It is
 not a proof of Erdos Problem #97, not a counterexample, not an official/global
 status update, and not an independently reviewed theorem. The geometric turn
-lemma below is the review bottleneck.
+lemma below is the review bottleneck. See `docs/turn-inequality-lemma.md` for
+the proof-facing lemma note and `docs/turn-packing-bridge.md` for the
+review-pending certificate principle extracted from the replay.
 
 ## Scope
 

--- a/docs/turn-inequality-lemma.md
+++ b/docs/turn-inequality-lemma.md
@@ -94,16 +94,27 @@ nonnegative, forcing `u.v >= 0`, contradiction.
 Therefore the turn along that arc is strictly greater than `pi/2`, proving the
 first inequality.
 
-For the second inequality, apply the same argument to the opposite arc from
+For the second inequality, apply the same dot-product argument to the arc from
 `p_{i+a}` back to `p_i`, using
 
 ```text
-u' = p_i - p_{i+a},
-v' = p_{i+b} - p_i.
+u' = p_{i+b} - p_{i+a},
+v' = p_i - p_{i+b}.
 ```
 
-Again `|u'+v'| = |u'|`, so the total turn along the complementary arc must
-exceed `pi/2`.
+Now `|v'| = |p_i - p_{i+b}| = |p_i - p_{i+a}| = |u' + v'|`. Squaring and
+cancelling gives
+
+```text
+2 u'.v' + |u'|^2 = 0,
+```
+
+so `u'.v' < 0`. Here `u'` is the positive sum of edge vectors on the arc from
+`p_{i+a}` to `p_{i+b}`, and `v'` is the positive sum of edge vectors on the arc
+from `p_{i+b}` to `p_i`. If the complementary arc from `p_{i+a}` back to `p_i`
+had total exterior turn at most `pi/2`, those edge directions would lie in a
+closed cone of angle at most `pi/2`, again forcing all cross dot products
+nonnegative. This contradiction proves the second inequality.
 
 ## Review Points
 

--- a/docs/turn-packing-bridge.md
+++ b/docs/turn-packing-bridge.md
@@ -1,0 +1,83 @@
+# Turn-Packing Bridge
+
+Status: review-pending bridge packet; not a proof of Erdos Problem #97.
+
+This note extracts the certificate principle behind
+`docs/n9-turn-inequality-frontier.md`. It should be read together with
+`docs/turn-inequality-lemma.md`.
+
+## Setup
+
+Let `P = (p_0,...,p_{n-1})` be a strictly convex polygon in cyclic order. Write
+`tau_i > 0` for its exterior turns and normalize
+
+```text
+t_i = 2*tau_i/pi.
+```
+
+Then
+
+```text
+t_i > 0,
+sum_i t_i = 4.
+```
+
+For a selected row at center `i`, every selected pair with offsets
+`1 <= a < b <= n-1` and equal center distance gives the weak turn inequalities
+
+```text
+sum_{h=1}^{b-1} t_{i+h} >= 1
+sum_{h=a+1}^{n-1} t_{i+h} >= 1,
+```
+
+with indices read modulo `n`. These are weaker than the strict inequalities
+given by the geometric turn lemma.
+
+## Certificate Lemma
+
+Consider any selected-witness incidence system and cyclic order. Suppose there
+is a multiset `I_1,...,I_m` of turn intervals forced by the selected equalities
+and a positive integer `lambda` such that:
+
+```text
+m > 4*lambda,
+each turn variable t_j lies in at most lambda of the intervals I_s.
+```
+
+Then no strictly convex realization can have those selected equal-distance
+rows in that cyclic order.
+
+Proof. Summing the forced weak inequalities gives
+
+```text
+sum_s sum_{j in I_s} t_j >= m > 4*lambda.
+```
+
+But each `t_j` appears at most `lambda` times, so nonnegativity and
+`sum_j t_j = 4` give
+
+```text
+sum_s sum_{j in I_s} t_j <= lambda * sum_j t_j = 4*lambda,
+```
+
+a contradiction.
+
+## Current Evidence
+
+The replay command
+
+```bash
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+```
+
+checks the stored `n=9` frontier artifact. It regenerates the 184 complete
+selected-witness assignments surviving the pair/crossing/count filters before
+vertex-circle pruning and verifies one integer turn-packing certificate for
+each assignment. The replay is arithmetic after the stored interval choices:
+180 certificates use `lambda = 1` and five intervals; 4 use `lambda = 2` and
+nine intervals.
+
+This is review-pending finite-case evidence only. It does not promote the
+repo source-of-truth status, and it does not imply a general theorem without a
+bridge proving that arbitrary counterexamples reduce to turn-packing-obstructed
+selected systems.


### PR DESCRIPTION
## Summary

- add a review-pending turn-packing bridge note for the n=9 frontier replay
- correct the second-arc dot-product setup in the turn-inequality lemma note
- link the bridge note from the existing n=9 frontier replay note
- preserve the repo status boundary: this is not a proof of Erdos #97 and not a counterexample claim

## Local validation

- `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json` passed; replayed 184 assignments, all unsat, certificate hash `1aed1b1f78178b967f93a3894e67cf9a0c314441a94423c8f24f2e0b8cb9bf89`
- `python -m pytest tests/test_n9_turn_inequality_frontier.py -q` passed: 4 passed
- `python scripts/check_text_clean.py` passed
- `python scripts/check_status_consistency.py` passed
- `python scripts/check_artifact_provenance.py` passed
- `git diff --check` passed
- `python -m ruff check .` passed
- `python -m pytest -q` passed: 1095 passed, 306 deselected
- after the cross-reference amend, affected doc checks were rerun: `check_text_clean.py`, `check_status_consistency.py`, `check_artifact_provenance.py`, and `git diff --check` all passed

## Review notes

This PR is intentionally documentation-only. The new bridge note states a finite certificate principle and records current review-pending evidence, but does not promote source-of-truth status or claim a general theorem.