### PR TITLE
[codex] Clarify rich-support counting checker

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -31,7 +31,7 @@ The directed 4-out incidence pattern and the pairwise cap imply no
 counterexample can have `n <= 6`; the convexity-of-indegree count gives
 `n >= 7`.
 
-### Lemma: rich-support counting wall
+### Lemma: edge-sensitive rich-support counting wall
 
 Status: proved.
 
@@ -42,18 +42,20 @@ of size four,
 sum_i binom(|R_i|, 2) <= n(n - 2).
 ```
 
-Indeed, a fixed unordered witness pair `{a,b}` can occur only on centers lying
-on the perpendicular bisector of `ab`. Non-boundary witness pairs have capacity
-at most `2`. Boundary-edge witness pairs have capacity at most `1`, because the
-perpendicular bisector enters the polygon through the edge midpoint and its
-polygon line-section has that midpoint as an endpoint. Summing these capacities
-gives `n + 2*(binom(n,2)-n) = n(n-2)`.
+Indeed, a fixed unordered witness pair `{a,b}` can occur in at most two
+supports, because all centers using both witnesses lie on the perpendicular
+bisector of `ab`. If `{a,b}` is a hull edge, its perpendicular bisector already
+meets the polygon boundary at the edge midpoint and cannot contain two further
+boundary vertices, so that edge pair has capacity one. There are `n` hull-edge
+witness pairs and `binom(n,2)-n` non-edge witness pairs, giving
+`n + 2*(binom(n,2)-n) = n(n-2)` by double-counting.
 
 Consequently, if every center has a rich class of size at least `k`, then
 `n >= binom(k, 2) + 2`. In particular, the all-centers size-five subcase is
 impossible for `n <= 11`; any hypothetical 4-bad nonagon has at least seven
-exact-four centers, any hypothetical 4-bad decagon has at least five, and
-`n=11` has at least three. See `docs/rich-support-counting-lemma.md`.
+exact-four centers, any hypothetical 4-bad decagon has at least five, and any
+hypothetical 4-bad hendecagon has at least three. See
+`docs/rich-support-counting-lemma.md`.
 
 ### Lemma: crossing-bisector and sharpened count
 

--- a/STATE.md
+++ b/STATE.md
@@ -245,15 +245,16 @@ least one center whose available rich classes are exact-four-only; it is still
 not an `n=9` proof, not the adaptive blocker bridge, and not a counterexample.
 See `docs/n9-all-five-rich-support-obstruction.md`.
 
-A rich-support counting lemma now gives a proof-level shortcut for that
-all-five-rich subcase: for any same-radius supports `R_i`,
-`sum_i binom(|R_i|, 2) <= n(n - 2)` by witness-pair sharing on perpendicular
-bisectors, sharpened by giving boundary-edge witness pairs capacity `1`.
-Hence every center having five equidistant witnesses requires `n >= 12`. The
-same counting relaxation says any hypothetical 4-bad nonagon has at least
-seven exact-four centers, any hypothetical 4-bad decagon has at least five,
-and `n=11` has at least three. This does not replace the mixed support
-catalogues or prove `n=9`, `n=10`, or `n=11`. See
+A sharpened rich-support counting lemma now gives a proof-level shortcut for
+all-five-rich subcases: for any same-radius supports `R_i`,
+`sum_i binom(|R_i|, 2) <= n(n - 2)`. The improvement over the coarse `n(n-1)`
+pair-sharing count is that a hull-edge witness pair can occur in at most one
+support, while a non-edge witness pair can occur in at most two. Hence every
+center having five equidistant witnesses requires `n >= 12`. The same counting
+relaxation says any hypothetical 4-bad nonagon has at least seven exact-four
+centers, any hypothetical 4-bad decagon has at least five, and any hypothetical
+4-bad hendecagon has at least three. This does not replace the mixed support
+catalogues or prove `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
 `docs/rich-support-counting-lemma.md`.
 
 The follow-up mixed rich-support reduction enumerates every four- or

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -79,7 +79,7 @@ source-of-truth status. The checked selected-witness artifacts remain the
 repo-local `n <= 8` source until this literature-backed note receives
 independent review.
 
