### PR TITLE
[codex] Sharpen rich-support counting bound

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -39,18 +39,21 @@ For any choice of one same-radius support `R_i` at each center, not necessarily
 of size four,
 
 ```text
-sum_i binom(|R_i|, 2) <= n(n - 1).
+sum_i binom(|R_i|, 2) <= n(n - 2).
 ```
 
-Indeed, a fixed unordered witness pair `{a,b}` can occur in at most two
-supports, because all centers using both witnesses lie on the perpendicular
-bisector of `ab`, and a line contains at most two vertices of a strictly convex
-polygon.
+Indeed, a fixed unordered witness pair `{a,b}` can occur only on centers lying
+on the perpendicular bisector of `ab`. Non-boundary witness pairs have capacity
+at most `2`. Boundary-edge witness pairs have capacity at most `1`, because the
+perpendicular bisector enters the polygon through the edge midpoint and its
+polygon line-section has that midpoint as an endpoint. Summing these capacities
+gives `n + 2*(binom(n,2)-n) = n(n-2)`.
 
 Consequently, if every center has a rich class of size at least `k`, then
-`n >= binom(k, 2) + 1`. In particular, the all-centers size-five subcase is
-impossible for `n <= 10`; any hypothetical 4-bad nonagon has at least five
-exact-four centers. See `docs/rich-support-counting-lemma.md`.
+`n >= binom(k, 2) + 2`. In particular, the all-centers size-five subcase is
+impossible for `n <= 11`; any hypothetical 4-bad nonagon has at least seven
+exact-four centers, any hypothetical 4-bad decagon has at least five, and
+`n=11` has at least three. See `docs/rich-support-counting-lemma.md`.
 
 ### Lemma: crossing-bisector and sharpened count
 

--- a/STATE.md
+++ b/STATE.md
@@ -247,12 +247,14 @@ See `docs/n9-all-five-rich-support-obstruction.md`.
 
 A rich-support counting lemma now gives a proof-level shortcut for that
 all-five-rich subcase: for any same-radius supports `R_i`,
-`sum_i binom(|R_i|, 2) <= n(n - 1)` by witness-pair sharing on perpendicular
-bisectors. Hence every center having five equidistant witnesses requires
-`n >= 11`. The same counting relaxation says any hypothetical 4-bad nonagon
-has at least five exact-four centers, and any hypothetical 4-bad decagon has
-at least three. This does not replace the mixed support catalogues or prove
-`n=9` or `n=10`. See `docs/rich-support-counting-lemma.md`.
+`sum_i binom(|R_i|, 2) <= n(n - 2)` by witness-pair sharing on perpendicular
+bisectors, sharpened by giving boundary-edge witness pairs capacity `1`.
+Hence every center having five equidistant witnesses requires `n >= 12`. The
+same counting relaxation says any hypothetical 4-bad nonagon has at least
+seven exact-four centers, any hypothetical 4-bad decagon has at least five,
+and `n=11` has at least three. This does not replace the mixed support
+catalogues or prove `n=9`, `n=10`, or `n=11`. See
+`docs/rich-support-counting-lemma.md`.
 
 The follow-up mixed rich-support reduction enumerates every four- or
 five-witness support at every center, for `126^9 =

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -87,24 +87,31 @@ Let `R_i` be any same-radius support chosen at center `i`; unlike selected
 witness rows, `R_i` may have size larger than four. Then
 
 ```text
