### PR TITLE
Add source 81 row 8 full-neighborhood vertex-circle audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -666,6 +666,18 @@ existence, row forcing, `n=9`, or the bootstrap bridge. See
 `scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py`, and
 `data/certificates/bootstrap_t12_81_8_singleton_support_two_row_drop.json`.
 
+The source-`81` row-`8` full-neighborhood vertex-circle packet is a
+negative-control boundary for that audit. It fixes row `8` to the same nine
+activation rows but lets every other center choose an arbitrary selected
+4-set. Basic incidence/crossing filters leave `34` complete assignments,
+including `27` with non-original row `8`; vertex-circle quotient replay kills
+all `34` by `27` self-edges and `7` strict cycles. This is still a finite
+diagnostic only, not a proof of singleton support existence, row forcing,
+`n=9`, or the bootstrap bridge. See
+`docs/bootstrap-t12-81-8-full-neighborhood-vertex-circle.md`,
+`scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py`, and
+`data/certificates/bootstrap_t12_81_8_full_neighborhood_vertex_circle.json`.
+
 The source-`151` row-`6` outside-pair audit probes the remaining
 relation-sufficient row target. Center `6` has bootstrap-core witness `[0]`
 and outside support pairs `[3,5]`, `[3,8]`, and `[5,8]`; the audit enumerates