-### Rich-support counting bound
+### Edge-sensitive rich-support counting bound
 
 Status: `LEMMA`.
 
@@ -90,23 +90,21 @@ witness rows, `R_i` may have size larger than four. Then
 sum_i binom(|R_i|, 2) <= n(n - 2).
 ```
 
-The proof is the pair-sharing cap in counting form. For a fixed unordered
-witness pair `{a,b}`, every center whose support contains both `a` and `b`
-lies on the perpendicular bisector of segment `ab`; strict convexity permits at
-most two polygon vertices on that line. Boundary-edge witness pairs sharpen the
-budget because their perpendicular bisectors enter the polygon through the
-edge midpoint, so their polygon line-section has that midpoint as an endpoint
-and can contain at most one polygon vertex as a center. Thus the `n` boundary
-edges have capacity `1`, and the other `binom(n,2)-n` witness pairs have
-capacity `2`. Double-counting witness pairs inside supports gives the
-displayed inequality.
+The proof is the pair-sharing cap with hull-edge pairs counted separately. For
+a fixed unordered witness pair `{a,b}`, every center whose support contains
+both `a` and `b` lies on the perpendicular bisector of segment `ab`. If `{a,b}`
+is a non-edge, strict convexity permits at most two polygon vertices on that
+line. If `{a,b}` is a hull edge, the perpendicular bisector already meets the
+polygon boundary at the edge midpoint and can contain at most one further
+boundary vertex, hence at most one center. Double-counting witness pairs inside
+supports gives the displayed inequality.
 
 Thus, if every center has a rich distance class of size at least `k`, then
 `n >= binom(k, 2) + 2`. In particular, every-vertex size-five richness is
 impossible for `n <= 11`. Choosing a maximum rich class at each center of a
 hypothetical 4-bad nonagon also shows that at most two centers can have
 `E(i) >= 5`, so at least seven centers must be exact-four. The same relaxation
-forces at least five exact-four centers for `n=10`, and at least three for
+forces at least five exact-four centers for `n=10` and at least three for
 `n=11`.
 
 This is a support-level counting lemma only. It does not rule out mixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,8 +60,8 @@ put detailed reconciliation in the canonical synthesis.
   selected/full-rich-class branching caution; review-pending local geometry
   only.
 - [`rich-support-counting-lemma.md`](rich-support-counting-lemma.md):
-  proof-facing support pair-counting lemma for all-centers large rich classes;
-  not an `n=9`, `n=10`, or global proof.
+  proof-facing edge-sensitive support pair-counting lemma for all-centers large
+  rich classes; not an `n=9`, `n=10`, `n=11`, or global proof.
 - [`k4e-kalmanson-stretch-audit.md`](k4e-kalmanson-stretch-audit.md): exact
   fixed-pattern audit extracting `K4-e` stretch relations and combining them
   with Kalmanson inequalities; kills only the displayed `n=10` quotient-level

--- a/docs/n9-all-five-rich-support-obstruction.md
+++ b/docs/n9-all-five-rich-support-obstruction.md
@@ -27,9 +27,9 @@ five, then each support contributes at least `binom(5,2)=10` unordered witness
 pairs. A fixed witness pair can be used by at most two centers, since all such
 centers lie on the perpendicular bisector of that pair and strict convexity
 allows at most two vertices on a line. The sharpened counting lemma gives
-capacity `1` to boundary-edge witness pairs: their perpendicular bisectors
-enter the polygon through the boundary-edge midpoint, so the polygon
-line-section has that midpoint as an endpoint. Therefore
+capacity `1` to hull-edge witness pairs: their perpendicular bisectors enter
+the polygon through the hull-edge midpoint, so the polygon line-section has
+that midpoint as an endpoint. Therefore
 
 ```text
 10n <= n + 2*(binom(n,2) - n) = n(n - 2),

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -1,12 +1,13 @@
 # Rich-support counting lemma
 