-sum_i binom(|R_i|, 2) <= n(n - 1).
+sum_i binom(|R_i|, 2) <= n(n - 2).
 ```
 
 The proof is the pair-sharing cap in counting form. For a fixed unordered
 witness pair `{a,b}`, every center whose support contains both `a` and `b`
 lies on the perpendicular bisector of segment `ab`; strict convexity permits at
-most two polygon vertices on that line. Double-counting witness pairs inside
-supports gives the displayed inequality.
+most two polygon vertices on that line. Boundary-edge witness pairs sharpen the
+budget because their perpendicular bisectors enter the polygon through the
+edge midpoint, so their polygon line-section has that midpoint as an endpoint
+and can contain at most one polygon vertex as a center. Thus the `n` boundary
+edges have capacity `1`, and the other `binom(n,2)-n` witness pairs have
+capacity `2`. Double-counting witness pairs inside supports gives the
+displayed inequality.
 
 Thus, if every center has a rich distance class of size at least `k`, then
-`n >= binom(k, 2) + 1`. In particular, every-vertex size-five richness is
-impossible for `n <= 10`. Choosing a maximum rich class at each center of a
-hypothetical 4-bad nonagon also shows that at most four centers can have
-`E(i) >= 5`, so at least five centers must be exact-four.
+`n >= binom(k, 2) + 2`. In particular, every-vertex size-five richness is
+impossible for `n <= 11`. Choosing a maximum rich class at each center of a
+hypothetical 4-bad nonagon also shows that at most two centers can have
+`E(i) >= 5`, so at least seven centers must be exact-four. The same relaxation
+forces at least five exact-four centers for `n=10`, and at least three for
+`n=11`.
 
 This is a support-level counting lemma only. It does not rule out mixed
-exact-four/rich catalogues and does not prove `n=9`, `n=10`, or Erdos Problem
-#97. See `docs/rich-support-counting-lemma.md` and the checker
+exact-four/rich catalogues and does not prove `n=9`, `n=10`, `n=11`, or Erdos
+Problem #97. See `docs/rich-support-counting-lemma.md` and the checker
 `scripts/check_rich_support_counting_bound.py`.
 
 ### Altman diagonal-order sums

--- a/docs/n9-all-five-rich-support-obstruction.md
+++ b/docs/n9-all-five-rich-support-obstruction.md
@@ -26,14 +26,17 @@ center of a strict convex `n`-gon has a same-radius support of size at least
 five, then each support contributes at least `binom(5,2)=10` unordered witness
 pairs. A fixed witness pair can be used by at most two centers, since all such
 centers lie on the perpendicular bisector of that pair and strict convexity
-allows at most two vertices on a line. Therefore
+allows at most two vertices on a line. The sharpened counting lemma gives
+capacity `1` to boundary-edge witness pairs: their perpendicular bisectors
+enter the polygon through the boundary-edge midpoint, so the polygon
+line-section has that midpoint as an endpoint. Therefore
 
 ```text
-10n <= 2*binom(n,2) = n(n - 1),
+10n <= n + 2*(binom(n,2) - n) = n(n - 2),
 ```
 
-so `n >= 11`. In particular, the `n=9` all-five-rich support subcase is closed
-by this one-line pair-sharing count.
+so `n >= 12`. In particular, the `n=9` all-five-rich support subcase is closed
+by this one-line sharpened pair-sharing count.
 
 The checked artifact below is still useful as a generator-independent
 support-catalogue regression: it exercises the explicit five-support option
@@ -86,5 +89,7 @@ This does not enumerate mixed exact-four and size-five rich catalogues. It
 does not prove `n=9`, does not prove the adaptive radius-blocker bridge, does
 not prove Erdos Problem #97, and does not provide a counterexample.
 
-The next useful bridge target is the mixed catalogue: at least one center must
-remain exact-four-only in any `n=9` selected-witness counterexample.
+The next useful bridge target is the mixed catalogue. The sharpened
+rich-support counting lemma now forces at least seven exact-four centers in
+any `n=9` selected-witness counterexample before any mixed-catalogue or
+vertex-circle machinery is used.

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -21,48 +21,62 @@ class witnessing `E(i)`.
 For any such choice of supports,
 
 ```text
