### PR TITLE
Add n10 mixed rich support capacity diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_block6_oriented_block_reversal_closure.py --check --assert-expected --json
 
 verify-n10-review:
+	$(PYTHON) scripts/check_n10_mixed_rich_support_capacity.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_singleton_input_audit.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -959,6 +959,18 @@ complete n=10 search, not a proof of `n=10`, and not a counterexample. See
 `docs/n10-turn-row0-pilot.md` and
 `docs/n10-turn-row0-escape-self-edges.md`.
 
+The generator-independent `n=10` mixed rich-support capacity diagnostic in
+`data/certificates/n10_mixed_rich_support_capacity.json` applies only
+support-level necessary filters: row-pair cap, two-overlap crossing, and
+witness-pair capacity. It checks all dihedral center-set representatives with
+`q=3,...,7` size-five supports and finds no complete assignments; a direct
+`q=2` witness shows this is sharp for those filters alone. Thus this
+abstraction leaves at most two size-five supports, or at least eight
+exact-four-only centers, in any surviving `n=10` support assignment. This is
+finite support bookkeeping only, not a proof of `n=10`, not a proof of Erdos
+Problem #97, and not a counterexample. See
+`docs/n10-mixed-rich-support-capacity.md`.
+
 The row-circle Ptolemy diagnostic in
 `docs/row-circle-ptolemy-nlp.md` adds the Ptolemy equality forced by each
 selected witness quadruple being concyclic around its center. It numerically

--- a/STATE.md
+++ b/STATE.md
@@ -630,6 +630,15 @@ not a proof of `n=10`, not a complete `n=10` search, and not a counterexample.
 See `docs/n10-turn-row0-pilot.md` and
 `docs/n10-turn-row0-escape-self-edges.md`.
 
+The `n=10` mixed rich-support capacity diagnostic is now recorded as
+review-pending finite support bookkeeping. Under only row-pair cap,
+two-overlap crossing, and witness-pair capacity filters, all support
+assignments with `q=3,...,7` size-five supports are obstructed; a direct `q=2`
+witness remains, so the bound is sharp for these filters. This says only that
+surviving four/five support assignments have at most two size-five supports.
+It does not prove `n=10`, does not close `q=0,1,2`, and does not change the
+global status. See `docs/n10-mixed-rich-support-capacity.md`.
+
 ## Best saved near-miss
 
 The best saved near-miss is still the historical `B12_3x4_danzer_lift`