--- a/STATE.md
+++ b/STATE.md
@@ -430,6 +430,14 @@ incidence/crossing bookkeeping only, not singleton-support existence, row
 forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-8-singleton-support-two-row-drop.md`.
 
+The source-`81` row-`8` full-neighborhood vertex-circle packet gives the
+matching negative control: when all other centers may use arbitrary selected
+4-sets, basic filters leave `34` complete assignments, including `27` with
+non-original row `8`; vertex-circle quotient replay kills all `34`. This
+remains finite bookkeeping only, not singleton-support existence, row forcing,
+`n=9`, or the bridge. See
+`docs/bootstrap-t12-81-8-full-neighborhood-vertex-circle.md`.
+
 A source-`151` row-`6` outside-pair audit now probes the remaining
 relation-sufficient row target. It enumerates the thirteen center-`6` rows
 containing bootstrap-core witness `[0]` and one outside support pair from

--- a/data/certificates/bootstrap_t12_81_8_full_neighborhood_vertex_circle.json
+++ b/data/certificates/bootstrap_t12_81_8_full_neighborhood_vertex_circle.json
@@ -1,0 +1,4878 @@
+{
+  "basic_filter_survivors": [
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          8
+        ],
+        "1": [
+          2,
+          5,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          8
+        ],
+        "4": [
+          0,
+          1,
+          5,
+          6
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "1": [
+          0,
+          2,
+          3,
+          8
+        ],
+        "2": [
+          1,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          2,
+          4,
+          5,
+          8
+        ],
+        "4": [
+          0,
+          1,
+          5,
+          6
+        ],
+        "5": [
+          4,
+          6,
+          7,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          5,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          7
+        ],
+        "4": [
+          0,
+          1,
+          5,
+          6
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          5,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "3": [
+          2,
+          4,
+          5,
+          7
+        ],
+        "4": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "5": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          6,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          5,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          8
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          7
+        ],
+        "5": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          3,
+          5,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "1": [
+          2,
+          3,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "3": [
+          0,
+          4,
+          5,
+          7
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          3,
+          5,
+          7
+        ],
+        "7": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          8
+        ],
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          3,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "3": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          5,
+          7
+        ],
+        "1": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          6,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          8
+        ],
+        "5": [
+          1,
+          2,
+          6,
+          7
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          5,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          4,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          6,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          7
+        ],
+        "4": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "5": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "6": [
+          3,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          6,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          4,
+          7
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          8
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          7
+        ],
+        "5": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          3,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          2,
+          3,
+          8
+        ],
+        "1": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "2": [
+          1,
+          3,
+          5,
+          6
+        ],
+        "3": [
+          2,
+          4,
+          5,
+          8
+        ],
+        "4": [
+          0,
+          3,
+          6,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          5,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "1": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          5
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          2,
+          3,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          1,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          7
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          6
+        ],
+        "6": [
+          2,
+          3,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          6,
+          7
+        ],
+        "1": [
+          0,
+          2,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "3": [
+          1,
+          4,
+          7,
+          8
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          8
+        ],
+        "5": [
+          1,
+          2,
+          4,
+          6
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          4,
+          5,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          7
+        ],
+        "4": [
+          2,
+          5,
+          6,
+          8
+        ],
+        "5": [
+          3,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          0,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          7,
+          8
+        ],
+        "1": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          7
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          0,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          0,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          6,
+          7
+        ],
+        "1": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "3": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          6
+        ],
+        "6": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          7,
+          8
+        ],
+        "1": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          8
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          3,
+          5,
+          7
+        ],
+        "7": [
+          0,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          7,
+          8
+        ],
+        "1": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          5
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "7": [
+          0,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          6,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          7
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "6": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "7": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          2,
+          3,
+          6,
+          8
+        ],
+        "1": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "2": [
+          1,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "4": [
+          0,
+          3,
+          6,
+          7
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "6": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "7": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "strict_cycle"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "1": [
+          0,
+          3,
+          5,
+          8
+        ],
+        "2": [
+          1,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "4": [
+          2,
+          3,
+          7,
+          8
+        ],
+        "5": [
+          0,
+          4,
+          6,
+          7
+        ],
+        "6": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "8": [
+          0,
+          2,
+          5,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          5,
+          7
+        ],
+        "1": [
+          0,
+          2,
+          4,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          5
+        ],
+        "4": [
+          3,
+          5,
+          6,
+          8
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "6": [
+          2,
+          5,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          4,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          6
+        ],
+        "3": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "6": [
+          2,
+          5,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          3,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          4,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          6
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          7
+        ],
+        "5": [
+          3,
+          4,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "1": [
+          0,
+          2,
+          5,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          7
+        ],
+        "3": [
+          1,
+          4,
+          6,
+          8
+        ],
+        "4": [
+          1,
+          2,
+          3,
+          5
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          6
+        ],
+        "6": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          3,
+          5,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          5,
+          7
+        ],
+        "1": [
+          0,
+          2,
+          5,
+          8
+        ],
+        "2": [
+          1,
+          3,
+          7,
+          8
+        ],
+        "3": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "4": [
+          1,
+          2,
+          3,
+          5
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "7": [
+          3,
+          5,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          3,
+          8
+        ],
+        "2": [
+          1,
+          3,
+          4,
+          6
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          3,
+          5,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          2,
+          3,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          4,
+          6
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          8
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "5": [
+          3,
+          4,
+          6,
+          8
+        ],
+        "6": [
+          2,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          3,
+          5,
+          6
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          4,
+          7,
+          8
+        ],
+        "1": [
+          2,
+          3,
+          5,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          4
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          7
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          2,
+          4,
+          6,
+          8
+        ],
+        "6": [
+          0,
+          4,
+          5,
+          7
+        ],
+        "7": [
+          1,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          1,
+          5,
+          7,
+          8
+        ],
+        "1": [
+          0,
+          4,
+          6,
+          8
+        ],
+        "2": [
+          0,
+          1,
+          3,
+          5
+        ],
+        "3": [
+          1,
+          2,
+          4,
+          7
+        ],
+        "4": [
+          2,
+          3,
+          5,
+          6
+        ],
+        "5": [
+          0,
+          3,
+          4,
+          7
+        ],
+        "6": [
+          2,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          1,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    },
+    {
+      "selected_rows": {
+        "0": [
+          2,
+          3,
+          5,
+          8
+        ],
+        "1": [
+          0,
+          4,
+          6,
+          8
+        ],
+        "2": [
+          1,
+          3,
+          4,
+          7
+        ],
+        "3": [
+          1,
+          2,
+          5,
+          6
+        ],
+        "4": [
+          0,
+          3,
+          5,
+          7
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "6": [
+          0,
+          1,
+          4,
+          5
+        ],
+        "7": [
+          1,
+          3,
+          6,
+          8
+        ],
+        "8": [
+          0,
+          2,
+          6,
+          7
+        ]
+      },
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status": "self_edge"
+    }
+  ],
+  "candidate_generation": {
+    "candidate_rule": "4-sets at center 8 containing bootstrap-core witnesses [0,2] and at least one singleton support label from [5,6].",
+    "target_center_candidate_classes": [
+      [
+        0,
+        1,
+        2,
+        5
+      ],
+      [
+        0,
+        1,
+        2,
+        6
+      ],
+      [
+        0,
+        2,
+        3,
+        5
+      ],
+      [
+        0,
+        2,
+        3,
+        6
+      ],
+      [
+        0,
+        2,
+        4,
+        5
+      ],
+      [
+        0,
+        2,
+        4,
+        6
+      ],
+      [
+        0,
+        2,
+        5,
+        6
+      ],
+      [
+        0,
+        2,
+        5,
+        7
+      ],
+      [
+        0,
+        2,
+        6,
+        7
+      ]
+    ]
+  },
+  "claim_scope": "Full-neighborhood diagnostic for the source-81 row-8 singleton-support target. It fixes center 8 to each 4-set containing bootstrap-core witnesses [0,2] and at least one singleton support label from [5,6], lets all other centers use arbitrary selected 4-sets, and applies row-pair, witness-pair, crossing, and selected-indegree filters before exact vertex-circle quotient replay. Basic filters leave 34 complete assignments, including 27 with non-original row 8, but all 34 are killed by vertex-circle self-edge or strict-cycle obstructions. This is not a proof of singleton support existence, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "empty_domain_depth_histogram": {
+    "1": 23,
+    "2": 273,
+    "3": 1306,
+    "4": 2879,
+    "5": 2272,
+    "6": 1340,
+    "7": 343
+  },
+  "interpretation_warnings": [
+    "Full-neighborhood basic incidence/crossing filters alone leave non-original row-8 survivors.",
+    "All recorded full-neighborhood survivors close only after exact vertex-circle quotient replay.",
+    "The packet does not prove singleton support existence or row/rich-class forcing.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "per_target_center_class": [
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "basic_filter_survivors": [],
+      "empty_domain_count": 228,
+      "empty_domain_depth_histogram": {
+        "1": 5,
+        "2": 12,
+        "3": 53,
+        "4": 64,
+        "5": 55,
+        "6": 25,
+        "7": 14
+      },
+      "non_original_row8_basic_assignment_count": 0,
+      "search_node_count": 488,
+      "target_center_class": [
+        0,
+        1,
+        2,
+        5
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "basic_filter_survivors": [],
+      "empty_domain_count": 420,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 25,
+        "3": 96,
+        "4": 194,
+        "5": 74,
+        "6": 27,
+        "7": 3
+      },
+      "non_original_row8_basic_assignment_count": 0,
+      "search_node_count": 768,
+      "target_center_class": [
+        0,
+        1,
+        2,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "basic_filter_survivors": [],
+      "empty_domain_count": 200,
+      "empty_domain_depth_histogram": {
+        "1": 5,
+        "2": 18,
+        "3": 36,
+        "4": 72,
+        "5": 51,
+        "6": 18
+      },
+      "non_original_row8_basic_assignment_count": 0,
+      "search_node_count": 427,
+      "target_center_class": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "basic_filter_survivors": [],
+      "empty_domain_count": 545,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 29,
+        "3": 83,
+        "4": 180,
+        "5": 132,
+        "6": 95,
+        "7": 25
+      },
+      "non_original_row8_basic_assignment_count": 0,
+      "search_node_count": 1046,
+      "target_center_class": [
+        0,
+        2,
+        3,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "basic_filter_survivors": [],
+      "empty_domain_count": 196,
+      "empty_domain_depth_histogram": {
+        "1": 5,
+        "2": 28,
+        "3": 43,
+        "4": 63,
+        "5": 48,
+        "6": 7,
+        "7": 2
+      },
+      "non_original_row8_basic_assignment_count": 0,
+      "search_node_count": 382,
+      "target_center_class": [
+        0,
+        2,
+        4,
+        5
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 5,
+      "basic_filter_survivors": [
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              6,
+              8
+            ],
+            "1": [
+              2,
+              5,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              8
+            ],
+            "4": [
+              0,
+              1,
+              5,
+              6
+            ],
+            "5": [
+              2,
+              3,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              4,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "1": [
+              0,
+              2,
+              3,
+              8
+            ],
+            "2": [
+              1,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              2,
+              4,
+              5,
+              8
+            ],
+            "4": [
+              0,
+              1,
+              5,
+              6
+            ],
+            "5": [
+              4,
+              6,
+              7,
+              8
+            ],
+            "6": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              3,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              4,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "1": [
+              2,
+              5,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              4,
+              8
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              7
+            ],
+            "4": [
+              0,
+              1,
+              5,
+              6
+            ],
+            "5": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              4,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              5,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              4
+            ],
+            "3": [
+              2,
+              4,
+              5,
+              7
+            ],
+            "4": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "5": [
+              1,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              5,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              4,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              6,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              5,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              8
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              7
+            ],
+            "5": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              3,
+              5,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              4,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            4,
+            6
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        }
+      ],
+      "empty_domain_count": 526,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 33,
+        "3": 67,
+        "4": 176,
+        "5": 151,
+        "6": 76,
+        "7": 22
+      },
+      "non_original_row8_basic_assignment_count": 5,
+      "search_node_count": 1065,
+      "target_center_class": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {
+        "self_edge": 4,
+        "strict_cycle": 1
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 7,
+      "basic_filter_survivors": [
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              6,
+              8
+            ],
+            "1": [
+              2,
+              3,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "3": [
+              0,
+              4,
+              5,
+              7
+            ],
+            "4": [
+              1,
+              2,
+              5,
+              8
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              3,
+              5,
+              7
+            ],
+            "7": [
+              0,
+              3,
+              4,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              6,
+              8
+            ],
+            "1": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "3": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "4": [
+              1,
+              2,
+              5,
+              8
+            ],
+            "5": [
+              2,
+              3,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              0,
+              3,
+              4,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              6,
+              7
+            ],
+            "1": [
+              2,
+              3,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "3": [
+              0,
+              4,
+              5,
+              8
+            ],
+            "4": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "7": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "1": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "3": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "4": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "5": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "7": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              5,
+              7
+            ],
+            "1": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              6,
+              8
+            ],
+            "3": [
+              0,
+              1,
+              4,
+              5
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              8
+            ],
+            "5": [
+              1,
+              2,
+              6,
+              7
+            ],
+            "6": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "7": [
+              1,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              5,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              4,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              6,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              7
+            ],
+            "4": [
+              0,
+              1,
+              3,
+              5
+            ],
+            "5": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "6": [
+              3,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              6,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              4,
+              7
+            ],
+            "2": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              8
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              7
+            ],
+            "5": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              3,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              6
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            6
+          ],
+          "target_center_class_is_original": true,
+          "vertex_circle_status": "self_edge"
+        }
+      ],
+      "empty_domain_count": 442,
+      "empty_domain_depth_histogram": {
+        "1": 1,
+        "2": 44,
+        "3": 94,
+        "4": 145,
+        "5": 101,
+        "6": 44,
+        "7": 13
+      },
+      "non_original_row8_basic_assignment_count": 0,
+      "search_node_count": 885,
+      "target_center_class": [
+        0,
+        2,
+        5,
+        6
+      ],
+      "target_center_class_is_original": true,
+      "vertex_circle_status_counts": {
+        "self_edge": 3,
+        "strict_cycle": 4
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 12,
+      "basic_filter_survivors": [
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              2,
+              3,
+              8
+            ],
+            "1": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "2": [
+              1,
+              3,
+              5,
+              6
+            ],
+            "3": [
+              2,
+              4,
+              5,
+              8
+            ],
+            "4": [
+              0,
+              3,
+              6,
+              8
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              5,
+              7,
+              8
+            ],
+            "7": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "1": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              5
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              1,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              2,
+              3,
+              7,
+              8
+            ],
+            "7": [
+              0,
+              1,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "1": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "3": [
+              0,
+              1,
+              4,
+              7
+            ],
+            "4": [
+              1,
+              2,
+              5,
+              6
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              6
+            ],
+            "6": [
+              2,
+              3,
+              7,
+              8
+            ],
+            "7": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              6,
+              7
+            ],
+            "1": [
+              0,
+              2,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              5
+            ],
+            "3": [
+              1,
+              4,
+              7,
+              8
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              8
+            ],
+            "5": [
+              1,
+              2,
+              4,
+              6
+            ],
+            "6": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "7": [
+              4,
+              5,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              4,
+              6
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              5
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              7
+            ],
+            "4": [
+              2,
+              5,
+              6,
+              8
+            ],
+            "5": [
+              3,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "7": [
+              0,
+              3,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              7,
+              8
+            ],
+            "1": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              5
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              7
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              0,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "7": [
+              0,
+              3,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              6,
+              7
+            ],
+            "1": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              7
+            ],
+            "3": [
+              0,
+              4,
+              5,
+              8
+            ],
+            "4": [
+              1,
+              2,
+              5,
+              6
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              6
+            ],
+            "6": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "7": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              7,
+              8
+            ],
+            "1": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              4
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              8
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              3,
+              5,
+              7
+            ],
+            "7": [
+              0,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              7,
+              8
+            ],
+            "1": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              5
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "7": [
+              0,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              6,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              4,
+              5,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              7
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "6": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "7": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              2,
+              3,
+              6,
+              8
+            ],
+            "1": [
+              0,
+              4,
+              5,
+              8
+            ],
+            "2": [
+              1,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              6
+            ],
+            "4": [
+              0,
+              3,
+              6,
+              7
+            ],
+            "5": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "6": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "7": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "strict_cycle"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "1": [
+              0,
+              3,
+              5,
+              8
+            ],
+            "2": [
+              1,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              6
+            ],
+            "4": [
+              2,
+              3,
+              7,
+              8
+            ],
+            "5": [
+              0,
+              4,
+              6,
+              7
+            ],
+            "6": [
+              1,
+              4,
+              5,
+              8
+            ],
+            "7": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "8": [
+              0,
+              2,
+              5,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            5,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        }
+      ],
+      "empty_domain_count": 2937,
+      "empty_domain_depth_histogram": {
+        "1": 2,
+        "2": 39,
+        "3": 395,
+        "4": 970,
+        "5": 855,
+        "6": 566,
+        "7": 110
+      },
+      "non_original_row8_basic_assignment_count": 12,
+      "search_node_count": 5455,
+      "target_center_class": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {
+        "self_edge": 10,
+        "strict_cycle": 2
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 10,
+      "basic_filter_survivors": [
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              5,
+              7
+            ],
+            "1": [
+              0,
+              2,
+              4,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              5
+            ],
+            "4": [
+              3,
+              5,
+              6,
+              8
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "6": [
+              2,
+              5,
+              7,
+              8
+            ],
+            "7": [
+              1,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              4,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              6
+            ],
+            "3": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "6": [
+              2,
+              5,
+              7,
+              8
+            ],
+            "7": [
+              1,
+              4,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              3,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              4,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              5
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              6
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              7
+            ],
+            "5": [
+              3,
+              4,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              5,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "1": [
+              0,
+              2,
+              5,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              7
+            ],
+            "3": [
+              1,
+              4,
+              6,
+              8
+            ],
+            "4": [
+              1,
+              2,
+              3,
+              5
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              6
+            ],
+            "6": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "7": [
+              3,
+              5,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              5,
+              7
+            ],
+            "1": [
+              0,
+              2,
+              5,
+              8
+            ],
+            "2": [
+              1,
+              3,
+              7,
+              8
+            ],
+            "3": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "4": [
+              1,
+              2,
+              3,
+              5
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "7": [
+              3,
+              5,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              3,
+              8
+            ],
+            "2": [
+              1,
+              3,
+              4,
+              6
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              3,
+              5,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              2,
+              3,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              4,
+              6
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              8
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "5": [
+              3,
+              4,
+              6,
+              8
+            ],
+            "6": [
+              2,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              3,
+              5,
+              6
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              4,
+              7,
+              8
+            ],
+            "1": [
+              2,
+              3,
+              5,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              4
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              7
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              2,
+              4,
+              6,
+              8
+            ],
+            "6": [
+              0,
+              4,
+              5,
+              7
+            ],
+            "7": [
+              1,
+              3,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              1,
+              5,
+              7,
+              8
+            ],
+            "1": [
+              0,
+              4,
+              6,
+              8
+            ],
+            "2": [
+              0,
+              1,
+              3,
+              5
+            ],
+            "3": [
+              1,
+              2,
+              4,
+              7
+            ],
+            "4": [
+              2,
+              3,
+              5,
+              6
+            ],
+            "5": [
+              0,
+              3,
+              4,
+              7
+            ],
+            "6": [
+              2,
+              4,
+              5,
+              8
+            ],
+            "7": [
+              1,
+              3,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        },
+        {
+          "selected_rows": {
+            "0": [
+              2,
+              3,
+              5,
+              8
+            ],
+            "1": [
+              0,
+              4,
+              6,
+              8
+            ],
+            "2": [
+              1,
+              3,
+              4,
+              7
+            ],
+            "3": [
+              1,
+              2,
+              5,
+              6
+            ],
+            "4": [
+              0,
+              3,
+              5,
+              7
+            ],
+            "5": [
+              2,
+              4,
+              7,
+              8
+            ],
+            "6": [
+              0,
+              1,
+              4,
+              5
+            ],
+            "7": [
+              1,
+              3,
+              6,
+              8
+            ],
+            "8": [
+              0,
+              2,
+              6,
+              7
+            ]
+          },
+          "target_center_class": [
+            0,
+            2,
+            6,
+            7
+          ],
+          "target_center_class_is_original": false,
+          "vertex_circle_status": "self_edge"
+        }
+      ],
+      "empty_domain_count": 2942,
+      "empty_domain_depth_histogram": {
+        "1": 2,
+        "2": 45,
+        "3": 439,
+        "4": 1015,
+        "5": 805,
+        "6": 482,
+        "7": 154
+      },
+      "non_original_row8_basic_assignment_count": 10,
+      "search_node_count": 5494,
+      "target_center_class": [
+        0,
+        2,
+        6,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "vertex_circle_status_counts": {
+        "self_edge": 10
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_8_full_neighborhood_vertex_circle.v1",
+  "source_singleton_support_audit": {
+    "path": "data/certificates/bootstrap_t12_81_8_singleton_support_audit.json",
+    "scan_status": "ONLY_ORIGINAL_ROW8_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS",
+    "schema": "erdos97.bootstrap_t12_81_8_singleton_support_audit.v1",
+    "status": "BOOTSTRAP_T12_81_8_SINGLETON_SUPPORT_AUDIT_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_8_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+  "summary": {
+    "basic_filter_complete_assignment_count": 34,
+    "basic_filter_non_original_row8_assignment_count": 27,
+    "bootstrap_core_witnesses": [
+      0,
+      2
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "empty_domain_count": 8436,
+    "free_row_centers": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "free_row_replacement_count_per_center": 70,
+    "implicit_assignment_space_size": 5188320900000000,
+    "non_original_vertex_circle_surviving_assignment_count": 0,
+    "original_target_center_class": [
+      0,
+      2,
+      5,
+      6
+    ],
+    "remaining_gap": "This does not prove singleton support existence, does not prove the row is forced by minimal or rich-class geometry, does not model additional auxiliary rich supports, and does not promote the review-pending n=9 checker.",
+    "scan_status": "FULL_NEIGHBORHOOD_BASIC_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED",
+    "search_node_count": 16010,
+    "singleton_support_labels": [
+      5,
+      6
+    ],
+    "source_record_ids": [
+      81
+    ],
+    "target_center": 8,
+    "target_center_candidate_count": 9,
+    "target_row_key": "81:8",
+    "vertex_circle_status_counts": {
+      "self_edge": 27,
+      "strict_cycle": 7
+    },
+    "vertex_circle_surviving_assignment_count": 0
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-8-full-neighborhood-vertex-circle.md
+++ b/docs/bootstrap-t12-81-8-full-neighborhood-vertex-circle.md
@@ -1,0 +1,78 @@
+# Bootstrap/T12 source-81 row-8 full-neighborhood vertex-circle packet
+
+Status: proof-mining diagnostic only.  No proof of Erdos Problem #97 and no
+counterexample are claimed.
+
+This packet widens the source-`81` row-`8` singleton-support audit.  The
+previous audit fixed the source-`81` selected-row neighborhood, or allowed one
+additional non-target row to move, and found that only the original row
+`[0,2,5,6]` survived the basic incidence/crossing filters.  Here center `8` is
+fixed to each activation row containing bootstrap-core witnesses `[0,2]` and at
+least one singleton support label from `[5,6]`, while all other centers
+`0..7` may choose arbitrary selected four-sets.
+
+The result is an explicit boundary for future bridge lemmas: basic filters do
+not force the original row once the full selected-row neighborhood is allowed
+to move.  They leave `34` complete assignments, including `27` with a
+non-original row `8`.  However, exact vertex-circle quotient replay kills all
+`34` complete assignments: `27` by self-edge and `7` by strict cycle.
+
+Run the checker with:
+
+```bash
+python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json
+```
+
+Regenerate the artifact with:
+
+```bash
+python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --write --assert-expected
+```
+
+## Scope
+
+The packet checks a fixed source-`81` singleton-support target under the
+natural `n=9` cyclic order.  It uses selected-row row-pair, witness-pair,
+two-overlap crossing, selected-indegree, and vertex-circle quotient filters. It
+does not prove the singleton support exists in a genuine rich-class catalogue,
+does not prove row forcing, does not prove `n=9`, does not prove the bootstrap
+bridge, and is not a counterexample.
+
+## Summary counts
+
+| Quantity | Value |
+|---|---:|
+| target center classes | 9 |
+| free row centers | 8 |
+| implicit selected-assignment space | 5,188,320,900,000,000 |
+| search nodes visited | 16,010 |
+| empty domains | 8,436 |
+| basic-filter complete assignments | 34 |
+| non-original row-8 basic assignments | 27 |
+| vertex-circle self-edges | 27 |
+| vertex-circle strict cycles | 7 |
+| vertex-circle survivors | 0 |
+
+The target-row split is:
+
+| row `8` class | basic survivors | vertex-circle statuses |
+|---|---:|---|
+| `[0,1,2,5]` | 0 | none |
+| `[0,1,2,6]` | 0 | none |
+| `[0,2,3,5]` | 0 | none |
+| `[0,2,3,6]` | 0 | none |
+| `[0,2,4,5]` | 0 | none |
+| `[0,2,4,6]` | 5 | `4` self-edge, `1` strict cycle |
+| `[0,2,5,6]` | 7 | `3` self-edge, `4` strict cycle |
+| `[0,2,5,7]` | 12 | `10` self-edge, `2` strict cycle |
+| `[0,2,6,7]` | 10 | `10` self-edge |
+
+## Interpretation
+
+This is useful mainly as a negative control.  A bridge proof cannot simply
+extend the one-row-drop singleton-support audit and claim that basic incidence
+filters force the original row `8`; the full-neighborhood CSP supplies
+non-original basic-filter survivors.  Any future forcing argument for this
+subtarget must either use additional minimal/rich-class structure before the
+full-neighborhood move, or use a geometric filter such as the vertex-circle
+quotient obstruction after the selected rows are present.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -951,6 +951,15 @@ to their original source-`81` choices. This remains a finite proof-mining
 diagnostic only, not a proof of singleton support existence, row forcing,
 `n=9`, the bootstrap bridge, or Erdos Problem #97.
 
+The source-`81` row-`8` full-neighborhood vertex-circle packet in
+`docs/bootstrap-t12-81-8-full-neighborhood-vertex-circle.md` fixes row `8` to
+the same nine activation rows but lets every other center choose any selected
+4-set. Basic filters leave `34` complete assignments, including `27` with a
+non-original row `8`; vertex-circle quotient replay kills all `34` by
+self-edge or strict-cycle obstructions. This remains a finite proof-mining
+diagnostic only, not a proof of singleton support existence, row forcing,
+`n=9`, the bootstrap bridge, or Erdos Problem #97.
+
 The source-`151` row-`6` outside-pair audit in
 `docs/bootstrap-t12-151-6-outside-pair-audit.md` checks the remaining
 relation-sufficient row target. It enumerates the thirteen center-`6` rows

--- a/docs/index.md
+++ b/docs/index.md
@@ -278,6 +278,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-8-singleton-support-two-row-drop.md`](bootstrap-t12-81-8-singleton-support-two-row-drop.md):
   two-row-drop relaxation audit for the source-`81` row-`8` singleton-support
   target.
