### PR TITLE
[codex] Add Lean proof-sketch pilot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: verify-lint verify-fast verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-lean verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review verify-artifacts audit-artifacts verify-all
 
 verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
@@ -11,6 +11,10 @@ verify-lint:
 
 verify-fast: verify-lint
 	$(PYTHON) -m pytest -q
+
+verify-lean:
+	$(PYTHON) scripts/check_lean_sketch_integrity.py
+	$(PYTHON) scripts/check_lean_files.py
 
 verify-pytest-artifacts:
 	$(PYTHON) -m pytest -q -m "artifact"

--- a/data/proof_sketches/README.md
+++ b/data/proof_sketches/README.md
@@ -1,0 +1,26 @@
+# Proof Sketch Population
+
+This directory is reserved for logged Lean proof-sketch attempts and ratings.
+Records here are planning and audit artifacts only. They must not be cited as
+mathematical evidence unless a separate Lean/Python verifier checks the exact
+certificate or proof target.
+
+Suggested JSONL fields:
+
+```json
+{
+  "id": "t10_strict_cycle_YYYY_MM_DD_a01",
+  "target": "lean/Erdos97/Sketches/T10StrictCycle.lean",
+  "claim_scope": "local_template_only",
+  "status": "compiles_with_sorries",
+  "remaining_goals": [],
+  "verifier_commands": [],
+  "score": {
+    "robustness": 0,
+    "decomposition": 0,
+    "logical_soundness": 0,
+    "novelty": 0
+  },
+  "do_not_claim": ["n=9", "Erdos97"]
+}
+```

--- a/docs/formalization.md
+++ b/docs/formalization.md
@@ -6,6 +6,35 @@ The Formal Conjectures repository contains
 `FormalConjectures/ErdosProblems/97.lean`. It defines
 `HasNEquidistantProperty 4` and states the open theorem using `ConvexIndep A`.
 
+## Local Lean pilot
+
+The local `lean/` directory is a proof-sketch pilot, not a formal proof of the
+official problem. Its first layer is deliberately abstract:
+
+- `lean/Erdos97/Basic.lean` defines a point-set selected-witness interface;
+- `lean/Erdos97/SelectedWitness.lean` proves the choice-based extraction from
+  that abstract interface;
+- `lean/Erdos97/CertificateFormats.lean` records tiny certificate shapes for
+  later Python-to-Lean kernels;
+- `lean/Erdos97/Sketches/` contains AI-editable sketch shells marked with
+  `-- EVOLVE-BLOCK-START` and `-- EVOLVE-BLOCK-END`.
+
+Run the local guardrails with:
+
+```bash
+make verify-lean
+```
+
+If `lake` is not installed, this target still checks sketch integrity and
+reports that Lean compilation was skipped. Use
+`python scripts/check_lean_files.py --require-lean` when a Lean environment is
+expected.
+
+The missing bridge remains explicit: prove that the Formal Conjectures
+`HasNEquidistantProperty 4` predicate implies the local
+`HasFourEquidistantProperty` interface, then connect point-set witnesses to any
+labelled cyclic-order certificate format.
+
 ## Local mathematical convention
 
 This repository often uses the language of a strictly convex polygon with

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,0 +1,11 @@
+import Lake
+open Lake DSL
+
+package erdos97_lean where
+  -- This package is intentionally dependency-free for the first Lean pilot.
+  -- Future work can add mathlib/Formal Conjectures imports once the local
+  -- bridge statements are stable enough to justify the dependency.
+
+@[default_target]
+lean_lib Erdos97 where
+  srcDir := "lean"

