### PR TITLE
[codex] Add transverse edge-event and cap-cut packets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -487,6 +487,9 @@ put detailed reconciliation in the canonical synthesis.
   ideas and submission policy.
 - [`../data/runs/README.md`](../data/runs/README.md): numerical artifact
   conventions.
+- [`transverse-edge-event-and-cap-cut-constraints.md`](transverse-edge-event-and-cap-cut-constraints.md):
+  exact local research packets for edge-event and cap-cut necessary
+  conditions; not a global obstruction.
 
 ## Planning and provenance
 

--- a/docs/transverse-edge-event-and-cap-cut-constraints.md
+++ b/docs/transverse-edge-event-and-cap-cut-constraints.md
@@ -1,0 +1,159 @@
+# Transverse Edge-Event And Cap-Cut Constraints
+
+Status: `RESEARCH_PACKET`.
+
+This note records two local necessary-condition packets for selected-witness
+systems. They do not solve Erdos Problem #97, do not promote any finite-case
+claim, and do not change the repository source of truth. Their purpose is to
+turn arbitrary selected 4-ties into exact constraints that can be checked,
+mined, or later combined with stronger bridge arguments.
+
+The two packets are deliberately complementary:
+
+- the edge-event packet works with actual polygon coordinates and edge-vector
+  identities;
+- the cap-cut packet works in squared-distance variables for a fixed selected
+  witness system and cyclic order.
+
+## Edge-Event / Gram Packet
+
+Let `P=(p_0,...,p_{n-1})` be a strictly convex polygon in cyclic order and put
+
+```text
+e_k = p_{k+1} - p_k
+```
+
+with indices modulo `n`. Define
+
+```text
+D_{i,k} = |p_i - p_{k+1}|^2 - |p_i - p_k|^2.
+```
+
+Then the exact first-difference identity is
+
+```text
+D_{i,k} = (|p_{k+1}|^2 - |p_k|^2) - 2 p_i . e_k.
+```
+
+Thus the matrix `D` has rank at most `3`. Adjacent row differences recover the
+edge Gram matrix:
+
+```text
+D_{i+1,k} - D_{i,k} = -2 e_i . e_k.
+```
+
+So, for `G_{i,k}=e_i.e_k`,
+
+```text
+G is positive semidefinite,   rank(G) <= 2,   G 1 = 0.
+```
+
+If a selected row centered at `i` has four equal-distance witnesses
+`a_1,a_2,a_3,a_4` in boundary order around `p_i`, each consecutive gap
+`I_s=[a_s,a_{s+1})` satisfies the zero interval identity
+
+```text
+sum_{k in I_s} D_{i,k} = 0.
+```
+
+The stronger transverse signs are
+
+```text
+sum_{k in I_s} G_{i,k} < 0,
+sum_{k in I_s} G_{i-1,k} < 0.
+```
+
+Equivalently,
+
+```text
+sum_{k in I_s} D_{i+1,k} > 0,
+sum_{k in I_s} D_{i-1,k} < 0.
+```
+
+This is stronger than raw row sign-change counting. The open bridge problem is
+to prove that no closed positive-turn edge system can support the `3n`
+selected zero intervals with these transverse signs and the Gram constraints,
+or to find the extra condition needed to make that statement true.
+
+The coordinate extractor is:
+
+```bash
+python scripts/check_edge_event_packet.py input.json --assert-verified
+```
+
+The input JSON uses `coordinates` or `vertices`, and may include
+`selected_rows` as either a dictionary or a list of row records.
+
+## Cap-Cut / Squared-Chord Packet
+
+Write
+
+```text
+D_uv = |p_u - p_v|^2.
+```
+
+If `D_ia = D_ib` and `x` lies on the open boundary arc from `a` to `b` that
+does not contain `i`, strict convexity gives the centered cap-cut inequality
+
+```text
+2D_ix - D_ax - D_bx + D_ab - D_ia - D_ib > 0.
+```
+
+If `x` is also tied at the same radius from `i`, this reduces to squared-chord
+superadditivity:
+
+```text
+D_ab > D_ax + D_xb.
+```
+
+For four selected witnesses `w_1,w_2,w_3,w_4` in boundary order around `i`,
+one useful row consequence is
+
+```text
+D_{w_1 w_4} > D_{w_1 w_2} + D_{w_2 w_3} + D_{w_3 w_4}.
+```
+
+Summing that chain inequality over all selected rows gives an immediate
+outer-dominance necessary condition. Let `O(e)` count selected rows where the
+unordered pair `e` is the outer pair `{w_1,w_4}`, and let `A(e)` count selected
+rows where `e` is one of the adjacent pairs
+`{w_1,w_2}`, `{w_2,w_3}`, `{w_3,w_4}`. Then any geometric counterexample with
+these selected rows must have some pair with
+
+```text
+O(e) > A(e).
+```
+
+The corrected pair-cap consequence is important. A fixed unordered pair can
+occur together in selected witness sets for at most two centers. Since a pair
+cannot be both outer and adjacent in the same selected row, the only
+pair-cap-compatible outer-dominant types are
+
+```text
+(O,A) = (1,0) or (2,0).
+```
+
+The previously suggested `(2,1)` type is not pair-cap-compatible.
+
+The selected-pattern checker is:
+
+```bash
+python scripts/check_cap_cut_constraints.py --pattern C13_sidon_1_2_4_10 --json
+```
+
+It emits selected triple superadditivity counts, chain inequality diagnostics,
+general cap-cut inequality counts, corrected pair-role counts, and a unit
+chain-superadditivity obstruction when the summed chain row is already
+coordinatewise nonpositive after selected-distance quotienting.
+
+## Trust Boundary
+
+These packets are exact local necessary conditions. They are useful only if
+later work either:
+
+- mines exact certificates for fixed selected systems;
+- finds reusable local templates from those certificates;
+- proves a global packing or infeasibility theorem for the combined edge-event
+  and cap-cut constraints.
+
+No such global theorem is claimed here.