+- [`bootstrap-t12-81-8-full-neighborhood-vertex-circle.md`](bootstrap-t12-81-8-full-neighborhood-vertex-circle.md):
+  full-neighborhood row-`8` negative control showing basic filters leave
+  non-original survivors that vertex-circle quotient replay then kills.
 - [`bootstrap-t12-151-6-outside-pair-audit.md`](bootstrap-t12-151-6-outside-pair-audit.md):
   source-`151` row-`6` outside-pair audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -5512,6 +5512,88 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_8_full_neighborhood_vertex_circle
+    path: data/certificates/bootstrap_t12_81_8_full_neighborhood_vertex_circle.json
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
+    command: python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
+    check_command: python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-81 row-8 full-neighborhood vertex-circle diagnostic; basic filters leave 34 complete assignments, including 27 with non-original row 8, but vertex-circle quotient replay kills all 34. This is not singleton-support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_8_full_neighborhood_vertex_circle.v1
+      status: BOOTSTRAP_T12_81_8_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:8"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.target_center: 8
+      summary.bootstrap_core_witnesses:
+        - 0
+        - 2
+      summary.singleton_support_labels:
+        - 5
+        - 6
+      summary.original_target_center_class:
+        - 0
+        - 2
+        - 5
+        - 6
+      summary.target_center_candidate_count: 9
+      summary.free_row_centers:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+      summary.free_row_replacement_count_per_center: 70
+      summary.implicit_assignment_space_size: 5188320900000000
+      summary.search_node_count: 16010
+      summary.empty_domain_count: 8436
+      summary.basic_filter_complete_assignment_count: 34
+      summary.basic_filter_non_original_row8_assignment_count: 27
+      summary.vertex_circle_status_counts.self_edge: 27
+      summary.vertex_circle_status_counts.strict_cycle: 7
+      summary.vertex_circle_surviving_assignment_count: 0
+      summary.non_original_vertex_circle_surviving_assignment_count: 0
+      summary.scan_status: FULL_NEIGHBORHOOD_BASIC_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED
+      source_singleton_support_audit.schema: erdos97.bootstrap_t12_81_8_singleton_support_audit.v1
+      source_singleton_support_audit.scan_status: ONLY_ORIGINAL_ROW8_SURVIVES_FIXED_AND_ONE_ROW_DROP_SUPPORT_AUDITS
+      provenance.generator: scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
+      provenance.command: python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - singleton support proves row-center forcing
+      - the 81:8 row is forced
+      - the 81:8 singleton support exists
+      - the 81:8 full-neighborhood audit proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_151_6_outside_pair_audit
     path: data/certificates/bootstrap_t12_151_6_outside_pair_audit.json
     kind: proof_mining_diagnostic_artifact

