### PR TITLE
[codex] Add n9 local lemma handoff checks

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -53,7 +53,9 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
    runs the focused packet/catalog, focused mini-replay,
    aggregate/simple-replay, exhaustive/local-lemma, and
-   relation-skeleton/local-lemma handoffs as one review-pending audit path.
+   relation-skeleton/local-lemma handoffs as one review-pending audit path,
+   with explicit adjacent handoff checks that identify where any future
+   count/schema drift first appears.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -642,7 +642,11 @@ The local-lemma audit-path checker then runs the reviewer-facing handoff as
 one chain. It checks that the focused packet/catalog audit, focused
 mini-replay crosswalk, aggregate/simple replay crosswalk,
 exhaustive/local-lemma crosswalk, and relation-skeleton/local-lemma crosswalk
-all agree on the same 12 templates, 16 families, and 184 assignments:
+all agree on the same 12 templates, 16 families, and 184 assignments. Its JSON
+payload now includes explicit adjacent handoff checks for each pair of
+successive layers, so a reviewer can see whether any drift starts at the
+focused-packet, mini-replay, aggregate, exhaustive, or relation-skeleton
+handoff:
 
 ```bash
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -416,7 +416,8 @@ Next steps:
   `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
   to run the focused packet/catalog, focused mini-replay,
   aggregate/simple-replay, exhaustive/local-lemma, and
