### PR TITLE
Add rich support counting lemma

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ verify-n9-review:
 
 verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
+	$(PYTHON) scripts/check_rich_support_counting_bound.py --check --json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -17,7 +17,7 @@ theorem-style claims.
 
 ### Lemma: pairwise circle-intersection cap
 
-Status: proved.
+Status: `LEMMA`.
 
 In any true counterexample, for distinct centers `a,b`,
 `|S_a cap S_b| <= 2`. Otherwise two distinct circles would share at least
@@ -30,6 +30,27 @@ Status: proved.
 The directed 4-out incidence pattern and the pairwise cap imply no
 counterexample can have `n <= 6`; the convexity-of-indegree count gives
 `n >= 7`.
+
+### Lemma: rich-support counting wall
+
+Status: proved.
+
+For any choice of one same-radius support `R_i` at each center, not necessarily
+of size four,
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 1).
+```
+
+Indeed, a fixed unordered witness pair `{a,b}` can occur in at most two
+supports, because all centers using both witnesses lie on the perpendicular
+bisector of `ab`, and a line contains at most two vertices of a strictly convex
+polygon.
+
+Consequently, if every center has a rich class of size at least `k`, then
+`n >= binom(k, 2) + 1`. In particular, the all-centers size-five subcase is
+impossible for `n <= 10`; any hypothetical 4-bad nonagon has at least five
+exact-four centers. See `docs/rich-support-counting-lemma.md`.
 
 ### Lemma: crossing-bisector and sharpened count
 

--- a/STATE.md
+++ b/STATE.md
@@ -245,6 +245,15 @@ least one center whose available rich classes are exact-four-only; it is still
 not an `n=9` proof, not the adaptive blocker bridge, and not a counterexample.
 See `docs/n9-all-five-rich-support-obstruction.md`.
 
+A rich-support counting lemma now gives a proof-level shortcut for that
+all-five-rich subcase: for any same-radius supports `R_i`,
+`sum_i binom(|R_i|, 2) <= n(n - 1)` by witness-pair sharing on perpendicular
+bisectors. Hence every center having five equidistant witnesses requires
+`n >= 11`. The same counting relaxation says any hypothetical 4-bad nonagon
+has at least five exact-four centers, and any hypothetical 4-bad decagon has
+at least three. This does not replace the mixed support catalogues or prove
+`n=9` or `n=10`. See `docs/rich-support-counting-lemma.md`.
+
 The follow-up mixed rich-support reduction enumerates every four- or
 five-witness support at every center, for `126^9 =
 8,004,512,848,309,157,376` raw assignments. With the same pair/crossing

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -79,6 +79,34 @@ source-of-truth status. The checked selected-witness artifacts remain the
 repo-local `n <= 8` source until this literature-backed note receives
 independent review.
 
+### Rich-support counting bound
+
+Status: `LEMMA`.
+
+Let `R_i` be any same-radius support chosen at center `i`; unlike selected
+witness rows, `R_i` may have size larger than four. Then
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 1).
+```
+
+The proof is the pair-sharing cap in counting form. For a fixed unordered
+witness pair `{a,b}`, every center whose support contains both `a` and `b`
+lies on the perpendicular bisector of segment `ab`; strict convexity permits at
+most two polygon vertices on that line. Double-counting witness pairs inside
+supports gives the displayed inequality.
+
+Thus, if every center has a rich distance class of size at least `k`, then
+`n >= binom(k, 2) + 1`. In particular, every-vertex size-five richness is
+impossible for `n <= 10`. Choosing a maximum rich class at each center of a
+hypothetical 4-bad nonagon also shows that at most four centers can have
+`E(i) >= 5`, so at least five centers must be exact-four.
+
+This is a support-level counting lemma only. It does not rule out mixed
+exact-four/rich catalogues and does not prove `n=9`, `n=10`, or Erdos Problem
+#97. See `docs/rich-support-counting-lemma.md` and the checker
+`scripts/check_rich_support_counting_bound.py`.
+
 ### Altman diagonal-order sums
 
 For a strict convex `n`-gon in cyclic order, the sums `U_k` of chord lengths of

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,9 @@ put detailed reconciliation in the canonical synthesis.
   diameter-pair lemmas, the seven-point lens-cap negative control, and the
   selected/full-rich-class branching caution; review-pending local geometry
   only.
