### PR TITLE
Add source 81 row 8 two-row drop audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -655,6 +655,17 @@ existence, row forcing, `n=9`, or the bootstrap bridge. See
 `scripts/check_bootstrap_t12_81_8_singleton_support_audit.py`, and
 `data/certificates/bootstrap_t12_81_8_singleton_support_audit.json`.
 
+The source-`81` row-`8` singleton-support two-row-drop follow-up lets any two
+non-target source-`81` rows move while row `8` ranges over the same nine
+activation rows. It checks `1,234,800` candidates and leaves `28` survivors,
+all of them trivial original-neighborhood survivors: row `8` is still
+`[0,2,5,6]`, and both dropped rows are still their original source-`81` rows.
+This is still a finite diagnostic only, not a proof of singleton support
+existence, row forcing, `n=9`, or the bootstrap bridge. See
+`docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md`,
+`scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py`, and
+`data/certificates/bootstrap_t12_81_8_singleton_support_two_row_drop.json`.
+
 The source-`151` row-`6` outside-pair audit probes the remaining
 relation-sufficient row target. Center `6` has bootstrap-core witness `[0]`
 and outside support pairs `[3,5]`, `[3,8]`, and `[5,8]`; the audit enumerates

--- a/STATE.md
+++ b/STATE.md
@@ -422,6 +422,14 @@ incidence/crossing bookkeeping only, not singleton-support existence, row
 forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-8-singleton-support-audit.md`.
 
+The source-`81` row-`8` two-row-drop follow-up lets any two non-target
+source-`81` rows move. It checks `1,234,800` candidates and leaves `28`
+survivors, all trivial original-neighborhood survivors with row `8` still
+`[0,2,5,6]` and both dropped rows still original. This remains basic
+incidence/crossing bookkeeping only, not singleton-support existence, row
+forcing, `n=9`, or the bridge. See
+`docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md`.
+
 A source-`151` row-`6` outside-pair audit now probes the remaining
 relation-sufficient row target. It enumerates the thirteen center-`6` rows
 containing bootstrap-core witness `[0]` and one outside support pair from

--- a/data/certificates/bootstrap_t12_81_8_singleton_support_two_row_drop.json
+++ b/data/certificates/bootstrap_t12_81_8_singleton_support_two_row_drop.json
@@ -1,0 +1,2025 @@
+{
+  "candidate_generation": {
+    "candidate_rule": "4-sets at center 8 containing bootstrap-core witnesses [0,2] and at least one singleton support label from [5,6].",
+    "dropped_row_choice_count_per_center": {
+      "0": 70,
+      "1": 70,
+      "2": 70,
+      "3": 70,
+      "4": 70,
+      "5": 70,
+      "6": 70,
+      "7": 70
+    },
+    "target_center_candidate_classes": [
+      [
+        0,
+        1,
+        2,
+        5
+      ],
+      [
+        0,
+        1,
+        2,
+        6
+      ],
+      [
+        0,
+        2,
+        3,
+        5
+      ],
+      [
+        0,
+        2,
+        3,
+        6
+      ],
+      [
+        0,
+        2,
+        4,
+        5
+      ],
+      [
+        0,
+        2,
+        4,
+        6
+      ],
+      [
+        0,
+        2,
+        5,
+        6
+      ],
+      [
+        0,
+        2,
+        5,
+        7
+      ],
+      [
+        0,
+        2,
+        6,
+        7
+      ]
+    ]
+  },
+  "claim_scope": "Two-row-drop relaxation of the source-81 row-8 singleton-support audit. For each pair of the eight source-81 rows outside center 8, it allows both rows to be replaced by arbitrary 4-sets while row 8 uses one of the nine singleton-support activation rows. The only 28 survivors are the trivial original-neighborhood survivors: row 8 is the original [0,2,5,6] row and both dropped rows are also original. This does not prove singleton support existence, row forcing, n=9, the bootstrap bridge, or Erdos Problem #97, and is not a counterexample.",
+  "interpretation_warnings": [
+    "This scan drops exactly two of the eight source-81 rows outside center 8.",
+    "Center 8 is still restricted to the nine singleton-support activation rows.",
+    "The scan uses incidence and crossing filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "per_dropped_pair": [
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        1
+      ],
+      "rejection_category_counts": {
+        "crossing": 23,
+        "row_pair+crossing": 48,
+        "row_pair+witness_pair": 132,
+        "row_pair+witness_pair+crossing": 43641,
+        "survive": 1,
+        "witness_pair+crossing": 255
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        2
+      ],
+      "rejection_category_counts": {
+        "crossing": 46,
+        "row_pair+crossing": 47,
+        "row_pair+witness_pair": 45,
+        "row_pair+witness_pair+crossing": 43523,
+        "survive": 1,
+        "witness_pair+crossing": 438
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        3
+      ],
+      "rejection_category_counts": {
+        "crossing": 91,
+        "row_pair+crossing": 14,
+        "row_pair+witness_pair": 22,
+        "row_pair+witness_pair+crossing": 43407,
+        "survive": 1,
+        "witness_pair+crossing": 565
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 124,
+        "row_pair+crossing": 43,
+        "row_pair+witness_pair": 59,
+        "row_pair+witness_pair+crossing": 42945,
+        "survive": 1,
+        "witness_pair+crossing": 928
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 49,
+        "row_pair+crossing": 16,
+        "row_pair+witness_pair": 32,
+        "row_pair+witness_pair+crossing": 43208,
+        "survive": 1,
+        "witness_pair+crossing": 794
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        6
+      ],
+      "rejection_category_counts": {
+        "crossing": 37,
+        "row_pair+crossing": 38,
+        "row_pair+witness_pair": 46,
+        "row_pair+witness_pair+crossing": 43649,
+        "survive": 1,
+        "witness_pair+crossing": 329
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        0,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 21,
+        "row_pair+crossing": 35,
+        "row_pair+witness_pair": 45,
+        "row_pair+witness_pair+crossing": 43663,
+        "survive": 1,
+        "witness_pair+crossing": 335
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        1,
+        2
+      ],
+      "rejection_category_counts": {
+        "crossing": 36,
+        "row_pair+crossing": 60,
+        "row_pair+witness_pair": 50,
+        "row_pair+witness_pair+crossing": 43507,
+        "survive": 1,
+        "witness_pair+crossing": 446
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        1,
+        3
+      ],
+      "rejection_category_counts": {
+        "crossing": 96,
+        "row_pair+crossing": 73,
+        "row_pair+witness_pair": 85,
+        "row_pair+witness_pair+crossing": 43377,
+        "survive": 1,
+        "witness_pair+crossing": 468
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        1,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 76,
+        "row_pair+crossing": 17,
+        "row_pair+witness_pair": 43,
+        "row_pair+witness_pair+crossing": 43447,
+        "survive": 1,
+        "witness_pair+crossing": 516
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        1,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 68,
+        "row_pair+crossing": 29,
+        "row_pair+witness_pair": 60,
+        "row_pair+witness_pair+crossing": 43106,
+        "survive": 1,
+        "witness_pair+crossing": 836
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        1,
+        6
+      ],
+      "rejection_category_counts": {
+        "crossing": 81,
+        "row_pair+crossing": 67,
+        "row_pair+witness_pair": 91,
+        "row_pair+witness_pair+crossing": 43433,
+        "survive": 1,
+        "witness_pair+crossing": 427
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        1,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 45,
+        "row_pair+crossing": 30,
+        "row_pair+witness_pair": 35,
+        "row_pair+witness_pair+crossing": 43673,
+        "survive": 1,
+        "witness_pair+crossing": 316
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        2,
+        3
+      ],
+      "rejection_category_counts": {
+        "crossing": 110,
+        "row_pair+crossing": 24,
+        "row_pair+witness_pair": 30,
+        "row_pair+witness_pair+crossing": 43190,
+        "survive": 1,
+        "witness_pair+crossing": 745
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        2,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 55,
+        "row_pair+crossing": 52,
+        "row_pair+witness_pair": 45,
+        "row_pair+witness_pair+crossing": 43219,
+        "survive": 1,
+        "witness_pair+crossing": 728
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        2,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 63,
+        "row_pair+witness_pair": 22,
+        "row_pair+witness_pair+crossing": 43378,
+        "survive": 1,
+        "witness_pair+crossing": 636
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        2,
+        6
+      ],
+      "rejection_category_counts": {
+        "crossing": 95,
+        "row_pair+crossing": 40,
+        "row_pair+witness_pair": 32,
+        "row_pair+witness_pair+crossing": 43264,
+        "survive": 1,
+        "witness_pair+crossing": 668
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        2,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 93,
+        "row_pair+crossing": 18,
+        "row_pair+witness_pair": 32,
+        "row_pair+witness_pair+crossing": 43098,
+        "survive": 1,
+        "witness_pair+crossing": 858
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        3,
+        4
+      ],
+      "rejection_category_counts": {
+        "crossing": 129,
+        "row_pair+crossing": 64,
+        "row_pair+witness_pair": 30,
+        "row_pair+witness_pair+crossing": 43125,
+        "survive": 1,
+        "witness_pair+crossing": 751
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        3,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 47,
+        "row_pair+crossing": 30,
+        "row_pair+witness_pair": 45,
+        "row_pair+witness_pair+crossing": 43263,
+        "survive": 1,
+        "witness_pair+crossing": 714
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        3,
+        6
+      ],
+      "rejection_category_counts": {
+        "crossing": 79,
+        "row_pair+crossing": 26,
+        "row_pair+witness_pair": 22,
+        "row_pair+witness_pair+crossing": 43462,
+        "survive": 1,
+        "witness_pair+crossing": 510
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        3,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 119,
+        "row_pair+crossing": 46,
+        "row_pair+witness_pair": 58,
+        "row_pair+witness_pair+crossing": 42920,
+        "survive": 1,
+        "witness_pair+crossing": 956
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        4,
+        5
+      ],
+      "rejection_category_counts": {
+        "crossing": 58,
+        "row_pair+crossing": 20,
+        "row_pair+witness_pair": 30,
+        "row_pair+witness_pair+crossing": 43315,
+        "survive": 1,
+        "witness_pair+crossing": 676
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        4,
+        6
+      ],
+      "rejection_category_counts": {
+        "crossing": 82,
+        "row_pair+crossing": 84,
+        "row_pair+witness_pair": 45,
+        "row_pair+witness_pair+crossing": 43519,
+        "survive": 1,
+        "witness_pair+crossing": 369
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        4,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 77,
+        "row_pair+crossing": 18,
+        "row_pair+witness_pair": 22,
+        "row_pair+witness_pair+crossing": 43421,
+        "survive": 1,
+        "witness_pair+crossing": 561
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        5,
+        6
+      ],
+      "rejection_category_counts": {
+        "crossing": 28,
+        "row_pair+crossing": 46,
+        "row_pair+witness_pair": 44,
+        "row_pair+witness_pair+crossing": 43683,
+        "survive": 1,
+        "witness_pair+crossing": 298
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        5,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 21,
+        "row_pair+crossing": 33,
+        "row_pair+witness_pair": 45,
+        "row_pair+witness_pair+crossing": 43505,
+        "survive": 1,
+        "witness_pair+crossing": 495
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    },
+    {
+      "candidate_count": 44100,
+      "dropped_centers": [
+        6,
+        7
+      ],
+      "rejection_category_counts": {
+        "crossing": 22,
+        "row_pair+crossing": 45,
+        "row_pair+witness_pair": 30,
+        "row_pair+witness_pair+crossing": 43742,
+        "survive": 1,
+        "witness_pair+crossing": 260
+      },
+      "replacement_row_count_per_center": 70,
+      "source_rows": {
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "surviving_candidate_count": 1
+    }
+  ],
+  "per_target_center_class": [
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 138,
+        "row_pair+crossing": 123,
+        "row_pair+witness_pair": 26,
+        "row_pair+witness_pair+crossing": 136360,
+        "witness_pair+crossing": 553
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 161,
+        "row_pair+crossing": 164,
+        "row_pair+witness_pair": 27,
+        "row_pair+witness_pair+crossing": 136232,
+        "witness_pair+crossing": 616
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        1,
+        2,
+        6
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 198,
+        "row_pair+crossing": 123,
+        "row_pair+witness_pair": 14,
+        "row_pair+witness_pair+crossing": 136119,
+        "witness_pair+crossing": 746
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 10,
+        "row_pair+crossing": 5,
+        "row_pair+witness_pair": 24,
+        "row_pair+witness_pair+crossing": 136325,
+        "witness_pair+crossing": 836
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        2,
+        3,
+        6
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 183,
+        "row_pair+crossing": 43,
+        "row_pair+witness_pair+crossing": 132500,
+        "witness_pair+crossing": 4474
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        2,
+        4,
+        5
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 122,
+        "row_pair+crossing": 219,
+        "row_pair+witness_pair": 27,
+        "row_pair+witness_pair+crossing": 136209,
+        "witness_pair+crossing": 623
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 819,
+        "row_pair+crossing": 175,
+        "row_pair+witness_pair": 903,
+        "row_pair+witness_pair+crossing": 132216,
+        "survive": 28,
+        "witness_pair+crossing": 3059
+      },
+      "surviving_candidate_count": 28,
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 92,
+        "row_pair+crossing": 156,
+        "row_pair+witness_pair": 181,
+        "row_pair+witness_pair+crossing": 136136,
+        "witness_pair+crossing": 635
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false
+    },
+    {
+      "candidate_count": 137200,
+      "rejection_category_counts": {
+        "crossing": 148,
+        "row_pair+crossing": 55,
+        "row_pair+witness_pair": 75,
+        "row_pair+witness_pair+crossing": 132586,
+        "witness_pair+crossing": 4336
+      },
+      "surviving_candidate_count": 0,
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_8_singleton_support_two_row_drop.v1",
+  "source_one_row_drop_scan": {
+    "path": "data/certificates/bootstrap_t12_81_8_singleton_support_audit.json",
+    "scan_status": "ONLY_ORIGINAL_ROW8_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS",
+    "schema": "erdos97.bootstrap_t12_81_8_singleton_support_audit.v1",
+    "status": "BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY"
+  },
+  "source_rows": {
+    "0": [
+      1,
+      3,
+      6,
+      7
+    ],
+    "1": [
+      2,
+      4,
+      7,
+      8
+    ],
+    "2": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "3": [
+      0,
+      1,
+      4,
+      6
+    ],
+    "4": [
+      1,
+      2,
+      5,
+      7
+    ],
+    "5": [
+      2,
+      3,
+      6,
+      8
+    ],
+    "6": [
+      0,
+      3,
+      4,
+      7
+    ],
+    "7": [
+      1,
+      4,
+      5,
+      8
+    ],
+    "8": [
+      0,
+      2,
+      5,
+      6
+    ]
+  },
+  "status": "BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_TWO_ROW_DROP_DIAGNOSTIC_ONLY",
+  "summary": {
+    "bootstrap_core_witnesses": [
+      0,
+      2
+    ],
+    "candidate_count": 1234800,
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "dropped_pair_count": 28,
+    "dropped_row_replacement_count_per_center": 70,
+    "original_target_center_class": [
+      0,
+      2,
+      5,
+      6
+    ],
+    "rejection_category_counts": {
+      "crossing": 1871,
+      "row_pair+crossing": 1063,
+      "row_pair+witness_pair": 1277,
+      "row_pair+witness_pair+crossing": 1214683,
+      "survive": 28,
+      "witness_pair+crossing": 15878
+    },
+    "remaining_gap": "This does not prove singleton support existence, does not prove the row is forced by minimal or rich-class geometry, does not allow three or more other rows to move, and does not model additional auxiliary rich supports.",
+    "scan_status": "ONLY_ORIGINAL_ROW8_SURVIVES_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP",
+    "singleton_support_labels": [
+      5,
+      6
+    ],
+    "source_record_ids": [
+      81
+    ],
+    "surviving_candidate_count": 28,
+    "target_center": 8,
+    "target_center_candidate_count": 9,
+    "target_row_key": "81:8",
+    "two_row_drop_centers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "two_row_drop_non_original_survivor_count": 0,
+    "two_row_drop_survivors_all_original_rows": true
+  },
+  "survivors": [
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        1
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        2
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        3
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        4
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        5
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        0,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        1,
+        2
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        1,
+        3
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        1,
+        4
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        1,
+        5
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        1,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        1,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        2,
+        3
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        2,
+        4
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        2,
+        5
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        2,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        2,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        3,
+        4
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        3,
+        5
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        3,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        3,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        4,
+        5
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        4,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        4,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        5,
+        6
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        5,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    },
+    {
+      "dropped_center_classes": {
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "dropped_center_classes_are_original": true,
+      "dropped_centers": [
+        6,
+        7
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-8-singleton-support-audit.md
+++ b/docs/bootstrap-t12-81-8-singleton-support-audit.md
@@ -103,13 +103,23 @@ The checked scan status is:
 ONLY_ORIGINAL_ROW8_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS
 ```
 