-  relation-skeleton/local-lemma handoffs as one review-pending audit path;
+  relation-skeleton/local-lemma handoffs as one review-pending audit path,
+  with adjacent handoff checks that localize future drift between layers;
 - use the focused mini-replay commands
   `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -72,6 +72,17 @@ EXPECTED_LAYER_IDS = [
     "relation_skeleton_local_lemma",
 ]
 EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
+EXPECTED_HANDOFF_EDGES = list(zip(EXPECTED_LAYER_IDS, EXPECTED_LAYER_IDS[1:]))
+HANDOFF_COMPARE_KEYS = (
+    "template_count",
+    "template_ids",
+    "family_count",
+    "assignment_count",
+    "self_edge_family_count",
+    "self_edge_assignment_count",
+    "strict_cycle_family_count",
+    "strict_cycle_assignment_count",
+)
 
 AssertFn = Callable[[Mapping[str, Any]], None]
 
@@ -140,6 +151,7 @@ def local_lemma_audit_path_payload(
     errors: list[str] = []
     _append_layer_expected_errors(errors, layers)
     layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
+    handoff_checks = _handoff_checks(layer_summaries, errors)
     coverage = _coverage_summary(layer_summaries, errors)
 
     return {
@@ -152,6 +164,8 @@ def local_lemma_audit_path_payload(
         "audit_path": {
             "layer_count": len(layer_summaries),
             "layer_ids": [summary["layer_id"] for summary in layer_summaries],
+            "handoff_count": len(handoff_checks),
+            "handoff_checks": handoff_checks,
             "layers": layer_summaries,
         },
         "coverage_summary": coverage,
@@ -198,6 +212,27 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
         raise AssertionError("audit_path must be an object")
     if audit_path.get("layer_ids") != EXPECTED_LAYER_IDS:
         raise AssertionError(f"layer ids mismatch: {audit_path.get('layer_ids')!r}")
+    if audit_path.get("handoff_count") != len(EXPECTED_HANDOFF_EDGES):
+        raise AssertionError(f"handoff count mismatch: {audit_path.get('handoff_count')!r}")
+    handoffs = audit_path.get("handoff_checks")
+    if not isinstance(handoffs, list):
+        raise AssertionError("handoff_checks must be a list")
+    expected_edges = [
+        {"from_layer": left, "to_layer": right}
+        for left, right in EXPECTED_HANDOFF_EDGES
+    ]
+    observed_edges = [
+        {
+            "from_layer": handoff.get("from_layer"),
+            "to_layer": handoff.get("to_layer"),
+        }
+        for handoff in handoffs
+    ]
+    if observed_edges != expected_edges:
+        raise AssertionError(f"handoff edge mismatch: {observed_edges!r}")
+    for handoff in handoffs:
+        if handoff.get("status") != "passed" or handoff.get("mismatches") != []:
+            raise AssertionError(f"handoff failed: {handoff!r}")
 
     coverage = payload.get("coverage_summary")
     if not isinstance(coverage, Mapping):
@@ -377,6 +412,43 @@ def _coverage_summary(
     }
 
 
+def _handoff_checks(
+    layer_summaries: list[Mapping[str, Any]],
+    errors: list[str],
+) -> list[dict[str, Any]]:
+    summaries = {str(summary.get("layer_id")): summary for summary in layer_summaries}
+    checks: list[dict[str, Any]] = []
+    for from_layer, to_layer in EXPECTED_HANDOFF_EDGES:
+        left = summaries[from_layer]
+        right = summaries[to_layer]
+        mismatches = []
+        for key in HANDOFF_COMPARE_KEYS:
+            left_value = left.get(key)
+            right_value = right.get(key)
+            if left_value != right_value:
+                mismatches.append(
+                    {
+                        "key": key,
+                        "from_value": left_value,
+                        "to_value": right_value,
+                    }
+                )
+                errors.append(
+                    f"{from_layer}->{to_layer} handoff mismatch on {key}: "
+                    f"{left_value!r} != {right_value!r}"
+                )
+        checks.append(
+            {
+                "from_layer": from_layer,
+                "to_layer": to_layer,
+                "compared_keys": list(HANDOFF_COMPARE_KEYS),
+                "status": "passed" if not mismatches else "failed",
+                "mismatches": mismatches,
+            }
+        )
+    return checks
+
+
 def _required_mapping(
     payload: Mapping[str, Any],
     key: str,
@@ -421,6 +493,7 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"status: {payload['status']}",
         f"validation: {payload['validation_status']}",
         f"layers: {coverage['layer_count']}",
+        f"handoffs: {payload['audit_path']['handoff_count']}",
         f"templates: {coverage['template_count']}",
         f"families: {coverage['family_count']}",
         f"assignments: {coverage['assignment_count']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
+    EXPECTED_HANDOFF_EDGES,
     EXPECTED_LAYER_IDS,
     assert_expected_local_lemma_audit_path,
     local_lemma_audit_path_payload,
@@ -26,6 +27,11 @@ def test_local_lemma_audit_path_counts_and_scope() -> None:
     assert_expected_local_lemma_audit_path(payload)
     assert payload["validation_status"] == "passed"
     assert payload["audit_path"]["layer_ids"] == EXPECTED_LAYER_IDS
+    assert payload["audit_path"]["handoff_count"] == len(EXPECTED_HANDOFF_EDGES)
+    assert [item["status"] for item in payload["audit_path"]["handoff_checks"]] == [
+        "passed"
+        for _ in EXPECTED_HANDOFF_EDGES
+    ]
     assert payload["coverage_summary"] == {
         "layer_count": 5,
         "template_count": 12,
@@ -55,6 +61,18 @@ def test_local_lemma_audit_path_layer_summaries() -> None:
     assert by_layer["relation_skeleton_local_lemma"]["relation_skeleton_count"] == 16
 
 
+def test_local_lemma_audit_path_handoff_summaries() -> None:
+    payload = local_lemma_audit_path_payload()
+    handoffs = payload["audit_path"]["handoff_checks"]
+
+    assert [
+        (handoff["from_layer"], handoff["to_layer"])
+        for handoff in handoffs
+    ] == EXPECTED_HANDOFF_EDGES
+    assert all("assignment_count" in handoff["compared_keys"] for handoff in handoffs)
+    assert all(handoff["mismatches"] == [] for handoff in handoffs)
+
+
 def test_local_lemma_audit_path_rejects_local_replay_drift() -> None:
     aggregate = load_artifact(DEFAULT_AGGREGATE)
     simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
@@ -74,6 +92,18 @@ def test_local_lemma_audit_path_rejects_local_replay_drift() -> None:
     assert (
         "assignment_count mismatch across audit path: (184, 184, 183, 184, 184)"
         in payload["validation_errors"]
+    )
+    assert any(
+        "focused_minireplay->aggregate_simple_replay handoff mismatch "
+        "on assignment_count: 184 != 183"
+        in error
+        for error in payload["validation_errors"]
+    )
+    assert any(
+        "aggregate_simple_replay->exhaustive_local_lemma handoff mismatch "
+        "on assignment_count: 183 != 184"
+        in error
+        for error in payload["validation_errors"]
     )
 
 


### PR DESCRIPTION
## What changed

- Added explicit adjacent handoff checks to `scripts/check_n9_vertex_circle_local_lemma_audit_path.py`.
- The audit-path JSON now reports four layer-to-layer checks across focused packet/catalog, focused mini-replay, aggregate/simple replay, exhaustive/local-lemma, and relation-skeleton/local-lemma layers.
- Updated focused tests and review-facing docs to explain the new drift-localization fields.

## Claim scope and evidence level

This is a `REVIEW_PENDING_DIAGNOSTIC` / audit-path hardening change only. It does not change the source-of-truth status, does not prove `n=9`, does not prove Erdos Problem #97, and does not claim a counterexample. The local `n <= 8` repo-local result and the review-pending status of the `n=9` artifacts are preserved.

## Commands run

- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1091 passed, 407 deselected`)
- `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
- `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`

`make verify-fast` was attempted but `make` is not installed in this Windows shell, so the raw fast tier was run directly.

## Artifacts generated or checked

No checked-in JSON artifact was regenerated. The PR checks the existing review-pending local-lemma packet and crosswalk artifacts as inputs through the audit-path chain.

## Known limitations / next review steps

- The new handoff checks localize count/schema drift between existing layers; they do not independently prove any layer's mathematical soundness.
- Packet soundness, mini-replay soundness, brancher coverage, strict-edge geometry review, quotient-soundness review, and full `n=9` review remain separate scopes.
- The original checkout at `C:\Users\User\Desktop\code\erdos97` remains dirty on stale branch `codex/d01`; this PR was created from a clean worktree based on `origin/main` to avoid disturbing that work.