--- a/data/certificates/n10_mixed_rich_support_capacity.json
+++ b/data/certificates/n10_mixed_rich_support_capacity.json
@@ -1,0 +1,257 @@
+{
+  "claim_scope": "Generator-independent n=10 four/five support-capacity diagnostic. It checks all dihedral center-set representatives with q=3..7 size-five supports and finds no full assignments under the row-pair cap, two-overlap crossing rule, and witness-pair capacity. A direct q=2 witness shows the bound is sharp for these filters. This does not prove n=10, does not prove Erdos Problem #97, and is not a counterexample.",
+  "filters": [
+    {
+      "meaning": "Two distinct distance circles can share at most two witness vertices.",
+      "name": "row_pair_cap"
+    },
+    {
+      "meaning": "When two centers share exactly two witnesses in their rich classes, the center chord and shared-witness chord must cross in the cyclic order.",
+      "name": "two_overlap_crossing"
+    },
+    {
+      "meaning": "Any unordered witness pair can occur together in rich classes at at most two centers, since all such centers lie on one perpendicular-bisector line.",
+      "name": "witness_pair_capacity"
+    }
+  ],
+  "interpretation_warnings": [
+    "This is a necessary support-catalogue diagnostic only.",
+    "It does not replay vertex-circle, Kalmanson, or Euclidean realizability filters.",
+    "It leaves the q=0, q=1, and q=2 four/five support cases open to stronger filters.",
+    "No n=10 theorem, general proof, or counterexample is claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_n10_mixed_rich_support_capacity.py --write --assert-expected",
+    "generator": "scripts/check_n10_mixed_rich_support_capacity.py",
+    "sources": [
+      "docs/claims.md#n9-mixed-rich-support-reduction",
+      "docs/review-priorities.md#priority-6b---audit-the-n10-singleton-slice-draft",
+      "docs/codex-backlog.md#recommended-next-technical-prs"
+    ]
+  },
+  "q2_witness": {
+    "0": [
+      1,
+      2,
+      3,
+      7,
+      9
+    ],
+    "1": [
+      0,
+      2,
+      4,
+      6,
+      8
+    ],
+    "2": [
+      1,
+      3,
+      5,
+      8
+    ],
+    "3": [
+      2,
+      4,
+      5,
+      9
+    ],
+    "4": [
+      0,
+      3,
+      5,
+      7
+    ],
+    "5": [
+      1,
+      4,
+      6,
+      7
+    ],
+    "6": [
+      2,
+      5,
+      7,
+      8
+    ],
+    "7": [
+      3,
+      6,
+      8,
+      9
+    ],
+    "8": [
+      0,
+      4,
+      7,
+      9
+    ],
+    "9": [
+      0,
+      1,
+      5,
+      6
+    ]
+  },
+  "schema": "erdos97.n10_mixed_rich_support_capacity.v1",
+  "status": "N10_MIXED_RICH_SUPPORT_CAPACITY_ONLY",
+  "summary": {
+    "debug_max_nodes": null,
+    "max_size_five_centers_surviving_filters": 2,
+    "min_exact_four_only_centers_in_any_counterexample_candidate": 8,
+    "n": 10,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "pair_budget_max_size_five_centers": 7,
+    "q2_witness_support_size_counts": {
+      "4": 8,
+      "5": 2
+    },
+    "q2_witness_valid": true,
+    "q_summaries": {
+      "3": {
+        "aborted_count": 0,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 8,
+        "raw_center_subset_count": 120,
+        "representatives_checked": 8,
+        "total_dead_end_count": 96385,
+        "total_nodes_visited": 133778,
+        "worst_representative": {
+          "aborted": false,
+          "dead_end_count": 25570,
+          "found": false,
+          "max_depth": 8,
+          "nodes_visited": 34613,
+          "size_five_centers": [
+            0,
+            3,
+            6
+          ]
+        }
+      },
+      "4": {
+        "aborted_count": 0,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 5,
+        "raw_center_subset_count": 210,
+        "representatives_checked": 16,
+        "total_dead_end_count": 57651,
+        "total_nodes_visited": 68540,
+        "worst_representative": {
+          "aborted": false,
+          "dead_end_count": 8189,
+          "found": false,
+          "max_depth": 5,
+          "nodes_visited": 10447,
+          "size_five_centers": [
+            0,
+            2,
+            5,
+            7
+          ]
+        }
+      },
+      "5": {
+        "aborted_count": 0,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 4,
+        "raw_center_subset_count": 252,
+        "representatives_checked": 16,
+        "total_dead_end_count": 33423,
+        "total_nodes_visited": 36894,
+        "worst_representative": {
+          "aborted": false,
+          "dead_end_count": 4387,
+          "found": false,
+          "max_depth": 4,
+          "nodes_visited": 5214,
+          "size_five_centers": [
+            0,
+            2,
+            4,
+            6,
+            8
+          ]
+        }
+      },
+      "6": {
+        "aborted_count": 0,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 2,
+        "raw_center_subset_count": 210,
+        "representatives_checked": 16,
+        "total_dead_end_count": 27182,
+        "total_nodes_visited": 29396,
+        "worst_representative": {
+          "aborted": false,
+          "dead_end_count": 2060,
+          "found": false,
+          "max_depth": 2,
+          "nodes_visited": 2264,
+          "size_five_centers": [
+            0,
+            1,
+            3,
+            4,
+            6,
+            7
+          ]
+        }
+      },
+      "7": {
+        "aborted_count": 0,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 1,
+        "raw_center_subset_count": 120,
+        "representatives_checked": 8,
+        "total_dead_end_count": 12784,
+        "total_nodes_visited": 13792,
+        "worst_representative": {
+          "aborted": false,
+          "dead_end_count": 1734,
+          "found": false,
+          "max_depth": 1,
+          "nodes_visited": 1860,
+          "size_five_centers": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ]
+        }
+      }
+    },
+    "searched_max_size_five_centers": 7,
+    "searched_min_size_five_centers": 3,
+    "searched_size_five_center_counts": [
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "support_sizes": [
+      4,
+      5
+    ]
+  },
+  "support_rule": {
+    "dihedral_reduction": "The natural cyclic order fixes labels 0..9. The set of centers represented by size-five supports is reduced by cyclic rotations and reflection; the support choices themselves are still labelled and searched for each representative.",
+    "rule": "A center with a rich class of size at least five is represented by an arbitrary five-witness sub-support; every other bad center is represented by an exact four-witness support."
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -624,6 +624,25 @@ and `26` strict cycles. This remains support-to-frontier bookkeeping only; it
 does not prove the exact-four checker, `n=9`, Erdos Problem #97, or a
 counterexample. See `docs/n9-mixed-rich-frontier-crosswalk.md`.
 
+### n=10 mixed rich-support capacity diagnostic
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / generator-independent finite support
+catalogue.
+
+For a cyclically labelled decagon, the checker in
+`scripts/check_n10_mixed_rich_support_capacity.py` applies only three
+necessary support filters: the row-pair cap, the two-overlap crossing rule,
+and witness-pair capacity. It searches all dihedral center-set representatives
+with `q=3,...,7` size-five supports and finds `0` complete assignments. A
+direct stored `q=2` witness survives the same filters, so this is sharp for
+that abstraction.
+
+Repo-locally, any `n=10` four/five support assignment surviving those filters
+has at most `2` size-five supports, hence at least `8` exact-four-only
+centers. This does not close the `q=0`, `q=1`, or `q=2` cases, does not prove
+`n=10`, does not prove Erdos Problem #97, and does not provide a
+counterexample. See `docs/n10-mixed-rich-support-capacity.md`.
+
 ### n=9 Kalmanson self-edge replay
 
 Status: `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -428,6 +428,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n10-vertex-circle-singleton-slices.md`](n10-vertex-circle-singleton-slices.md):
   review-pending `n=10` singleton-slice finite-case draft, including the
   secondary first-five replay cross-check.
+- [`n10-mixed-rich-support-capacity.md`](n10-mixed-rich-support-capacity.md):
+  generator-independent `n=10` four/five support-capacity diagnostic; finite
+  support bookkeeping only, not an `n=10` proof.
 - [`n10-turn-row0-pilot.md`](n10-turn-row0-pilot.md): bounded `n=10`
   row0-index-0 turn-frontier pilot; finite bookkeeping only, not a proof of
   `n=10`.

--- a/docs/n10-mixed-rich-support-capacity.md
+++ b/docs/n10-mixed-rich-support-capacity.md
@@ -1,0 +1,104 @@
+# n=10 mixed rich-support capacity diagnostic
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / generator-independent finite support
+catalogue.
+
+This note records a small support-level widening of the `n=9` mixed
+rich-support reduction. It is not a proof of `n=10`, not a proof of Erdős
+Problem #97, and not a counterexample.
+
+## Setup
+
+Fix the natural cyclic order on labels `0,1,...,9`. At each center, represent
+one available rich distance class by a support of size `4` or `5`:
+
+- an exact-four class is represented by its four witnesses;
+- a class of size at least five is represented by an arbitrary five-witness
+  sub-support.
+
+The checker applies only the same support-level necessary filters used in the
+mixed `n=9` catalogue:
+
+1. **row-pair cap:** two distinct distance circles share at most two witness
+   vertices;
+2. **two-overlap crossing:** when two rows share exactly two witnesses, the
+   center chord and shared-witness chord must cross in the cyclic order;
+3. **witness-pair capacity:** an unordered witness pair can occur together in
+   rich classes at at most two centers.
+
+Thus, if a genuine convex decagon counterexample had `q` centers with a rich
+class of size at least five, then some support assignment with exactly `q`
+size-five supports would survive these necessary filters.
+
+## Pair-budget first pass
+
+The witness-pair capacity alone gives a quick upper bound. A size-four support
+uses `binom(4,2)=6` witness pairs, while a size-five support uses
+`binom(5,2)=10`. Since each unordered label pair can be used at most twice,
+the total capacity for `n=10` is `2*binom(10,2)=90`. Therefore
+
+```text
+6(10-q) + 10q <= 90,
+```
+
+so `q <= 7`. The new checker exhausts the remaining cases `q=3,...,7`.
+
+## Exhaustive support search
+
+For each `q` from `3` through `7`, the checker enumerates the dihedral
+representatives of the `q` centers that receive size-five supports. It then
+searches all labelled support choices for that representative center set using
+bitset domains, pair-cap propagation, row-pair compatibility propagation, and
+minimum-domain branching. The support choices themselves are not quotient by
+symmetry.
+
+Checked command:
+
+```bash
+python scripts/check_n10_mixed_rich_support_capacity.py --check --assert-expected --json
+```
+
+Artifact:
+
+```text
+data/certificates/n10_mixed_rich_support_capacity.json
+```
+
+Summary of the checked run:
+
+```text
+q  dihedral reps checked  complete assignments  max depth reached
+3  8                       0                     8
+4  16                      0                     5
+5  16                      0                     4
+6  16                      0                     2
+7  8                       0                     1
+```
+
+The checker also validates a direct `q=2` support assignment, so the bound is
+sharp for these three necessary filters alone.
+
+## Consequence
+
+Repo-locally, this finite catalogue reduces the `n=10` four/five support
+abstraction as follows:
+
+```text
+any support assignment surviving these filters has at most 2 size-five supports;
+equivalently, at least 8 centers are exact-four-only.
+```
+
+This is a useful branch cut for the review-pending `n=10` work because it says
+that any size-at-least-five rich-class escape must be extremely sparse before
+vertex-circle, Kalmanson, turn, or Euclidean realizability filters are even
+applied.
+
+## Scope warnings
+
+- This is a necessary support-catalogue diagnostic only.
+- It does not replay vertex-circle, Kalmanson, turn-inequality, or Euclidean
+  realizability filters.
+- It leaves the `q=0`, `q=1`, and `q=2` four/five support cases to stronger
+  filters.
+- It does not prove `n=10`, does not prove Erdős Problem #97, and does not
+  provide a counterexample.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3859,6 +3859,60 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: n10_mixed_rich_support_capacity
+    path: data/certificates/n10_mixed_rich_support_capacity.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n10_mixed_rich_support_capacity.py
+    command: python scripts/check_n10_mixed_rich_support_capacity.py --write --assert-expected
+    checker: scripts/check_n10_mixed_rich_support_capacity.py
+    check_command: python scripts/check_n10_mixed_rich_support_capacity.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Generator-independent n=10 four/five support-capacity diagnostic under row-pair cap, two-overlap crossing, and witness-pair capacity filters; finite support reduction only, not a proof of n=10, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n10_mixed_rich_support_capacity.v1
+      status: N10_MIXED_RICH_SUPPORT_CAPACITY_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 10
+      summary.support_sizes:
+        - 4
+        - 5
+      summary.searched_min_size_five_centers: 3
+      summary.searched_max_size_five_centers: 7
+      summary.pair_budget_max_size_five_centers: 7
+      summary.q2_witness_valid: true
+      summary.q2_witness_support_size_counts.4: 8
+      summary.q2_witness_support_size_counts.5: 2
+      summary.max_size_five_centers_surviving_filters: 2
+      summary.min_exact_four_only_centers_in_any_counterexample_candidate: 8
+      summary.debug_max_nodes:
+      summary.q_summaries.3.representatives_checked: 8
+      summary.q_summaries.3.complete_assignments_found: 0
+      summary.q_summaries.3.total_nodes_visited: 133778
+      summary.q_summaries.4.representatives_checked: 16
+      summary.q_summaries.4.complete_assignments_found: 0
+      summary.q_summaries.4.total_nodes_visited: 68540
+      summary.q_summaries.5.representatives_checked: 16
+      summary.q_summaries.5.complete_assignments_found: 0
+      summary.q_summaries.5.total_nodes_visited: 36894
+      summary.q_summaries.6.representatives_checked: 16
+      summary.q_summaries.6.complete_assignments_found: 0
+      summary.q_summaries.6.total_nodes_visited: 29396
+      summary.q_summaries.7.representatives_checked: 8
+      summary.q_summaries.7.complete_assignments_found: 0
+      summary.q_summaries.7.total_nodes_visited: 13792
+      provenance.command: python scripts/check_n10_mixed_rich_support_capacity.py --write --assert-expected
+    forbidden_claims:
+      - n=10 is proved
+      - the q=0, q=1, or q=2 cases are closed
+      - support-capacity filters prove Euclidean realizability or nonrealizability
+      - source-of-truth strongest result
+      - official/global status update
+      - counterexample to Erdos Problem #97
+      - general proof of Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     kind: finite_case_draft_artifact

--- a/scripts/check_n10_mixed_rich_support_capacity.py
+++ b/scripts/check_n10_mixed_rich_support_capacity.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Check the n=10 mixed rich-support size-five capacity diagnostic.
+
+This finite support-catalogue diagnostic uses only necessary incidence filters:
+row-pair cap, radical-axis crossing for two-overlaps, and witness-pair capacity.
+It proves no n=10 theorem, no general theorem about Erdos Problem #97, and
+supplies no counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations
+from math import comb, floor
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCHEMA = "erdos97.n10_mixed_rich_support_capacity.v1"
+STATUS = "N10_MIXED_RICH_SUPPORT_CAPACITY_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n10_mixed_rich_support_capacity.json"
+N = 10
+ORDER = tuple(range(N))
+SEARCH_Q_RANGE = tuple(range(3, 8))
+SIZE_FIVE_WITNESS = {
+    "0": [1, 2, 3, 7, 9],
+    "1": [0, 2, 4, 6, 8],
+    "2": [1, 3, 5, 8],
+    "3": [2, 4, 5, 9],
+    "4": [0, 3, 5, 7],
+    "5": [1, 4, 6, 7],
+    "6": [2, 5, 7, 8],
+    "7": [3, 6, 8, 9],
+    "8": [0, 4, 7, 9],
+    "9": [0, 1, 5, 6],
+}
+EXPECTED_Q_SUMMARIES = {
+    "3": {
+        "representatives_checked": 8,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 8,
+    },
+    "4": {
+        "representatives_checked": 16,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 5,
+    },
+    "5": {
+        "representatives_checked": 16,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 4,
+    },
+    "6": {
+        "representatives_checked": 16,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 2,
+    },
+    "7": {
+        "representatives_checked": 8,
+        "complete_assignments_found": 0,
+        "max_depth_reached": 1,
+    },
+}
+EXPECTED_CONSEQUENCES = {
+    "pair_budget_max_size_five_centers": 7,
+    "searched_min_size_five_centers": 3,
+    "searched_max_size_five_centers": 7,
+    "q2_witness_support_size_counts": {"4": 8, "5": 2},
+    "max_size_five_centers_surviving_filters": 2,
+    "min_exact_four_only_centers_in_any_counterexample_candidate": 8,
+}
+
+Support = tuple[int, ...]
+Assignment = dict[int, Support]
+
+
+def normalized_pair(left: int, right: int) -> tuple[int, int]:
+    """Return a normalized non-loop pair."""
+
+    if left == right:
+        raise ValueError("loop pair")
+    return (left, right) if left < right else (right, left)
+
+
+def support_mask(support: Sequence[int]) -> int:
+    """Return the bitmask of a support."""
+
+    out = 0
+    for label in support:
+        out |= 1 << int(label)
+    return out
+
+
+def iter_bits(mask: int):
+    """Yield set-bit indices of a nonnegative integer bitset."""
+
+    while mask:
+        low_bit = mask & -mask
+        yield low_bit.bit_length() - 1
+        mask ^= low_bit
+
+
+def chords_cross_in_natural_order(
+    first: tuple[int, int],
+    second: tuple[int, int],
+) -> bool:
+    """Return whether two disjoint chords cross in the natural cyclic order."""
+
+    if set(first) & set(second):
+        return False
+    a, b = normalized_pair(*first)
+    c, d = normalized_pair(*second)
+    c_inside = a < c < b
+    d_inside = a < d < b
+    return c_inside != d_inside
+
+
+def canonical_center_subset(subset: Sequence[int], n: int = N) -> tuple[int, ...]:
+    """Return the dihedral canonical representative of a center subset."""
+
+    raw = set(subset)
+    variants: list[tuple[int, ...]] = []
+    for shift in range(n):
+        variants.append(tuple(sorted((label + shift) % n for label in raw)))
+        variants.append(tuple(sorted((shift - label) % n for label in raw)))
+    return min(variants)
+
+
+def dihedral_representatives(q: int, n: int = N) -> tuple[tuple[int, ...], ...]:
+    """Return dihedral representatives of q-subsets of centers."""
+
+    representatives = {
+        canonical_center_subset(subset, n)
+        for subset in combinations(range(n), q)
+    }
+    return tuple(sorted(representatives))
+
+
+def pair_budget_max_size_five_centers(n: int = N) -> int:
+    """Return the pair-budget maximum q in a four/five support catalogue."""
+
+    base_load = n * comb(4, 2)
+    capacity = 2 * comb(n, 2)
+    if base_load > capacity:
+        return -1
+    return min(n, floor((capacity - base_load) / (comb(5, 2) - comb(4, 2))))
+
+
+@dataclass(frozen=True)
+class PreparedCatalogue:
+    options: Mapping[tuple[int, int], tuple[Support, ...]]
+    masks: Mapping[tuple[int, int], tuple[int, ...]]
+    pair_ids: Mapping[tuple[int, int], tuple[tuple[int, ...], ...]]
+    pair_option_bits: Mapping[tuple[int, int], tuple[int, ...]]
+    compatible_option_bits: Mapping[tuple[int, int, int, int], tuple[int, ...]]
+    full_domain: Mapping[tuple[int, int], int]
+    pair_count: int
+
+
+def prepare_catalogue(n: int = N) -> PreparedCatalogue:
+    """Precompute support options and compatibility bitsets."""
+
+    pair_index = {
+        pair: index for index, pair in enumerate(combinations(range(n), 2))
+    }
+    options: dict[tuple[int, int], tuple[Support, ...]] = {}
+    masks: dict[tuple[int, int], tuple[int, ...]] = {}
+    pair_ids: dict[tuple[int, int], tuple[tuple[int, ...], ...]] = {}
+    pair_option_bits: dict[tuple[int, int], tuple[int, ...]] = {}
+    full_domain: dict[tuple[int, int], int] = {}
+
+    for center in range(n):
+        labels = tuple(label for label in range(n) if label != center)
+        for support_size in (4, 5):
+            rows = tuple(tuple(row) for row in combinations(labels, support_size))
+            options[(center, support_size)] = rows
+            masks[(center, support_size)] = tuple(support_mask(row) for row in rows)
+            row_pair_ids = tuple(
+                tuple(
+                    pair_index[normalized_pair(left, right)]
+                    for left, right in combinations(row, 2)
+                )
+                for row in rows
+            )
+            pair_ids[(center, support_size)] = row_pair_ids
+            full_domain[(center, support_size)] = (1 << len(rows)) - 1
+
+            option_bits = [0] * len(pair_index)
+            for row_index, row_pair_id in enumerate(row_pair_ids):
+                bit = 1 << row_index
+                for pair_id in row_pair_id:
+                    option_bits[pair_id] |= bit
+            pair_option_bits[(center, support_size)] = tuple(option_bits)
+
+    compatible_option_bits: dict[tuple[int, int, int, int], tuple[int, ...]] = {}
+    for left, right in combinations(range(n), 2):
+        for left_size in (4, 5):
+            for right_size in (4, 5):
+                left_to_right: list[int] = []
+                right_to_left = [0] * len(options[(right, right_size)])
+                for left_index, left_mask in enumerate(masks[(left, left_size)]):
+                    bits = 0
+                    right_masks = masks[(right, right_size)]
+                    for right_index, right_mask in enumerate(right_masks):
+                        intersection_mask = left_mask & right_mask
+                        intersection_size = intersection_mask.bit_count()
+                        compatible = True
+                        if intersection_size > 2:
+                            compatible = False
+                        elif intersection_size == 2:
+                            shared = [
+                                label
+                                for label in range(n)
+                                if (intersection_mask >> label) & 1
+                            ]
+                            compatible = chords_cross_in_natural_order(
+                                (left, right),
+                                (shared[0], shared[1]),
+                            )
+                        if compatible:
+                            bits |= 1 << right_index
+                            right_to_left[right_index] |= 1 << left_index
+                    left_to_right.append(bits)
+                compatible_option_bits[(left, left_size, right, right_size)] = tuple(
+                    left_to_right
+                )
+                compatible_option_bits[(right, right_size, left, left_size)] = tuple(
+                    right_to_left
+                )
+
+    return PreparedCatalogue(
+        options=options,
+        masks=masks,
+        pair_ids=pair_ids,
+        pair_option_bits=pair_option_bits,
+        compatible_option_bits=compatible_option_bits,
+        full_domain=full_domain,
+        pair_count=len(pair_index),
+    )
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    found: bool
+    nodes_visited: int
+    dead_end_count: int
+    max_depth: int
+    aborted: bool
+    first_assignment: Assignment | None
+
+
+def search_size_five_subset(
+    catalogue: PreparedCatalogue,
+    size_five_centers: Sequence[int],
+    *,
+    max_nodes: int | None = None,
+) -> SearchResult:
+    """Search one fixed set of size-five centers."""
+
+    size_five_set = set(size_five_centers)
+    support_sizes = tuple(5 if center in size_five_set else 4 for center in range(N))
+    domains = tuple(
+        catalogue.full_domain[(center, support_sizes[center])] for center in range(N)
+    )
+    pair_counts = [0] * catalogue.pair_count
+    assigned: list[int | None] = [None] * N
+    nodes_visited = 0
+    dead_end_count = 0
+    max_depth = 0
+    aborted = False
+    first_assignment: Assignment | None = None
+
+    def recurse(
+        depth: int,
+        assigned_mask: int,
+        current_domains: tuple[int, ...],
+    ) -> bool:
+        nonlocal aborted
+        nonlocal dead_end_count
+        nonlocal first_assignment
+        nonlocal max_depth
+        nonlocal nodes_visited
+
+        if max_nodes is not None and nodes_visited >= max_nodes:
+            aborted = True
+            return True
+        max_depth = max(max_depth, depth)
+        if depth == N:
+            first_assignment = {
+                center: catalogue.options[(center, support_sizes[center])][
+                    assigned_index
+                ]
+                for center, assigned_index in enumerate(assigned)
+                if assigned_index is not None
+            }
+            return True
+
+        best_center: int | None = None
+        best_count: int | None = None
+        for center in range(N):
+            if (assigned_mask >> center) & 1:
+                continue
+            option_count = current_domains[center].bit_count()
+            if best_count is None or option_count < best_count:
+                best_center = center
+                best_count = option_count
+            if option_count == 0:
+                break
+
+        if best_center is None:
+            return True
+        if best_count == 0:
+            dead_end_count += 1
+            return False
+
+        center = best_center
+        center_size = support_sizes[center]
+        for option_index in iter_bits(current_domains[center]):
+            nodes_visited += 1
+            newly_saturated: list[int] = []
+            for pair_id in catalogue.pair_ids[(center, center_size)][option_index]:
+                old_count = pair_counts[pair_id]
+                if old_count >= 2:
+                    raise AssertionError("domain allowed an already saturated pair")
+                pair_counts[pair_id] = old_count + 1
+                if old_count + 1 == 2:
+                    newly_saturated.append(pair_id)
+
+            new_domains = list(current_domains)
+            new_domains[center] = 1 << option_index
+            new_assigned_mask = assigned_mask | (1 << center)
+            empty_domain = False
+            for other_center in range(N):
+                if (new_assigned_mask >> other_center) & 1:
+                    continue
+                other_size = support_sizes[other_center]
+                domain = new_domains[other_center]
+                domain &= catalogue.compatible_option_bits[
+                    (center, center_size, other_center, other_size)
+                ][option_index]
+                if newly_saturated:
+                    pair_bits = catalogue.pair_option_bits[(other_center, other_size)]
+                    for pair_id in newly_saturated:
+                        domain &= ~pair_bits[pair_id]
+                new_domains[other_center] = domain
+                if domain == 0:
+                    empty_domain = True
+                    break
+
+            assigned[center] = option_index
+            if empty_domain:
+                dead_end_count += 1
+                found = False
+            else:
+                found = recurse(depth + 1, new_assigned_mask, tuple(new_domains))
+            assigned[center] = None
+            for pair_id in catalogue.pair_ids[(center, center_size)][option_index]:
+                pair_counts[pair_id] -= 1
+            if found:
+                return True
+        return False
+
+    found = recurse(0, 0, domains)
+    return SearchResult(
+        found=bool(found and first_assignment is not None),
+        nodes_visited=nodes_visited,
+        dead_end_count=dead_end_count,
+        max_depth=max_depth,
+        aborted=aborted,
+        first_assignment=first_assignment,
+    )
+
+
+def assignment_is_valid(assignment: Mapping[int, Sequence[int]], n: int = N) -> bool:
+    """Check the three necessary filters directly for a full assignment."""
+
+    rows = {int(center): tuple(row) for center, row in assignment.items()}
+    if set(rows) != set(range(n)):
+        return False
+    pair_counts: Counter[tuple[int, int]] = Counter()
+    masks = {center: support_mask(row) for center, row in rows.items()}
+    for center, row in rows.items():
+        if (
+            len(row) not in (4, 5)
+            or center in row
+            or len(set(row)) != len(row)
+            or any(label < 0 or label >= n for label in row)
+        ):
+            return False
+        for left, right in combinations(row, 2):
+            pair_counts[normalized_pair(left, right)] += 1
+            if pair_counts[normalized_pair(left, right)] > 2:
+                return False
+    for left, right in combinations(range(n), 2):
+        intersection_mask = masks[left] & masks[right]
+        intersection_size = intersection_mask.bit_count()
+        if intersection_size > 2:
+            return False
+        if intersection_size == 2:
+            shared = [label for label in range(n) if (intersection_mask >> label) & 1]
+            if not chords_cross_in_natural_order((left, right), (shared[0], shared[1])):
+                return False
+    return True
+
+
+def assignment_to_json(assignment: Mapping[int, Sequence[int]]) -> dict[str, list[int]]:
+    """Return a stable JSON object for an assignment."""
+
+    return {str(center): list(assignment[center]) for center in sorted(assignment)}
+
+
+def support_size_counts(assignment: Mapping[int, Sequence[int]]) -> dict[str, int]:
+    """Return support-size counts for a full assignment."""
+
+    counts = Counter(len(row) for row in assignment.values())
+    return {str(size): counts[size] for size in sorted(counts)}
+
+
+def run_capacity_check(*, max_nodes: int | None = None) -> dict[str, object]:
+    """Run the q=3..7 no-survivor searches and return summary records."""
+
+    catalogue = prepare_catalogue(N)
+    q_summaries: dict[str, object] = {}
+    raw_counts: dict[str, int] = {}
+    for q in SEARCH_Q_RANGE:
+        representatives = dihedral_representatives(q, N)
+        raw_counts[str(q)] = comb(N, q)
+        total_nodes = 0
+        total_dead_ends = 0
+        max_depth = 0
+        complete_assignments_found = 0
+        aborted_count = 0
+        worst: dict[str, object] | None = None
+        for representative in representatives:
+            result = search_size_five_subset(
+                catalogue,
+                representative,
+                max_nodes=max_nodes,
+            )
+            total_nodes += result.nodes_visited
+            total_dead_ends += result.dead_end_count
+            max_depth = max(max_depth, result.max_depth)
+            if result.aborted:
+                aborted_count += 1
+            if result.found:
+                complete_assignments_found += 1
+            if worst is None or result.nodes_visited > worst["nodes_visited"]:
+                worst = {
+                    "size_five_centers": list(representative),
+                    "nodes_visited": result.nodes_visited,
+                    "dead_end_count": result.dead_end_count,
+                    "max_depth": result.max_depth,
+                    "found": result.found,
+                    "aborted": result.aborted,
+                }
+        q_summaries[str(q)] = {
+            "raw_center_subset_count": raw_counts[str(q)],
+            "representatives_checked": len(representatives),
+            "complete_assignments_found": complete_assignments_found,
+            "aborted_count": aborted_count,
+            "total_nodes_visited": total_nodes,
+            "total_dead_end_count": total_dead_ends,
+            "max_depth_reached": max_depth,
+            "worst_representative": worst,
+        }
+
+    witness = {int(center): tuple(row) for center, row in SIZE_FIVE_WITNESS.items()}
+    if not assignment_is_valid(witness, N):
+        raise AssertionError("stored q=2 witness failed direct validation")
+    witness_size_counts = support_size_counts(witness)
+    if witness_size_counts != {"4": 8, "5": 2}:
+        raise AssertionError(
+            f"stored witness has support-size counts {witness_size_counts!r}"
+        )
+
+    return {
+        "q_summaries": q_summaries,
+        "raw_center_subset_counts": raw_counts,
+        "q2_witness": assignment_to_json(witness),
+        "q2_witness_support_size_counts": witness_size_counts,
+    }
+
+
+def build_payload(*, max_nodes: int | None = None) -> dict[str, object]:
+    """Build the n=10 mixed rich-support capacity payload."""
+
+    capacity = run_capacity_check(max_nodes=max_nodes)
+    q_summaries = capacity["q_summaries"]
+    assert isinstance(q_summaries, Mapping)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Generator-independent n=10 four/five support-capacity diagnostic. "
+            "It checks all dihedral center-set representatives with q=3..7 "
+            "size-five supports and finds no full assignments under the "
+            "row-pair cap, two-overlap crossing rule, and witness-pair capacity. "
+            "A direct q=2 witness shows the bound is sharp for these filters. "
+            "This does not prove n=10, does not prove Erdos Problem #97, and "
+            "is not a counterexample."
+        ),
+        "summary": {
+            "n": N,
+            "order": list(ORDER),
+            "support_sizes": [4, 5],
+            "searched_size_five_center_counts": list(SEARCH_Q_RANGE),
+            "searched_min_size_five_centers": min(SEARCH_Q_RANGE),
+            "searched_max_size_five_centers": max(SEARCH_Q_RANGE),
+            "pair_budget_max_size_five_centers": pair_budget_max_size_five_centers(N),
+            "q_summaries": q_summaries,
+            "q2_witness_valid": True,
+            "q2_witness_support_size_counts": capacity[
+                "q2_witness_support_size_counts"
+            ],
+            "max_size_five_centers_surviving_filters": 2,
+            "min_exact_four_only_centers_in_any_counterexample_candidate": 8,
+            "debug_max_nodes": max_nodes,
+        },
+        "q2_witness": capacity["q2_witness"],
+        "filters": [
+            {
+                "name": "row_pair_cap",
+                "meaning": (
+                    "Two distinct distance circles can share at most two "
+                    "witness vertices."
+                ),
+            },
+            {
+                "name": "two_overlap_crossing",
+                "meaning": (
+                    "When two centers share exactly two witnesses in their "
+                    "rich classes, the center chord and shared-witness chord "
+                    "must cross in the cyclic order."
+                ),
+            },
+            {
+                "name": "witness_pair_capacity",
+                "meaning": (
+                    "Any unordered witness pair can occur together in rich "
+                    "classes at at most two centers, since all such centers "
+                    "lie on one perpendicular-bisector line."
+                ),
+            },
+        ],
+        "support_rule": {
+            "rule": (
+                "A center with a rich class of size at least five is "
+                "represented by an arbitrary five-witness sub-support; "
+                "every other bad center is represented by an exact "
+                "four-witness support."
+            ),
+            "dihedral_reduction": (
+                "The natural cyclic order fixes labels 0..9. The set of "
+                "centers represented by size-five supports is reduced by "
+                "cyclic rotations and reflection; the support choices "
+                "themselves are still labelled and searched for each "
+                "representative."
+            ),
+        },
+        "interpretation_warnings": [
+            "This is a necessary support-catalogue diagnostic only.",
+            (
+                "It does not replay vertex-circle, Kalmanson, or Euclidean "
+                "realizability filters."
+            ),
+            (
+                "It leaves the q=0, q=1, and q=2 four/five support cases "
+                "open to stronger filters."
+            ),
+            "No n=10 theorem, general proof, or counterexample is claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n10_mixed_rich_support_capacity.py",
+            "command": (
+                "python scripts/check_n10_mixed_rich_support_capacity.py "
+                "--write --assert-expected"
+            ),
+            "sources": [
+                "docs/claims.md#n9-mixed-rich-support-reduction",
+                (
+                    "docs/review-priorities.md#priority-6b---audit-the-"
+                    "n10-singleton-slice-draft"
+                ),
+                "docs/codex-backlog.md#recommended-next-technical-prs",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert stable expected n=10 capacity counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"unexpected trust: {payload.get('trust')!r}")
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    if summary.get("debug_max_nodes") is not None:
+        raise AssertionError("expected payload must not use debug node limits")
+    for key, expected in EXPECTED_CONSEQUENCES.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    q_summaries = summary.get("q_summaries")
+    if not isinstance(q_summaries, Mapping):
+        raise AssertionError("q_summaries is missing")
+    for q, expected_items in EXPECTED_Q_SUMMARIES.items():
+        q_summary = q_summaries.get(q)
+        if not isinstance(q_summary, Mapping):
+            raise AssertionError(f"missing q={q} summary")
+        for key, expected in expected_items.items():
+            if q_summary.get(key) != expected:
+                raise AssertionError(
+                    f"q={q} key {key!r} is {q_summary.get(key)!r}, "
+                    f"expected {expected!r}"
+                )
+        if q_summary.get("aborted_count") != 0:
+            raise AssertionError(f"q={q} unexpectedly aborted")
+    if payload.get("q2_witness") != assignment_to_json(
+        {int(center): tuple(row) for center, row in SIZE_FIVE_WITNESS.items()}
+    ):
+        raise AssertionError("unexpected q=2 witness")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    """Compare a checked artifact with a freshly built payload."""
+
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    """Print a compact human-readable summary."""
+
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=10 mixed rich-support capacity diagnostic")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(
+        "max size-five centers surviving these filters: "
+        f"{summary['max_size_five_centers_surviving_filters']}"
+    )
+    print(
+        "minimum exact-four-only centers in any candidate: "
+        f"{summary['min_exact_four_only_centers_in_any_counterexample_candidate']}"
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare the artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    parser.add_argument(
+        "--max-nodes",
+        type=int,
+        default=None,
+        help=(
+            "debug/testing node limit per center-set representative; "
+            "do not use for checked artifacts"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(max_nodes=args.max_nodes)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2279,6 +2279,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n10_mixed_rich_support_capacity",
+        command=(
+            "python",
+            "scripts/check_n10_mixed_rich_support_capacity.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Generator-independent n=10 four/five support-capacity "
+            "diagnostic under row-pair cap, two-overlap crossing, and "
+            "witness-pair capacity filters; finite support reduction only, "
+            "not a proof of n=10, not a proof of Erdos Problem #97, and "
+            "not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="n10_turn_row0_pilot",
         command=(
             "python",

--- a/tests/test_n10_mixed_rich_support_capacity.py
+++ b/tests/test_n10_mixed_rich_support_capacity.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n10_mixed_rich_support_capacity import (  # noqa: E402
+    SIZE_FIVE_WITNESS,
+    assignment_is_valid,
+    assert_expected_payload,
+    build_payload,
+    dihedral_representatives,
+    pair_budget_max_size_five_centers,
+    support_size_counts,
+)
+
+
+def test_pair_budget_and_dihedral_representative_counts() -> None:
+    assert pair_budget_max_size_five_centers() == 7
+    assert {
+        q: len(dihedral_representatives(q))
+        for q in range(3, 8)
+    } == {
+        3: 8,
+        4: 16,
+        5: 16,
+        6: 16,
+        7: 8,
+    }
+
+
+def test_q2_witness_shape_and_filters_are_pinned() -> None:
+    witness = {
+        int(center): tuple(row)
+        for center, row in SIZE_FIVE_WITNESS.items()
+    }
+
+    assert support_size_counts(witness) == {"4": 8, "5": 2}
+    assert assignment_is_valid(witness)
+
+
+def test_expected_payload_counts() -> None:
+    payload = build_payload()
+    assert_expected_payload(payload)
+
+    summary = payload["summary"]
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert summary["q_summaries"]["3"]["total_nodes_visited"] == 133778
+    assert summary["q_summaries"]["7"]["total_nodes_visited"] == 13792
+
+
+def test_debug_payload_is_not_an_expected_artifact() -> None:
+    payload = build_payload(max_nodes=1)
+
+    assert payload["summary"]["debug_max_nodes"] == 1
+    with pytest.raises(AssertionError, match="debug node limits"):
+        assert_expected_payload(payload)


### PR DESCRIPTION
## Summary

- add a generator-independent n=10 four/five rich-support capacity diagnostic
- record the checked JSON artifact, documentation, claims/status notes, and provenance metadata
- wire the checker into the n10 review/audit paths and add focused tests

## Review notes

This is scoped as `REVIEW_PENDING_DIAGNOSTIC`: it proves only that, under row-pair cap, two-overlap crossing, and witness-pair capacity filters, q=3..7 size-five support cases have no complete assignments. A stored q=2 witness remains valid, so the bound is sharp for these filters. No n=10 theorem, global proof, or counterexample is claimed.

## Verification

- `python -m py_compile scripts/check_n10_mixed_rich_support_capacity.py tests/test_n10_mixed_rich_support_capacity.py`
- `python scripts/check_n10_mixed_rich_support_capacity.py --check --assert-expected --json`
- `python -m pytest -q tests/test_n10_mixed_rich_support_capacity.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --cached --check`
- `python -m ruff check .`
- direct `verify-n10-review` recipe commands (PowerShell lacks `make`)
- `python -m pytest -q` reached `1106 passed, 306 deselected`; the local command wrapper timed out immediately after pytest printed the passing summary, so this is recorded as attempted rather than a clean process exit.