-sum_i binom(|R_i|, 2) <= n(n - 1).
+sum_i binom(|R_i|, 2) <= n(n - 2).
 ```
 
 Proof: fix an unordered witness pair `{a,b}`. If `{a,b} subset R_i`, then the
 center `i` is equidistant from `a` and `b`, so `i` lies on the perpendicular
-bisector of segment `ab`. A line contains at most two vertices of a strictly
-convex polygon. Therefore the pair `{a,b}` can occur together in at most two
-supports. Double-counting triples `(i,{a,b})` with `{a,b} subset R_i` gives the
-bound.
+bisector of segment `ab`.
+
+For a non-boundary pair `{a,b}`, this gives the usual capacity `2`: a line
+contains at most two vertices of a strictly convex polygon. For a boundary edge
+`{a,b}`, the perpendicular bisector enters the polygon through the midpoint of
+that edge. The line-section of the polygon therefore has that midpoint as an
+endpoint, so it can contain at most one polygon vertex as a center. Thus the
+`n` boundary-edge witness pairs have capacity `1`, while the remaining
+`binom(n,2)-n` witness pairs have capacity `2`. Double-counting triples
+`(i,{a,b})` with `{a,b} subset R_i` gives
+
+```text
+n*1 + (binom(n,2) - n)*2 = n(n - 2).
+```
 
 ## Consequences
 
 If every center has a same-radius support of size at least `k`, then
 
 ```text
-n * binom(k, 2) <= n(n - 1),
+n * binom(k, 2) <= n(n - 2),
 ```
 
 so
 
 ```text
-n >= binom(k, 2) + 1.
+n >= binom(k, 2) + 2.
 ```
 
+For `k=4`, this gives the support-level wall `n >= 8`.
+
 In particular, a strict convex polygon in which every vertex has five
-equidistant witnesses must have `n >= 11`. Thus the `n=9` all-five-rich support
-subcase is already impossible by this pair-sharing count, before using cyclic
-order, crossing, selected-distance quotienting, or vertex-circle pruning.
+equidistant witnesses must have `n >= 12`. Thus the `n=9`, `n=10`, and `n=11`
+all-five-rich support subcases are already impossible by this pair-sharing
+count, before using cyclic order, crossing, selected-distance quotienting, or
+vertex-circle pruning.
 
 For a hypothetical 4-bad nonagon, choose a maximum rich support at every
 center, so `|R_i| = E(i) >= 4`. The same inequality gives
 
 ```text
-sum_i (binom(E(i), 2) - binom(4, 2)) <= 9*8 - 9*6 = 18.
+sum_i (binom(E(i), 2) - binom(4, 2)) <= 9*7 - 9*6 = 9.
 ```
 
 Since any center with `E(i) >= 5` costs at least `binom(5,2)-binom(4,2)=4`,
-at most four centers can have `E(i) >= 5`. Equivalently, any hypothetical
-4-bad nonagon has at least five exact-four centers.
+at most two centers can have `E(i) >= 5`. Equivalently, any hypothetical 4-bad
+nonagon has at least seven exact-four centers.
 
-The corresponding necessary counting relaxation for `n=10` gives at least
-three exact-four centers in any hypothetical 4-bad decagon.
+The corresponding necessary counting relaxation gives at least five exact-four
+centers in any hypothetical 4-bad decagon, and at least three exact-four
+centers for `n=11`.
 
 ## Verification command
 
@@ -72,14 +86,14 @@ The helper script
 python scripts/check_rich_support_counting_bound.py --check --json
 ```
 
-checks the threshold `n >= 11` for all-centers size-five support and the small
-`n=7..11` surplus table used above. It is only a counting-bound checker; it is
+checks the threshold `n >= 12` for all-centers size-five support and the small
+`n=5..11` surplus table used above. It is only a counting-bound checker; it is
 not a realization search.
 
 ## Boundary
 
 This lemma does not rule out mixed exact-four and size-five catalogues. For