--- a/lean/Erdos97/Basic.lean
+++ b/lean/Erdos97/Basic.lean
@@ -1,0 +1,70 @@
+/-!
+# Erdos97 Lean Pilot
+
+This module is a small abstract interface for proof-sketch work. It does not
+formalize the official geometric statement of Erdos Problem #97 and it does not
+claim a proof or a counterexample.
+
+The purpose is to isolate the selected-witness extraction shape before binding
+it to `Finset R^2`, `ConvexIndep`, cyclic orders, or squared-distance
+certificate formats.
+-/
+
+namespace Erdos97
+
+universe u
+
+/-- Four distinct points chosen as witnesses for a center. -/
+structure Witness4 (Point : Type u) where
+  a : Point
+  b : Point
+  c : Point
+  d : Point
+  a_ne_b : Not (a = b)
+  a_ne_c : Not (a = c)
+  a_ne_d : Not (a = d)
+  b_ne_c : Not (b = c)
+  b_ne_d : Not (b = d)
+  c_ne_d : Not (c = d)
+
+/--
+The chosen witnesses are members of `A` and are not the center.
+
+This stays point-set based on purpose. Cyclic labels and finite incidence rows
+should be added by later bridge modules, not baked into the first extraction
+lemma.
+-/
+def WitnessInSet {Point : Type u} (A : Point -> Prop) (p : Point)
+    (W : Witness4 Point) : Prop :=
+  And (A W.a)
+    (And (A W.b)
+      (And (A W.c)
+        (And (A W.d)
+          (And (Not (W.a = p))
+            (And (Not (W.b = p))
+              (And (Not (W.c = p)) (Not (W.d = p))))))))
+
+/--
+`SameDistanceFrom p q r` should later be instantiated as
+`dist p q = dist p r`, or as an equivalent squared-distance relation with the
+needed nonnegativity bridge.
+-/
+def WitnessEquidistant {Point : Type u}
+    (SameDistanceFrom : Point -> Point -> Point -> Prop) (p : Point)
+    (W : Witness4 Point) : Prop :=
+  And (SameDistanceFrom p W.a W.b)
+    (And (SameDistanceFrom p W.a W.c) (SameDistanceFrom p W.a W.d))
+
+/--
+An abstract point-set version of "every point has four other equidistant
+points". This is not the Formal Conjectures definition; it is the local
+selected-witness interface that the official definition should imply.
+-/
+def HasFourEquidistantProperty {Point : Type u} (A : Point -> Prop)
+    (SameDistanceFrom : Point -> Point -> Point -> Prop) : Prop :=
+  forall p : Point,
+    A p ->
+      Exists fun W : Witness4 Point =>
+        And (WitnessInSet A p W) (WitnessEquidistant SameDistanceFrom p W)
+
+end Erdos97

--- a/lean/Erdos97/CertificateFormats.lean
+++ b/lean/Erdos97/CertificateFormats.lean
@@ -1,0 +1,46 @@
+/-!
+# Tiny Certificate Shapes
+
+These structures are lightweight Lean-side mirrors of the certificate kernels
+that the Python tooling should eventually emit. They are intentionally
+syntactic: they do not yet check Euclidean geometry or quotient arithmetic.
+-/
+
+namespace Erdos97
+
+/-- A named quotient class of pair-distance expressions. -/
+structure QuotientClass where
+  name : String
+deriving Repr, BEq
+
+/-- A replayable equality path between two quotient classes. -/
+structure EqualityPath where
+  start : QuotientClass
+  finish : QuotientClass
+  reasons : List String
+deriving Repr
+
+/-- A certificate shape for a strict self-edge contradiction. -/
+structure SelfEdgeCertificate where
+  className : QuotientClass
+  equalityPath : EqualityPath
+  strictReason : String
+deriving Repr
+
+/-- A directed strict edge between quotient classes. -/
+structure StrictEdge where
+  source : QuotientClass
+  target : QuotientClass
+  reason : String
+deriving Repr
+
+/-- A certificate shape for a strict directed cycle. -/
+structure StrictCycleCertificate where
+  edges : List StrictEdge
+  cycleReason : String
+deriving Repr
+
+def StrictCycleCertificate.hasEdges (c : StrictCycleCertificate) : Prop :=
+  Not (c.edges = [])
+
+end Erdos97