+## Two-Row-Drop Follow-Up
+
+A follow-up relaxation is recorded in
+`docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md`. It lets any two
+non-target source-`81` rows move arbitrarily while row `8` ranges over the same
+nine singleton-support activation rows. The checked scan covers `1,234,800`
+two-row-drop candidates and leaves only the `28` trivial original-neighborhood
+survivors, one for each dropped pair.
+
 ## Remaining Gap
 
 This closes a narrow local escape route for the `81:8` bridge target under a
-fixed source-`81` neighborhood and a one-row-drop stress test. It does not
-prove that singleton support labels are forced by a genuine rich-class
-catalogue, does not allow two or more other rows to move, and does not model
-additional auxiliary rich supports.
+fixed source-`81` neighborhood and a one-row-drop stress test. The two-row-drop
+follow-up closes the next stress-test layer. These diagnostics do not prove
+that singleton support labels are forced by a genuine rich-class catalogue, do
+not allow three or more other rows to move, and do not model additional
+auxiliary rich supports.
 
 ## What This Does Not Prove
 

--- a/docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md
+++ b/docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md
@@ -1,0 +1,116 @@
+# Bootstrap T12 81:8 Singleton-Support Two-Row-Drop Audit
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet continues the source-`81`, row-`8` singleton-support audit by
+relaxing the fixed source-`81` neighborhood one step beyond the one-row-drop
+scan. The target row still contains bootstrap-core witnesses `[0,2]` and at
+least one singleton support from `[5,6]`.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_8_singleton_support_two_row_drop.json`.
+
+## Scan Scope
+
+The scan uses the same nine center-`8` activation rows as
+`docs/bootstrap-t12-81-8-singleton-support-audit.md`:
+
+```text
+[0,1,2,5]
+[0,1,2,6]
+[0,2,3,5]
+[0,2,3,6]
+[0,2,4,5]
+[0,2,4,6]
+[0,2,5,6]
+[0,2,5,7]
+[0,2,6,7]
+```
+
+For every unordered pair of non-target centers from
+
+```text
+0,1,2,3,4,5,6,7
+```
+
+both dropped rows may be any of their `70` possible selected 4-sets while row
+`8` uses one of the nine activation rows. This gives
+
+```text
+9 * binomial(8,2) * 70 * 70 = 1,234,800
+```
+
+two-row-drop candidates.
+
+The scan uses only the basic selected-row filters:
+
+- row-pair cap;
+- witness-pair cap;
+- two-overlap crossing.
+
+No Euclidean realization, exact distance equation, minimality hypothesis, or
+rich-class forcing hypothesis is used.
+
+## Result
+
+There are `28` survivors, one for each dropped pair. All `28` are the trivial
+original-neighborhood survivors:
+
+```text
+row 8 = [0,2,5,6]
+both dropped rows = their original source-81 rows
+```
+
+The aggregate two-row-drop rejection counts are:
+
+```text
+crossing: 1871
+row_pair+crossing: 1063
+row_pair+witness_pair: 1277
+row_pair+witness_pair+crossing: 1214683
+witness_pair+crossing: 15878
+survive: 28
+```
+
+The checked scan status is:
+
+```text
+ONLY_ORIGINAL_ROW8_SURVIVES_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP
+```
+
+## Interpretation
+
+This closes the first two-row relaxation of the `81:8` local escape route:
+there is no non-original center-`8` singleton-support activation survivor even
+when any two other source-`81` rows are allowed to move arbitrarily under the
+basic selected-row incidence and crossing filters.
+
+This is still a finite proof-mining diagnostic. It does not prove that
+singleton support labels exist in a genuine rich-class catalogue, and it does
+not prove that row `8` is forced by minimality or geometry.
+
+## Remaining Gap
+
+The next gap is no longer the one-row or two-row stress test for this fixed
+target. Remaining escape mechanisms could still move three or more other
+source-`81` rows, use additional auxiliary rich supports, or require a new
+minimal/rich-class hypothesis that forces the support before any fixed-row
+neighborhood is available.
+
+## What This Does Not Prove
+
+This artifact does not prove singleton support existence, row forcing, `n=9`,
+the bootstrap bridge, or Erdos Problem #97. It does not produce or certify a
+counterexample.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -927,6 +927,14 @@ dropped row equal to its original source-`81` row. This remains a finite
 proof-mining diagnostic only, not a proof of singleton support existence, row
 forcing, `n=9`, the bootstrap bridge, or Erdos Problem #97.
 
+The source-`81` row-`8` two-row-drop follow-up in
+`docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md` allows any two
+non-target source-`81` rows to move. It checks `1,234,800` candidates and
+leaves `28` survivors, all of which keep row `8` and both dropped rows equal
+to their original source-`81` choices. This remains a finite proof-mining
+diagnostic only, not a proof of singleton support existence, row forcing,
+`n=9`, the bootstrap bridge, or Erdos Problem #97.
+
 The source-`151` row-`6` outside-pair audit in
 `docs/bootstrap-t12-151-6-outside-pair-audit.md` checks the remaining
 relation-sufficient row target. It enumerates the thirteen center-`6` rows

--- a/docs/index.md
+++ b/docs/index.md
@@ -275,6 +275,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-8-singleton-support-audit.md`](bootstrap-t12-81-8-singleton-support-audit.md):
   source-`81` row-`8` singleton-support audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.