+- [`rich-support-counting-lemma.md`](rich-support-counting-lemma.md):
+  proof-facing support pair-counting lemma for all-centers large rich classes;
+  not an `n=9`, `n=10`, or global proof.
 - [`k4e-kalmanson-stretch-audit.md`](k4e-kalmanson-stretch-audit.md): exact
   fixed-pattern audit extracting `K4-e` stretch relations and combining them
   with Kalmanson inequalities; kills only the displayed `n=10` quotient-level

--- a/docs/n9-all-five-rich-support-obstruction.md
+++ b/docs/n9-all-five-rich-support-obstruction.md
@@ -18,6 +18,29 @@ The checker applies only two exact necessary filters:
 These are the same circle-intersection and radical-axis crossing conditions
 recorded in `docs/claims.md`.
 
+## Counting shortcut
+
+The all-five-rich conclusion also follows from the rich-support counting lemma
+in `docs/rich-support-counting-lemma.md`, without backtracking. If every
+center of a strict convex `n`-gon has a same-radius support of size at least
+five, then each support contributes at least `binom(5,2)=10` unordered witness
+pairs. A fixed witness pair can be used by at most two centers, since all such
+centers lie on the perpendicular bisector of that pair and strict convexity
+allows at most two vertices on a line. Therefore
+
+```text
+10n <= 2*binom(n,2) = n(n - 1),
+```
+
+so `n >= 11`. In particular, the `n=9` all-five-rich support subcase is closed
+by this one-line pair-sharing count.
+
+The checked artifact below is still useful as a generator-independent
+support-catalogue regression: it exercises the explicit five-support option
+catalogue, row-pair cap, and two-overlap crossing rule that are reused in the
+mixed rich-support machinery. It is no longer the shortest proof of the
+all-five-rich subcase itself.
+
 ## Checked Result
 
 The checked artifact is:

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -1,0 +1,86 @@
+# Rich-support counting lemma
+
+Status: `LEMMA` / proof-facing counting bound. This note does not claim a
+general proof of Erdos Problem #97 and does not claim a counterexample.
+
+## Setup
+
+Let `V` be the vertex set of a strictly convex `n`-gon. For each center
+`i in V`, choose one same-radius support
+
+```text
+R_i subset V \ {i}
+```
+
+meaning that all vertices of `R_i` lie on one circle centered at `i`. The set
+`R_i` may have size larger than four; for example, it may be a maximum rich
+class witnessing `E(i)`.
+
+## Lemma
+
+For any such choice of supports,
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 1).
+```
+
+Proof: fix an unordered witness pair `{a,b}`. If `{a,b} subset R_i`, then the
+center `i` is equidistant from `a` and `b`, so `i` lies on the perpendicular
+bisector of segment `ab`. A line contains at most two vertices of a strictly
+convex polygon. Therefore the pair `{a,b}` can occur together in at most two
+supports. Double-counting triples `(i,{a,b})` with `{a,b} subset R_i` gives the
+bound.
+
+## Consequences
+
+If every center has a same-radius support of size at least `k`, then
+
+```text
+n * binom(k, 2) <= n(n - 1),
+```
+
+so
+
+```text
+n >= binom(k, 2) + 1.
+```
+
+In particular, a strict convex polygon in which every vertex has five
+equidistant witnesses must have `n >= 11`. Thus the `n=9` all-five-rich support
+subcase is already impossible by this pair-sharing count, before using cyclic
+order, crossing, selected-distance quotienting, or vertex-circle pruning.
+
+For a hypothetical 4-bad nonagon, choose a maximum rich support at every
+center, so `|R_i| = E(i) >= 4`. The same inequality gives
+
+```text
+sum_i (binom(E(i), 2) - binom(4, 2)) <= 9*8 - 9*6 = 18.
+```
+
+Since any center with `E(i) >= 5` costs at least `binom(5,2)-binom(4,2)=4`,
+at most four centers can have `E(i) >= 5`. Equivalently, any hypothetical
+4-bad nonagon has at least five exact-four centers.
+
+The corresponding necessary counting relaxation for `n=10` gives at least
+three exact-four centers in any hypothetical 4-bad decagon.
+
+## Verification command
+
+The helper script
+
+```bash
+python scripts/check_rich_support_counting_bound.py --check --json
+```
+
+checks the threshold `n >= 11` for all-centers size-five support and the small
+`n=7..11` surplus table used above. It is only a counting-bound checker; it is
+not a realization search.
+
+## Boundary
+
+This lemma does not rule out mixed exact-four and size-five catalogues. For
+`n=9`, it narrows such a catalogue by forcing at least five exact-four centers,
+but it does not replace the review-pending exact-four frontier or the mixed
+support crosswalk. The existing `n=9` all-five-rich checker remains useful as a
+crossing-aware support-catalogue regression and as provenance for the richer
+support-search machinery.

--- a/scripts/check_rich_support_counting_bound.py
+++ b/scripts/check_rich_support_counting_bound.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Check the rich-support counting bound for Erdos Problem #97.
+
+This standalone checker verifies a simple proof-facing counting lemma:
+for any choice of one same-radius support R_i at each center of a strict convex
+n-gon, sum_i binom(|R_i|, 2) <= n(n - 1).  The reason is that a fixed witness
+pair {a,b} can occur in at most two supports, since all centers using both
+witnesses lie on the perpendicular bisector of ab, and a line contains at most
+two vertices of a strictly convex polygon.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from math import comb
+from typing import Any
+
+SCHEMA = "erdos97.rich_support_counting_bound.v1"
+TRUST = "LEMMA"
+
+
+def pair_budget(n: int) -> int:
+    """Maximum total center-witness-pair incidences allowed by pair-sharing."""
+
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    return n * (n - 1)
+
+
+def all_centers_min_n(k: int) -> int:
+    """Smallest n not ruled out when every center has support size at least k."""
+
+    if k < 0:
+        raise ValueError("k must be nonnegative")
+    return comb(k, 2) + 1
+
+
+def max_total_support_size(n: int, min_size: int = 4) -> tuple[int, list[int]]:
+    """Maximize sum |R_i| under sum binom(|R_i|,2) <= n(n-1).
+
+    This is only a necessary counting relaxation.  It ignores all cyclic-order,
+    row-intersection, and vertex-circle constraints.
+    """
+
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if min_size < 0 or min_size >= n:
+        raise ValueError("min_size must satisfy 0 <= min_size < n")
+
+    budget = pair_budget(n)
+    if n * comb(min_size, 2) > budget:
+        raise ValueError(
+            f"no counting-feasible family with {n} supports of size at least {min_size}"
+        )
+    # dp[cost] = (total_support_size, sorted support-size multiset)
+    dp: dict[int, tuple[int, list[int]]] = {0: (0, [])}
+    for _ in range(n):
+        next_dp: dict[int, tuple[int, list[int]]] = {}
+        for used, (total, sizes) in dp.items():
+            for size in range(min_size, n):
+                new_used = used + comb(size, 2)
+                if new_used > budget:
+                    continue
+                candidate = (total + size, sorted([*sizes, size]))
+                if new_used not in next_dp or candidate[0] > next_dp[new_used][0]:
+                    next_dp[new_used] = candidate
+        dp = next_dp
+    used, (total, sizes) = max(dp.items(), key=lambda item: (item[1][0], -item[0]))
+    # Include the exact used budget in a harmless way by returning the witness sizes.
+    _ = used
+    return total, sizes
+
+
+def max_non_exact_four_centers(n: int) -> int:
+    """Maximum number of centers with support size at least 5 in a 4-bad relaxation."""
+
+    baseline = n * comb(4, 2)
+    extra_budget = pair_budget(n) - baseline
+    if extra_budget < 0:
+        return -1
+    # Raising one center from size 4 to size 5 costs 4 pair incidences, and
+    # this is the cheapest way to make a center non-exact-four.
+    return min(n, extra_budget // (comb(5, 2) - comb(4, 2)))
+
+
+def row_summary(n: int) -> dict[str, Any]:
+    """Return the counting-bound row for one n."""
+
+    if n <= 4:
+        # The Erdos #97 selected-witness problem starts at n >= 5; keep this
+        # helper focused on the bad-polygon range where min_size=4 is feasible.
+        raise ValueError("n must be at least 5")
+    baseline_cost = n * comb(4, 2)
+    budget = pair_budget(n)
+    four_bad_ruled_out = baseline_cost > budget
+    if four_bad_ruled_out:
+        return {
+            "n": n,
+            "pair_budget": budget,
+            "four_bad_ruled_out_by_pair_counting": True,
+            "max_total_support_size_given_E_ge_4": None,
+            "max_surplus_over_exact_four": None,
+            "one_extremal_support_size_multiset": None,
+            "all_centers_size_at_least_5_ruled_out_by_counting": True,
+            "max_centers_with_E_at_least_5_by_counting": 0,
+            "min_centers_with_E_equal_4_by_counting": None,
+        }
+
+    total, sizes = max_total_support_size(n, min_size=4)
+    max_non_exact = max_non_exact_four_centers(n)
+    return {
+        "n": n,
+        "pair_budget": budget,
+        "four_bad_ruled_out_by_pair_counting": False,
+        "max_total_support_size_given_E_ge_4": total,
+        "max_surplus_over_exact_four": total - 4 * n,
+        "one_extremal_support_size_multiset": sizes,
+        "all_centers_size_at_least_5_ruled_out_by_counting": n < all_centers_min_n(5),
+        "max_centers_with_E_at_least_5_by_counting": max_non_exact,
+        "min_centers_with_E_equal_4_by_counting": max(0, n - max_non_exact),
+    }
+
+
+def build_summary(min_n: int = 5, max_n: int = 11) -> dict[str, Any]:
+    """Build a stable JSON summary for the lemma and small-n consequences."""
+
+    return {
+        "schema": SCHEMA,
+        "status": "PROVED_COUNTING_LEMMA",
+        "trust": TRUST,
+        "claim_scope": (
+            "Proof-facing rich-support pair-counting lemma only. It records "
+            "necessary support-size consequences and does not prove n=9, "
+            "n=10, or Erdos Problem #97."
+        ),
+        "lemma": (
+            "For same-radius supports R_i in a strict convex n-gon, "
+            "sum_i binom(|R_i|, 2) <= n(n - 1)."
+        ),
+        "all_centers_min_support_thresholds": {
+            str(k): all_centers_min_n(k) for k in range(4, 8)
+        },
+        "rows": [row_summary(n) for n in range(min_n, max_n + 1)],
+    }
+
+
+def check_expected(summary: dict[str, Any]) -> None:
+    """Check the small consequences used by the proposed repo note."""
+
+    thresholds = summary["all_centers_min_support_thresholds"]
+    if thresholds["5"] != 11:
+        raise AssertionError("all-centers size-five threshold should be n >= 11")
+
+    rows = {row["n"]: row for row in summary["rows"]}
+    expected = {
+        7: (28, 0, 0, 7),
+        8: (34, 2, 2, 6),
+        9: (40, 4, 4, 5),
+        10: (47, 7, 7, 3),
+        11: (55, 11, 11, 0),
+    }
+    for n, (total, surplus, max_non_exact, min_exact) in expected.items():
+        row = rows[n]
+        got = (
+            row["max_total_support_size_given_E_ge_4"],
+            row["max_surplus_over_exact_four"],
+            row["max_centers_with_E_at_least_5_by_counting"],
+            row["min_centers_with_E_equal_4_by_counting"],
+        )
+        want = (total, surplus, max_non_exact, min_exact)
+        if got != want:
+            raise AssertionError(f"n={n}: got {got}, expected {want}")
+
+    for n in (5, 6):
+        if not rows[n]["four_bad_ruled_out_by_pair_counting"]:
+            raise AssertionError(f"n={n}: expected pair-counting to rule out four-bad supports")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-n", type=int, default=5)
+    parser.add_argument("--max-n", type=int, default=11)
+    parser.add_argument("--check", action="store_true", help="assert expected small-n consequences")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    summary = build_summary(args.min_n, args.max_n)
+    if args.check:
+        if (args.min_n, args.max_n) != (5, 11):
+            raise SystemExit("--check is only defined for the default n range")
+        check_expected(summary)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"schema: {summary['schema']}")
+        print("all centers with size >=5 requires n >=", all_centers_min_n(5))
+        for row in summary["rows"]:
+            if row["four_bad_ruled_out_by_pair_counting"]:
+                print(f"n={row['n']}: four-bad supports ruled out by pair-counting")
+            else:
+                print(
+                    f"n={row['n']}: max total={row['max_total_support_size_given_E_ge_4']}, "
+                    f"max surplus={row['max_surplus_over_exact_four']}, "
+                    f"min exact-four centers={row['min_centers_with_E_equal_4_by_counting']}"
+                )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1441,6 +1441,20 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="rich_support_counting_bound",
+        command=(
+            "python",
+            "scripts/check_rich_support_counting_bound.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Proof-facing rich-support pair-counting lemma and small-n "
+            "consequences; not a proof of n=9, not a proof of n=10, not a "
+            "proof of Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="radius_blocker_vertex_circle_pilot",
         command=(
             "python",

--- a/tests/test_rich_support_counting_bound.py
+++ b/tests/test_rich_support_counting_bound.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_rich_support_counting_bound import (  # noqa: E402
+    all_centers_min_n,
+    build_summary,
+    check_expected,
+    max_non_exact_four_centers,
+    row_summary,
+)
+
+
+def test_rich_support_counting_expected_summary() -> None:
+    summary = build_summary()
+
+    check_expected(summary)
+    rows = {row["n"]: row for row in summary["rows"]}
+    assert summary["trust"] == "LEMMA"
+    assert summary["all_centers_min_support_thresholds"]["5"] == 11
+    assert rows[9]["max_centers_with_E_at_least_5_by_counting"] == 4
+    assert rows[9]["min_centers_with_E_equal_4_by_counting"] == 5
+    assert rows[10]["max_centers_with_E_at_least_5_by_counting"] == 7
+    assert rows[10]["min_centers_with_E_equal_4_by_counting"] == 3
+
+
+def test_rich_support_counting_threshold_helpers() -> None:
+    assert all_centers_min_n(4) == 7
+    assert all_centers_min_n(5) == 11
+    assert all_centers_min_n(6) == 16
+    assert max_non_exact_four_centers(9) == 4
+    assert max_non_exact_four_centers(10) == 7
+
+
+def test_rich_support_counting_rows() -> None:
+    row9 = row_summary(9)
+    row10 = row_summary(10)
+
+    assert row9["pair_budget"] == 72
+    assert row9["max_total_support_size_given_E_ge_4"] == 40
+    assert row10["pair_budget"] == 90
+    assert row10["max_total_support_size_given_E_ge_4"] == 47
+
+
+def test_rich_support_counting_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_rich_support_counting_bound.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "erdos97.rich_support_counting_bound.v1"
+    assert payload["status"] == "PROVED_COUNTING_LEMMA"
+    assert payload["rows"][4]["n"] == 9


### PR DESCRIPTION
## Summary

- add a proof-facing rich-support pair-counting lemma and exact-arithmetic checker
- record n=9/n=10 support-size consequences without promoting global status
- wire the checker into review/audit paths and add focused tests

## Review notes

This is intentionally scoped as a `LEMMA`/`PROVED_COUNTING_LEMMA` local counting statement: `sum_i C(|R_i|, 2) <= n(n - 1)` for chosen same-radius supports in a strict convex n-gon. It removes only the all-centers-size-five rich-support branch for n=9/n=10 and records mixed exact-four/rich consequences. It does not prove n=9, n=10, or Erdos Problem #97.

## Verification

- `python scripts/check_rich_support_counting_bound.py --check --json`
- `python -m pytest -q tests/test_rich_support_counting_bound.py`
- `python -m ruff check .`
- `python scripts/check_status_consistency.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`