--- a/scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
+++ b/scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:8 full-neighborhood vertex-circle packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_8_full_neighborhood_vertex_circle import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_8_full_neighborhood_vertex_circle_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:8 full-neighborhood vertex-circle packet")
+    print(f"target row-8 classes: {summary['target_center_candidate_count']}")
+    print(
+        "basic-filter complete assignments: "
+        f"{summary['basic_filter_complete_assignment_count']}"
+    )
+    print(
+        "non-original row-8 basic survivors: "
+        f"{summary['basic_filter_non_original_row8_assignment_count']}"
+    )
+    print(
+        "vertex-circle survivors: "
+        f"{summary['vertex_circle_surviving_assignment_count']}"
+    )
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_8_full_neighborhood_vertex_circle_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:8 full-neighborhood artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:8 full-neighborhood expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2045,6 +2045,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_81_8_full_neighborhood_vertex_circle",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Source-81 row-8 full-neighborhood vertex-circle diagnostic; "
+            "not singleton-support existence, row forcing, an n=9 proof, "
+            "a bridge proof, or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_151_6_outside_pair_audit",
         command=(
             "python",

--- a/src/erdos97/bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
+++ b/src/erdos97/bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
@@ -1,0 +1,593 @@
+"""Full-neighborhood vertex-circle packet for bootstrap/T12 source 81 row 8.
+
+The earlier singleton-support audit for source 81 row 8 keeps the surrounding
+source-81 selected-row neighborhood fixed, or drops one additional row.  This
+packet widens that boundary: it fixes center 8 to each activation row containing
+bootstrap-core witnesses [0,2] and at least one singleton support label from
+[5,6], while every other center may choose an arbitrary selected 4-set.
+
+Basic incidence/crossing filters alone leave non-original row-8 complete
+assignments.  The packet records that all such full-neighborhood survivors are
+then killed by the exact vertex-circle quotient self-edge/strict-cycle filter.
+It is proof-mining bookkeeping only, not a Euclidean realizability theorem and
+not a proof of row forcing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_8_singleton_support_audit import (
+    BOOTSTRAP_CORE_WITNESSES,
+    DEFAULT_ARTIFACT as SINGLETON_AUDIT_ARTIFACT,
+    ORIGINAL_ROW,
+    SCAN_STATUS as SINGLETON_AUDIT_SCAN_STATUS,
+    SCHEMA as SINGLETON_AUDIT_SCHEMA,
+    SINGLETON_SUPPORT_LABELS,
+    SOURCE_RECORD_ID,
+    STATUS as SINGLETON_AUDIT_STATUS,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+    _target_row_candidates,
+)
+from erdos97.n9_vertex_circle_exhaustive import (
+    MASK_BITS,
+    MAX_INDEGREE,
+    N,
+    OPTIONS,
+    PAIR_CAP,
+    PAIRS,
+    ROW_PAIR_INDICES,
+    rows_compatible,
+    vertex_circle_status,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_8_full_neighborhood_vertex_circle.v1"
+STATUS = "BOOTSTRAP_T12_81_8_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "FULL_NEIGHBORHOOD_BASIC_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED"
+CLAIM_SCOPE = (
+    "Full-neighborhood diagnostic for the source-81 row-8 singleton-support "
+    "target. It fixes center 8 to each 4-set containing bootstrap-core "
+    "witnesses [0,2] and at least one singleton support label from [5,6], "
+    "lets all other centers use arbitrary selected 4-sets, and applies "
+    "row-pair, witness-pair, crossing, and selected-indegree filters before "
+    "exact vertex-circle quotient replay. Basic filters leave 34 complete "
+    "assignments, including 27 with non-original row 8, but all 34 are killed "
+    "by vertex-circle self-edge or strict-cycle obstructions. This is not a "
+    "proof of singleton support existence, not a proof of row forcing, not a "
+    "proof of n=9, not a proof of the bridge, and not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_8_full_neighborhood_vertex_circle.json"
+)
+
+FREE_ROW_CENTERS = [center for center in range(N) if center != TARGET_ROW_CENTER]
+ROW_REPLACEMENT_COUNT_PER_CENTER = 70
+IMPLICIT_ASSIGNMENT_SPACE_SIZE = len(_target_row_candidates()) * (
+    ROW_REPLACEMENT_COUNT_PER_CENTER ** len(FREE_ROW_CENTERS)
+)
+EXPECTED_VERTEX_CIRCLE_STATUS_COUNTS = {"self_edge": 27, "strict_cycle": 7}
+EXPECTED_EMPTY_DOMAIN_DEPTH_HISTOGRAM = {
+    "1": 23,
+    "2": 273,
+    "3": 1306,
+    "4": 2879,
+    "5": 2272,
+    "6": 1340,
+    "7": 343,
+}
+EXPECTED_PER_TARGET_ROW: dict[str, dict[str, object]] = {
+    "0,1,2,5": {
+        "search_node_count": 488,
+        "empty_domain_count": 228,
+        "basic_filter_complete_assignment_count": 0,
+        "vertex_circle_status_counts": {},
+        "empty_domain_depth_histogram": {
+            "1": 5,
+            "2": 12,
+            "3": 53,
+            "4": 64,
+            "5": 55,
+            "6": 25,
+            "7": 14,
+        },
+    },
+    "0,1,2,6": {
+        "search_node_count": 768,
+        "empty_domain_count": 420,
+        "basic_filter_complete_assignment_count": 0,
+        "vertex_circle_status_counts": {},
+        "empty_domain_depth_histogram": {
+            "1": 1,
+            "2": 25,
+            "3": 96,
+            "4": 194,
+            "5": 74,
+            "6": 27,
+            "7": 3,
+        },
+    },
+    "0,2,3,5": {
+        "search_node_count": 427,
+        "empty_domain_count": 200,
+        "basic_filter_complete_assignment_count": 0,
+        "vertex_circle_status_counts": {},
+        "empty_domain_depth_histogram": {
+            "1": 5,
+            "2": 18,
+            "3": 36,
+            "4": 72,
+            "5": 51,
+            "6": 18,
+        },
+    },
+    "0,2,3,6": {
+        "search_node_count": 1046,
+        "empty_domain_count": 545,
+        "basic_filter_complete_assignment_count": 0,
+        "vertex_circle_status_counts": {},
+        "empty_domain_depth_histogram": {
+            "1": 1,
+            "2": 29,
+            "3": 83,
+            "4": 180,
+            "5": 132,
+            "6": 95,
+            "7": 25,
+        },
+    },
+    "0,2,4,5": {
+        "search_node_count": 382,
+        "empty_domain_count": 196,
+        "basic_filter_complete_assignment_count": 0,
+        "vertex_circle_status_counts": {},
+        "empty_domain_depth_histogram": {
+            "1": 5,
+            "2": 28,
+            "3": 43,
+            "4": 63,
+            "5": 48,
+            "6": 7,
+            "7": 2,
+        },
+    },
+    "0,2,4,6": {
+        "search_node_count": 1065,
+        "empty_domain_count": 526,
+        "basic_filter_complete_assignment_count": 5,
+        "vertex_circle_status_counts": {"self_edge": 4, "strict_cycle": 1},
+        "empty_domain_depth_histogram": {
+            "1": 1,
+            "2": 33,
+            "3": 67,
+            "4": 176,
+            "5": 151,
+            "6": 76,
+            "7": 22,
+        },
+    },
+    "0,2,5,6": {
+        "search_node_count": 885,
+        "empty_domain_count": 442,
+        "basic_filter_complete_assignment_count": 7,
+        "vertex_circle_status_counts": {"self_edge": 3, "strict_cycle": 4},
+        "empty_domain_depth_histogram": {
+            "1": 1,
+            "2": 44,
+            "3": 94,
+            "4": 145,
+            "5": 101,
+            "6": 44,
+            "7": 13,
+        },
+    },
+    "0,2,5,7": {
+        "search_node_count": 5455,
+        "empty_domain_count": 2937,
+        "basic_filter_complete_assignment_count": 12,
+        "vertex_circle_status_counts": {"self_edge": 10, "strict_cycle": 2},
+        "empty_domain_depth_histogram": {
+            "1": 2,
+            "2": 39,
+            "3": 395,
+            "4": 970,
+            "5": 855,
+            "6": 566,
+            "7": 110,
+        },
+    },
+    "0,2,6,7": {
+        "search_node_count": 5494,
+        "empty_domain_count": 2942,
+        "basic_filter_complete_assignment_count": 10,
+        "vertex_circle_status_counts": {"self_edge": 10},
+        "empty_domain_depth_histogram": {
+            "1": 2,
+            "2": 45,
+            "3": 439,
+            "4": 1015,
+            "5": 805,
+            "6": 482,
+            "7": 154,
+        },
+    },
+}
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _row_key(row: Sequence[int]) -> str:
+    return ",".join(str(label) for label in row)
+
+
+def _row_mask(row: Iterable[int]) -> int:
+    mask = 0
+    for label in row:
+        mask |= 1 << int(label)
+    return mask
+
+
+def _mask_to_row(row_mask: int) -> list[int]:
+    return _int_list(MASK_BITS[row_mask])
+
+
+def _update_counts(
+    row_mask: int,
+    column_counts: list[int],
+    witness_pair_counts: list[int],
+    delta: int,
+) -> None:
+    for witness in MASK_BITS[row_mask]:
+        column_counts[witness] += delta
+    for pair_index in ROW_PAIR_INDICES[row_mask]:
+        witness_pair_counts[pair_index] += delta
+
+
+def _compatible_with_assignment(
+    center: int,
+    row_mask: int,
+    assigned: Mapping[int, int],
+    column_counts: Sequence[int],
+    witness_pair_counts: Sequence[int],
+) -> bool:
+    if any(column_counts[witness] >= MAX_INDEGREE for witness in MASK_BITS[row_mask]):
+        return False
+    if any(
+        witness_pair_counts[pair_index] >= PAIR_CAP
+        for pair_index in ROW_PAIR_INDICES[row_mask]
+    ):
+        return False
+    return all(
+        rows_compatible(center, row_mask, other_center, other_row)
+        for other_center, other_row in assigned.items()
+    )
+
+
+def _search_with_fixed_target(target_row: Sequence[int]) -> dict[str, object]:
+    target_mask = _row_mask(target_row)
+    assigned: dict[int, int] = {TARGET_ROW_CENTER: target_mask}
+    column_counts = [0] * N
+    witness_pair_counts = [0] * len(PAIRS)
+    _update_counts(target_mask, column_counts, witness_pair_counts, 1)
+
+    stats: Counter[str] = Counter()
+    empty_depths: Counter[int] = Counter()
+    survivors: list[dict[str, object]] = []
+
+    def search() -> None:
+        stats["search_node_count"] += 1
+        if len(assigned) == N:
+            status = vertex_circle_status(assigned)
+            stats["basic_filter_complete_assignment_count"] += 1
+            stats[f"vertex_circle_status:{status}"] += 1
+            survivors.append(
+                {
+                    "target_center_class": list(target_row),
+                    "target_center_class_is_original": list(target_row) == ORIGINAL_ROW,
+                    "vertex_circle_status": status,
+                    "selected_rows": {
+                        str(center): _mask_to_row(assigned[center])
+                        for center in range(N)
+                    },
+                }
+            )
+            return
+
+        best_center: int | None = None
+        best_options: list[int] | None = None
+        for center in FREE_ROW_CENTERS:
+            if center in assigned:
+                continue
+            options = [
+                row_mask
+                for row_mask in OPTIONS[center]
+                if _compatible_with_assignment(
+                    center,
+                    row_mask,
+                    assigned,
+                    column_counts,
+                    witness_pair_counts,
+                )
+            ]
+            if best_options is None or len(options) < len(best_options):
+                best_center = center
+                best_options = options
+            if not options:
+                stats["empty_domain_count"] += 1
+                empty_depths[len(assigned) - 1] += 1
+                return
+
+        if best_center is None or best_options is None:
+            raise AssertionError("search reached inconsistent assignment state")
+        for row_mask in best_options:
+            assigned[best_center] = row_mask
+            _update_counts(row_mask, column_counts, witness_pair_counts, 1)
+            search()
+            _update_counts(row_mask, column_counts, witness_pair_counts, -1)
+            del assigned[best_center]
+
+    search()
+    vertex_circle_counts = {
+        key.removeprefix("vertex_circle_status:"): value
+        for key, value in sorted(stats.items())
+        if key.startswith("vertex_circle_status:")
+    }
+    return {
+        "target_center_class": list(target_row),
+        "target_center_class_is_original": list(target_row) == ORIGINAL_ROW,
+        "search_node_count": stats["search_node_count"],
+        "empty_domain_count": stats["empty_domain_count"],
+        "empty_domain_depth_histogram": _json_counter(empty_depths),
+        "basic_filter_complete_assignment_count": stats[
+            "basic_filter_complete_assignment_count"
+        ],
+        "non_original_row8_basic_assignment_count": (
+            0
+            if list(target_row) == ORIGINAL_ROW
+            else stats["basic_filter_complete_assignment_count"]
+        ),
+        "vertex_circle_status_counts": vertex_circle_counts,
+        "vertex_circle_surviving_assignment_count": vertex_circle_counts.get("ok", 0),
+        "basic_filter_survivors": survivors,
+    }
+
+
+def _scan_payload() -> dict[str, object]:
+    per_target = [_search_with_fixed_target(row) for row in _target_row_candidates()]
+    aggregate: Counter[str] = Counter()
+    empty_depths: Counter[str] = Counter()
+    vertex_circle_counts: Counter[str] = Counter()
+    survivors: list[dict[str, object]] = []
+    for record in per_target:
+        aggregate["search_node_count"] += int(record["search_node_count"])
+        aggregate["empty_domain_count"] += int(record["empty_domain_count"])
+        aggregate["basic_filter_complete_assignment_count"] += int(
+            record["basic_filter_complete_assignment_count"]
+        )
+        aggregate["non_original_row8_basic_assignment_count"] += int(
+            record["non_original_row8_basic_assignment_count"]
+        )
+        for depth, count in dict(record["empty_domain_depth_histogram"]).items():
+            empty_depths[str(depth)] += int(count)
+        for status, count in dict(record["vertex_circle_status_counts"]).items():
+            vertex_circle_counts[str(status)] += int(count)
+        basic_survivors = record["basic_filter_survivors"]
+        if not isinstance(basic_survivors, Sequence):
+            raise AssertionError("basic_filter_survivors must be a sequence")
+        survivors.extend(list(basic_survivors))
+
+    return {
+        "per_target_center_class": per_target,
+        "aggregate": dict(sorted(aggregate.items())),
+        "empty_domain_depth_histogram": dict(sorted(empty_depths.items())),
+        "vertex_circle_status_counts": dict(sorted(vertex_circle_counts.items())),
+        "basic_filter_survivors": survivors,
+    }
+
+
+def build_t12_81_8_full_neighborhood_vertex_circle_payload() -> dict[str, object]:
+    """Return the deterministic source-81 row-8 full-neighborhood packet."""
+
+    scan = _scan_payload()
+    aggregate = scan["aggregate"]
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("aggregate must be a mapping")
+    vertex_circle_counts = scan["vertex_circle_status_counts"]
+    if not isinstance(vertex_circle_counts, Mapping):
+        raise AssertionError("vertex_circle_status_counts must be a mapping")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "Full-neighborhood basic incidence/crossing filters alone leave non-original row-8 survivors.",
+            "All recorded full-neighborhood survivors close only after exact vertex-circle quotient replay.",
+            "The packet does not prove singleton support existence or row/rich-class forcing.",
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [SOURCE_RECORD_ID],
+            "cyclic_order": list(range(N)),
+            "target_center": TARGET_ROW_CENTER,
+            "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+            "singleton_support_labels": SINGLETON_SUPPORT_LABELS,
+            "original_target_center_class": ORIGINAL_ROW,
+            "target_center_candidate_count": len(_target_row_candidates()),
+            "free_row_centers": FREE_ROW_CENTERS,
+            "free_row_replacement_count_per_center": ROW_REPLACEMENT_COUNT_PER_CENTER,
+            "implicit_assignment_space_size": IMPLICIT_ASSIGNMENT_SPACE_SIZE,
+            "search_node_count": aggregate["search_node_count"],
+            "empty_domain_count": aggregate["empty_domain_count"],
+            "basic_filter_complete_assignment_count": aggregate[
+                "basic_filter_complete_assignment_count"
+            ],
+            "basic_filter_non_original_row8_assignment_count": aggregate[
+                "non_original_row8_basic_assignment_count"
+            ],
+            "vertex_circle_status_counts": dict(vertex_circle_counts),
+            "vertex_circle_surviving_assignment_count": int(
+                vertex_circle_counts.get("ok", 0)
+            ),
+            "non_original_vertex_circle_surviving_assignment_count": 0,
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This does not prove singleton support existence, does not "
+                "prove the row is forced by minimal or rich-class geometry, "
+                "does not model additional auxiliary rich supports, and does "
+                "not promote the review-pending n=9 checker."
+            ),
+        },
+        "candidate_generation": {
+            "target_center_candidate_classes": _target_row_candidates(),
+            "candidate_rule": (
+                "4-sets at center 8 containing bootstrap-core witnesses [0,2] "
+                "and at least one singleton support label from [5,6]."
+            ),
+        },
+        "empty_domain_depth_histogram": scan["empty_domain_depth_histogram"],
+        "per_target_center_class": scan["per_target_center_class"],
+        "basic_filter_survivors": scan["basic_filter_survivors"],
+        "source_singleton_support_audit": {
+            "path": SINGLETON_AUDIT_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": SINGLETON_AUDIT_SCHEMA,
+            "status": SINGLETON_AUDIT_STATUS,
+            "scan_status": SINGLETON_AUDIT_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [SOURCE_RECORD_ID],
+        "cyclic_order": list(range(N)),
+        "target_center": TARGET_ROW_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "singleton_support_labels": SINGLETON_SUPPORT_LABELS,
+        "original_target_center_class": ORIGINAL_ROW,
+        "target_center_candidate_count": 9,
+        "free_row_centers": FREE_ROW_CENTERS,
+        "free_row_replacement_count_per_center": ROW_REPLACEMENT_COUNT_PER_CENTER,
+        "implicit_assignment_space_size": 5188320900000000,
+        "search_node_count": 16010,
+        "empty_domain_count": 8436,
+        "basic_filter_complete_assignment_count": 34,
+        "basic_filter_non_original_row8_assignment_count": 27,
+        "vertex_circle_status_counts": EXPECTED_VERTEX_CIRCLE_STATUS_COUNTS,
+        "vertex_circle_surviving_assignment_count": 0,
+        "non_original_vertex_circle_surviving_assignment_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    if payload.get("empty_domain_depth_histogram") != EXPECTED_EMPTY_DOMAIN_DEPTH_HISTOGRAM:
+        raise AssertionError("empty-domain depth histogram drifted")
+
+    per_target = payload.get("per_target_center_class")
+    if not isinstance(per_target, Sequence) or len(per_target) != 9:
+        raise AssertionError("expected nine target-center class summaries")
+    for record in per_target:
+        if not isinstance(record, Mapping):
+            raise AssertionError("target-center class summaries must be mappings")
+        target_class = record.get("target_center_class")
+        if not isinstance(target_class, Sequence):
+            raise AssertionError("target_center_class must be a sequence")
+        key = _row_key(_int_list(target_class))
+        expected = EXPECTED_PER_TARGET_ROW.get(key)
+        if expected is None:
+            raise AssertionError(f"unexpected target-center class {key!r}")
+        for expected_key, expected_value in expected.items():
+            if record.get(expected_key) != expected_value:
+                raise AssertionError(
+                    f"target {key} {expected_key} is {record.get(expected_key)!r}, expected {expected_value!r}"
+                )
+        if record.get("vertex_circle_surviving_assignment_count") != 0:
+            raise AssertionError(f"target {key} has vertex-circle survivors")
+
+    survivors = payload.get("basic_filter_survivors")
+    if not isinstance(survivors, Sequence) or len(survivors) != 34:
+        raise AssertionError("expected 34 full-neighborhood basic-filter survivors")
+    if any(
+        isinstance(survivor, Mapping) and survivor.get("vertex_circle_status") == "ok"
+        for survivor in survivors
+    ):
+        raise AssertionError("all basic-filter survivors must be vertex-circle obstructed")
+    non_original_survivors = [
+        survivor
+        for survivor in survivors
+        if isinstance(survivor, Mapping)
+        and not survivor.get("target_center_class_is_original")
+    ]
+    if len(non_original_survivors) != 27:
+        raise AssertionError("expected 27 non-original row-8 basic-filter survivors")
+
+    source = payload.get("source_singleton_support_audit")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_singleton_support_audit must be a mapping")
+    if source.get("schema") != SINGLETON_AUDIT_SCHEMA:
+        raise AssertionError("source singleton-support schema drifted")
+    if source.get("scan_status") != SINGLETON_AUDIT_SCAN_STATUS:
+        raise AssertionError("source singleton-support scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
+++ b/tests/test_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_8_full_neighborhood_vertex_circle import (
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_8_full_neighborhood_vertex_circle_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_8_full_neighborhood_vertex_circle_payload()
+
+
+def test_81_8_full_neighborhood_counts_and_scope(payload: dict[str, object]) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_8_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "non-original row 8" in claim_scope
+    assert "not a proof of row forcing" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_8_full_neighborhood_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:8"
+    assert summary["source_record_ids"] == [81]
+    assert summary["target_center"] == 8
+    assert summary["bootstrap_core_witnesses"] == [0, 2]
+    assert summary["singleton_support_labels"] == [5, 6]
+    assert summary["original_target_center_class"] == [0, 2, 5, 6]
+    assert summary["target_center_candidate_count"] == 9
+    assert summary["free_row_centers"] == list(range(8))
+    assert summary["free_row_replacement_count_per_center"] == 70
+    assert summary["implicit_assignment_space_size"] == 5_188_320_900_000_000
+    assert summary["search_node_count"] == 16_010
+    assert summary["empty_domain_count"] == 8_436
+    assert summary["basic_filter_complete_assignment_count"] == 34
+    assert summary["basic_filter_non_original_row8_assignment_count"] == 27
+    assert summary["vertex_circle_status_counts"] == {
+        "self_edge": 27,
+        "strict_cycle": 7,
+    }
+    assert summary["vertex_circle_surviving_assignment_count"] == 0
+    assert summary["non_original_vertex_circle_surviving_assignment_count"] == 0
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_8_full_neighborhood_per_target_boundary(
+    payload: dict[str, object],
+) -> None:
+    per_target = payload["per_target_center_class"]
+    by_target = {
+        tuple(record["target_center_class"]): record for record in per_target
+    }
+
+    zero_basic_survivor_rows = {
+        (0, 1, 2, 5),
+        (0, 1, 2, 6),
+        (0, 2, 3, 5),
+        (0, 2, 3, 6),
+        (0, 2, 4, 5),
+    }
+    for row in zero_basic_survivor_rows:
+        assert by_target[row]["basic_filter_complete_assignment_count"] == 0
+        assert by_target[row]["vertex_circle_status_counts"] == {}
+
+    assert by_target[(0, 2, 4, 6)]["vertex_circle_status_counts"] == {
+        "self_edge": 4,
+        "strict_cycle": 1,
+    }
+    assert by_target[(0, 2, 5, 6)]["vertex_circle_status_counts"] == {
+        "self_edge": 3,
+        "strict_cycle": 4,
+    }
+    assert by_target[(0, 2, 5, 7)]["vertex_circle_status_counts"] == {
+        "self_edge": 10,
+        "strict_cycle": 2,
+    }
+    assert by_target[(0, 2, 6, 7)]["vertex_circle_status_counts"] == {
+        "self_edge": 10,
+    }
+
+
+def test_81_8_full_neighborhood_survivors_are_obstructed(
+    payload: dict[str, object],
+) -> None:
+    survivors = payload["basic_filter_survivors"]
+
+    assert len(survivors) == 34
+    assert sum(
+        1 for survivor in survivors if not survivor["target_center_class_is_original"]
+    ) == 27
+    assert {survivor["vertex_circle_status"] for survivor in survivors} == {
+        "self_edge",
+        "strict_cycle",
+    }
+    for survivor in survivors:
+        selected_rows = survivor["selected_rows"]
+        assert set(selected_rows) == {str(center) for center in range(9)}
+        assert all(len(row) == 4 for row in selected_rows.values())
+
+
+def test_81_8_full_neighborhood_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["basic_filter_non_original_row8_assignment_count"] == 27
+    assert payload["summary"]["vertex_circle_surviving_assignment_count"] == 0
+
+
+def test_81_8_full_neighborhood_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["vertex_circle_surviving_assignment_count"] = 1
+
+    with pytest.raises(AssertionError, match="vertex_circle_surviving_assignment_count"):
+        assert_expected_payload(bad)


### PR DESCRIPTION
## Summary

- add a source-81 row-8 full-neighborhood vertex-circle diagnostic packet
- record the generated JSON artifact, provenance metadata, docs, and focused tests
- wire the checker into bridge-frontier/audit paths

## Review notes

This is a `REVIEW_PENDING_DIAGNOSTIC` and a negative-control boundary. It fixes row 8 to the nine singleton-support activation rows while every other center may choose any selected 4-set. Basic filters leave 34 complete assignments, including 27 with non-original row 8; vertex-circle quotient replay kills all 34 by 27 self-edges and 7 strict cycles. It does not prove singleton-support existence, row forcing, n=9, the bootstrap bridge, or Erdos Problem #97.

## Verification

- `python scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py`
- `python -m ruff check .`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`