+- [`bootstrap-t12-81-8-singleton-support-two-row-drop.md`](bootstrap-t12-81-8-singleton-support-two-row-drop.md):
+  two-row-drop relaxation audit for the source-`81` row-`8` singleton-support
+  target.
 - [`bootstrap-t12-151-6-outside-pair-audit.md`](bootstrap-t12-151-6-outside-pair-audit.md):
   source-`151` row-`6` outside-pair audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -5386,6 +5386,85 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_8_singleton_support_two_row_drop
+    path: data/certificates/bootstrap_t12_81_8_singleton_support_two_row_drop.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py
+    command: python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py
+    check_command: python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-81 row-8 singleton-support two-row-drop relaxation; only original row-8 and original dropped-row choices survive when any two non-target source-81 rows move under basic incidence/crossing filters, but this is not singleton-support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_8_singleton_support_two_row_drop.v1
+      status: BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_TWO_ROW_DROP_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:8"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.target_center: 8
+      summary.bootstrap_core_witnesses:
+        - 0
+        - 2
+      summary.singleton_support_labels:
+        - 5
+        - 6
+      summary.original_target_center_class:
+        - 0
+        - 2
+        - 5
+        - 6
+      summary.target_center_candidate_count: 9
+      summary.two_row_drop_centers:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+      summary.dropped_pair_count: 28
+      summary.dropped_row_replacement_count_per_center: 70
+      summary.candidate_count: 1234800
+      summary.surviving_candidate_count: 28
+      summary.two_row_drop_non_original_survivor_count: 0
+      summary.two_row_drop_survivors_all_original_rows: true
+      summary.scan_status: ONLY_ORIGINAL_ROW8_SURVIVES_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP
+      source_one_row_drop_scan.schema: erdos97.bootstrap_t12_81_8_singleton_support_audit.v1
+      source_one_row_drop_scan.status: BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY
+      source_one_row_drop_scan.scan_status: ONLY_ORIGINAL_ROW8_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS
+      provenance.generator: scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py
+      provenance.command: python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - singleton support proves row-center forcing
+      - the 81:8 row is forced
+      - the 81:8 singleton support exists
+      - the 81:8 two-row-drop audit proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_151_6_outside_pair_audit
     path: data/certificates/bootstrap_t12_151_6_outside_pair_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py