--- a/scripts/check_cap_cut_constraints.py
+++ b/scripts/check_cap_cut_constraints.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check centered cap-cut and squared-chord constraints for a fixed pattern."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.cap_cut_constraints import cap_cut_report  # noqa: E402
+from erdos97.search import built_in_patterns  # noqa: E402
+
+
+def parse_order(raw: str) -> list[int]:
+    try:
+        return [int(item.strip()) for item in raw.split(",") if item.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid comma-separated order: {raw}") from exc
+
+
+def print_summary(report: dict[str, object]) -> None:
+    unit = report["unit_chain_superadditivity"]
+    outer = report["outer_dominance"]
+    print("cap-cut / squared-chord constraint report")
+    print(f"n: {report['n']}")
+    print(f"selected rows: {report['selected_row_count']}")
+    print(f"selected triple inequalities: {report['selected_superadditivity_row_count']}")
+    print(f"chain inequalities: {report['chain_superadditivity_row_count']}")
+    print(f"cap-cut inequalities: {report['cap_cut_row_count']}")
+    print(f"unit-chain status: {unit['status']}")
+    print(f"outer-dominant pairs: {outer['outer_dominant_pair_count']}")
+    print(
+        "pair-cap-compatible outer-dominant types: "
+        f"{outer['pair_cap_compatible_outer_dominant_types']}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pattern", required=True, help="built-in pattern name")
+    parser.add_argument(
+        "--order",
+        type=parse_order,
+        help="comma-separated cyclic order; defaults to natural label order",
+    )
+    parser.add_argument(
+        "--no-cap-cuts",
+        action="store_true",
+        help="omit general nonselected cap-cut inequalities from the report",
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON")
+    parser.add_argument("--write-certificate", help="write JSON report to this path")
+    parser.add_argument(
+        "--assert-unit-obstructed",
+        action="store_true",
+        help="assert that unit chain-superadditivity already obstructs the pattern",
+    )
+    args = parser.parse_args()
+
+    patterns = built_in_patterns()
+    if args.pattern not in patterns:
+        raise SystemExit(f"unknown pattern {args.pattern}; known: {', '.join(patterns)}")
+    pattern = patterns[args.pattern]
+    report = cap_cut_report(
+        pattern.S,
+        args.order,
+        include_cap_cuts=not args.no_cap_cuts,
+    )
+
+    if args.assert_unit_obstructed:
+        unit = report["unit_chain_superadditivity"]
+        if unit["obstructed"] is not True:
+            raise AssertionError("expected unit chain-superadditivity obstruction")
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_summary(report)
+        if args.assert_unit_obstructed:
+            print("OK: unit obstruction expectation verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_edge_event_packet.py
+++ b/scripts/check_edge_event_packet.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Extract an exact edge-event / Gram packet from coordinate JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.edge_event_packet import edge_event_report  # noqa: E402
+
+
+def _parse_selected_rows(raw: object) -> dict[int, list[int]]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return {int(center): [int(v) for v in row] for center, row in raw.items()}
+    if isinstance(raw, list):
+        return {
+            int(item["center"]): [int(v) for v in item["witnesses"]]
+            for item in raw
+        }
+    raise ValueError("selected_rows must be a dict or a list of row records")
+
+
+def print_summary(report: dict[str, object]) -> None:
+    checks = report["identity_checks"]
+    print("edge-event / Gram packet")
+    print(f"n: {report['n']}")
+    print(f"row-difference identity: {checks['row_difference_identity_verified']}")
+    print(f"Gram closure: {checks['gram_closure_verified']}")
+    print(f"column line-cut checks: {checks['column_line_cut_checks_verified']}")
+    print(f"selected interval packets: {checks['selected_interval_packets_verified']}")
+    print(f"interval packet count: {len(report['selected_interval_packets'])}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "input",
+        help=(
+            "JSON file with coordinates or vertices, and optional selected_rows. "
+            "Coordinates may be ints or rational strings."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON")
+    parser.add_argument("--write-certificate", help="write JSON report to this path")
+    parser.add_argument(
+        "--assert-verified",
+        action="store_true",
+        help="assert all reported identity checks are true",
+    )
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8-sig"))
+    coordinates = payload.get("coordinates", payload.get("vertices"))
+    if coordinates is None:
+        raise SystemExit("input JSON must contain coordinates or vertices")
+    selected_rows = _parse_selected_rows(payload.get("selected_rows"))
+    report = edge_event_report(coordinates, selected_rows)
+
+    if args.assert_verified:
+        checks = report["identity_checks"]
+        failed = [name for name, value in checks.items() if value is not True]
+        if failed:
+            raise AssertionError(f"expected all identity checks true; failed={failed}")
+
+    if args.write_certificate:
+        path = Path(args.write_certificate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_summary(report)
+        if args.assert_verified:
+            print("OK: edge-event packet verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/cap_cut_constraints.py
+++ b/src/erdos97/cap_cut_constraints.py
@@ -1,0 +1,423 @@
+"""Centered cap-cut and squared-chord superadditivity constraints.
+
+The checks in this module are exact finite bookkeeping over selected-witness
+rows and a supplied cyclic order.  They generate necessary strict inequalities
+for a geometric realization, but they do not claim that any surviving abstract
+system is realizable.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Sequence
+
+from erdos97.quotient_cone import DistanceQuotient, Term, pair, selected_distance_quotient
+from erdos97.stuck_sets import validate_selected_pattern
+
+Pattern = Sequence[Sequence[int]]
+
+
+@dataclass(frozen=True)
+class CapCutRow:
+    """One strict linear squared-distance inequality."""
+
+    kind: str
+    center: int
+    terms: tuple[Term, ...]
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True)
+class PairRoleCount:
+    """Role counts for one unordered witness-witness pair."""
+
+    pair: tuple[int, int]
+    outer: int
+    adjacent: int
+    skipped: int
+
+    @property
+    def total_selected_row_occurrences(self) -> int:
+        return self.outer + self.adjacent + self.skipped
+
+    @property
+    def outer_dominant(self) -> bool:
+        return self.outer > self.adjacent
+
+    @property
+    def pair_cap_compatible(self) -> bool:
+        return self.total_selected_row_occurrences <= 2
+
+    @property
+    def corrected_outer_dominant_type(self) -> tuple[int, int] | None:
+        if not self.outer_dominant or not self.pair_cap_compatible:
+            return None
+        return (self.outer, self.adjacent)
+
+
+@dataclass(frozen=True)
+class UnitSuperadditivityCertificate:
+    """Unit-weight sum of selected-row chain superadditivity inequalities."""
+
+    status: str
+    quotient: DistanceQuotient
+    combined_coefficients: tuple[int, ...]
+    coefficient_positive_count: int
+    coefficient_negative_count: int
+    coefficient_zero_count: int
+    strict_row_count: int
+    selected_distance_class_count: int
+
+    @property
+    def obstructed(self) -> bool:
+        return self.status == "EXACT_UNIT_SUPERADDITIVITY_OBSTRUCTION"
+
+
+def validate_cyclic_order(order: Sequence[int], n: int) -> None:
+    """Validate that ``order`` is a cyclic ordering of labels ``0..n-1``."""
+
+    if len(order) != n:
+        raise ValueError(f"order length {len(order)} does not match n={n}")
+    if set(order) != set(range(n)):
+        raise ValueError("order must be a permutation of 0..n-1")
+
+
+def angular_witness_order(
+    order: Sequence[int],
+    center: int,
+    witnesses: Sequence[int],
+) -> tuple[int, ...]:
+    """Return witnesses in boundary order around the hull vertex ``center``."""
+
+    n = len(order)
+    validate_cyclic_order(order, n)
+    positions = {label: idx for idx, label in enumerate(order)}
+    if center not in positions:
+        raise ValueError(f"center {center} is missing from order")
+    center_pos = positions[center]
+    missing = [witness for witness in witnesses if witness not in positions]
+    if missing:
+        raise ValueError(f"witness {missing[0]} is missing from order")
+    return tuple(
+        sorted(
+            (int(witness) for witness in witnesses),
+            key=lambda witness: (positions[witness] - center_pos) % n,
+        )
+    )
+
+
+def open_arc_not_containing_center(
+    order: Sequence[int],
+    a: int,
+    b: int,
+    center: int,
+) -> tuple[int, ...]:
+    """Return the open boundary arc from ``a`` to ``b`` not containing ``center``."""
+
+    n = len(order)
+    validate_cyclic_order(order, n)
+    positions = {label: idx for idx, label in enumerate(order)}
+    for label in (a, b, center):
+        if label not in positions:
+            raise ValueError(f"label {label} is missing from order")
+    if len({a, b, center}) != 3:
+        raise ValueError("a, b, and center must be distinct")
+
+    def forward_arc(start: int, end: int) -> list[int]:
+        out: list[int] = []
+        pos = (positions[start] + 1) % n
+        end_pos = positions[end]
+        while pos != end_pos:
+            out.append(int(order[pos]))
+            pos = (pos + 1) % n
+        return out
+
+    arc_ab = forward_arc(a, b)
+    arc_ba = forward_arc(b, a)
+    if center in arc_ab and center in arc_ba:
+        raise AssertionError("center cannot lie in both open arcs")
+    if center not in arc_ab:
+        return tuple(arc_ab)
+    return tuple(arc_ba)
+
+
+def superadditivity_terms(a: int, b: int, c: int) -> tuple[Term, ...]:
+    """Return terms for ``D_ac - D_ab - D_bc > 0``."""
+
+    return ((pair(a, c), +1), (pair(a, b), -1), (pair(b, c), -1))
+
+
+def cap_cut_terms(center: int, a: int, b: int, x: int) -> tuple[Term, ...]:
+    """Return terms for the centered cap-cut inequality.
+
+    The row is
+    ``2D_ix - D_ax - D_bx + D_ab - D_ia - D_ib > 0``.
+    """
+
+    return (
+        (pair(center, x), +2),
+        (pair(a, x), -1),
+        (pair(b, x), -1),
+        (pair(a, b), +1),
+        (pair(center, a), -1),
+        (pair(center, b), -1),
+    )
+
+
+def selected_superadditivity_rows(
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+) -> list[CapCutRow]:
+    """Generate selected-witness triple superadditivity inequalities."""
+
+    validate_selected_pattern(rows)
+    n = len(rows)
+    if order is None:
+        order = list(range(n))
+    validate_cyclic_order(order, n)
+
+    output: list[CapCutRow] = []
+    for center, witnesses in enumerate(rows):
+        ordered = angular_witness_order(order, center, witnesses)
+        for left_index, middle_index, right_index in combinations(range(4), 3):
+            a = ordered[left_index]
+            b = ordered[middle_index]
+            c = ordered[right_index]
+            output.append(
+                CapCutRow(
+                    kind="selected_superadditivity",
+                    center=center,
+                    terms=superadditivity_terms(a, b, c),
+                    metadata={
+                        "witness_order": list(ordered),
+                        "triple": [a, b, c],
+                    },
+                )
+            )
+    return output
+
+
+def chain_superadditivity_rows(
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+) -> list[CapCutRow]:
+    """Generate one four-witness chain inequality per selected row."""
+
+    validate_selected_pattern(rows)
+    n = len(rows)
+    if order is None:
+        order = list(range(n))
+    validate_cyclic_order(order, n)
+
+    output: list[CapCutRow] = []
+    for center, witnesses in enumerate(rows):
+        w0, w1, w2, w3 = angular_witness_order(order, center, witnesses)
+        terms: tuple[Term, ...] = (
+            (pair(w0, w3), +1),
+            (pair(w0, w1), -1),
+            (pair(w1, w2), -1),
+            (pair(w2, w3), -1),
+        )
+        output.append(
+            CapCutRow(
+                kind="selected_chain_superadditivity",
+                center=center,
+                terms=terms,
+                metadata={"witness_order": [w0, w1, w2, w3]},
+            )
+        )
+    return output
+
+
+def cap_cut_rows(
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+) -> list[CapCutRow]:
+    """Generate centered cap-cut inequalities for selected tied pairs."""
+
+    validate_selected_pattern(rows)
+    n = len(rows)
+    if order is None:
+        order = list(range(n))
+    validate_cyclic_order(order, n)
+
+    output: list[CapCutRow] = []
+    for center, witnesses in enumerate(rows):
+        ordered = angular_witness_order(order, center, witnesses)
+        for a, b in combinations(ordered, 2):
+            for x in open_arc_not_containing_center(order, a, b, center):
+                if x in (a, b):
+                    continue
+                output.append(
+                    CapCutRow(
+                        kind="centered_cap_cut",
+                        center=center,
+                        terms=cap_cut_terms(center, a, b, x),
+                        metadata={
+                            "tied_pair": [a, b],
+                            "cap_vertex": x,
+                            "witness_order": list(ordered),
+                        },
+                    )
+                )
+    return output
+
+
+def pair_role_counts(
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+) -> list[PairRoleCount]:
+    """Return outer, adjacent, and skipped role counts for witness pairs."""
+
+    validate_selected_pattern(rows)
+    n = len(rows)
+    if order is None:
+        order = list(range(n))
+    validate_cyclic_order(order, n)
+
+    outer: Counter[tuple[int, int]] = Counter()
+    adjacent: Counter[tuple[int, int]] = Counter()
+    skipped: Counter[tuple[int, int]] = Counter()
+
+    for center, witnesses in enumerate(rows):
+        ordered = angular_witness_order(order, center, witnesses)
+        outer[pair(ordered[0], ordered[3])] += 1
+        for left, right in zip(ordered, ordered[1:]):
+            adjacent[pair(left, right)] += 1
+        for left, right in ((ordered[0], ordered[2]), (ordered[1], ordered[3])):
+            skipped[pair(left, right)] += 1
+
+    all_pairs = sorted(set(outer) | set(adjacent) | set(skipped))
+    return [
+        PairRoleCount(
+            pair=item,
+            outer=outer[item],
+            adjacent=adjacent[item],
+            skipped=skipped[item],
+        )
+        for item in all_pairs
+    ]
+
+
+def unit_chain_superadditivity_certificate(
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+) -> UnitSuperadditivityCertificate:
+    """Check the unit-weight chain-superadditivity obstruction.
+
+    Summing one strict chain inequality per row gives a certificate whenever
+    the reduced selected-distance quotient coefficient vector is coordinatewise
+    nonpositive.  If it is zero, the sum gives ``0 > 0``.  If some coefficients
+    are negative, positivity of squared distances makes the left-hand side
+    strictly negative, again contradicting the strict positive sum.
+    """
+
+    validate_selected_pattern(rows)
+    quotient = selected_distance_quotient(rows)
+    rows_to_sum = chain_superadditivity_rows(rows, order)
+    combined = [0] * quotient.class_count
+    for strict_row in rows_to_sum:
+        for raw_pair, coefficient in strict_row.terms:
+            class_index = quotient.pair_class[pair(*raw_pair)]
+            combined[class_index] += coefficient
+    coefficients = tuple(combined)
+    positive = sum(1 for value in coefficients if value > 0)
+    negative = sum(1 for value in coefficients if value < 0)
+    zero = len(coefficients) - positive - negative
+    status = (
+        "EXACT_UNIT_SUPERADDITIVITY_OBSTRUCTION"
+        if positive == 0 and (negative > 0 or zero == len(coefficients))
+        else "PASS_UNIT_SUPERADDITIVITY"
+    )
+    return UnitSuperadditivityCertificate(
+        status=status,
+        quotient=quotient,
+        combined_coefficients=coefficients,
+        coefficient_positive_count=positive,
+        coefficient_negative_count=negative,
+        coefficient_zero_count=zero,
+        strict_row_count=len(rows_to_sum),
+        selected_distance_class_count=quotient.class_count,
+    )
+
+
+def cap_cut_report(
+    rows: Pattern,
+    order: Sequence[int] | None = None,
+    *,
+    include_cap_cuts: bool = True,
+) -> dict[str, object]:
+    """Return a JSON-friendly diagnostic report for one selected system."""
+
+    validate_selected_pattern(rows)
+    n = len(rows)
+    if order is None:
+        order = list(range(n))
+    validate_cyclic_order(order, n)
+
+    selected_triples = selected_superadditivity_rows(rows, order)
+    chains = chain_superadditivity_rows(rows, order)
+    cuts = cap_cut_rows(rows, order) if include_cap_cuts else []
+    role_counts = pair_role_counts(rows, order)
+    unit = unit_chain_superadditivity_certificate(rows, order)
+    outer_dominant = [row for row in role_counts if row.outer_dominant]
+    corrected_types = sorted(
+        {
+            row.corrected_outer_dominant_type
+            for row in outer_dominant
+            if row.corrected_outer_dominant_type is not None
+        }
+    )
+
+    return {
+        "schema": "erdos97.cap_cut_constraints.v1",
+        "trust": "RESEARCH_PACKET_LOCAL_NECESSARY_CONDITIONS",
+        "claim_scope": (
+            "Necessary strict inequalities for one fixed selected-witness "
+            "system and cyclic order; not a proof of Erdos #97."
+        ),
+        "n": n,
+        "order": list(order),
+        "selected_row_count": len(rows),
+        "selected_superadditivity_row_count": len(selected_triples),
+        "chain_superadditivity_row_count": len(chains),
+        "cap_cut_row_count": len(cuts),
+        "unit_chain_superadditivity": {
+            "status": unit.status,
+            "obstructed": unit.obstructed,
+            "strict_row_count": unit.strict_row_count,
+            "selected_distance_class_count": unit.selected_distance_class_count,
+            "coefficient_positive_count": unit.coefficient_positive_count,
+            "coefficient_negative_count": unit.coefficient_negative_count,
+            "coefficient_zero_count": unit.coefficient_zero_count,
+        },
+        "outer_dominance": {
+            "outer_dominant_pair_count": len(outer_dominant),
+            "pair_cap_compatible_outer_dominant_types": [
+                list(item) for item in corrected_types
+            ],
+            "note": (
+                "Under the witness-pair cap, corrected outer-dominant types "
+                "can only be [1, 0] or [2, 0]."
+            ),
+        },
+        "pair_role_counts": [
+            {
+                "pair": list(row.pair),
+                "outer": row.outer,
+                "adjacent": row.adjacent,
+                "skipped": row.skipped,
+                "total_selected_row_occurrences": row.total_selected_row_occurrences,
+                "outer_dominant": row.outer_dominant,
+                "pair_cap_compatible": row.pair_cap_compatible,
+                "corrected_outer_dominant_type": (
+                    list(row.corrected_outer_dominant_type)
+                    if row.corrected_outer_dominant_type is not None
+                    else None
+                ),
+            }
+            for row in role_counts
+        ],
+    }

--- a/src/erdos97/edge_event_packet.py
+++ b/src/erdos97/edge_event_packet.py
@@ -1,0 +1,366 @@
+"""Coordinate-level edge-event and edge-Gram packet checks.
+
+This module extracts the transverse edge-event packet suggested by the bridge
+review.  It verifies exact algebraic identities for supplied polygon
+coordinates and optional selected witness rows.  It is a diagnostic layer only;
+it does not certify global infeasibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Iterable, Sequence
+
+Point = tuple[Fraction, Fraction]
+Matrix = tuple[tuple[Fraction, ...], ...]
+
+
+@dataclass(frozen=True)
+class IntervalPacket:
+    """One consecutive selected-witness gap in one row."""
+
+    center: int
+    left_witness: int
+    right_witness: int
+    edge_interval: tuple[int, ...]
+    row_zero_sum: Fraction
+    gram_center_sum: Fraction
+    gram_prev_sum: Fraction
+    next_row_sum: Fraction
+    prev_row_sum: Fraction
+    zero_sum_verified: bool
+    transverse_verified: bool
+
+
+@dataclass(frozen=True)
+class ColumnSignSummary:
+    """Vertex-level sign shape for one edge-bisector column."""
+
+    edge: int
+    positive_vertices: tuple[int, ...]
+    negative_vertices: tuple[int, ...]
+    zero_vertices: tuple[int, ...]
+    positive_is_cyclic_interval: bool
+    negative_is_cyclic_interval: bool
+    zero_count_at_most_two: bool
+    forced_edge_sign_transition: bool
+
+
+def as_fraction(value: object) -> Fraction:
+    """Parse ints, strings, and floats into a deterministic Fraction."""
+
+    if isinstance(value, Fraction):
+        return value
+    if isinstance(value, int):
+        return Fraction(value, 1)
+    if isinstance(value, str):
+        return Fraction(value)
+    if isinstance(value, float):
+        return Fraction(str(value))
+    raise TypeError(f"unsupported coordinate value {value!r}")
+
+
+def normalize_points(points: Iterable[Sequence[object]]) -> list[Point]:
+    """Return points with Fraction coordinates."""
+
+    output: list[Point] = []
+    for raw in points:
+        if len(raw) != 2:
+            raise ValueError(f"point must have two coordinates, got {raw!r}")
+        output.append((as_fraction(raw[0]), as_fraction(raw[1])))
+    if len(output) < 3:
+        raise ValueError("expected at least three polygon vertices")
+    return output
+
+
+def add(left: Point, right: Point) -> Point:
+    return (left[0] + right[0], left[1] + right[1])
+
+
+def sub(left: Point, right: Point) -> Point:
+    return (left[0] - right[0], left[1] - right[1])
+
+
+def dot(left: Point, right: Point) -> Fraction:
+    return left[0] * right[0] + left[1] * right[1]
+
+
+def cross(left: Point, right: Point) -> Fraction:
+    return left[0] * right[1] - left[1] * right[0]
+
+
+def norm2(point: Point) -> Fraction:
+    return dot(point, point)
+
+
+def edge_vectors(points: Sequence[Point]) -> list[Point]:
+    n = len(points)
+    return [sub(points[(idx + 1) % n], points[idx]) for idx in range(n)]
+
+
+def cyclic_interval(start: int, end: int, n: int) -> tuple[int, ...]:
+    """Return edge indices in the cyclic interval ``[start,end)``."""
+
+    if not 0 <= start < n or not 0 <= end < n:
+        raise ValueError("interval endpoints out of range")
+    output: list[int] = []
+    cursor = start
+    while cursor != end:
+        output.append(cursor)
+        cursor = (cursor + 1) % n
+        if len(output) > n:
+            raise AssertionError("cyclic interval did not terminate")
+    return tuple(output)
+
+
+def boundary_order_from_center(
+    n: int,
+    center: int,
+    vertices: Sequence[int],
+) -> tuple[int, ...]:
+    """Order vertices on the boundary chain ``center+1,...,center-1``."""
+
+    if not 0 <= center < n:
+        raise ValueError("center out of range")
+    for vertex in vertices:
+        if vertex == center:
+            raise ValueError("center cannot be a witness")
+        if not 0 <= vertex < n:
+            raise ValueError(f"vertex {vertex} out of range")
+    return tuple(sorted((int(v) for v in vertices), key=lambda v: (v - center) % n))
+
+
+def edge_event_matrix(points: Sequence[Point]) -> Matrix:
+    """Return ``D[i][k]=|p_i-p_{k+1}|^2-|p_i-p_k|^2``."""
+
+    n = len(points)
+    rows: list[tuple[Fraction, ...]] = []
+    for center in range(n):
+        row = []
+        for edge in range(n):
+            row.append(
+                norm2(sub(points[center], points[(edge + 1) % n]))
+                - norm2(sub(points[center], points[edge]))
+            )
+        rows.append(tuple(row))
+    return tuple(rows)
+
+
+def edge_gram_matrix(points: Sequence[Point]) -> Matrix:
+    """Return the edge Gram matrix ``G[i][k]=e_i.e_k``."""
+
+    edges = edge_vectors(points)
+    return tuple(tuple(dot(left, right) for right in edges) for left in edges)
+
+
+def row_difference_identity_errors(d_matrix: Matrix, g_matrix: Matrix) -> Matrix:
+    """Return errors in ``D[i+1,k]-D[i,k]+2G[i,k]=0``."""
+
+    n = len(d_matrix)
+    return tuple(
+        tuple(
+            d_matrix[(row + 1) % n][col] - d_matrix[row][col] + 2 * g_matrix[row][col]
+            for col in range(n)
+        )
+        for row in range(n)
+    )
+
+
+def gram_closure_sums(g_matrix: Matrix) -> tuple[Fraction, ...]:
+    """Return row sums of ``G``; closure gives zero sums."""
+
+    return tuple(sum(row, Fraction(0)) for row in g_matrix)
+
+
+def _sign(value: Fraction) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+def _is_cyclic_interval(vertices: Sequence[int], n: int) -> bool:
+    """Return whether a subset is one cyclic interval of vertex labels."""
+
+    subset = set(vertices)
+    if not subset or len(subset) == n:
+        return True
+    transitions = 0
+    for idx in range(n):
+        if (idx in subset) != ((idx + 1) % n in subset):
+            transitions += 1
+    return transitions <= 2
+
+
+def column_sign_summaries(d_matrix: Matrix) -> list[ColumnSignSummary]:
+    """Return softened line-cut sign checks for each edge column."""
+
+    n = len(d_matrix)
+    summaries: list[ColumnSignSummary] = []
+    for edge in range(n):
+        positive = tuple(row for row in range(n) if _sign(d_matrix[row][edge]) > 0)
+        negative = tuple(row for row in range(n) if _sign(d_matrix[row][edge]) < 0)
+        zero = tuple(row for row in range(n) if _sign(d_matrix[row][edge]) == 0)
+        summaries.append(
+            ColumnSignSummary(
+                edge=edge,
+                positive_vertices=positive,
+                negative_vertices=negative,
+                zero_vertices=zero,
+                positive_is_cyclic_interval=_is_cyclic_interval(positive, n),
+                negative_is_cyclic_interval=_is_cyclic_interval(negative, n),
+                zero_count_at_most_two=len(zero) <= 2,
+                forced_edge_sign_transition=(
+                    d_matrix[edge][edge] > 0
+                    and d_matrix[(edge + 1) % n][edge] < 0
+                ),
+            )
+        )
+    return summaries
+
+
+def selected_interval_packets(
+    points: Sequence[Point],
+    selected_rows: dict[int, Sequence[int]],
+) -> list[IntervalPacket]:
+    """Return selected-row zero interval and transverse sign packets."""
+
+    n = len(points)
+    d_matrix = edge_event_matrix(points)
+    g_matrix = edge_gram_matrix(points)
+    packets: list[IntervalPacket] = []
+    for center, raw_witnesses in sorted(selected_rows.items()):
+        witnesses = boundary_order_from_center(n, center, raw_witnesses)
+        if len(witnesses) != 4:
+            raise ValueError(f"row {center} must have four witnesses")
+        for left, right in zip(witnesses, witnesses[1:]):
+            interval = cyclic_interval(left, right, n)
+            row_zero = sum((d_matrix[center][edge] for edge in interval), Fraction(0))
+            gram_center = sum((g_matrix[center][edge] for edge in interval), Fraction(0))
+            gram_prev = sum(
+                (g_matrix[(center - 1) % n][edge] for edge in interval),
+                Fraction(0),
+            )
+            next_row = sum(
+                (d_matrix[(center + 1) % n][edge] for edge in interval),
+                Fraction(0),
+            )
+            prev_row = sum(
+                (d_matrix[(center - 1) % n][edge] for edge in interval),
+                Fraction(0),
+            )
+            packets.append(
+                IntervalPacket(
+                    center=center,
+                    left_witness=left,
+                    right_witness=right,
+                    edge_interval=interval,
+                    row_zero_sum=row_zero,
+                    gram_center_sum=gram_center,
+                    gram_prev_sum=gram_prev,
+                    next_row_sum=next_row,
+                    prev_row_sum=prev_row,
+                    zero_sum_verified=row_zero == 0,
+                    transverse_verified=(
+                        gram_center < 0
+                        and gram_prev < 0
+                        and next_row > 0
+                        and prev_row < 0
+                    ),
+                )
+            )
+    return packets
+
+
+def fraction_to_json(value: Fraction) -> int | str:
+    """Return compact JSON for an exact Fraction."""
+
+    if value.denominator == 1:
+        return value.numerator
+    return f"{value.numerator}/{value.denominator}"
+
+
+def _matrix_to_json(matrix: Matrix) -> list[list[int | str]]:
+    return [[fraction_to_json(value) for value in row] for row in matrix]
+
+
+def edge_event_report(
+    points: Iterable[Sequence[object]],
+    selected_rows: dict[int, Sequence[int]] | None = None,
+) -> dict[str, object]:
+    """Return a JSON-friendly edge-event packet report."""
+
+    normalized = normalize_points(points)
+    selected_rows = selected_rows or {}
+    d_matrix = edge_event_matrix(normalized)
+    g_matrix = edge_gram_matrix(normalized)
+    identity_errors = row_difference_identity_errors(d_matrix, g_matrix)
+    closure_sums = gram_closure_sums(g_matrix)
+    column_summaries = column_sign_summaries(d_matrix)
+    interval_packets = selected_interval_packets(normalized, selected_rows)
+
+    return {
+        "schema": "erdos97.edge_event_packet.v1",
+        "trust": "RESEARCH_PACKET_COORDINATE_DIAGNOSTIC",
+        "claim_scope": (
+            "Exact edge-event and Gram identities for supplied coordinates; "
+            "not a proof of Erdos #97."
+        ),
+        "n": len(normalized),
+        "rank_bounds": {
+            "edge_event_matrix_rank_at_most": 3,
+            "edge_gram_matrix_rank_at_most": 2,
+        },
+        "identity_checks": {
+            "row_difference_identity_verified": all(
+                value == 0 for row in identity_errors for value in row
+            ),
+            "gram_closure_verified": all(value == 0 for value in closure_sums),
+            "column_line_cut_checks_verified": all(
+                row.positive_is_cyclic_interval
+                and row.negative_is_cyclic_interval
+                and row.zero_count_at_most_two
+                and row.forced_edge_sign_transition
+                for row in column_summaries
+            ),
+            "selected_interval_packets_verified": all(
+                row.zero_sum_verified and row.transverse_verified
+                for row in interval_packets
+            ),
+        },
+        "D": _matrix_to_json(d_matrix),
+        "G": _matrix_to_json(g_matrix),
+        "row_difference_identity_errors": _matrix_to_json(identity_errors),
+        "gram_closure_sums": [fraction_to_json(value) for value in closure_sums],
+        "column_sign_summaries": [
+            {
+                "edge": row.edge,
+                "positive_vertices": list(row.positive_vertices),
+                "negative_vertices": list(row.negative_vertices),
+                "zero_vertices": list(row.zero_vertices),
+                "positive_is_cyclic_interval": row.positive_is_cyclic_interval,
+                "negative_is_cyclic_interval": row.negative_is_cyclic_interval,
+                "zero_count_at_most_two": row.zero_count_at_most_two,
+                "forced_edge_sign_transition": row.forced_edge_sign_transition,
+            }
+            for row in column_summaries
+        ],
+        "selected_interval_packets": [
+            {
+                "center": row.center,
+                "left_witness": row.left_witness,
+                "right_witness": row.right_witness,
+                "edge_interval": list(row.edge_interval),
+                "row_zero_sum": fraction_to_json(row.row_zero_sum),
+                "gram_center_sum": fraction_to_json(row.gram_center_sum),
+                "gram_prev_sum": fraction_to_json(row.gram_prev_sum),
+                "next_row_sum": fraction_to_json(row.next_row_sum),
+                "prev_row_sum": fraction_to_json(row.prev_row_sum),
+                "zero_sum_verified": row.zero_sum_verified,
+                "transverse_verified": row.transverse_verified,
+            }
+            for row in interval_packets
+        ],
+    }

--- a/tests/test_cap_cut_constraints.py
+++ b/tests/test_cap_cut_constraints.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from erdos97.cap_cut_constraints import (
+    PairRoleCount,
+    cap_cut_report,
+    cap_cut_terms,
+    open_arc_not_containing_center,
+    pair_role_counts,
+    unit_chain_superadditivity_certificate,
+)
+
+
+def test_cap_cut_terms_match_centered_inequality() -> None:
+    terms = cap_cut_terms(center=0, a=1, b=4, x=2)
+
+    assert terms == (
+        ((0, 2), +2),
+        ((1, 2), -1),
+        ((2, 4), -1),
+        ((1, 4), +1),
+        ((0, 1), -1),
+        ((0, 4), -1),
+    )
+
+
+def test_open_arc_not_containing_center_chooses_cap_side() -> None:
+    order = [0, 1, 2, 3, 4, 5]
+
+    assert open_arc_not_containing_center(order, 1, 5, 0) == (2, 3, 4)
+    assert open_arc_not_containing_center(order, 5, 1, 0) == (2, 3, 4)
+
+
+def test_corrected_outer_dominant_types_respect_pair_cap() -> None:
+    valid_once = PairRoleCount(pair=(0, 1), outer=1, adjacent=0, skipped=1)
+    valid_twice = PairRoleCount(pair=(0, 1), outer=2, adjacent=0, skipped=0)
+    invalid_total = PairRoleCount(pair=(0, 1), outer=2, adjacent=1, skipped=0)
+
+    assert valid_once.corrected_outer_dominant_type == (1, 0)
+    assert valid_twice.corrected_outer_dominant_type == (2, 0)
+    assert invalid_total.pair_cap_compatible is False
+    assert invalid_total.corrected_outer_dominant_type is None
+
+
+def test_all_other_pentagon_has_unit_chain_obstruction() -> None:
+    rows = [[j for j in range(5) if j != i] for i in range(5)]
+
+    certificate = unit_chain_superadditivity_certificate(rows, list(range(5)))
+
+    assert certificate.obstructed
+    assert certificate.coefficient_positive_count == 0
+    assert certificate.strict_row_count == 5
+
+
+def test_pair_role_counts_expose_outer_dominance() -> None:
+    rows = [[j for j in range(5) if j != i] for i in range(5)]
+
+    counts = pair_role_counts(rows, list(range(5)))
+    outer_dominant = [row for row in counts if row.outer_dominant]
+
+    assert outer_dominant
+    assert all(
+        row.corrected_outer_dominant_type in {(1, 0), (2, 0)}
+        or not row.pair_cap_compatible
+        for row in outer_dominant
+    )
+
+
+def test_cap_cut_report_is_scoped_research_packet() -> None:
+    rows = [[j for j in range(5) if j != i] for i in range(5)]
+
+    report = cap_cut_report(rows, list(range(5)), include_cap_cuts=False)
+
+    assert report["schema"] == "erdos97.cap_cut_constraints.v1"
+    assert report["trust"] == "RESEARCH_PACKET_LOCAL_NECESSARY_CONDITIONS"
+    assert "not a proof" in str(report["claim_scope"])
+    assert report["unit_chain_superadditivity"]["obstructed"] is True

--- a/tests/test_edge_event_packet.py
+++ b/tests/test_edge_event_packet.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from erdos97.edge_event_packet import (
+    edge_event_report,
+    edge_gram_matrix,
+    edge_event_matrix,
+    normalize_points,
+    row_difference_identity_errors,
+    selected_interval_packets,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RATIONAL_ARC_PENTAGON = [
+    (0, 0),
+    (1, 0),
+    ("4/5", "3/5"),
+    ("3/5", "4/5"),
+    (0, 1),
+]
+
+
+def test_row_difference_identity_is_exact_on_rational_polygon() -> None:
+    points = normalize_points(RATIONAL_ARC_PENTAGON)
+    d_matrix = edge_event_matrix(points)
+    g_matrix = edge_gram_matrix(points)
+
+    errors = row_difference_identity_errors(d_matrix, g_matrix)
+
+    assert all(value == 0 for row in errors for value in row)
+
+
+def test_selected_equal_radius_row_gives_transverse_packets() -> None:
+    points = normalize_points(RATIONAL_ARC_PENTAGON)
+
+    packets = selected_interval_packets(points, {0: [1, 2, 3, 4]})
+
+    assert len(packets) == 3
+    assert all(packet.zero_sum_verified for packet in packets)
+    assert all(packet.transverse_verified for packet in packets)
+    assert [packet.edge_interval for packet in packets] == [(1,), (2,), (3,)]
+
+
+def test_edge_event_report_is_json_friendly_and_verified() -> None:
+    report = edge_event_report(RATIONAL_ARC_PENTAGON, {0: [1, 2, 3, 4]})
+
+    assert report["schema"] == "erdos97.edge_event_packet.v1"
+    assert report["identity_checks"]["row_difference_identity_verified"] is True
+    assert report["identity_checks"]["gram_closure_verified"] is True
+    assert report["identity_checks"]["column_line_cut_checks_verified"] is True
+    assert report["identity_checks"]["selected_interval_packets_verified"] is True
+    assert report["selected_interval_packets"][0]["row_zero_sum"] == 0
+
+
+def test_edge_event_checker_accepts_utf8_sig_json(tmp_path: Path) -> None:
+    input_path = tmp_path / "edge-event-input.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "coordinates": RATIONAL_ARC_PENTAGON,
+                "selected_rows": {"0": [1, 2, 3, 4]},
+            }
+        ),
+        encoding="utf-8-sig",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_edge_event_packet.py",
+            str(input_path),
+            "--assert-verified",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "erdos97.edge_event_packet.v1"
+    assert payload["identity_checks"]["selected_interval_packets_verified"] is True


### PR DESCRIPTION
## Summary

Adds two scoped research-packet checkers for local necessary conditions:

- `edge_event_packet`: exact edge-event and edge-Gram identities for supplied rational coordinates, including selected-row zero interval and transverse sign packets.
- `cap_cut_constraints`: squared-distance cap-cut / chain-superadditivity inequalities for a fixed selected-witness pattern and cyclic order, including corrected pair-cap-compatible outer-dominance bookkeeping.

The documentation is explicit that these are local necessary-condition packets only: not a proof of Erdős #97, not a finite-case status promotion, not a counterexample, and not a global obstruction.

## Validation

- `python -m py_compile src/erdos97/cap_cut_constraints.py src/erdos97/edge_event_packet.py scripts/check_cap_cut_constraints.py scripts/check_edge_event_packet.py tests/test_cap_cut_constraints.py tests/test_edge_event_packet.py`
- `python -m pytest -q tests/test_cap_cut_constraints.py tests/test_edge_event_packet.py`
- `python scripts/check_edge_event_packet.py tmp_edge_event_packet_input.json --assert-verified --json`
- `python scripts/check_cap_cut_constraints.py --pattern C13_sidon_1_2_4_10 --no-cap-cuts --assert-unit-obstructed`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check .`
- `git diff --cached --check`

CI should be treated as the merge gate for the full `make verify-fast` matrix.