### PR TITLE
Add source 151 singleton two-row drop audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json
 	$(PYTHON) scripts/check_closure_activation_negative_controls.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -683,6 +683,16 @@ row forcing, `n=9`, or the bootstrap bridge. See
 `scripts/check_bootstrap_t12_151_singleton_support_audit.py`, and
 `data/certificates/bootstrap_t12_151_singleton_support_audit.json`.
 
+The source-`151` singleton-support two-row-drop follow-up extends the same
+audit by allowing any unordered pair of non-target rows to move arbitrarily.
+It checks `2,469,600` candidate states across targets `151:5` and `151:8`,
+leaves `56` survivors, and all survivors are the trivial original-neighborhood
+rows. This closes only the next relaxation level for that diagnostic; it is
+not singleton-support existence, row forcing, `n=9`, or the bootstrap bridge.
+See `docs/bootstrap-t12-151-singleton-two-row-drop.md`,
+`scripts/check_bootstrap_t12_151_singleton_two_row_drop.py`, and
+`data/certificates/bootstrap_t12_151_singleton_two_row_drop.json`.
+
 ### Fixed-pattern exact obstructions
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -442,6 +442,13 @@ incidence/crossing bookkeeping only, not singleton-support existence, row
 forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-151-singleton-support-audit.md`.
 
+The source-`151` singleton-support two-row-drop extension checks the next
+relaxation level: any unordered pair of non-target rows may move to arbitrary
+selected 4-sets. Across targets `151:5` and `151:8`, it checks `2,469,600`
+candidates and leaves only `56` original-neighborhood survivors. This is still
+diagnostic bookkeeping only, not row forcing or a bridge proof. See
+`docs/bootstrap-t12-151-singleton-two-row-drop.md`.
+
 ## New exact fixed-pattern obstructions
 
 The crossing-bisector, mutual-rhombus, phi 4-cycle rectangle-trap, cyclic

--- a/data/certificates/bootstrap_t12_151_singleton_two_row_drop.json
+++ b/data/certificates/bootstrap_t12_151_singleton_two_row_drop.json
@@ -1,0 +1,3735 @@
+{
+  "claim_scope": "Two-row-drop singleton-support stress test for source 151 rows 5 and 8. It treats the existing source-151 singleton-support audit packet as input, keeps each target row in the bootstrap-core-plus-singleton-support candidate family, allows two non-target selected rows to move arbitrarily, and checks only row-pair, witness-pair, and two-overlap crossing filters. The only survivors keep the original target row and both dropped rows equal to their source-151 rows. This does not prove singleton support existence, row forcing, n=9, the bootstrap bridge, Erdos Problem #97, or any counterexample.",
+  "interpretation_warnings": [
+    "This is a finite proof-mining diagnostic around the fixed source-151 selected-row neighborhood.",
+    "The scan allows exactly two non-target selected rows to move; it does not model three or more moving rows.",
+    "Activation rows are bookkeeping objects; the scan does not prove a genuine rich class exists.",
+    "The scan uses only incidence and crossing filters, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_151_singleton_two_row_drop.py"
+  },
+  "schema": "erdos97.bootstrap_t12_151_singleton_two_row_drop.v1",
+  "source_rows": {
+    "0": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "1": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "2": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "3": [
+      0,
+      2,
+      5,
+      6
+    ],
+    "4": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "5": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "6": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "7": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "8": [
+      1,
+      2,
+      5,
+      7
+    ]
+  },
+  "source_singleton_support_packet": {
+    "path": "data/certificates/bootstrap_t12_151_singleton_support_audit.json",
+    "schema": "erdos97.bootstrap_t12_151_singleton_support_audit.v1",
+    "status": "BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_151_SINGLETON_TWO_ROW_DROP_DIAGNOSTIC_ONLY",
+  "summary": {
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "remaining_gap": "This does not prove singleton support existence, does not prove the rows are forced by minimal or rich-class geometry, does not allow three or more other rows to move, and does not model additional auxiliary rich supports.",
+    "scan_status": "ONLY_ORIGINAL_SOURCE151_ROWS_SURVIVE_TWO_ROW_DROP_SUPPORT_AUDIT",
+    "source_record_ids": [
+      151
+    ],
+    "target_center_candidate_count_by_key": {
+      "151:5": 9,
+      "151:8": 9
+    },
+    "target_centers": [
+      5,
+      8
+    ],
+    "target_count": 2,
+    "target_row_keys": [
+      "151:5",
+      "151:8"
+    ],
+    "two_row_drop_candidate_count": 2469600,
+    "two_row_drop_non_original_survivor_count": 0,
+    "two_row_drop_surviving_candidate_count": 56,
+    "two_row_drop_survivors_all_original_rows": true
+  },
+  "target_audits": [
+    {
+      "bootstrap_core_witnesses": [
+        2,
+        4
+      ],
+      "original_target_center_class": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "singleton_support_labels": [
+        7,
+        8
+      ],
+      "target_center": 5,
+      "target_center_candidate_classes": [
+        [
+          0,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          2,
+          3,
+          4,
+          7
+        ],
+        [
+          2,
+          4,
+          6,
+          7
+        ],
+        [
+          0,
+          2,
+          4,
+          8
+        ],
+        [
+          1,
+          2,
+          4,
+          8
+        ],
+        [
+          2,
+          3,
+          4,
+          8
+        ],
+        [
+          2,
+          4,
+          6,
+          8
+        ],
+        [
+          2,
+          4,
+          7,
+          8
+        ]
+      ],
+      "target_center_candidate_count": 9,
+      "target_row_key": "151:5",
+      "two_row_drop_candidate_count": 1234800,
+      "two_row_drop_centers": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        6,
+        7,
+        8
+      ],
+      "two_row_drop_dropped_center_pair_count": 28,
+      "two_row_drop_non_original_survivor_count": 0,
+      "two_row_drop_per_dropped_center_pair": [
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            1
+          ],
+          "rejection_category_counts": {
+            "crossing": 129,
+            "row_pair+crossing": 64,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43125,
+            "survive": 1,
+            "witness_pair+crossing": 751
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              4,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            2
+          ],
+          "rejection_category_counts": {
+            "crossing": 55,
+            "row_pair+crossing": 52,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43219,
+            "survive": 1,
+            "witness_pair+crossing": 728
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            3
+          ],
+          "rejection_category_counts": {
+            "crossing": 76,
+            "row_pair+crossing": 17,
+            "row_pair+witness_pair": 43,
+            "row_pair+witness_pair+crossing": 43447,
+            "survive": 1,
+            "witness_pair+crossing": 516
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 124,
+            "row_pair+crossing": 43,
+            "row_pair+witness_pair": 59,
+            "row_pair+witness_pair+crossing": 42945,
+            "survive": 1,
+            "witness_pair+crossing": 928
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 77,
+            "row_pair+crossing": 18,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43421,
+            "survive": 1,
+            "witness_pair+crossing": 561
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 82,
+            "row_pair+crossing": 84,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43519,
+            "survive": 1,
+            "witness_pair+crossing": 369
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 58,
+            "row_pair+crossing": 20,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43315,
+            "survive": 1,
+            "witness_pair+crossing": 676
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            2
+          ],
+          "rejection_category_counts": {
+            "crossing": 110,
+            "row_pair+crossing": 24,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43190,
+            "survive": 1,
+            "witness_pair+crossing": 745
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            3
+          ],
+          "rejection_category_counts": {
+            "crossing": 96,
+            "row_pair+crossing": 73,
+            "row_pair+witness_pair": 85,
+            "row_pair+witness_pair+crossing": 43377,
+            "survive": 1,
+            "witness_pair+crossing": 468
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 91,
+            "row_pair+crossing": 14,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43407,
+            "survive": 1,
+            "witness_pair+crossing": 565
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 119,
+            "row_pair+crossing": 46,
+            "row_pair+witness_pair": 58,
+            "row_pair+witness_pair+crossing": 42920,
+            "survive": 1,
+            "witness_pair+crossing": 956
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 79,
+            "row_pair+crossing": 26,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43462,
+            "survive": 1,
+            "witness_pair+crossing": 510
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 47,
+            "row_pair+crossing": 30,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43263,
+            "survive": 1,
+            "witness_pair+crossing": 714
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            3
+          ],
+          "rejection_category_counts": {
+            "crossing": 36,
+            "row_pair+crossing": 60,
+            "row_pair+witness_pair": 50,
+            "row_pair+witness_pair+crossing": 43507,
+            "survive": 1,
+            "witness_pair+crossing": 446
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 46,
+            "row_pair+crossing": 47,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43523,
+            "survive": 1,
+            "witness_pair+crossing": 438
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 93,
+            "row_pair+crossing": 18,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43098,
+            "survive": 1,
+            "witness_pair+crossing": 858
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 95,
+            "row_pair+crossing": 40,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43264,
+            "survive": 1,
+            "witness_pair+crossing": 668
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 63,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43378,
+            "survive": 1,
+            "witness_pair+crossing": 636
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 23,
+            "row_pair+crossing": 48,
+            "row_pair+witness_pair": 132,
+            "row_pair+witness_pair+crossing": 43641,
+            "survive": 1,
+            "witness_pair+crossing": 255
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 45,
+            "row_pair+crossing": 30,
+            "row_pair+witness_pair": 35,
+            "row_pair+witness_pair+crossing": 43673,
+            "survive": 1,
+            "witness_pair+crossing": 316
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 81,
+            "row_pair+crossing": 67,
+            "row_pair+witness_pair": 91,
+            "row_pair+witness_pair+crossing": 43433,
+            "survive": 1,
+            "witness_pair+crossing": 427
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 68,
+            "row_pair+crossing": 29,
+            "row_pair+witness_pair": 60,
+            "row_pair+witness_pair+crossing": 43106,
+            "survive": 1,
+            "witness_pair+crossing": 836
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            4,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 21,
+            "row_pair+crossing": 35,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43663,
+            "survive": 1,
+            "witness_pair+crossing": 335
+          },
+          "source_rows": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            4,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 37,
+            "row_pair+crossing": 38,
+            "row_pair+witness_pair": 46,
+            "row_pair+witness_pair+crossing": 43649,
+            "survive": 1,
+            "witness_pair+crossing": 329
+          },
+          "source_rows": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            4,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 49,
+            "row_pair+crossing": 16,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43208,
+            "survive": 1,
+            "witness_pair+crossing": 794
+          },
+          "source_rows": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            6,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 22,
+            "row_pair+crossing": 45,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43742,
+            "survive": 1,
+            "witness_pair+crossing": 260
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            6,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 21,
+            "row_pair+crossing": 33,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43505,
+            "survive": 1,
+            "witness_pair+crossing": 495
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            7,
+            8
+          ],
+          "rejection_category_counts": {
+            "crossing": 28,
+            "row_pair+crossing": 46,
+            "row_pair+witness_pair": 44,
+            "row_pair+witness_pair+crossing": 43683,
+            "survive": 1,
+            "witness_pair+crossing": 298
+          },
+          "source_rows": [
+            [
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        }
+      ],
+      "two_row_drop_rejection_category_counts": {
+        "crossing": 1871,
+        "row_pair+crossing": 1063,
+        "row_pair+witness_pair": 1277,
+        "row_pair+witness_pair+crossing": 1214683,
+        "survive": 28,
+        "witness_pair+crossing": 15878
+      },
+      "two_row_drop_replacement_count_per_center": 70,
+      "two_row_drop_surviving_candidate_count": 28,
+      "two_row_drop_survivors": [
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              4,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            1
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            2
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            3
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            4
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            6
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            7
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            2
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            3
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            4
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            6
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            7
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            3
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            4
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            6
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            7
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            4
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            6
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            7
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            4,
+            6
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            4,
+            7
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            4,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            6,
+            7
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            6,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              1,
+              4,
+              6
+            ],
+            [
+              1,
+              2,
+              5,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            7,
+            8
+          ],
+          "target_center_class": [
+            2,
+            4,
+            7,
+            8
+          ],
+          "target_center_class_is_original": true
+        }
+      ],
+      "two_row_drop_survivors_all_original_rows": true
+    },
+    {
+      "bootstrap_core_witnesses": [
+        1,
+        2
+      ],
+      "original_target_center_class": [
+        1,
+        2,
+        5,
+        7
+      ],
+      "singleton_support_labels": [
+        5,
+        7
+      ],
+      "target_center": 8,
+      "target_center_candidate_classes": [
+        [
+          0,
+          1,
+          2,
+          5
+        ],
+        [
+          1,
+          2,
+          3,
+          5
+        ],
+        [
+          1,
+          2,
+          4,
+          5
+        ],
+        [
+          1,
+          2,
+          5,
+          6
+        ],
+        [
+          0,
+          1,
+          2,
+          7
+        ],
+        [
+          1,
+          2,
+          3,
+          7
+        ],
+        [
+          1,
+          2,
+          4,
+          7
+        ],
+        [
+          1,
+          2,
+          5,
+          7
+        ],
+        [
+          1,
+          2,
+          6,
+          7
+        ]
+      ],
+      "target_center_candidate_count": 9,
+      "target_row_key": "151:8",
+      "two_row_drop_candidate_count": 1234800,
+      "two_row_drop_centers": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "two_row_drop_dropped_center_pair_count": 28,
+      "two_row_drop_non_original_survivor_count": 0,
+      "two_row_drop_per_dropped_center_pair": [
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            1
+          ],
+          "rejection_category_counts": {
+            "crossing": 46,
+            "row_pair+crossing": 64,
+            "row_pair+witness_pair": 89,
+            "row_pair+witness_pair+crossing": 43663,
+            "survive": 1,
+            "witness_pair+crossing": 237
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              4,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            2
+          ],
+          "rejection_category_counts": {
+            "crossing": 92,
+            "row_pair+crossing": 67,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43480,
+            "survive": 1,
+            "witness_pair+crossing": 415
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            3
+          ],
+          "rejection_category_counts": {
+            "crossing": 99,
+            "row_pair+crossing": 31,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43414,
+            "survive": 1,
+            "witness_pair+crossing": 533
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 225,
+            "row_pair+crossing": 64,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43030,
+            "survive": 1,
+            "witness_pair+crossing": 748
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            5
+          ],
+          "rejection_category_counts": {
+            "crossing": 168,
+            "row_pair+crossing": 19,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43221,
+            "survive": 1,
+            "witness_pair+crossing": 659
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 72,
+            "row_pair+crossing": 28,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43718,
+            "survive": 1,
+            "witness_pair+crossing": 259
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            0,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 59,
+            "row_pair+crossing": 70,
+            "row_pair+witness_pair": 136,
+            "row_pair+witness_pair+crossing": 43605,
+            "survive": 1,
+            "witness_pair+crossing": 229
+          },
+          "source_rows": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            2
+          ],
+          "rejection_category_counts": {
+            "crossing": 69,
+            "row_pair+crossing": 47,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43605,
+            "survive": 1,
+            "witness_pair+crossing": 348
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            3
+          ],
+          "rejection_category_counts": {
+            "crossing": 104,
+            "row_pair+crossing": 72,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43402,
+            "survive": 1,
+            "witness_pair+crossing": 476
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 81,
+            "row_pair+crossing": 8,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43422,
+            "survive": 1,
+            "witness_pair+crossing": 566
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            5
+          ],
+          "rejection_category_counts": {
+            "crossing": 107,
+            "row_pair+crossing": 17,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43316,
+            "survive": 1,
+            "witness_pair+crossing": 627
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 135,
+            "row_pair+crossing": 35,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43468,
+            "survive": 1,
+            "witness_pair+crossing": 429
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            1,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 62,
+            "row_pair+crossing": 26,
+            "row_pair+witness_pair": 39,
+            "row_pair+witness_pair+crossing": 43703,
+            "survive": 1,
+            "witness_pair+crossing": 269
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            3
+          ],
+          "rejection_category_counts": {
+            "crossing": 115,
+            "row_pair+crossing": 61,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43252,
+            "survive": 1,
+            "witness_pair+crossing": 641
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 150,
+            "row_pair+crossing": 38,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43058,
+            "survive": 1,
+            "witness_pair+crossing": 808
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            5
+          ],
+          "rejection_category_counts": {
+            "crossing": 137,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43462,
+            "survive": 1,
+            "witness_pair+crossing": 478
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 166,
+            "row_pair+crossing": 17,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43169,
+            "survive": 1,
+            "witness_pair+crossing": 715
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            2,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 168,
+            "row_pair+crossing": 43,
+            "row_pair+witness_pair": 32,
+            "row_pair+witness_pair+crossing": 43298,
+            "survive": 1,
+            "witness_pair+crossing": 558
+          },
+          "source_rows": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            4
+          ],
+          "rejection_category_counts": {
+            "crossing": 153,
+            "row_pair+crossing": 40,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43090,
+            "survive": 1,
+            "witness_pair+crossing": 786
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            5
+          ],
+          "rejection_category_counts": {
+            "crossing": 127,
+            "row_pair+crossing": 36,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43235,
+            "survive": 1,
+            "witness_pair+crossing": 656
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 75,
+            "row_pair+crossing": 5,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43458,
+            "survive": 1,
+            "witness_pair+crossing": 539
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            3,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 206,
+            "row_pair+crossing": 68,
+            "row_pair+witness_pair": 49,
+            "row_pair+witness_pair+crossing": 43162,
+            "survive": 1,
+            "witness_pair+crossing": 614
+          },
+          "source_rows": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            4,
+            5
+          ],
+          "rejection_category_counts": {
+            "crossing": 76,
+            "row_pair+crossing": 39,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43406,
+            "survive": 1,
+            "witness_pair+crossing": 548
+          },
+          "source_rows": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            4,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 89,
+            "row_pair+crossing": 49,
+            "row_pair+witness_pair": 45,
+            "row_pair+witness_pair+crossing": 43426,
+            "survive": 1,
+            "witness_pair+crossing": 490
+          },
+          "source_rows": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            4,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 112,
+            "row_pair+crossing": 29,
+            "row_pair+witness_pair": 22,
+            "row_pair+witness_pair+crossing": 43451,
+            "survive": 1,
+            "witness_pair+crossing": 485
+          },
+          "source_rows": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            5,
+            6
+          ],
+          "rejection_category_counts": {
+            "crossing": 45,
+            "row_pair+crossing": 37,
+            "row_pair+witness_pair": 30,
+            "row_pair+witness_pair+crossing": 43659,
+            "survive": 1,
+            "witness_pair+crossing": 328
+          },
+          "source_rows": [
+            [
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            5,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 72,
+            "row_pair+crossing": 59,
+            "row_pair+witness_pair": 65,
+            "row_pair+witness_pair+crossing": 43650,
+            "survive": 1,
+            "witness_pair+crossing": 253
+          },
+          "source_rows": [
+            [
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        },
+        {
+          "candidate_count": 44100,
+          "dropped_centers": [
+            6,
+            7
+          ],
+          "rejection_category_counts": {
+            "crossing": 49,
+            "row_pair+crossing": 77,
+            "row_pair+witness_pair": 58,
+            "row_pair+witness_pair+crossing": 43733,
+            "survive": 1,
+            "witness_pair+crossing": 182
+          },
+          "source_rows": [
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "surviving_candidate_count": 1
+        }
+      ],
+      "two_row_drop_rejection_category_counts": {
+        "crossing": 3059,
+        "row_pair+crossing": 1146,
+        "row_pair+witness_pair": 1135,
+        "row_pair+witness_pair+crossing": 1215556,
+        "survive": 28,
+        "witness_pair+crossing": 13876
+      },
+      "two_row_drop_replacement_count_per_center": 70,
+      "two_row_drop_surviving_candidate_count": 28,
+      "two_row_drop_survivors": [
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              4,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            1
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            2
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            3
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            4
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            5
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            6
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              3,
+              6,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            0,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              4,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            2
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            3
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            4
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            5
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            6
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              4,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            1,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              2,
+              5,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            3
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            4
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            5
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            6
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              4,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            2,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              1,
+              3,
+              6,
+              7
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            4
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            5
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            6
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              2,
+              5,
+              6
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            3,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              2,
+              4,
+              7,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            4,
+            5
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            4,
+            6
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              1,
+              3,
+              6,
+              7
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            4,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              0,
+              3,
+              5,
+              8
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            5,
+            6
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              2,
+              4,
+              7,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            5,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        },
+        {
+          "dropped_center_classes": [
+            [
+              0,
+              3,
+              5,
+              8
+            ],
+            [
+              0,
+              1,
+              4,
+              6
+            ]
+          ],
+          "dropped_center_classes_are_original": [
+            true,
+            true
+          ],
+          "dropped_centers": [
+            6,
+            7
+          ],
+          "target_center_class": [
+            1,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": true
+        }
+      ],
+      "two_row_drop_survivors_all_original_rows": true
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-151-singleton-support-audit.md
+++ b/docs/bootstrap-t12-151-singleton-support-audit.md
@@ -87,6 +87,12 @@ one-row-drop stress test. It does not prove that singleton support labels are
 forced by a genuine rich-class catalogue, does not allow two or more other rows
 to move, and does not model additional auxiliary rich supports.
 
+A follow-up two-row-drop relaxation is recorded in
+`docs/bootstrap-t12-151-singleton-two-row-drop.md`. It allows any unordered
+pair of non-target rows to move arbitrarily and finds only the same trivial
+original-neighborhood survivors. That extension is still finite
+incidence/crossing bookkeeping only, not row forcing or a bridge proof.
+
 ## What This Does Not Prove
 
 This artifact does not prove singleton support existence, row forcing, `n=9`,

--- a/docs/bootstrap-t12-151-singleton-two-row-drop.md
+++ b/docs/bootstrap-t12-151-singleton-two-row-drop.md
@@ -1,0 +1,114 @@
+# Bootstrap T12 151 Singleton Two-Row-Drop Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet extends the source-`151` singleton-support audit for the two
+one-outside-label targets:
+
+```text
+151:5
+151:8
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_151_singleton_two_row_drop.json`.
+
+## Scan Scope
+
+The source input is the existing singleton-support audit packet:
+
+```text
+data/certificates/bootstrap_t12_151_singleton_support_audit.json
+```
+
+For row `151:5`, the target row ranges over the nine selected rows containing
+bootstrap-core witnesses `[2,4]` and at least one singleton support from
+`[7,8]`.
+
+For row `151:8`, the target row ranges over the nine selected rows containing
+bootstrap-core witnesses `[1,2]` and at least one singleton support from
+`[5,7]`.
+
+For each target, the scan chooses two non-target row centers and allows both
+of those selected rows to be arbitrary `4`-sets. Thus each target checks
+
+```text
+9 * binom(8,2) * 70 * 70 = 1,234,800
+```
+
+candidate states, and the two targets together check `2,469,600` states.
+
+The scan uses only the same basic selected-row filters as the one-row-drop
+audit:
+
+- row-pair cap;
+- witness-pair cap;
+- two-overlap crossing in the natural cyclic order.
+
+No Euclidean realization, exact distance equation, minimality hypothesis, or
+rich-class forcing hypothesis is used.
+
+## Result
+
+The two-row-drop relaxation has `56` survivors in total:
+
+```text
+151:5 -> 28 survivors
+151:8 -> 28 survivors
+```
+
+All survivors are trivial original-neighborhood survivors: the target row is
+the original source-`151` row, and both dropped rows are also equal to their
+original source-`151` rows.
+
+The checked scan status is:
+
+```text
+ONLY_ORIGINAL_SOURCE151_ROWS_SURVIVE_TWO_ROW_DROP_SUPPORT_AUDIT
+```
+
+The rejection category counts are:
+
+```text
+151:5
+  crossing                         1,871
+  row_pair+crossing                1,063
+  row_pair+witness_pair            1,277
+  row_pair+witness_pair+crossing   1,214,683
+  witness_pair+crossing            15,878
+  survive                          28
+
+151:8
+  crossing                         3,059
+  row_pair+crossing                1,146
+  row_pair+witness_pair            1,135
+  row_pair+witness_pair+crossing   1,215,556
+  witness_pair+crossing            13,876
+  survive                          28
+```
+
+## Remaining Gap
+
+This closes the two-moving-row version of the narrow local escape route for
+source-`151` singleton-support targets under the same basic filters. It still
+does not prove that singleton support labels are forced by a genuine rich-class
+catalogue, does not allow three or more other rows to move, and does not model
+additional auxiliary rich supports.
+
+## What This Does Not Prove
+
+This artifact does not prove singleton support existence, row forcing, `n=9`,
+the bootstrap bridge, or Erdos Problem #97. It is a finite proof-mining
+diagnostic for two T12 row targets.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -947,6 +947,15 @@ original source-`151` row. This remains a finite proof-mining diagnostic only,
 not a proof of singleton support existence, row forcing, `n=9`, the bootstrap
 bridge, or Erdos Problem #97.
 
+The source-`151` two-row-drop extension in
+`docs/bootstrap-t12-151-singleton-two-row-drop.md` lets any unordered pair of
+non-target rows move arbitrarily while the target row stays in its
+bootstrap-core-plus-singleton activation family. It checks `2,469,600`
+candidates across rows `151:5` and `151:8`, leaves `56` survivors, and every
+survivor keeps the target row and both dropped rows equal to their source-`151`
+rows. This is still finite incidence/crossing bookkeeping only, not singleton
+support existence, row forcing, `n=9`, or a bridge proof.
+
 ### n=8 witness indegree regularity
 
 For `n=8`, the pair-sharing cap forces every witness indegree to equal 4. If a

--- a/docs/index.md
+++ b/docs/index.md
@@ -280,6 +280,8 @@ put detailed reconciliation in the canonical synthesis.
   survives the fixed-neighborhood and one-row-drop activation-row scans.
 - [`bootstrap-t12-151-singleton-support-audit.md`](bootstrap-t12-151-singleton-support-audit.md):
   source-`151` singleton-support audit covering rows `151:5` and `151:8`.
+- [`bootstrap-t12-151-singleton-two-row-drop.md`](bootstrap-t12-151-singleton-two-row-drop.md):
+  two-row-drop relaxation audit for the source-`151` singleton-support rows.
 - [`bootstrap-t12-row-pressure.md`](bootstrap-t12-row-pressure.md):
   row-pressure refinement classifying those missing T12 row centers by core
   deficit, deletion-closure exposure, and private-halo support.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -5545,6 +5545,68 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_151_singleton_two_row_drop
+    path: data/certificates/bootstrap_t12_151_singleton_two_row_drop.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_151_singleton_two_row_drop.py
+    command: python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_151_singleton_two_row_drop.py
+    check_command: python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-151 singleton-support two-row-drop stress test for rows 5 and 8; only original source-151 rows survive when exactly two non-target selected rows move under basic incidence/crossing filters, but this is not singleton-support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_151_singleton_two_row_drop.v1
+      status: BOOTSTRAP_T12_151_SINGLETON_TWO_ROW_DROP_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.source_record_ids:
+        - 151
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.target_row_keys:
+        - "151:5"
+        - "151:8"
+      summary.target_centers:
+        - 5
+        - 8
+      summary.target_count: 2
+      summary.target_center_candidate_count_by_key.151:5: 9
+      summary.target_center_candidate_count_by_key.151:8: 9
+      summary.two_row_drop_candidate_count: 2469600
+      summary.two_row_drop_surviving_candidate_count: 56
+      summary.two_row_drop_non_original_survivor_count: 0
+      summary.two_row_drop_survivors_all_original_rows: true
+      summary.scan_status: ONLY_ORIGINAL_SOURCE151_ROWS_SURVIVE_TWO_ROW_DROP_SUPPORT_AUDIT
+      source_singleton_support_packet.schema: erdos97.bootstrap_t12_151_singleton_support_audit.v1
+      source_singleton_support_packet.status: BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY
+      provenance.generator: scripts/check_bootstrap_t12_151_singleton_two_row_drop.py
+      provenance.command: python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - singleton support proves row-center forcing
+      - source 151 singleton rows are forced
+      - source 151 singleton support exists
+      - the source 151 singleton two-row-drop audit proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_row_pressure
     path: data/certificates/bootstrap_t12_row_pressure.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_151_singleton_two_row_drop.py
+++ b/scripts/check_bootstrap_t12_151_singleton_two_row_drop.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 source-151 singleton two-row-drop audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_151_singleton_two_row_drop import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    DEFAULT_SOURCE_ARTIFACT,
+    assert_expected_payload,
+    build_t12_151_singleton_two_row_drop_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 source-151 singleton two-row-drop audit")
+    print(f"target rows: {summary['target_row_keys']}")
+    print(f"two-row-drop candidates: {summary['two_row_drop_candidate_count']}")
+    print(f"two-row-drop survivors: {summary['two_row_drop_surviving_candidate_count']}")
+    print(
+        "non-original survivors: "
+        f"{summary['two_row_drop_non_original_survivor_count']}"
+    )
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--source-artifact",
+        type=Path,
+        default=DEFAULT_SOURCE_ARTIFACT,
+        help="source singleton-support audit packet",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+    source_artifact = args.source_artifact
+    if not source_artifact.is_absolute():
+        source_artifact = ROOT / source_artifact
+
+    generated = build_t12_151_singleton_two_row_drop_payload(source_artifact)
+    payload = generated
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored source-151 singleton two-row artifact matches")
+        if args.assert_expected:
+            print("OK: source-151 singleton two-row expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2060,6 +2060,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_151_singleton_two_row_drop",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_151_singleton_two_row_drop.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Two-row-drop singleton-support stress test for source 151 rows "
+            "5 and 8; not singleton-support existence, row forcing, an n=9 "
+            "proof, a bridge proof, or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="closure_activation_wrong_fourth_negative_control",
         command=(
             "python",

--- a/src/erdos97/bootstrap_t12_151_singleton_two_row_drop.py
+++ b/src/erdos97/bootstrap_t12_151_singleton_two_row_drop.py
@@ -1,0 +1,640 @@
+"""Two-row-drop audit for the bootstrap/T12 source-151 singleton targets.
+
+This replay treats ``data/certificates/bootstrap_t12_151_singleton_support_audit.json``
+as input data.  For each source-151 singleton-support target row, it keeps the
+target row inside the previously audited bootstrap-core-plus-singleton-support
+candidate family, lets two non-target selected rows move arbitrarily, and checks
+only the basic selected-row filters: row-pair cap, witness-pair cap, and the
+natural-order two-overlap crossing condition.
+
+The result is a proof-mining diagnostic, not a Euclidean realization theorem and
+not a proof of row/rich-class forcing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SCHEMA = "erdos97.bootstrap_t12_151_singleton_two_row_drop.v1"
+STATUS = "BOOTSTRAP_T12_151_SINGLETON_TWO_ROW_DROP_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "ONLY_ORIGINAL_SOURCE151_ROWS_SURVIVE_TWO_ROW_DROP_SUPPORT_AUDIT"
+CLAIM_SCOPE = (
+    "Two-row-drop singleton-support stress test for source 151 rows 5 and 8. "
+    "It treats the existing source-151 singleton-support audit packet as input, "
+    "keeps each target row in the bootstrap-core-plus-singleton-support "
+    "candidate family, allows two non-target selected rows to move arbitrarily, "
+    "and checks only row-pair, witness-pair, and two-overlap crossing filters. "
+    "The only survivors keep the original target row and both dropped rows "
+    "equal to their source-151 rows. This does not prove singleton support "
+    "existence, row forcing, n=9, the bootstrap bridge, Erdos Problem #97, or "
+    "any counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_singleton_support_audit.json"
+)
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_singleton_two_row_drop.json"
+)
+SOURCE_SCHEMA = "erdos97.bootstrap_t12_151_singleton_support_audit.v1"
+SOURCE_STATUS = "BOOTSTRAP_T12_151_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY"
+
+EXPECTED_BY_KEY: dict[str, dict[str, object]] = {
+    "151:5": {
+        "target_center": 5,
+        "candidate_count": 1_234_800,
+        "surviving_candidate_count": 28,
+        "non_original_survivor_count": 0,
+        "rejection_category_counts": {
+            "crossing": 1_871,
+            "row_pair+crossing": 1_063,
+            "row_pair+witness_pair": 1_277,
+            "row_pair+witness_pair+crossing": 1_214_683,
+            "survive": 28,
+            "witness_pair+crossing": 15_878,
+        },
+    },
+    "151:8": {
+        "target_center": 8,
+        "candidate_count": 1_234_800,
+        "surviving_candidate_count": 28,
+        "non_original_survivor_count": 0,
+        "rejection_category_counts": {
+            "crossing": 3_059,
+            "row_pair+crossing": 1_146,
+            "row_pair+witness_pair": 1_135,
+            "row_pair+witness_pair+crossing": 1_215_556,
+            "survive": 28,
+            "witness_pair+crossing": 13_876,
+        },
+    },
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[str]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise AssertionError(f"{name} must be a mapping")
+    return value
+
+
+def _require_sequence(value: Any, name: str) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise AssertionError(f"{name} must be a sequence")
+    return value
+
+
+def _mask(row: Iterable[int]) -> int:
+    out = 0
+    for label in row:
+        out |= 1 << int(label)
+    return out
+
+
+def _row_from_mask(mask: int, n: int) -> list[int]:
+    return [label for label in range(n) if (mask >> label) & 1]
+
+
+def _all_replacement_masks(center: int, cyclic_order: Sequence[int]) -> list[int]:
+    labels = [label for label in cyclic_order if label != center]
+    return [_mask(row) for row in combinations(labels, 4)]
+
+
+def _extract_target_candidates(record: Mapping[str, Any]) -> list[int]:
+    raw = record.get("target_center_candidate_classes")
+    if raw is None:
+        # Defensive fallback for older input packets: the fixed-neighborhood
+        # candidate table contains exactly the same target-row family.
+        fixed = _require_sequence(
+            record.get("fixed_neighborhood_candidates"),
+            "fixed_neighborhood_candidates",
+        )
+        raw = [
+            _require_mapping(candidate, "fixed_neighborhood_candidate")[
+                "target_center_class"
+            ]
+            for candidate in fixed
+        ]
+    return sorted({_mask(_int_list(row)) for row in _require_sequence(raw, "candidates")})
+
+
+def _support_packet_input(
+    source_artifact: Path = DEFAULT_SOURCE_ARTIFACT,
+) -> tuple[list[int], list[list[int]], list[dict[str, object]], dict[str, object]]:
+    payload = _load_json(source_artifact)
+    if payload.get("schema") != SOURCE_SCHEMA:
+        raise AssertionError("source singleton-support artifact schema drifted")
+    if payload.get("status") != SOURCE_STATUS:
+        raise AssertionError("source singleton-support artifact status drifted")
+
+    summary = _require_mapping(payload.get("summary"), "source summary")
+    cyclic_order = _int_list(_require_sequence(summary.get("cyclic_order"), "cyclic_order"))
+    if cyclic_order != list(range(len(cyclic_order))):
+        raise AssertionError(
+            "two-row-drop replay currently expects the natural source-151 order"
+        )
+
+    source_rows_raw = _require_mapping(payload.get("source_rows"), "source_rows")
+    source_rows = [_int_list(source_rows_raw[str(center)]) for center in cyclic_order]
+
+    records_raw = _require_sequence(payload.get("target_audits"), "target_audits")
+    targets: list[dict[str, object]] = []
+    for raw_record in records_raw:
+        record = _require_mapping(raw_record, "target_audit")
+        key = str(record["target_row_key"])
+        if key not in EXPECTED_BY_KEY:
+            continue
+        targets.append(
+            {
+                "target_row_key": key,
+                "target_center": int(record["target_center"]),
+                "bootstrap_core_witnesses": _int_list(record["bootstrap_core_witnesses"]),
+                "singleton_support_labels": _int_list(record["singleton_support_labels"]),
+                "original_target_center_class": _int_list(
+                    record["original_target_center_class"]
+                ),
+                "target_center_candidate_classes": [
+                    _row_from_mask(mask, len(cyclic_order))
+                    for mask in _extract_target_candidates(record)
+                ],
+            }
+        )
+    if sorted(str(target["target_row_key"]) for target in targets) != sorted(EXPECTED_BY_KEY):
+        raise AssertionError("source singleton-support target rows drifted")
+
+    source_packet = {
+        "path": source_artifact.relative_to(REPO_ROOT).as_posix()
+        if source_artifact.is_relative_to(REPO_ROOT)
+        else str(source_artifact),
+        "schema": SOURCE_SCHEMA,
+        "status": SOURCE_STATUS,
+    }
+    return (
+        cyclic_order,
+        source_rows,
+        sorted(targets, key=lambda target: str(target["target_row_key"])),
+        source_packet,
+    )
+
+
+def _pair_index_data(n: int) -> tuple[dict[tuple[int, int], int], list[tuple[int, int]]]:
+    pair_to_index: dict[tuple[int, int], int] = {}
+    index_to_pair: list[tuple[int, int]] = []
+    for index, pair in enumerate(combinations(range(n), 2)):
+        pair_to_index[pair] = index
+        index_to_pair.append(pair)
+    return pair_to_index, index_to_pair
+
+
+def _pair_indices_for_mask(
+    mask: int,
+    n: int,
+    pair_to_index: Mapping[tuple[int, int], int],
+) -> tuple[int, ...]:
+    labels = _row_from_mask(mask, n)
+    return tuple(pair_to_index[(a, b)] for a, b in combinations(labels, 2))
+
+
+def _crosses_in_natural_order(
+    source: tuple[int, int], target_mask: int, n: int
+) -> bool:
+    labels = _row_from_mask(target_mask, n)
+    if len(labels) != 2:
+        raise ValueError("target_mask must contain exactly two labels")
+    a, b = sorted(source)
+    c, d = sorted(labels)
+    if {a, b} & {c, d}:
+        return False
+    return (a < c < b) != (a < d < b)
+
+
+def _affected_center_pairs(
+    cyclic_order: Sequence[int], changed_centers: Sequence[int]
+) -> tuple[tuple[int, int], ...]:
+    changed = set(changed_centers)
+    return tuple(
+        (i, j)
+        for i, j in combinations(cyclic_order, 2)
+        if i in changed or j in changed
+    )
+
+
+def _scan_category(
+    rows: Sequence[int],
+    base_rows: Sequence[int],
+    base_pair_counts: Sequence[int],
+    row_pair_indices: Mapping[int, tuple[int, ...]],
+    affected_pairs: Sequence[tuple[int, int]],
+    changed_centers: Sequence[int],
+    n: int,
+) -> str:
+    row_pair = any((rows[i] & rows[j]).bit_count() > 2 for i, j in affected_pairs)
+
+    deltas: dict[int, int] = {}
+    for center in changed_centers:
+        for pair_index in row_pair_indices[base_rows[center]]:
+            deltas[pair_index] = deltas.get(pair_index, 0) - 1
+        for pair_index in row_pair_indices[rows[center]]:
+            deltas[pair_index] = deltas.get(pair_index, 0) + 1
+    witness_pair = any(
+        base_pair_counts[pair_index] + delta > 2
+        for pair_index, delta in deltas.items()
+    )
+
+    crossing = False
+    for i, j in affected_pairs:
+        intersection = rows[i] & rows[j]
+        if intersection.bit_count() == 2 and not _crosses_in_natural_order(
+            (i, j), intersection, n
+        ):
+            crossing = True
+            break
+
+    reasons: list[str] = []
+    if row_pair:
+        reasons.append("row_pair")
+    if witness_pair:
+        reasons.append("witness_pair")
+    if crossing:
+        reasons.append("crossing")
+    return "+".join(reasons) if reasons else "survive"
+
+
+def _build_context(
+    cyclic_order: Sequence[int],
+    source_rows: Sequence[Sequence[int]],
+) -> dict[str, object]:
+    n = len(cyclic_order)
+    base_masks = [_mask(row) for row in source_rows]
+    all_four_masks = [_mask(row) for row in combinations(cyclic_order, 4)]
+    pair_to_index, index_to_pair = _pair_index_data(n)
+    row_pair_indices = {
+        mask: _pair_indices_for_mask(mask, n, pair_to_index) for mask in all_four_masks
+    }
+    base_pair_counts = [0] * len(index_to_pair)
+    for base_mask in base_masks:
+        for pair_index in row_pair_indices[base_mask]:
+            base_pair_counts[pair_index] += 1
+    return {
+        "n": n,
+        "base_masks": base_masks,
+        "base_pair_counts": base_pair_counts,
+        "row_pair_indices": row_pair_indices,
+        "all_replacement_masks": {
+            center: _all_replacement_masks(center, cyclic_order) for center in cyclic_order
+        },
+    }
+
+
+def _scan_target(
+    cyclic_order: Sequence[int],
+    source_rows: Sequence[Sequence[int]],
+    target: Mapping[str, object],
+    context: Mapping[str, object],
+) -> dict[str, object]:
+    n = int(context["n"])
+    base_masks = list(_require_sequence(context["base_masks"], "base_masks"))
+    base_pair_counts = list(
+        _require_sequence(context["base_pair_counts"], "base_pair_counts")
+    )
+    row_pair_indices = _require_mapping(
+        context["row_pair_indices"], "row_pair_indices"
+    )
+    all_replacements = _require_mapping(
+        context["all_replacement_masks"], "all_replacement_masks"
+    )
+
+    center = int(target["target_center"])
+    target_key = str(target["target_row_key"])
+    target_candidate_rows = _require_sequence(
+        target["target_center_candidate_classes"],
+        "target_center_candidate_classes",
+    )
+    target_masks = [_mask(_int_list(row)) for row in target_candidate_rows]
+    original_target_mask = _mask(target["original_target_center_class"])  # type: ignore[arg-type]
+    dropped_centers = [label for label in cyclic_order if label != center]
+
+    total_counts: Counter[str] = Counter()
+    per_pair_counts: dict[tuple[int, int], Counter[str]] = {
+        pair: Counter() for pair in combinations(dropped_centers, 2)
+    }
+    survivors: list[dict[str, object]] = []
+    non_original_survivors: list[dict[str, object]] = []
+
+    for target_mask in target_masks:
+        target_is_original = target_mask == original_target_mask
+        for dropped_left, dropped_right in combinations(dropped_centers, 2):
+            changed_centers = (center, dropped_left, dropped_right)
+            affected_pairs = _affected_center_pairs(cyclic_order, changed_centers)
+            left_rows = list(all_replacements[dropped_left])
+            right_rows = list(all_replacements[dropped_right])
+            for left_mask in left_rows:
+                left_is_original = left_mask == base_masks[dropped_left]
+                for right_mask in right_rows:
+                    right_is_original = right_mask == base_masks[dropped_right]
+                    rows = list(base_masks)
+                    rows[center] = target_mask
+                    rows[dropped_left] = left_mask
+                    rows[dropped_right] = right_mask
+                    category = _scan_category(
+                        rows=rows,
+                        base_rows=base_masks,
+                        base_pair_counts=base_pair_counts,
+                        row_pair_indices=row_pair_indices,
+                        affected_pairs=affected_pairs,
+                        changed_centers=changed_centers,
+                        n=n,
+                    )
+                    total_counts[category] += 1
+                    per_pair_counts[(dropped_left, dropped_right)][category] += 1
+                    if category == "survive":
+                        survivor = {
+                            "target_center_class": _row_from_mask(target_mask, n),
+                            "target_center_class_is_original": bool(target_is_original),
+                            "dropped_centers": [int(dropped_left), int(dropped_right)],
+                            "dropped_center_classes": [
+                                _row_from_mask(left_mask, n),
+                                _row_from_mask(right_mask, n),
+                            ],
+                            "dropped_center_classes_are_original": [
+                                bool(left_is_original),
+                                bool(right_is_original),
+                            ],
+                        }
+                        survivors.append(survivor)
+                        if not (
+                            target_is_original
+                            and left_is_original
+                            and right_is_original
+                        ):
+                            non_original_survivors.append(survivor)
+
+    return {
+        "target_row_key": target_key,
+        "target_center": center,
+        "bootstrap_core_witnesses": list(target["bootstrap_core_witnesses"]),
+        "singleton_support_labels": list(target["singleton_support_labels"]),
+        "original_target_center_class": list(target["original_target_center_class"]),
+        "target_center_candidate_classes": [
+            _row_from_mask(target_mask, n) for target_mask in target_masks
+        ],
+        "target_center_candidate_count": len(target_masks),
+        "two_row_drop_centers": dropped_centers,
+        "two_row_drop_dropped_center_pair_count": len(per_pair_counts),
+        "two_row_drop_replacement_count_per_center": len(
+            list(all_replacements[dropped_centers[0]])
+        ),
+        "two_row_drop_candidate_count": sum(total_counts.values()),
+        "two_row_drop_surviving_candidate_count": len(survivors),
+        "two_row_drop_non_original_survivor_count": len(non_original_survivors),
+        "two_row_drop_survivors_all_original_rows": all(
+            bool(survivor["target_center_class_is_original"])
+            and all(survivor["dropped_center_classes_are_original"])
+            for survivor in survivors
+        ),
+        "two_row_drop_rejection_category_counts": _json_counter(total_counts),
+        "two_row_drop_per_dropped_center_pair": [
+            {
+                "dropped_centers": [int(dropped_left), int(dropped_right)],
+                "source_rows": [
+                    list(source_rows[dropped_left]),
+                    list(source_rows[dropped_right]),
+                ],
+                "candidate_count": sum(
+                    per_pair_counts[(dropped_left, dropped_right)].values()
+                ),
+                "surviving_candidate_count": per_pair_counts[
+                    (dropped_left, dropped_right)
+                ].get("survive", 0),
+                "rejection_category_counts": _json_counter(
+                    per_pair_counts[(dropped_left, dropped_right)]
+                ),
+            }
+            for dropped_left, dropped_right in sorted(per_pair_counts)
+        ],
+        "two_row_drop_survivors": survivors,
+    }
+
+
+def build_t12_151_singleton_two_row_drop_payload(
+    source_artifact: Path = DEFAULT_SOURCE_ARTIFACT,
+) -> dict[str, object]:
+    """Return the deterministic two-row-drop singleton-support audit payload."""
+
+    cyclic_order, source_rows, targets, source_packet = _support_packet_input(
+        source_artifact
+    )
+    context = _build_context(cyclic_order, source_rows)
+    target_audits = [
+        _scan_target(cyclic_order, source_rows, target, context) for target in targets
+    ]
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            (
+                "This is a finite proof-mining diagnostic around the fixed "
+                "source-151 selected-row neighborhood."
+            ),
+            (
+                "The scan allows exactly two non-target selected rows to move; "
+                "it does not model three or more moving rows."
+            ),
+            (
+                "Activation rows are bookkeeping objects; the scan does not "
+                "prove a genuine rich class exists."
+            ),
+            "The scan uses only incidence and crossing filters, not Euclidean realizability.",
+            (
+                "No n=9 finite-case status, bridge status, official status, "
+                "or counterexample status changes."
+            ),
+        ],
+        "summary": {
+            "source_record_ids": [151],
+            "cyclic_order": cyclic_order,
+            "target_row_keys": [str(record["target_row_key"]) for record in target_audits],
+            "target_centers": [int(record["target_center"]) for record in target_audits],
+            "target_count": len(target_audits),
+            "target_center_candidate_count_by_key": {
+                str(record["target_row_key"]): int(
+                    record["target_center_candidate_count"]
+                )
+                for record in target_audits
+            },
+            "two_row_drop_candidate_count": sum(
+                int(record["two_row_drop_candidate_count"])
+                for record in target_audits
+            ),
+            "two_row_drop_surviving_candidate_count": sum(
+                int(record["two_row_drop_surviving_candidate_count"])
+                for record in target_audits
+            ),
+            "two_row_drop_non_original_survivor_count": sum(
+                int(record["two_row_drop_non_original_survivor_count"])
+                for record in target_audits
+            ),
+            "two_row_drop_survivors_all_original_rows": all(
+                bool(record["two_row_drop_survivors_all_original_rows"])
+                for record in target_audits
+            ),
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not prove singleton support existence, does not "
+                "prove the rows are forced by minimal or rich-class geometry, "
+                "does not allow three or more other rows to move, and does not "
+                "model additional auxiliary rich supports."
+            ),
+        },
+        "source_rows": {str(center): source_rows[center] for center in cyclic_order},
+        "target_audits": target_audits,
+        "source_singleton_support_packet": source_packet,
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_151_singleton_two_row_drop.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = _require_mapping(payload.get("summary"), "summary")
+    expected_summary = {
+        "source_record_ids": [151],
+        "cyclic_order": list(range(9)),
+        "target_row_keys": ["151:5", "151:8"],
+        "target_centers": [5, 8],
+        "target_count": 2,
+        "target_center_candidate_count_by_key": {"151:5": 9, "151:8": 9},
+        "two_row_drop_candidate_count": 2_469_600,
+        "two_row_drop_surviving_candidate_count": 56,
+        "two_row_drop_non_original_survivor_count": 0,
+        "two_row_drop_survivors_all_original_rows": True,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    records = _require_sequence(payload.get("target_audits"), "target_audits")
+    if len(records) != 2:
+        raise AssertionError("expected two source-151 singleton two-row audits")
+    by_key = {
+        str(_require_mapping(record, "target_audit")["target_row_key"]): _require_mapping(
+            record, "target_audit"
+        )
+        for record in records
+    }
+    if sorted(by_key) != sorted(EXPECTED_BY_KEY):
+        raise AssertionError("unexpected source-151 singleton two-row audit keys")
+
+    for key, expected in EXPECTED_BY_KEY.items():
+        record = by_key[key]
+        if record.get("target_center") != expected["target_center"]:
+            raise AssertionError(f"{key} target center drifted")
+        if record.get("target_center_candidate_count") != 9:
+            raise AssertionError(f"{key} target candidate count drifted")
+        if record.get("two_row_drop_dropped_center_pair_count") != 28:
+            raise AssertionError(f"{key} dropped-center-pair count drifted")
+        if record.get("two_row_drop_replacement_count_per_center") != 70:
+            raise AssertionError(f"{key} replacement count drifted")
+        if record.get("two_row_drop_candidate_count") != expected["candidate_count"]:
+            raise AssertionError(f"{key} candidate count drifted")
+        if (
+            record.get("two_row_drop_surviving_candidate_count")
+            != expected["surviving_candidate_count"]
+        ):
+            raise AssertionError(f"{key} survivor count drifted")
+        if (
+            record.get("two_row_drop_non_original_survivor_count")
+            != expected["non_original_survivor_count"]
+        ):
+            raise AssertionError(f"{key} non-original survivor count drifted")
+        if record.get("two_row_drop_survivors_all_original_rows") is not True:
+            raise AssertionError(f"{key} survivor originality drifted")
+        if (
+            record.get("two_row_drop_rejection_category_counts")
+            != expected["rejection_category_counts"]
+        ):
+            raise AssertionError(f"{key} rejection category counts drifted")
+
+        per_pair = _require_sequence(
+            record.get("two_row_drop_per_dropped_center_pair"),
+            "two_row_drop_per_dropped_center_pair",
+        )
+        if len(per_pair) != 28:
+            raise AssertionError(f"{key} per-pair table length drifted")
+        for item in per_pair:
+            row = _require_mapping(item, "per_pair_row")
+            if row.get("candidate_count") != 44_100:
+                raise AssertionError(f"{key} per-pair candidate count drifted")
+            if row.get("surviving_candidate_count") != 1:
+                raise AssertionError(f"{key} per-pair survivor count drifted")
+
+        survivors = _require_sequence(
+            record.get("two_row_drop_survivors"), "two_row_drop_survivors"
+        )
+        if len(survivors) != 28:
+            raise AssertionError(f"{key} survivor list length drifted")
+        for survivor in survivors:
+            survivor_map = _require_mapping(survivor, "survivor")
+            if survivor_map.get("target_center_class_is_original") is not True:
+                raise AssertionError(f"{key} target survivor should be original")
+            if survivor_map.get("dropped_center_classes_are_original") != [True, True]:
+                raise AssertionError(f"{key} dropped-row survivors should be original")
+
+    source_packet = _require_mapping(
+        payload.get("source_singleton_support_packet"), "source_singleton_support_packet"
+    )
+    if source_packet.get("schema") != SOURCE_SCHEMA:
+        raise AssertionError("source singleton packet schema drifted")
+    if source_packet.get("status") != SOURCE_STATUS:
+        raise AssertionError("source singleton packet status drifted")

--- a/tests/test_bootstrap_t12_151_singleton_two_row_drop.py
+++ b/tests/test_bootstrap_t12_151_singleton_two_row_drop.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from erdos97.bootstrap_t12_151_singleton_two_row_drop import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    load_artifact,
+)
+
+
+def test_source151_two_row_drop_artifact_matches_expected_counts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["scan_status"] == SCAN_STATUS
+    assert summary["two_row_drop_candidate_count"] == 2_469_600
+    assert summary["two_row_drop_surviving_candidate_count"] == 56
+    assert summary["two_row_drop_non_original_survivor_count"] == 0
+
+
+def test_source151_two_row_drop_target_counts() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    by_key = {
+        record["target_row_key"]: record
+        for record in payload["target_audits"]
+    }
+
+    assert by_key["151:5"]["two_row_drop_candidate_count"] == 1_234_800
+    assert by_key["151:8"]["two_row_drop_candidate_count"] == 1_234_800
+    assert by_key["151:5"]["two_row_drop_surviving_candidate_count"] == 28
+    assert by_key["151:8"]["two_row_drop_surviving_candidate_count"] == 28
+    assert by_key["151:5"]["two_row_drop_survivors_all_original_rows"] is True
+    assert by_key["151:8"]["two_row_drop_survivors_all_original_rows"] is True


### PR DESCRIPTION
## Summary

- add a source-151 singleton-support two-row-drop audit for targets 151:5 and 151:8
- record the generated JSON certificate and provenance metadata
- wire the checker into bridge-frontier/audit paths with focused tests and scoped docs/status notes

## Review notes

This is a `REVIEW_PENDING_DIAGNOSTIC`. It checks 2,469,600 two-row-drop candidates across the two source-151 singleton-support targets and leaves 56 survivors, all trivial original-neighborhood survivors. It does not prove singleton-support existence, row forcing, n=9, the bootstrap bridge, or Erdos Problem #97.

## Verification

- `python scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_151_singleton_two_row_drop.py`
- `python -m ruff check .`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`