+++ b/scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:8 singleton-support two-row-drop audit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_8_singleton_support_two_row_drop import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_8_singleton_support_two_row_drop_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:8 singleton-support two-row-drop audit")
+    print(f"row-8 candidate count: {summary['target_center_candidate_count']}")
+    print(f"dropped pair count: {summary['dropped_pair_count']}")
+    print(f"two-row-drop candidates: {summary['candidate_count']}")
+    print(f"two-row-drop survivors: {summary['surviving_candidate_count']}")
+    print(
+        "non-original survivors: "
+        f"{summary['two_row_drop_non_original_survivor_count']}"
+    )
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write regenerated payload",
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert pinned values",
+    )
+    args = parser.parse_args()
+
+    generated = build_t12_81_8_singleton_support_two_row_drop_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:8 two-row-drop artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:8 two-row-drop expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2030,6 +2030,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_81_8_singleton_support_two_row_drop",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Source-81 row-8 singleton-support two-row-drop relaxation; not "
+            "singleton-support existence, row forcing, an n=9 proof, a bridge "
+            "proof, or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_151_6_outside_pair_audit",
         command=(
             "python",

--- a/src/erdos97/bootstrap_t12_81_8_singleton_support_two_row_drop.py
+++ b/src/erdos97/bootstrap_t12_81_8_singleton_support_two_row_drop.py
@@ -1,0 +1,682 @@
+"""Two-row-drop audit for the bootstrap/T12 81:8 singleton-support target.
+
+This packet relaxes the source-81 row-8 singleton-support audit one step beyond
+the one-row-drop scan.  For each pair of source-81 rows outside center 8, it
+allows both rows to be replaced by arbitrary 4-sets while row 8 ranges over the
+nine singleton-support activation rows.
+
+The scan uses only selected-row incidence and cyclic crossing filters.  It is a
+proof-mining diagnostic, not a Euclidean realizability theorem and not a proof
+of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_8_singleton_support_audit import (
+    BOOTSTRAP_CORE_WITNESSES,
+    CYCLIC_ORDER,
+    DEFAULT_ARTIFACT as ONE_ROW_DROP_ARTIFACT,
+    ORIGINAL_ROW,
+    SCAN_STATUS as ONE_ROW_DROP_SCAN_STATUS,
+    SCHEMA as ONE_ROW_DROP_SCHEMA,
+    SINGLETON_SUPPORT_LABELS,
+    SOURCE_RECORD_ID,
+    STATUS as ONE_ROW_DROP_STATUS,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+    _base_selected_rows,
+    _target_row_candidates,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_8_singleton_support_two_row_drop.v1"
+STATUS = "BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_TWO_ROW_DROP_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "ONLY_ORIGINAL_ROW8_SURVIVES_WHEN_ANY_TWO_OTHER_SOURCE81_ROWS_DROP"
+CLAIM_SCOPE = (
+    "Two-row-drop relaxation of the source-81 row-8 singleton-support audit. "
+    "For each pair of the eight source-81 rows outside center 8, it allows both "
+    "rows to be replaced by arbitrary 4-sets while row 8 uses one of the nine "
+    "singleton-support activation rows. The only 28 survivors are the trivial "
+    "original-neighborhood survivors: row 8 is the original [0,2,5,6] row and "
+    "both dropped rows are also original. This does not prove singleton "
+    "support existence, row forcing, n=9, the bootstrap bridge, or Erdos "
+    "Problem #97, and is not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_8_singleton_support_two_row_drop.json"
+)
+
+LABELS = list(CYCLIC_ORDER)
+TWO_ROW_DROP_CENTERS = [
+    center for center in CYCLIC_ORDER if center != TARGET_ROW_CENTER
+]
+ALL_PAIRS = list(combinations(LABELS, 2))
+EXPECTED_REJECTION_COUNTS = {'crossing': 1871,
+ 'row_pair+crossing': 1063,
+ 'row_pair+witness_pair': 1277,
+ 'row_pair+witness_pair+crossing': 1214683,
+ 'survive': 28,
+ 'witness_pair+crossing': 15878}
+EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS = {'0,1': {'crossing': 23,
+         'row_pair+crossing': 48,
+         'row_pair+witness_pair': 132,
+         'row_pair+witness_pair+crossing': 43641,
+         'survive': 1,
+         'witness_pair+crossing': 255},
+ '0,2': {'crossing': 46,
+         'row_pair+crossing': 47,
+         'row_pair+witness_pair': 45,
+         'row_pair+witness_pair+crossing': 43523,
+         'survive': 1,
+         'witness_pair+crossing': 438},
+ '0,3': {'crossing': 91,
+         'row_pair+crossing': 14,
+         'row_pair+witness_pair': 22,
+         'row_pair+witness_pair+crossing': 43407,
+         'survive': 1,
+         'witness_pair+crossing': 565},
+ '0,4': {'crossing': 124,
+         'row_pair+crossing': 43,
+         'row_pair+witness_pair': 59,
+         'row_pair+witness_pair+crossing': 42945,
+         'survive': 1,
+         'witness_pair+crossing': 928},
+ '0,5': {'crossing': 49,
+         'row_pair+crossing': 16,
+         'row_pair+witness_pair': 32,
+         'row_pair+witness_pair+crossing': 43208,
+         'survive': 1,
+         'witness_pair+crossing': 794},
+ '0,6': {'crossing': 37,
+         'row_pair+crossing': 38,
+         'row_pair+witness_pair': 46,
+         'row_pair+witness_pair+crossing': 43649,
+         'survive': 1,
+         'witness_pair+crossing': 329},
+ '0,7': {'crossing': 21,
+         'row_pair+crossing': 35,
+         'row_pair+witness_pair': 45,
+         'row_pair+witness_pair+crossing': 43663,
+         'survive': 1,
+         'witness_pair+crossing': 335},
+ '1,2': {'crossing': 36,
+         'row_pair+crossing': 60,
+         'row_pair+witness_pair': 50,
+         'row_pair+witness_pair+crossing': 43507,
+         'survive': 1,
+         'witness_pair+crossing': 446},
+ '1,3': {'crossing': 96,
+         'row_pair+crossing': 73,
+         'row_pair+witness_pair': 85,
+         'row_pair+witness_pair+crossing': 43377,
+         'survive': 1,
+         'witness_pair+crossing': 468},
+ '1,4': {'crossing': 76,
+         'row_pair+crossing': 17,
+         'row_pair+witness_pair': 43,
+         'row_pair+witness_pair+crossing': 43447,
+         'survive': 1,
+         'witness_pair+crossing': 516},
+ '1,5': {'crossing': 68,
+         'row_pair+crossing': 29,
+         'row_pair+witness_pair': 60,
+         'row_pair+witness_pair+crossing': 43106,
+         'survive': 1,
+         'witness_pair+crossing': 836},
+ '1,6': {'crossing': 81,
+         'row_pair+crossing': 67,
+         'row_pair+witness_pair': 91,
+         'row_pair+witness_pair+crossing': 43433,
+         'survive': 1,
+         'witness_pair+crossing': 427},
+ '1,7': {'crossing': 45,
+         'row_pair+crossing': 30,
+         'row_pair+witness_pair': 35,
+         'row_pair+witness_pair+crossing': 43673,
+         'survive': 1,
+         'witness_pair+crossing': 316},
+ '2,3': {'crossing': 110,
+         'row_pair+crossing': 24,
+         'row_pair+witness_pair': 30,
+         'row_pair+witness_pair+crossing': 43190,
+         'survive': 1,
+         'witness_pair+crossing': 745},
+ '2,4': {'crossing': 55,
+         'row_pair+crossing': 52,
+         'row_pair+witness_pair': 45,
+         'row_pair+witness_pair+crossing': 43219,
+         'survive': 1,
+         'witness_pair+crossing': 728},
+ '2,5': {'crossing': 63,
+         'row_pair+witness_pair': 22,
+         'row_pair+witness_pair+crossing': 43378,
+         'survive': 1,
+         'witness_pair+crossing': 636},
+ '2,6': {'crossing': 95,
+         'row_pair+crossing': 40,
+         'row_pair+witness_pair': 32,
+         'row_pair+witness_pair+crossing': 43264,
+         'survive': 1,
+         'witness_pair+crossing': 668},
+ '2,7': {'crossing': 93,
+         'row_pair+crossing': 18,
+         'row_pair+witness_pair': 32,
+         'row_pair+witness_pair+crossing': 43098,
+         'survive': 1,
+         'witness_pair+crossing': 858},
+ '3,4': {'crossing': 129,
+         'row_pair+crossing': 64,
+         'row_pair+witness_pair': 30,
+         'row_pair+witness_pair+crossing': 43125,
+         'survive': 1,
+         'witness_pair+crossing': 751},
+ '3,5': {'crossing': 47,
+         'row_pair+crossing': 30,
+         'row_pair+witness_pair': 45,
+         'row_pair+witness_pair+crossing': 43263,
+         'survive': 1,
+         'witness_pair+crossing': 714},
+ '3,6': {'crossing': 79,
+         'row_pair+crossing': 26,
+         'row_pair+witness_pair': 22,
+         'row_pair+witness_pair+crossing': 43462,
+         'survive': 1,
+         'witness_pair+crossing': 510},
+ '3,7': {'crossing': 119,
+         'row_pair+crossing': 46,
+         'row_pair+witness_pair': 58,
+         'row_pair+witness_pair+crossing': 42920,
+         'survive': 1,
+         'witness_pair+crossing': 956},
+ '4,5': {'crossing': 58,
+         'row_pair+crossing': 20,
+         'row_pair+witness_pair': 30,
+         'row_pair+witness_pair+crossing': 43315,
+         'survive': 1,
+         'witness_pair+crossing': 676},
+ '4,6': {'crossing': 82,
+         'row_pair+crossing': 84,
+         'row_pair+witness_pair': 45,
+         'row_pair+witness_pair+crossing': 43519,
+         'survive': 1,
+         'witness_pair+crossing': 369},
+ '4,7': {'crossing': 77,
+         'row_pair+crossing': 18,
+         'row_pair+witness_pair': 22,
+         'row_pair+witness_pair+crossing': 43421,
+         'survive': 1,
+         'witness_pair+crossing': 561},
+ '5,6': {'crossing': 28,
+         'row_pair+crossing': 46,
+         'row_pair+witness_pair': 44,
+         'row_pair+witness_pair+crossing': 43683,
+         'survive': 1,
+         'witness_pair+crossing': 298},
+ '5,7': {'crossing': 21,
+         'row_pair+crossing': 33,
+         'row_pair+witness_pair': 45,
+         'row_pair+witness_pair+crossing': 43505,
+         'survive': 1,
+         'witness_pair+crossing': 495},
+ '6,7': {'crossing': 22,
+         'row_pair+crossing': 45,
+         'row_pair+witness_pair': 30,
+         'row_pair+witness_pair+crossing': 43742,
+         'survive': 1,
+         'witness_pair+crossing': 260}}
+EXPECTED_PER_TARGET_CENTER_CLASS_REJECTION_COUNTS = {'0,1,2,5': {'crossing': 138,
+             'row_pair+crossing': 123,
+             'row_pair+witness_pair': 26,
+             'row_pair+witness_pair+crossing': 136360,
+             'witness_pair+crossing': 553},
+ '0,1,2,6': {'crossing': 161,
+             'row_pair+crossing': 164,
+             'row_pair+witness_pair': 27,
+             'row_pair+witness_pair+crossing': 136232,
+             'witness_pair+crossing': 616},
+ '0,2,3,5': {'crossing': 198,
+             'row_pair+crossing': 123,
+             'row_pair+witness_pair': 14,
+             'row_pair+witness_pair+crossing': 136119,
+             'witness_pair+crossing': 746},
+ '0,2,3,6': {'crossing': 10,
+             'row_pair+crossing': 5,
+             'row_pair+witness_pair': 24,
+             'row_pair+witness_pair+crossing': 136325,
+             'witness_pair+crossing': 836},
+ '0,2,4,5': {'crossing': 183,
+             'row_pair+crossing': 43,
+             'row_pair+witness_pair+crossing': 132500,
+             'witness_pair+crossing': 4474},
+ '0,2,4,6': {'crossing': 122,
+             'row_pair+crossing': 219,
+             'row_pair+witness_pair': 27,
+             'row_pair+witness_pair+crossing': 136209,
+             'witness_pair+crossing': 623},
+ '0,2,5,6': {'crossing': 819,
+             'row_pair+crossing': 175,
+             'row_pair+witness_pair': 903,
+             'row_pair+witness_pair+crossing': 132216,
+             'survive': 28,
+             'witness_pair+crossing': 3059},
+ '0,2,5,7': {'crossing': 92,
+             'row_pair+crossing': 156,
+             'row_pair+witness_pair': 181,
+             'row_pair+witness_pair+crossing': 136136,
+             'witness_pair+crossing': 635},
+ '0,2,6,7': {'crossing': 148,
+             'row_pair+crossing': 55,
+             'row_pair+witness_pair': 75,
+             'row_pair+witness_pair+crossing': 132586,
+             'witness_pair+crossing': 4336}}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _row_key(row: Sequence[int]) -> str:
+    return ",".join(str(label) for label in row)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _row_mask(row: Iterable[int]) -> int:
+    mask = 0
+    for label in row:
+        mask |= 1 << int(label)
+    return mask
+
+
+def _mask_to_row(mask: int) -> list[int]:
+    return [label for label in LABELS if (mask >> label) & 1]
+
+
+def _all_replacement_row_masks(center: int) -> list[int]:
+    labels = [label for label in LABELS if label != center]
+    return [_row_mask(row) for row in combinations(labels, 4)]
+
+
+def _between_cyclic(a: int, x: int, b: int) -> bool:
+    if a < b:
+        return a < x < b
+    return x > a or x < b
+
+
+def _crosses_pair(i: int, j: int, a: int, b: int) -> bool:
+    if len({i, j, a, b}) < 4:
+        return False
+    return (
+        _between_cyclic(i, a, j) != _between_cyclic(i, b, j)
+        and _between_cyclic(a, i, b) != _between_cyclic(a, j, b)
+    )
+
+
+PAIR_INDEX = {pair: index for index, pair in enumerate(ALL_PAIRS)}
+MASK_TO_PAIR_INDEX = {
+    (1 << a) | (1 << b): PAIR_INDEX[(a, b)] for a, b in ALL_PAIRS
+}
+CROSS_OK = {
+    (i, j, PAIR_INDEX[(a, b)]): _crosses_pair(i, j, a, b)
+    for i, j in ALL_PAIRS
+    for a, b in ALL_PAIRS
+}
+ROW_PAIR_INDICES = {
+    row_mask: [
+        PAIR_INDEX[(a, b)]
+        for a, b in combinations(_mask_to_row(row_mask), 2)
+    ]
+    for row_mask in [_row_mask(row) for row in combinations(LABELS, 4)]
+}
+
+
+def _scan_candidate_category(row_masks: Sequence[int]) -> str:
+    row_pair_violation = False
+    crossing_violation = False
+    for i, j in ALL_PAIRS:
+        intersection = row_masks[i] & row_masks[j]
+        intersection_size = intersection.bit_count()
+        if intersection_size > 2:
+            row_pair_violation = True
+        elif intersection_size == 2:
+            pair_index = MASK_TO_PAIR_INDEX[intersection]
+            if not CROSS_OK[(i, j, pair_index)]:
+                crossing_violation = True
+
+    witness_pair_violation = False
+    pair_counts = [0] * len(ALL_PAIRS)
+    for row_mask in row_masks:
+        for pair_index in ROW_PAIR_INDICES[row_mask]:
+            pair_counts[pair_index] += 1
+            if pair_counts[pair_index] > 2:
+                witness_pair_violation = True
+
+    rejection_reasons = []
+    if row_pair_violation:
+        rejection_reasons.append("row_pair")
+    if witness_pair_violation:
+        rejection_reasons.append("witness_pair")
+    if crossing_violation:
+        rejection_reasons.append("crossing")
+    return "+".join(rejection_reasons) if rejection_reasons else "survive"
+
+
+def _scan_candidates(base_rows: Sequence[Sequence[int]]) -> dict[str, object]:
+    base_masks = [_row_mask(row) for row in base_rows]
+    target_rows = _target_row_candidates()
+    target_masks = [_row_mask(row) for row in target_rows]
+    replacement_masks = {
+        center: _all_replacement_row_masks(center) for center in TWO_ROW_DROP_CENTERS
+    }
+
+    total_counts: Counter[str] = Counter()
+    per_target_row_counts: dict[str, Counter[str]] = {
+        _row_key(candidate): Counter() for candidate in target_rows
+    }
+    dropped_pair_summaries: list[dict[str, object]] = []
+    survivors: list[dict[str, object]] = []
+
+    for dropped_a, dropped_b in combinations(TWO_ROW_DROP_CENTERS, 2):
+        dropped_counts: Counter[str] = Counter()
+        for target_row, target_mask in zip(target_rows, target_masks, strict=True):
+            target_key = _row_key(target_row)
+            base_candidate = list(base_masks)
+            base_candidate[TARGET_ROW_CENTER] = target_mask
+            for row_a in replacement_masks[dropped_a]:
+                candidate_a = list(base_candidate)
+                candidate_a[dropped_a] = row_a
+                for row_b in replacement_masks[dropped_b]:
+                    row_masks = list(candidate_a)
+                    row_masks[dropped_b] = row_b
+                    category = _scan_candidate_category(row_masks)
+                    dropped_counts[category] += 1
+                    total_counts[category] += 1
+                    per_target_row_counts[target_key][category] += 1
+                    if category == "survive":
+                        dropped_classes = {
+                            str(dropped_a): _mask_to_row(row_a),
+                            str(dropped_b): _mask_to_row(row_b),
+                        }
+                        survivors.append(
+                            {
+                                "target_center_class": list(target_row),
+                                "target_center_class_is_original": (
+                                    list(target_row) == ORIGINAL_ROW
+                                ),
+                                "dropped_centers": [dropped_a, dropped_b],
+                                "dropped_center_classes": dropped_classes,
+                                "dropped_center_classes_are_original": (
+                                    dropped_classes[str(dropped_a)]
+                                    == list(base_rows[dropped_a])
+                                    and dropped_classes[str(dropped_b)]
+                                    == list(base_rows[dropped_b])
+                                ),
+                            }
+                        )
+
+        dropped_pair_summaries.append(
+            {
+                "dropped_centers": [dropped_a, dropped_b],
+                "source_rows": {
+                    str(dropped_a): list(base_rows[dropped_a]),
+                    str(dropped_b): list(base_rows[dropped_b]),
+                },
+                "replacement_row_count_per_center": 70,
+                "candidate_count": sum(dropped_counts.values()),
+                "surviving_candidate_count": dropped_counts.get("survive", 0),
+                "rejection_category_counts": _json_counter(dropped_counts),
+            }
+        )
+
+    return {
+        "candidate_count": sum(total_counts.values()),
+        "rejection_category_counts": _json_counter(total_counts),
+        "per_target_center_class": [
+            {
+                "target_center_class": list(candidate),
+                "target_center_class_is_original": list(candidate) == ORIGINAL_ROW,
+                "candidate_count": sum(
+                    per_target_row_counts[_row_key(candidate)].values()
+                ),
+                "surviving_candidate_count": per_target_row_counts[
+                    _row_key(candidate)
+                ].get("survive", 0),
+                "rejection_category_counts": _json_counter(
+                    per_target_row_counts[_row_key(candidate)]
+                ),
+            }
+            for candidate in target_rows
+        ],
+        "per_dropped_pair": dropped_pair_summaries,
+        "survivors": survivors,
+    }
+
+
+def build_t12_81_8_singleton_support_two_row_drop_payload() -> dict[str, object]:
+    """Return the deterministic source-81 row-8 two-row-drop audit."""
+
+    base_rows = _base_selected_rows()
+    if base_rows[TARGET_ROW_CENTER] != ORIGINAL_ROW:
+        raise AssertionError("source-81 row 8 drifted")
+
+    target_rows = _target_row_candidates()
+    scan = _scan_candidates(base_rows)
+    survivors = scan["survivors"]
+    if not isinstance(survivors, Sequence):
+        raise AssertionError("survivors must be a sequence")
+    non_original_survivors = [
+        survivor
+        for survivor in survivors
+        if not isinstance(survivor, Mapping)
+        or not survivor["target_center_class_is_original"]
+        or not survivor["dropped_center_classes_are_original"]
+    ]
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This scan drops exactly two of the eight source-81 rows outside center 8.",
+            (
+                "Center 8 is still restricted to the nine singleton-support "
+                "activation rows."
+            ),
+            (
+                "The scan uses incidence and crossing filters only, not "
+                "Euclidean realizability."
+            ),
+            (
+                "No n=9 finite-case status, bridge status, official status, "
+                "or counterexample status changes."
+            ),
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [SOURCE_RECORD_ID],
+            "cyclic_order": CYCLIC_ORDER,
+            "target_center": TARGET_ROW_CENTER,
+            "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+            "singleton_support_labels": SINGLETON_SUPPORT_LABELS,
+            "original_target_center_class": ORIGINAL_ROW,
+            "target_center_candidate_count": len(target_rows),
+            "two_row_drop_centers": TWO_ROW_DROP_CENTERS,
+            "dropped_pair_count": len(list(combinations(TWO_ROW_DROP_CENTERS, 2))),
+            "dropped_row_replacement_count_per_center": 70,
+            "candidate_count": scan["candidate_count"],
+            "surviving_candidate_count": len(survivors),
+            "two_row_drop_non_original_survivor_count": len(non_original_survivors),
+            "two_row_drop_survivors_all_original_rows": not non_original_survivors,
+            "rejection_category_counts": scan["rejection_category_counts"],
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not prove singleton support existence, does not "
+                "prove the row is forced by minimal or rich-class geometry, "
+                "does not allow three or more other rows to move, and does not "
+                "model additional auxiliary rich supports."
+            ),
+        },
+        "source_rows": {str(center): base_rows[center] for center in CYCLIC_ORDER},
+        "candidate_generation": {
+            "target_center_candidate_classes": target_rows,
+            "candidate_rule": (
+                "4-sets at center 8 containing bootstrap-core witnesses [0,2] "
+                "and at least one singleton support label from [5,6]."
+            ),
+            "dropped_row_choice_count_per_center": {
+                str(center): len(_all_replacement_row_masks(center))
+                for center in TWO_ROW_DROP_CENTERS
+            },
+        },
+        "per_target_center_class": scan["per_target_center_class"],
+        "per_dropped_pair": scan["per_dropped_pair"],
+        "survivors": survivors,
+        "source_one_row_drop_scan": {
+            "path": ONE_ROW_DROP_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": ONE_ROW_DROP_SCHEMA,
+            "status": ONE_ROW_DROP_STATUS,
+            "scan_status": ONE_ROW_DROP_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": (
+                "scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py"
+            ),
+            "command": (
+                "python "
+                "scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [SOURCE_RECORD_ID],
+        "cyclic_order": CYCLIC_ORDER,
+        "target_center": TARGET_ROW_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "singleton_support_labels": SINGLETON_SUPPORT_LABELS,
+        "original_target_center_class": ORIGINAL_ROW,
+        "target_center_candidate_count": 9,
+        "two_row_drop_centers": TWO_ROW_DROP_CENTERS,
+        "dropped_pair_count": 28,
+        "dropped_row_replacement_count_per_center": 70,
+        "candidate_count": 1234800,
+        "surviving_candidate_count": 28,
+        "two_row_drop_non_original_survivor_count": 0,
+        "two_row_drop_survivors_all_original_rows": True,
+        "rejection_category_counts": EXPECTED_REJECTION_COUNTS,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    per_target = payload.get("per_target_center_class")
+    if not isinstance(per_target, Sequence) or len(per_target) != 9:
+        raise AssertionError("expected nine per-target-center-class summaries")
+    for record in per_target:
+        if not isinstance(record, Mapping):
+            raise AssertionError("per-target-center-class summaries must be mappings")
+        row_key = _row_key(_int_list(record["target_center_class"]))
+        expected_counts = EXPECTED_PER_TARGET_CENTER_CLASS_REJECTION_COUNTS[row_key]
+        if record.get("candidate_count") != 137200:
+            raise AssertionError(f"target row {row_key} has bad candidate count")
+        if record.get("rejection_category_counts") != expected_counts:
+            raise AssertionError(f"target row {row_key} rejection counts drifted")
+        expected_survivors = 28 if record.get("target_center_class_is_original") else 0
+        if record.get("surviving_candidate_count") != expected_survivors:
+            raise AssertionError(f"target row {row_key} survivor count drifted")
+
+    per_dropped = payload.get("per_dropped_pair")
+    if not isinstance(per_dropped, Sequence) or len(per_dropped) != 28:
+        raise AssertionError("expected 28 dropped-pair summaries")
+    for record in per_dropped:
+        if not isinstance(record, Mapping):
+            raise AssertionError("dropped-pair summaries must be mappings")
+        centers = record.get("dropped_centers")
+        if not isinstance(centers, Sequence) or len(centers) != 2:
+            raise AssertionError("dropped_centers must be a pair")
+        key = f"{centers[0]},{centers[1]}"
+        if key not in EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS:
+            raise AssertionError(f"unexpected dropped pair {key!r}")
+        if record.get("replacement_row_count_per_center") != 70:
+            raise AssertionError(f"dropped pair {key!r} has bad row count")
+        if record.get("candidate_count") != 44100:
+            raise AssertionError(f"dropped pair {key!r} has bad candidate count")
+        if record.get("surviving_candidate_count") != 1:
+            raise AssertionError(f"dropped pair {key!r} should have one survivor")
+        expected_counts = EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS[key]
+        if record.get("rejection_category_counts") != expected_counts:
+            raise AssertionError(f"dropped pair {key!r} rejection counts drifted")
+
+    survivors = payload.get("survivors")
+    if not isinstance(survivors, Sequence) or len(survivors) != 28:
+        raise AssertionError("expected 28 two-row-drop survivors")
+    if any(
+        not isinstance(survivor, Mapping)
+        or not survivor.get("target_center_class_is_original")
+        or not survivor.get("dropped_center_classes_are_original")
+        for survivor in survivors
+    ):
+        raise AssertionError("two-row-drop survivors should keep original rows")
+
+    source = payload.get("source_one_row_drop_scan")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_one_row_drop_scan must be a mapping")
+    if source.get("schema") != ONE_ROW_DROP_SCHEMA:
+        raise AssertionError("source one-row-drop schema drifted")
+    if source.get("scan_status") != ONE_ROW_DROP_SCAN_STATUS:
+        raise AssertionError("source one-row-drop scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_8_singleton_support_two_row_drop.py
+++ b/tests/test_bootstrap_t12_81_8_singleton_support_two_row_drop.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_8_singleton_support_audit import (
+    _base_selected_rows,
+    _rejection_data,
+    _target_row_candidates,
+)
+from erdos97.bootstrap_t12_81_8_singleton_support_two_row_drop import (
+    DEFAULT_ARTIFACT,
+    EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS,
+    EXPECTED_REJECTION_COUNTS,
+    SCAN_STATUS,
+    TARGET_ROW_CENTER,
+    _row_mask,
+    _scan_candidate_category,
+    assert_expected_payload,
+    build_t12_81_8_singleton_support_two_row_drop_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_8_singleton_support_two_row_drop_payload()
+
+
+def test_81_8_two_row_drop_counts_and_scope(payload: dict[str, object]) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_TWO_ROW_DROP_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Two-row-drop" in claim_scope
+    assert "only 28 survivors" in claim_scope
+    assert "does not prove singleton support existence" in claim_scope
+    assert "Erdos Problem #97" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_8_two_row_drop_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:8"
+    assert summary["source_record_ids"] == [81]
+    assert summary["target_center"] == 8
+    assert summary["bootstrap_core_witnesses"] == [0, 2]
+    assert summary["singleton_support_labels"] == [5, 6]
+    assert summary["original_target_center_class"] == [0, 2, 5, 6]
+    assert summary["target_center_candidate_count"] == 9
+    assert summary["two_row_drop_centers"] == list(range(8))
+    assert summary["dropped_pair_count"] == 28
+    assert summary["dropped_row_replacement_count_per_center"] == 70
+    assert summary["candidate_count"] == 1234800
+    assert summary["surviving_candidate_count"] == 28
+    assert summary["two_row_drop_non_original_survivor_count"] == 0
+    assert summary["two_row_drop_survivors_all_original_rows"] is True
+    assert summary["rejection_category_counts"] == EXPECTED_REJECTION_COUNTS
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_8_two_row_drop_per_pair_counts(payload: dict[str, object]) -> None:
+    per_dropped = payload["per_dropped_pair"]
+
+    assert len(per_dropped) == 28
+    for record in per_dropped:
+        key = ",".join(str(center) for center in record["dropped_centers"])
+        assert record["replacement_row_count_per_center"] == 70
+        assert record["candidate_count"] == 44100
+        assert record["surviving_candidate_count"] == 1
+        assert (
+            record["rejection_category_counts"]
+            == EXPECTED_PER_DROPPED_PAIR_REJECTION_COUNTS[key]
+        )
+
+
+def test_81_8_two_row_drop_survivors_are_original(
+    payload: dict[str, object],
+) -> None:
+    survivors = payload["survivors"]
+
+    assert len(survivors) == 28
+    assert {
+        tuple(survivor["dropped_centers"]) for survivor in survivors
+    } == set(__import__("itertools").combinations(range(8), 2))
+    assert all(
+        survivor["target_center_class"] == [0, 2, 5, 6]
+        and survivor["target_center_class_is_original"]
+        and survivor["dropped_center_classes_are_original"]
+        for survivor in survivors
+    )
+
+
+def test_81_8_two_row_drop_fast_filter_matches_reference_fixed_scan() -> None:
+    base_rows = _base_selected_rows()
+
+    for target_row in _target_row_candidates():
+        rows = [list(row) for row in base_rows]
+        rows[TARGET_ROW_CENTER] = list(target_row)
+        category = _scan_candidate_category([_row_mask(row) for row in rows])
+        reference = _rejection_data(rows)["rejection_category"]
+        assert category == reference
+
+
+def test_81_8_two_row_drop_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_8_two_row_drop_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["two_row_drop_non_original_survivor_count"] == 0
+
+
+def test_81_8_two_row_drop_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["two_row_drop_non_original_survivor_count"] = 1
+
+    with pytest.raises(AssertionError, match="non_original_survivor_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a source-81 row-8 singleton-support two-row-drop audit
- record the generated certificate, provenance metadata, and focused tests
- wire the checker into bridge-frontier/audit paths with scoped docs/status notes

## Review notes

This is a `REVIEW_PENDING_DIAGNOSTIC`. It checks 1,234,800 two-row-drop candidates where row 8 uses one of the nine singleton-support activation rows and any two non-target source-81 rows may move. The 28 survivors are all trivial original-neighborhood survivors. It does not prove singleton-support existence, row forcing, n=9, the bootstrap bridge, or Erdos Problem #97.

## Verification

- `python scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_81_8_singleton_support_two_row_drop.py`
- `python -m ruff check .`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`