--- a/lean/Erdos97/SelectedWitness.lean
+++ b/lean/Erdos97/SelectedWitness.lean
@@ -1,0 +1,60 @@
+import Erdos97.Basic
+
+/-!
+# Selected Witness Extraction
+
+This file contains the first bridge-shaped lemma for the Lean pilot. It is
+abstract and point-set based: later work must connect the official
+`HasNEquidistantProperty 4` statement to `HasFourEquidistantProperty`.
+-/
+
+namespace Erdos97
+
+universe u
+
+/-- A selected witness row for every point of `A`. -/
+structure SelectedWitnessSystem {Point : Type u} (A : Point -> Prop)
+    (SameDistanceFrom : Point -> Point -> Point -> Prop) where
+  witness : (p : Point) -> A p -> Witness4 Point
+  witness_in_set :
+    forall (p : Point) (hp : A p), WitnessInSet A p (witness p hp)
+  witness_equidistant :
+    forall (p : Point) (hp : A p),
+      WitnessEquidistant SameDistanceFrom p (witness p hp)
+
+noncomputable section
+
+/-- Choice-based extraction of selected witnesses from the abstract property. -/
+def selectedWitnessSystemOfProperty {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (h : HasFourEquidistantProperty A SameDistanceFrom) :
+    SelectedWitnessSystem A SameDistanceFrom := by
+  refine
+    { witness := ?_
+      witness_in_set := ?_
+      witness_equidistant := ?_ }
+  · intro p hp
+    exact Classical.choose (h p hp)
+  · intro p hp
+    exact (Classical.choose_spec (h p hp)).left
+  · intro p hp
+    exact (Classical.choose_spec (h p hp)).right
+
+/--
+Bridge-shaped statement: the abstract four-equidistant property gives a
+selected-witness system.
+
+This is intentionally weaker than the eventual repository goal. The missing
+work is to prove that the official Formal Conjectures predicate implies the
+abstract local predicate above.
+-/
+theorem has_property_gives_selected_witness_system {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (h : HasFourEquidistantProperty A SameDistanceFrom) :
+    Exists fun _S : SelectedWitnessSystem A SameDistanceFrom => True := by
+  exact Exists.intro (selectedWitnessSystemOfProperty h) True.intro
+
+end
+
+end Erdos97

--- a/lean/Erdos97/Sketches/T01SelfEdge.lean
+++ b/lean/Erdos97/Sketches/T01SelfEdge.lean
@@ -1,0 +1,22 @@
+import Erdos97.CertificateFormats
+
+/-!
+# T01 Self-Edge Sketch
+
+This is a marked proof-sketch shell for one local vertex-circle self-edge
+template. It is not a theorem about `n = 9` and it is not evidence for the
+global problem.
+-/
+
+namespace Erdos97.Sketches.T01SelfEdge
+
+-- EVOLVE-BLOCK-START
+
+def target : Prop := True
+
+theorem t01_self_edge_kernel_placeholder : target := by
+  trivial
+
+-- EVOLVE-BLOCK-END
+
+end Erdos97.Sketches.T01SelfEdge

--- a/lean/Erdos97/Sketches/T10StrictCycle.lean
+++ b/lean/Erdos97/Sketches/T10StrictCycle.lean
@@ -1,0 +1,22 @@
+import Erdos97.CertificateFormats
+
+/-!
+# T10 Strict-Cycle Sketch
+
+This is a marked proof-sketch shell for one local vertex-circle strict-cycle
+template. It is not a theorem about `n = 9` and it is not evidence for the
+global problem.
+-/
+
+namespace Erdos97.Sketches.T10StrictCycle
+
+-- EVOLVE-BLOCK-START
+
+def target : Prop := True
+
+theorem t10_strict_cycle_kernel_placeholder : target := by
+  trivial
+
+-- EVOLVE-BLOCK-END
+
+end Erdos97.Sketches.T10StrictCycle

--- a/scripts/check_lean_files.py
+++ b/scripts/check_lean_files.py
@@ -1,0 +1,42 @@
+"""Compile Lean pilot files when Lake is available."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--require-lean",
+        action="store_true",
+        help="fail instead of skipping when lake is not on PATH",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    lake = shutil.which("lake")
+    if lake is None:
+        print("lake not found; skipped Lean compilation")
+        return 1 if args.require_lean else 0
+
+    files = sorted((root / "lean").rglob("*.lean"))
+    if not files:
+        print("no Lean files found")
+        return 0
+
+    for path in files:
+        rel = path.relative_to(root)
+        print(f"checking {rel}")
+        subprocess.run([lake, "env", "lean", str(path)], cwd=root, check=True)
+
+    print(f"checked {len(files)} Lean file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_lean_sketch_integrity.py
+++ b/scripts/check_lean_sketch_integrity.py
@@ -1,0 +1,174 @@
+"""Check Lean proof-sketch guardrails.
+
+This checker is intentionally lightweight. It does not prove mathematics; it
+keeps AI-editable Lean sketches inside marked regions and flags common
+"miracle lemma" shapes before they become review noise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+START_MARKER = "-- EVOLVE-BLOCK-START"
+END_MARKER = "-- EVOLVE-BLOCK-END"
+
+DECL_RE = re.compile(r"^\s*(axiom|lemma|theorem)\s+([A-Za-z0-9_'.]+)\b")
+
+BANNED_DECL_NAME_PARTS = (
+    "no_bad_convex_polygon",
+    "no_counterexample",
+    "global_obstruction",
+    "vertex_circle_obstruction_general",
+    "erdos_97_solved",
+    "erdos97_solved",
+    "n9_complete",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    message: str
+
+    def as_dict(self, root: Path) -> dict[str, object]:
+        return {
+            "path": str(self.path.relative_to(root)),
+            "line": self.line,
+            "message": self.message,
+        }
+
+
+def _line_is_inside_block(line_number: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= line_number <= end for start, end in ranges)
+
+
+def _evolve_ranges(path: Path, lines: list[str]) -> tuple[list[tuple[int, int]], list[Finding]]:
+    findings: list[Finding] = []
+    ranges: list[tuple[int, int]] = []
+    active_start: int | None = None
+
+    for idx, line in enumerate(lines, start=1):
+        has_start = START_MARKER in line
+        has_end = END_MARKER in line
+        if has_start and has_end:
+            findings.append(
+                Finding(path, idx, "start and end markers must be on separate lines")
+            )
+            continue
+        if has_start:
+            if active_start is not None:
+                findings.append(Finding(path, idx, "nested EVOLVE blocks are not allowed"))
+            active_start = idx
+            continue
+        if has_end:
+            if active_start is None:
+                findings.append(Finding(path, idx, "EVOLVE block end without a start"))
+            else:
+                ranges.append((active_start, idx))
+            active_start = None
+
+    if active_start is not None:
+        findings.append(Finding(path, active_start, "EVOLVE block start without an end"))
+
+    return ranges, findings
+
+
+def check_file(path: Path, sketch_root: Path, lean_root: Path) -> list[Finding]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    findings: list[Finding] = []
+    is_sketch = path.is_relative_to(sketch_root)
+
+    ranges, marker_findings = _evolve_ranges(path, lines)
+    findings.extend(marker_findings)
+
+    if is_sketch and not ranges:
+        findings.append(Finding(path, 1, "sketch file has no EVOLVE block"))
+
+    for idx, line in enumerate(lines, start=1):
+        if "sorry" in line or "admit" in line:
+            if not is_sketch:
+                findings.append(
+                    Finding(path, idx, "sorry/admit is only allowed in sketch files")
+                )
+            elif not _line_is_inside_block(idx, ranges):
+                findings.append(
+                    Finding(path, idx, "sorry/admit must stay inside an EVOLVE block")
+                )
+
+        match = DECL_RE.match(line)
+        if match is None:
+            continue
+
+        kind, name = match.groups()
+        lower_name = name.lower()
+        if kind == "axiom":
+            findings.append(Finding(path, idx, "axioms are not allowed in Lean pilot files"))
+        for banned in BANNED_DECL_NAME_PARTS:
+            if banned in lower_name:
+                findings.append(
+                    Finding(
+                        path,
+                        idx,
+                        f"declaration name looks like a miracle lemma: {name}",
+                    )
+                )
+
+        if kind in {"lemma", "theorem"} and "known" in line.lower() and "sorry" in text:
+            findings.append(
+                Finding(
+                    path,
+                    idx,
+                    "do not cite a 'known' theorem in a sketch that still contains sorry",
+                )
+            )
+
+    if path == lean_root / "Erdos97" / "Basic.lean" and "official geometric statement" not in text:
+        findings.append(
+            Finding(path, 1, "Basic.lean must state that it is not the official theorem")
+        )
+
+    return findings
+
+
+def check_tree(root: Path) -> list[Finding]:
+    lean_root = root / "lean"
+    sketch_root = lean_root / "Erdos97" / "Sketches"
+    if not lean_root.exists():
+        return [Finding(lean_root, 1, "lean directory does not exist")]
+
+    findings: list[Finding] = []
+    for path in sorted(lean_root.rglob("*.lean")):
+        findings.extend(check_file(path, sketch_root, lean_root))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--json", action="store_true", help="emit JSON findings")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    findings = check_tree(root)
+
+    if args.json:
+        print(json.dumps([finding.as_dict(root) for finding in findings], indent=2))
+    elif findings:
+        for finding in findings:
+            rel = finding.path.relative_to(root)
+            print(f"{rel}:{finding.line}: {finding.message}")
+    else:
+        print("Lean sketch integrity checks passed")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lean_sketch_integrity.py
+++ b/tests/test_lean_sketch_integrity.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from scripts.check_lean_sketch_integrity import check_tree
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_accepts_marked_sketch(tmp_path: Path) -> None:
+    write(
+        tmp_path / "lean" / "Erdos97" / "Basic.lean",
+        "/- not the official geometric statement -/\n",
+    )
+    write(
+        tmp_path / "lean" / "Erdos97" / "Sketches" / "T01.lean",
+        "\n".join(
+            [
+                "-- EVOLVE-BLOCK-START",
+                "theorem local_placeholder : True := by",
+                "  trivial",
+                "-- EVOLVE-BLOCK-END",
+            ]
+        ),
+    )
+
+    assert check_tree(tmp_path) == []
+
+
+def test_rejects_sorry_outside_evolve_block(tmp_path: Path) -> None:
+    write(
+        tmp_path / "lean" / "Erdos97" / "Basic.lean",
+        "/- not the official geometric statement -/\n",
+    )
+    write(
+        tmp_path / "lean" / "Erdos97" / "Sketches" / "T01.lean",
+        "\n".join(
+            [
+                "theorem local_placeholder : True := by",
+                "  sorry",
+                "-- EVOLVE-BLOCK-START",
+                "-- EVOLVE-BLOCK-END",
+            ]
+        ),
+    )
+
+    findings = check_tree(tmp_path)
+
+    assert any("inside an EVOLVE block" in finding.message for finding in findings)
+
+
+def test_rejects_miracle_lemma_name(tmp_path: Path) -> None:
+    write(
+        tmp_path / "lean" / "Erdos97" / "Basic.lean",
+        "/- not the official geometric statement -/\n",
+    )
+    write(
+        tmp_path / "lean" / "Erdos97" / "Sketches" / "T01.lean",
+        "\n".join(
+            [
+                "-- EVOLVE-BLOCK-START",
+                "lemma no_bad_convex_polygon_nine : True := by",
+                "  trivial",
+                "-- EVOLVE-BLOCK-END",
+            ]
+        ),
+    )
+
+    findings = check_tree(tmp_path)
+
+    assert any("miracle lemma" in finding.message for finding in findings)


### PR DESCRIPTION
## Summary

- Add a dependency-free Lean pilot scaffold for abstract selected-witness proof sketches.
- Add certificate-shape shells for self-edge and strict-cycle kernels plus T01/T10 EVOLVE-block sketch files.
- Add Lean sketch integrity checks, focused tests, and a `verify-lean` Makefile target.
- Document the local Lean pilot as proof infrastructure only, with no change to Erdős #97 status.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check --cached`
- `python -m ruff check .`
- `python scripts/check_lean_sketch_integrity.py`
- `python scripts/check_lean_files.py` (skipped Lean compilation because `lake` is not installed locally)
- `python -m pytest -q` (`1086 passed, 407 deselected`)

## Notes

This PR is intentionally scoped to proof-sketch infrastructure. It does not claim a formal proof, a counterexample, or a promotion of any finite-case result.