-`n=9`, it narrows such a catalogue by forcing at least five exact-four centers,
+`n=9`, it narrows such a catalogue by forcing at least seven exact-four centers,
 but it does not replace the review-pending exact-four frontier or the mixed
 support crosswalk. The existing `n=9` all-five-rich checker remains useful as a
 crossing-aware support-catalogue regression and as provenance for the richer

--- a/scripts/check_rich_support_counting_bound.py
+++ b/scripts/check_rich_support_counting_bound.py
@@ -3,10 +3,11 @@
 
 This standalone checker verifies a simple proof-facing counting lemma:
 for any choice of one same-radius support R_i at each center of a strict convex
-n-gon, sum_i binom(|R_i|, 2) <= n(n - 1).  The reason is that a fixed witness
-pair {a,b} can occur in at most two supports, since all centers using both
-witnesses lie on the perpendicular bisector of ab, and a line contains at most
-two vertices of a strictly convex polygon.
+n-gon, sum_i binom(|R_i|, 2) <= n(n - 2).  A non-boundary witness pair {a,b}
+can occur in at most two supports, since all centers using both witnesses lie
+on the perpendicular bisector of ab.  A boundary-edge witness pair has capacity
+one, because the perpendicular bisector enters the polygon through the edge
+midpoint, so its polygon section has that midpoint as an endpoint.
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ def pair_budget(n: int) -> int:
 
     if n < 0:
         raise ValueError("n must be nonnegative")
-    return n * (n - 1)
+    return max(0, n * (n - 2))
 
 
 def all_centers_min_n(k: int) -> int:
@@ -33,11 +34,11 @@ def all_centers_min_n(k: int) -> int:
 
     if k < 0:
         raise ValueError("k must be nonnegative")
-    return comb(k, 2) + 1
+    return comb(k, 2) + 2
 
 
 def max_total_support_size(n: int, min_size: int = 4) -> tuple[int, list[int]]:
-    """Maximize sum |R_i| under sum binom(|R_i|,2) <= n(n-1).
+    """Maximize sum |R_i| under sum binom(|R_i|,2) <= n(n-2).
 
     This is only a necessary counting relaxation.  It ignores all cyclic-order,
     row-intersection, and vertex-circle constraints.