-Status: `LEMMA` / proof-facing counting bound. This note does not claim a
-general proof of Erdos Problem #97 and does not claim a counterexample.
+Status: `LEMMA` / proof-facing edge-sensitive counting bound. This note does
+not claim a general proof of Erdos Problem #97 and does not claim a
+counterexample.
 
 ## Setup
 
-Let `V` be the vertex set of a strictly convex `n`-gon. For each center
-`i in V`, choose one same-radius support
+Let `V` be the vertex set of a strictly convex `n`-gon in its cyclic hull
+order. For each center `i in V`, choose one same-radius support
 
 ```text
 R_i subset V \ {i}
@@ -24,21 +25,28 @@ For any such choice of supports,
 sum_i binom(|R_i|, 2) <= n(n - 2).
 ```
 
-Proof: fix an unordered witness pair `{a,b}`. If `{a,b} subset R_i`, then the
-center `i` is equidistant from `a` and `b`, so `i` lies on the perpendicular
-bisector of segment `ab`.
+Proof: fix an unordered witness pair `{a,b}`.
 
-For a non-boundary pair `{a,b}`, this gives the usual capacity `2`: a line
-contains at most two vertices of a strictly convex polygon. For a boundary edge
-`{a,b}`, the perpendicular bisector enters the polygon through the midpoint of
-that edge. The line-section of the polygon therefore has that midpoint as an
-endpoint, so it can contain at most one polygon vertex as a center. Thus the
-`n` boundary-edge witness pairs have capacity `1`, while the remaining
-`binom(n,2)-n` witness pairs have capacity `2`. Double-counting triples
-`(i,{a,b})` with `{a,b} subset R_i` gives
+If `{a,b}` is not a hull edge, then every center `i` with
+`{a,b} subset R_i` is equidistant from `a` and `b`, hence lies on the
+perpendicular bisector of segment `ab`. A line contains at most two vertices of
+a strictly convex polygon, so this non-edge witness pair can occur together in
+at most two supports.
+
+If `{a,b}` is a hull edge, its perpendicular bisector already meets the polygon
+boundary at the midpoint of that edge. The same perpendicular bisector cannot
+coincide with the edge line. Its intersection with the boundary of a convex
+polygon therefore has at most one further boundary point, so it contains at
+most one polygon vertex that can serve as a center. Thus a hull-edge witness
+pair can occur together in at most one support.
+
+There are `n` hull-edge witness pairs and `binom(n,2)-n` non-edge witness
+pairs. Double-counting triples `(i,{a,b})` with `{a,b} subset R_i` gives
 
 ```text
-n*1 + (binom(n,2) - n)*2 = n(n - 2).
+sum_i binom(|R_i|, 2)
+  <= n + 2 * (binom(n,2) - n)
+   = n(n - 2).
 ```
 
 ## Consequences
@@ -75,8 +83,13 @@ at most two centers can have `E(i) >= 5`. Equivalently, any hypothetical 4-bad
 nonagon has at least seven exact-four centers.
 
 The corresponding necessary counting relaxation gives at least five exact-four
-centers in any hypothetical 4-bad decagon, and at least three exact-four
-centers for `n=11`.
+centers in any hypothetical 4-bad decagon and at least three exact-four centers
+in any hypothetical 4-bad hendecagon.
+
+The same count also gives a short support-level exclusion of `n <= 7`: a 4-bad
+`n`-gon would require `6n <= n(n-2)`, hence `n >= 8`. This agrees with the
+repository's separate sharpened incidence and geometric proof-note routes; the
+older `n=7` Fano enumeration remains useful structural provenance.
 
 ## Verification command
 