@@ -132,11 +133,11 @@ def build_summary(min_n: int = 5, max_n: int = 11) -> dict[str, Any]:
         "claim_scope": (
             "Proof-facing rich-support pair-counting lemma only. It records "
             "necessary support-size consequences and does not prove n=9, "
-            "n=10, or Erdos Problem #97."
+            "n=10, n=11, or Erdos Problem #97."
         ),
         "lemma": (
             "For same-radius supports R_i in a strict convex n-gon, "
-            "sum_i binom(|R_i|, 2) <= n(n - 1)."
+            "sum_i binom(|R_i|, 2) <= n(n - 2)."
         ),
         "all_centers_min_support_thresholds": {
             str(k): all_centers_min_n(k) for k in range(4, 8)
@@ -149,16 +150,15 @@ def check_expected(summary: dict[str, Any]) -> None:
     """Check the small consequences used by the proposed repo note."""
 
     thresholds = summary["all_centers_min_support_thresholds"]
-    if thresholds["5"] != 11:
-        raise AssertionError("all-centers size-five threshold should be n >= 11")
+    if thresholds["5"] != 12:
+        raise AssertionError("all-centers size-five threshold should be n >= 12")
 
     rows = {row["n"]: row for row in summary["rows"]}
     expected = {
-        7: (28, 0, 0, 7),
-        8: (34, 2, 2, 6),
-        9: (40, 4, 4, 5),
-        10: (47, 7, 7, 3),
-        11: (55, 11, 11, 0),
+        8: (32, 0, 0, 8),
+        9: (38, 2, 2, 7),
+        10: (45, 5, 5, 5),
+        11: (52, 8, 8, 3),
     }
     for n, (total, surplus, max_non_exact, min_exact) in expected.items():
         row = rows[n]
@@ -172,7 +172,7 @@ def check_expected(summary: dict[str, Any]) -> None:
         if got != want:
             raise AssertionError(f"n={n}: got {got}, expected {want}")
 
-    for n in (5, 6):
+    for n in (5, 6, 7):
         if not rows[n]["four_bad_ruled_out_by_pair_counting"]:
             raise AssertionError(f"n={n}: expected pair-counting to rule out four-bad supports")
 

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1501,7 +1501,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope=(
             "Proof-facing rich-support pair-counting lemma and small-n "
             "consequences; not a proof of n=9, not a proof of n=10, not a "
-            "proof of Erdos Problem #97, and not a counterexample."
+            "proof of n=11, not a proof of Erdos Problem #97, and not a "
+            "counterexample."
         ),
     ),
     AuditCommand(

--- a/tests/test_rich_support_counting_bound.py
+++ b/tests/test_rich_support_counting_bound.py
@@ -25,29 +25,31 @@ def test_rich_support_counting_expected_summary() -> None:
     check_expected(summary)
     rows = {row["n"]: row for row in summary["rows"]}
     assert summary["trust"] == "LEMMA"
-    assert summary["all_centers_min_support_thresholds"]["5"] == 11
-    assert rows[9]["max_centers_with_E_at_least_5_by_counting"] == 4
-    assert rows[9]["min_centers_with_E_equal_4_by_counting"] == 5
-    assert rows[10]["max_centers_with_E_at_least_5_by_counting"] == 7
-    assert rows[10]["min_centers_with_E_equal_4_by_counting"] == 3
+    assert summary["all_centers_min_support_thresholds"]["5"] == 12
+    assert rows[9]["max_centers_with_E_at_least_5_by_counting"] == 2
+    assert rows[9]["min_centers_with_E_equal_4_by_counting"] == 7
+    assert rows[10]["max_centers_with_E_at_least_5_by_counting"] == 5
+    assert rows[10]["min_centers_with_E_equal_4_by_counting"] == 5
+    assert rows[11]["max_centers_with_E_at_least_5_by_counting"] == 8
+    assert rows[11]["min_centers_with_E_equal_4_by_counting"] == 3
 
 
 def test_rich_support_counting_threshold_helpers() -> None:
-    assert all_centers_min_n(4) == 7
-    assert all_centers_min_n(5) == 11
-    assert all_centers_min_n(6) == 16
-    assert max_non_exact_four_centers(9) == 4
-    assert max_non_exact_four_centers(10) == 7
+    assert all_centers_min_n(4) == 8
+    assert all_centers_min_n(5) == 12
+    assert all_centers_min_n(6) == 17
+    assert max_non_exact_four_centers(9) == 2
+    assert max_non_exact_four_centers(10) == 5
 
 
 def test_rich_support_counting_rows() -> None:
     row9 = row_summary(9)
     row10 = row_summary(10)
 
-    assert row9["pair_budget"] == 72
-    assert row9["max_total_support_size_given_E_ge_4"] == 40
-    assert row10["pair_budget"] == 90
-    assert row10["max_total_support_size_given_E_ge_4"] == 47
+    assert row9["pair_budget"] == 63
+    assert row9["max_total_support_size_given_E_ge_4"] == 38
+    assert row10["pair_budget"] == 80
+    assert row10["max_total_support_size_given_E_ge_4"] == 45
 
 
 def test_rich_support_counting_cli_json() -> None:


### PR DESCRIPTION
## Summary

- sharpen the rich-support counting lemma from `n(n - 1)` to `n(n - 2)` using boundary-edge witness pairs at capacity 1
- update the checker, tests, and source-of-truth notes with the `n >= binom(k, 2) + 2` consequence
- record the revised small-n exact-four lower bounds for `n=9`, `n=10`, and `n=11` without changing the global/open status

## Validation

- `python scripts/check_rich_support_counting_bound.py --check --json`
- `python -m pytest tests/test_rich_support_counting_bound.py tests/test_run_artifact_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`