@@ -87,7 +100,7 @@ python scripts/check_rich_support_counting_bound.py --check --json
 ```
 
 checks the threshold `n >= 12` for all-centers size-five support and the small
-`n=5..11` surplus table used above. It is only a counting-bound checker; it is
+`n=8..12` surplus table used above. It is only a counting-bound checker; it is
 not a realization search.
 
 ## Boundary
@@ -97,4 +110,5 @@ This lemma does not rule out mixed exact-four and size-five catalogues. For
 but it does not replace the review-pending exact-four frontier or the mixed
 support crosswalk. The existing `n=9` all-five-rich checker remains useful as a
 crossing-aware support-catalogue regression and as provenance for the richer
-support-search machinery.
+support-search machinery, but the all-five-rich subcase itself is already
+closed by the edge-sensitive count.

--- a/scripts/check_rich_support_counting_bound.py
+++ b/scripts/check_rich_support_counting_bound.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""Check the rich-support counting bound for Erdos Problem #97.
+"""Check the edge-sensitive rich-support counting bound for Erdos Problem #97.
 
-This standalone checker verifies a simple proof-facing counting lemma:
-for any choice of one same-radius support R_i at each center of a strict convex
-n-gon, sum_i binom(|R_i|, 2) <= n(n - 2).  A non-boundary witness pair {a,b}
-can occur in at most two supports, since all centers using both witnesses lie
-on the perpendicular bisector of ab.  A boundary-edge witness pair has capacity
-one, because the perpendicular bisector enters the polygon through the edge
-midpoint, so its polygon section has that midpoint as an endpoint.
+This standalone checker verifies a proof-facing counting lemma: for any choice
+of one same-radius support R_i at each center of a strict convex n-gon,
+
+    sum_i binom(|R_i|, 2) <= n(n - 2).
+
+The coarse reason is that a fixed witness pair {a,b} can occur in at most two
+supports, since all centers using both witnesses lie on the perpendicular
+bisector of ab.  The edge-sensitive improvement is that if {a,b} is a hull
+edge, its perpendicular bisector already meets the polygon boundary at the
+midpoint of that edge, so it can contain at most one further boundary vertex
+and hence at most one center.  There are n hull-edge witness pairs and
+binom(n,2)-n non-edge witness pairs.
 """
 
 from __future__ import annotations
@@ -17,16 +22,34 @@ import json
 from math import comb
 from typing import Any
 
-SCHEMA = "erdos97.rich_support_counting_bound.v1"
+SCHEMA = "erdos97.rich_support_counting_bound.v2"
 TRUST = "LEMMA"
+
+
+def coarse_pair_budget(n: int) -> int:
+    """Pair-sharing budget when every witness pair has capacity two."""
+
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    return n * (n - 1)
+
+
+def edge_sensitive_pair_budget(n: int) -> int:
+    """Pair-sharing budget with hull-edge witness pairs counted at capacity one."""
+
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    if n == 0:
+        return 0
+    # n hull edges have capacity 1; the remaining binom(n,2)-n pairs have
+    # capacity 2.
+    return max(0, n + 2 * (comb(n, 2) - n))
 
 
 def pair_budget(n: int) -> int:
     """Maximum total center-witness-pair incidences allowed by pair-sharing."""
 
-    if n < 0:
-        raise ValueError("n must be nonnegative")
-    return max(0, n * (n - 2))
+    return edge_sensitive_pair_budget(n)
 
 
 def all_centers_min_n(k: int) -> int:
@@ -41,7 +64,8 @@ def max_total_support_size(n: int, min_size: int = 4) -> tuple[int, list[int]]:
     """Maximize sum |R_i| under sum binom(|R_i|,2) <= n(n-2).
 
     This is only a necessary counting relaxation.  It ignores all cyclic-order,
-    row-intersection, and vertex-circle constraints.
+    row-intersection, and vertex-circle constraints beyond the hull-edge
+    witness-pair capacity used in the counting lemma.
     """
 
     if n <= 0:
@@ -95,35 +119,42 @@ def row_summary(n: int) -> dict[str, Any]:
     baseline_cost = n * comb(4, 2)
     budget = pair_budget(n)
     four_bad_ruled_out = baseline_cost > budget
+    row: dict[str, Any] = {
+        "n": n,
+        "coarse_pair_budget": coarse_pair_budget(n),
+        "edge_sensitive_pair_budget": budget,
+    }
     if four_bad_ruled_out:
-        return {
-            "n": n,
-            "pair_budget": budget,
-            "four_bad_ruled_out_by_pair_counting": True,
-            "max_total_support_size_given_E_ge_4": None,
-            "max_surplus_over_exact_four": None,
-            "one_extremal_support_size_multiset": None,
-            "all_centers_size_at_least_5_ruled_out_by_counting": True,
-            "max_centers_with_E_at_least_5_by_counting": 0,
-            "min_centers_with_E_equal_4_by_counting": None,
-        }
+        row.update(
+            {
+                "four_bad_ruled_out_by_edge_sensitive_pair_counting": True,
+                "max_total_support_size_given_E_ge_4": None,
+                "max_surplus_over_exact_four": None,
+                "one_extremal_support_size_multiset": None,
+                "all_centers_size_at_least_5_ruled_out_by_counting": True,
+                "max_centers_with_E_at_least_5_by_counting": 0,
+                "min_centers_with_E_equal_4_by_counting": None,
+            }
+        )
+        return row
 
     total, sizes = max_total_support_size(n, min_size=4)
     max_non_exact = max_non_exact_four_centers(n)
-    return {
-        "n": n,
-        "pair_budget": budget,
-        "four_bad_ruled_out_by_pair_counting": False,
-        "max_total_support_size_given_E_ge_4": total,
-        "max_surplus_over_exact_four": total - 4 * n,
-        "one_extremal_support_size_multiset": sizes,
-        "all_centers_size_at_least_5_ruled_out_by_counting": n < all_centers_min_n(5),
-        "max_centers_with_E_at_least_5_by_counting": max_non_exact,
-        "min_centers_with_E_equal_4_by_counting": max(0, n - max_non_exact),
-    }
+    row.update(
+        {
+            "four_bad_ruled_out_by_edge_sensitive_pair_counting": False,
+            "max_total_support_size_given_E_ge_4": total,
+            "max_surplus_over_exact_four": total - 4 * n,
+            "one_extremal_support_size_multiset": sizes,
+            "all_centers_size_at_least_5_ruled_out_by_counting": n < all_centers_min_n(5),
+            "max_centers_with_E_at_least_5_by_counting": max_non_exact,
+            "min_centers_with_E_equal_4_by_counting": max(0, n - max_non_exact),
+        }
+    )
+    return row
 
 
-def build_summary(min_n: int = 5, max_n: int = 11) -> dict[str, Any]:
+def build_summary(min_n: int = 5, max_n: int = 12) -> dict[str, Any]:
     """Build a stable JSON summary for the lemma and small-n consequences."""
 
     return {
@@ -131,14 +162,20 @@ def build_summary(min_n: int = 5, max_n: int = 11) -> dict[str, Any]:
         "status": "PROVED_COUNTING_LEMMA",
         "trust": TRUST,
         "claim_scope": (
-            "Proof-facing rich-support pair-counting lemma only. It records "
-            "necessary support-size consequences and does not prove n=9, "
-            "n=10, n=11, or Erdos Problem #97."
+            "Proof-facing edge-sensitive rich-support pair-counting lemma only. "
+            "It records necessary support-size consequences and does not prove "
+            "n=9, n=10, n=11, or Erdos Problem #97."
         ),
         "lemma": (
             "For same-radius supports R_i in a strict convex n-gon, "
             "sum_i binom(|R_i|, 2) <= n(n - 2)."
         ),
+        "capacity_accounting": {
+            "hull_edge_pairs": "n pairs, capacity 1 each",
+            "nonedge_pairs": "binom(n, 2) - n pairs, capacity 2 each",
+            "total_capacity": "n + 2*(binom(n,2)-n) = n(n-2)",
+            "coarse_capacity_for_comparison": "n(n-1)",
+        },
         "all_centers_min_support_thresholds": {
             str(k): all_centers_min_n(k) for k in range(4, 8)
         },
@@ -150,8 +187,9 @@ def check_expected(summary: dict[str, Any]) -> None:
     """Check the small consequences used by the proposed repo note."""
 
     thresholds = summary["all_centers_min_support_thresholds"]
-    if thresholds["5"] != 12:
-        raise AssertionError("all-centers size-five threshold should be n >= 12")
+    expected_thresholds = {"4": 8, "5": 12, "6": 17, "7": 23}
+    if thresholds != expected_thresholds:
+        raise AssertionError(f"got thresholds {thresholds}, expected {expected_thresholds}")
 
     rows = {row["n"]: row for row in summary["rows"]}
     expected = {
@@ -159,6 +197,7 @@ def check_expected(summary: dict[str, Any]) -> None:
         9: (38, 2, 2, 7),
         10: (45, 5, 5, 5),
         11: (52, 8, 8, 3),
+        12: (60, 12, 12, 0),
     }
     for n, (total, surplus, max_non_exact, min_exact) in expected.items():
         row = rows[n]
@@ -173,21 +212,23 @@ def check_expected(summary: dict[str, Any]) -> None:
             raise AssertionError(f"n={n}: got {got}, expected {want}")
 
     for n in (5, 6, 7):
-        if not rows[n]["four_bad_ruled_out_by_pair_counting"]:
-            raise AssertionError(f"n={n}: expected pair-counting to rule out four-bad supports")
+        if not rows[n]["four_bad_ruled_out_by_edge_sensitive_pair_counting"]:
+            raise AssertionError(
+                f"n={n}: expected edge-sensitive pair-counting to rule out four-bad supports"
+            )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--min-n", type=int, default=5)
-    parser.add_argument("--max-n", type=int, default=11)
+    parser.add_argument("--max-n", type=int, default=12)
     parser.add_argument("--check", action="store_true", help="assert expected small-n consequences")
     parser.add_argument("--json", action="store_true", help="emit JSON")
     args = parser.parse_args()
 
     summary = build_summary(args.min_n, args.max_n)
     if args.check:
-        if (args.min_n, args.max_n) != (5, 11):
+        if (args.min_n, args.max_n) != (5, 12):
             raise SystemExit("--check is only defined for the default n range")
         check_expected(summary)
     if args.json:
@@ -196,8 +237,8 @@ def main() -> int:
         print(f"schema: {summary['schema']}")
         print("all centers with size >=5 requires n >=", all_centers_min_n(5))
         for row in summary["rows"]:
-            if row["four_bad_ruled_out_by_pair_counting"]:
-                print(f"n={row['n']}: four-bad supports ruled out by pair-counting")
+            if row["four_bad_ruled_out_by_edge_sensitive_pair_counting"]:
+                print(f"n={row['n']}: four-bad supports ruled out by edge-sensitive pair-counting")
             else:
                 print(
                     f"n={row['n']}: max total={row['max_total_support_size_given_E_ge_4']}, "

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1516,10 +1516,10 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--json",
         ),
         claim_scope=(
-            "Proof-facing rich-support pair-counting lemma and small-n "
-            "consequences; not a proof of n=9, not a proof of n=10, not a "
-            "proof of n=11, not a proof of Erdos Problem #97, and not a "
-            "counterexample."
+            "Proof-facing edge-sensitive rich-support pair-counting lemma "
+            "and small-n consequences; not a proof of n=9, not a proof of "
+            "n=10, not a proof of n=11, not a proof of Erdos Problem #97, "
+            "and not a counterexample."
         ),
     ),
     AuditCommand(

--- a/tests/test_rich_support_counting_bound.py
+++ b/tests/test_rich_support_counting_bound.py
@@ -14,6 +14,8 @@ from check_rich_support_counting_bound import (  # noqa: E402
     all_centers_min_n,
     build_summary,
     check_expected,
+    coarse_pair_budget,
+    edge_sensitive_pair_budget,
     max_non_exact_four_centers,
     row_summary,
 )
@@ -30,25 +32,36 @@ def test_rich_support_counting_expected_summary() -> None:
     assert rows[9]["min_centers_with_E_equal_4_by_counting"] == 7
     assert rows[10]["max_centers_with_E_at_least_5_by_counting"] == 5
     assert rows[10]["min_centers_with_E_equal_4_by_counting"] == 5
-    assert rows[11]["max_centers_with_E_at_least_5_by_counting"] == 8
     assert rows[11]["min_centers_with_E_equal_4_by_counting"] == 3
+    assert rows[12]["min_centers_with_E_equal_4_by_counting"] == 0
 
 
 def test_rich_support_counting_threshold_helpers() -> None:
     assert all_centers_min_n(4) == 8
     assert all_centers_min_n(5) == 12
     assert all_centers_min_n(6) == 17
+    assert edge_sensitive_pair_budget(1) == 0
+    assert edge_sensitive_pair_budget(9) == 63
+    assert coarse_pair_budget(9) == 72
     assert max_non_exact_four_centers(9) == 2
     assert max_non_exact_four_centers(10) == 5
+    assert max_non_exact_four_centers(11) == 8
 
 
 def test_rich_support_counting_rows() -> None:
+    row7 = row_summary(7)
+    row8 = row_summary(8)
     row9 = row_summary(9)
     row10 = row_summary(10)
 
-    assert row9["pair_budget"] == 63
+    assert row7["edge_sensitive_pair_budget"] == 35
+    assert row7["four_bad_ruled_out_by_edge_sensitive_pair_counting"] is True
+    assert row8["edge_sensitive_pair_budget"] == 48
+    assert row8["max_total_support_size_given_E_ge_4"] == 32
+    assert row9["edge_sensitive_pair_budget"] == 63
+    assert row9["coarse_pair_budget"] == 72
     assert row9["max_total_support_size_given_E_ge_4"] == 38
-    assert row10["pair_budget"] == 80
+    assert row10["edge_sensitive_pair_budget"] == 80
     assert row10["max_total_support_size_given_E_ge_4"] == 45
 
 
@@ -67,6 +80,7 @@ def test_rich_support_counting_cli_json() -> None:
     )
 
     payload = json.loads(result.stdout)
-    assert payload["schema"] == "erdos97.rich_support_counting_bound.v1"
+    assert payload["schema"] == "erdos97.rich_support_counting_bound.v2"
     assert payload["status"] == "PROVED_COUNTING_LEMMA"
     assert payload["rows"][4]["n"] == 9
+    assert payload["rows"][4]["min_centers_with_E_equal_4_by_counting"] == 7


### PR DESCRIPTION
## Summary

This is a follow-up clarity pass on the already-merged sharpened rich-support counting lemma. It does not change the global status and does not claim a proof or counterexample.

- bump the checker payload schema to `erdos97.rich_support_counting_bound.v2`
- expose both the coarse `n(n-1)` pair budget and the edge-sensitive `n(n-2)` budget in row summaries
- add capacity-accounting metadata and extend the default checked table through `n=12`
- align the docs/source-of-truth wording around hull-edge / edge-sensitive terminology

## Validation

- `python -m py_compile scripts/check_rich_support_counting_bound.py tests/test_rich_support_counting_bound.py`
- `python scripts/check_rich_support_counting_bound.py --check --json`
- `python -m pytest tests/test_rich_support_counting_bound.py tests/test_run_artifact_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1153 passed, 320 deselected`)
