### PR TITLE
[codex] Add C19 order CNF export diagnostic

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -368,6 +368,10 @@ Use this queue when no more specific issue is selected.
 5. Extend the Kalmanson template diagnostics toward order-search coverage:
    C13/C19 template records and C25/C29 availability records now exist, but
    they are not cyclic-order coverage or obstructions for the larger frontier.
+   The C19 order-CNF export
+   `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
+   gives a standard SAT target for the stored Z3 clauses, but the external
+   DRAT/LRAT or equivalent UNSAT replay is still open.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
    with an independent input-data replay. The current SymPy-free
    `n=8` replay command,
@@ -610,6 +614,7 @@ python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c
 python scripts/analyze_kalmanson_certificates.py
 python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
 python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
+python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json
 ```
 
 Expected artifacts:
@@ -626,6 +631,10 @@ Expected artifacts:
 - optional C25/C29 sparse-frontier template-availability diagnostics such as
   `scripts/analyze_kalmanson_sparse_frontier_templates.py`, kept separate from
   cyclic-order coverage or all-order obstruction claims.
+- optional order-CNF export diagnostics such as
+  `reports/c19_kalmanson_order_cnf_summary.json`, kept separate from any
+  solver-independent UNSAT proof claim until a DRAT/LRAT or equivalent proof
+  artifact is checked.
 
 Acceptance criteria:
 

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -116,6 +116,27 @@ This is an inspection aid for the already checked fixed abstract `C19_skew`
 all-order certificate. It is not an independent proof, not a statement about
 all C19-like patterns, and not a proof of Erdos Problem #97.
 
+## C19 Order-CNF Export
+
+The same stored C19 order clauses now have a DIMACS CNF export summary:
+
+```bash
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --assert-expected \
+  --check-artifact reports/c19_kalmanson_order_cnf_summary.json
+```
+
+The exporter does not call Z3 for the order-UNSAT step. It validates each
+stored forbidden ordered-quadrilateral pair as an exact inverse-pair clause,
+then encodes the rotation-fixed cyclic-order problem with pair-precedence
+variables, label-0 unit clauses, transitivity clauses, and the 7,981 stored
+forbidden-order clauses. The checked summary records the DIMACS header
+`p cnf 171 13813` and a deterministic SHA256 hash for the generated text.
+
+This is a replay target for a future DRAT/LRAT or equivalent proof artifact.
+It is not a solver-independent UNSAT proof by itself, and it does not alter the
+fixed-pattern scope of the C19 obstruction.
+
 ## C13/C19 Inverse-Pair Template Diagnostic
 
 The coefficient-template diagnostic

--- a/docs/kalmanson-two-order-search.md
+++ b/docs/kalmanson-two-order-search.md
@@ -110,6 +110,22 @@ two selected-distance classes against two selected-distance classes. This is
 template-mining guidance only; it does not transfer the fixed-pattern
 obstructions to arbitrary selected-witness systems.
 
+The C19 order-clause CNF export is:
+
+```bash
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --assert-expected \
+  --check-artifact reports/c19_kalmanson_order_cnf_summary.json
+```
+
+This checker validates the stored C19 forbidden ordered-quadrilateral pairs as
+exact inverse-pair clauses, then exports the same order problem as a DIMACS CNF
+target using pair-precedence variables and transitivity clauses. The checked
+summary records 171 variables, 13,813 clauses, and a deterministic SHA256 hash
+of the DIMACS text. This is a Z3-independent representation only; it is not yet
+a solver-independent UNSAT proof because no DRAT/LRAT or equivalent proof
+object is checked.
+
 ## Reproduction
 
 Regenerate the artifact:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -508,6 +508,9 @@ Review checklist:
 - the all-order UNSAT step is replayed by at least one Z3-independent route,
   such as a DIMACS/DRAT/LRAT proof, another SMT solver with a checkable proof,
   or a pure finite-order proof checker for the stored clauses;
+- `scripts/export_c19_kalmanson_order_cnf.py` now provides the DIMACS CNF
+  target and checked summary hash for that replay, but no DRAT/LRAT or
+  equivalent proof object is checked yet;
 - an UNSAT core alone is not treated as a proof object unless a separate
   checker verifies it;
 - the claim remains scoped to the fixed abstract `C19_skew` selected-witness

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -269,6 +269,42 @@ artifacts:
       - this diagnostic is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: c19_order_cnf_summary
+    path: reports/c19_kalmanson_order_cnf_summary.json
+    sha256: e05b758355299a4dce3038a759cb9bc19da715ed940f0da269d4990c466cb2ea
+    size_bytes: 2523
+    kind: certificate_diagnostic_artifact
+    generator: scripts/export_c19_kalmanson_order_cnf.py
+    command: python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --out reports/c19_kalmanson_order_cnf_summary.json
+    checker: scripts/export_c19_kalmanson_order_cnf.py
+    check_command: python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: EXACT_CERTIFICATE_DIAGNOSTIC
+    claim_scope: Z3-independent DIMACS encoding summary for the checked fixed abstract C19_skew Kalmanson order clauses.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.c19_kalmanson_order_cnf_summary.v1
+      trust: EXACT_CERTIFICATE_DIAGNOSTIC
+      status: C19_ORDER_CNF_EXPORT_DIAGNOSTIC_ONLY
+      source_certificate.pattern.name: C19_skew
+      source_certificate.status: EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION
+      encoding.format: DIMACS CNF
+      encoding.variable_count: 171
+      encoding.clause_count: 13813
+      encoding.transitivity_clause_count: 5814
+      encoding.forbidden_order_clause_count: 7981
+      validation.dimacs_header: p cnf 171 13813
+      validation.dimacs_sha256: dd4b8f429fea232bf09ff878342d7a28f4e9b6e743c99cd1b48f681d0f9ec450
+      provenance.command: python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --out reports/c19_kalmanson_order_cnf_summary.json
+    forbidden_claims:
+      - C19_skew proves Erdos Problem #97
+      - all C19-like patterns are impossible
+      - this closes the frontier
+      - this CNF export is an independent proof
+      - solver-independent UNSAT proof
+      - general proof of Erdos Problem #97
+
   - id: c19_compact_vs_legacy_diagnostic
     path: reports/c19_kalmanson_compact_vs_legacy.json
     sha256: 5bd877f2556d1d789d9a1810edd184d9d3ee2ddc1cf53d5a60c996b2a31bf17e

--- a/reports/c19_kalmanson_order_cnf_summary.json
+++ b/reports/c19_kalmanson_order_cnf_summary.json
@@ -1,0 +1,50 @@
+{
+  "claim_scope": "Z3-independent DIMACS encoding summary for the checked fixed abstract C19_skew Kalmanson order clauses. It validates the stored forbidden ordered-quadrilateral pairs and exports the order-CNF target for an external SAT proof replay. It does not include a DRAT/LRAT proof, does not prove Erdos Problem #97, does not claim a counterexample, and does not transfer the obstruction to other patterns.",
+  "encoding": {
+    "clause_count": 13813,
+    "forbidden_clause_semantics": "Each stored pair of ordered quadrilaterals contributes one six-literal clause forbidding both quadrilateral orders from appearing simultaneously.",
+    "forbidden_order_clause_count": 7981,
+    "format": "DIMACS CNF",
+    "reversal_quotient": "none",
+    "rotation_quotient": "label 0 is fixed first by unit clauses",
+    "transitivity_clause_count": 5814,
+    "unit_clause_count": 18,
+    "variable_count": 171,
+    "variable_semantics": "For 0 <= i < j < n, variable o_i_j is true exactly when label i precedes label j in the linear representative order."
+  },
+  "interpretation": "This artifact provides a deterministic SAT encoding target for the stored C19 order clauses. A solver-independent UNSAT result still needs a separately checked DRAT/LRAT proof or equivalent finite proof replay.",
+  "provenance": {
+    "command": "python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --out reports/c19_kalmanson_order_cnf_summary.json",
+    "generator": "scripts/export_c19_kalmanson_order_cnf.py"
+  },
+  "schema": "erdos97.c19_kalmanson_order_cnf_summary.v1",
+  "source_certificate": {
+    "forbidden_clause_count": 7981,
+    "path": "data/certificates/c19_skew_all_orders_kalmanson_z3.json",
+    "pattern": {
+      "circulant_offsets": [
+        -8,
+        -3,
+        5,
+        9
+      ],
+      "n": 19,
+      "name": "C19_skew"
+    },
+    "smt_solver": "z3",
+    "solver_result": "unsat",
+    "status": "EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION",
+    "trust": "SMT_EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
+    "type": "kalmanson_two_order_z3_refinement_v1"
+  },
+  "status": "C19_ORDER_CNF_EXPORT_DIAGNOSTIC_ONLY",
+  "trust": "EXACT_CERTIFICATE_DIAGNOSTIC",
+  "validation": {
+    "all_forbidden_clauses_validate_as_inverse_pairs": true,
+    "dimacs_header": "p cnf 171 13813",
+    "dimacs_line_count": 13817,
+    "dimacs_sha256": "dd4b8f429fea232bf09ff878342d7a28f4e9b6e743c99cd1b48f681d0f9ec450",
+    "parsed_forbidden_clause_count": 7981,
+    "unique_forbidden_clause_count": 7981
+  }
+}

--- a/scripts/export_c19_kalmanson_order_cnf.py
+++ b/scripts/export_c19_kalmanson_order_cnf.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Export the checked C19 order clauses to a Z3-independent DIMACS encoding.
+
+The stored C19 certificate already records exact forbidden ordered-quadrilateral
+pairs.  This script validates those pairs against the selected-distance
+quotient table and emits a standard CNF encoding of the cyclic-order problem:
+
+* one Boolean variable records the precedence direction for each unordered
+  label pair;
+* unit clauses fix label 0 as the first label, matching the stored rotation
+  quotient;
+* transitivity clauses force the precedence tournament to be a linear order;
+* each stored inverse-pair clause forbids the two ordered quadrilaterals from
+  appearing simultaneously.
+
+The generated CNF is a replay target for an external SAT proof checker.  This
+script does not prove UNSAT and does not prove Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_kalmanson_two_order_search import _prepare_vector_tables  # noqa: E402
+from erdos97.path_display import display_path  # noqa: E402
+
+
+Quad = tuple[int, int, int, int]
+Clause = tuple[Quad, Quad]
+
+SCHEMA = "erdos97.c19_kalmanson_order_cnf_summary.v1"
+STATUS = "C19_ORDER_CNF_EXPORT_DIAGNOSTIC_ONLY"
+TRUST = "EXACT_CERTIFICATE_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Z3-independent DIMACS encoding summary for the checked fixed abstract "
+    "C19_skew Kalmanson order clauses. It validates the stored forbidden "
+    "ordered-quadrilateral pairs and exports the order-CNF target for an "
+    "external SAT proof replay. It does not include a DRAT/LRAT proof, does "
+    "not prove Erdos Problem #97, does not claim a counterexample, and does "
+    "not transfer the obstruction to other patterns."
+)
+
+DEFAULT_CERTIFICATE = (
+    ROOT / "data" / "certificates" / "c19_skew_all_orders_kalmanson_z3.json"
+)
+DEFAULT_ARTIFACT = ROOT / "reports" / "c19_kalmanson_order_cnf_summary.json"
+DEFAULT_COMMAND = (
+    "python scripts/export_c19_kalmanson_order_cnf.py --assert-expected "
+    "--out reports/c19_kalmanson_order_cnf_summary.json"
+)
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _clause_key(left: Quad, right: Quad) -> Clause:
+    return (left, right) if left <= right else (right, left)
+
+
+def _parse_quad(raw: str) -> Quad:
+    labels = tuple(int(label) for label in raw.split(","))
+    if len(labels) != 4:
+        raise AssertionError(f"bad ordered quadrilateral: {raw!r}")
+    return labels  # type: ignore[return-value]
+
+
+def parse_clause(item: object) -> Clause:
+    if not isinstance(item, str):
+        raise AssertionError(f"forbidden clause must be a string: {item!r}")
+    parts = item.split("|")
+    if len(parts) != 2:
+        raise AssertionError(f"bad forbidden clause: {item!r}")
+    return _clause_key(_parse_quad(parts[0]), _parse_quad(parts[1]))
+
+
+def clause_is_valid(
+    clause: Clause,
+    quad_ids: Mapping[Quad, tuple[int, int]],
+    inverse_id: Sequence[int],
+) -> bool:
+    left, right = clause
+    left_ids = quad_ids[left]
+    right_ids = set(quad_ids[right])
+    return any(inverse_id[vector_id] in right_ids for vector_id in left_ids)
+
+
+def validate_clause(
+    clause: Clause,
+    *,
+    n: int,
+    quad_ids: Mapping[Quad, tuple[int, int]],
+    inverse_id: Sequence[int],
+) -> None:
+    for quad in clause:
+        if len(set(quad)) != 4:
+            raise AssertionError(f"bad clause quadrilateral: {quad}")
+        if any(label < 0 or label >= n for label in quad):
+            raise AssertionError(f"clause label out of range: {quad}")
+        if quad not in quad_ids:
+            raise AssertionError(f"unknown ordered quadrilateral: {quad}")
+    if not clause_is_valid(clause, quad_ids, inverse_id):
+        raise AssertionError(f"clause is not justified by an inverse pair: {clause}")
+
+
+def pair_variable(a: int, b: int, n: int) -> int:
+    """Return the 1-based variable id for the unordered label pair {a,b}."""
+
+    if a == b:
+        raise ValueError("pair_variable needs distinct labels")
+    i, j = sorted((a, b))
+    variable = 1
+    for left in range(i):
+        variable += n - left - 1
+    variable += j - i - 1
+    return variable
+
+
+def before_literal(a: int, b: int, n: int) -> int:
+    """Return the literal meaning label ``a`` precedes label ``b``."""
+
+    variable = pair_variable(a, b, n)
+    return variable if a < b else -variable
+
+
+def transitivity_clauses(n: int) -> list[list[int]]:
+    clauses: list[list[int]] = []
+    for a in range(n):
+        for b in range(n):
+            if b == a:
+                continue
+            for c in range(n):
+                if c == a or c == b:
+                    continue
+                clauses.append(
+                    [
+                        -before_literal(a, b, n),
+                        -before_literal(b, c, n),
+                        before_literal(a, c, n),
+                    ]
+                )
+    return clauses
+
+
+def unit_clauses(n: int) -> list[list[int]]:
+    return [[before_literal(0, label, n)] for label in range(1, n)]
+
+
+def forbidden_cnf_clause(clause: Clause, n: int) -> list[int]:
+    literals: list[int] = []
+    for quad in clause:
+        literals.extend(
+            [
+                -before_literal(quad[0], quad[1], n),
+                -before_literal(quad[1], quad[2], n),
+                -before_literal(quad[2], quad[3], n),
+            ]
+        )
+    return literals
+
+
+def dimacs_text(n: int, forbidden: Sequence[Clause]) -> str:
+    units = unit_clauses(n)
+    transitivity = transitivity_clauses(n)
+    forbidden_clauses = [forbidden_cnf_clause(clause, n) for clause in forbidden]
+    clauses = units + transitivity + forbidden_clauses
+    lines = [
+        "c C19_skew Kalmanson order-CNF export",
+        "c variable o_i_j with i<j is true iff label i precedes label j",
+        "c label 0 is fixed first by unit clauses",
+        f"p cnf {n * (n - 1) // 2} {len(clauses)}",
+    ]
+    lines.extend(" ".join(str(literal) for literal in clause) + " 0" for clause in clauses)
+    return "\n".join(lines) + "\n"
+
+
+def source_clauses(payload: Mapping[str, Any]) -> tuple[dict[str, Any], list[Clause]]:
+    pattern = payload.get("pattern")
+    if not isinstance(pattern, dict):
+        raise AssertionError("pattern must be an object")
+    raw_clauses = payload.get("forbidden_order_pairs")
+    if not isinstance(raw_clauses, list):
+        raise AssertionError("forbidden_order_pairs must be a list")
+    clauses = [parse_clause(item) for item in raw_clauses]
+    if len(set(clauses)) != len(clauses):
+        raise AssertionError("duplicate forbidden order clauses")
+    return pattern, clauses
+
+
+def diagnostic_payload(certificate: Path = DEFAULT_CERTIFICATE) -> dict[str, Any]:
+    raw_payload = load_json(certificate)
+    if not isinstance(raw_payload, dict):
+        raise TypeError("source certificate must be a JSON object")
+    pattern, clauses = source_clauses(raw_payload)
+    name = str(pattern["name"])
+    n = int(pattern["n"])
+    offsets = [int(offset) for offset in pattern["circulant_offsets"]]
+    quad_ids, inverse_id = _prepare_vector_tables(n, offsets)
+    for clause in clauses:
+        validate_clause(clause, n=n, quad_ids=quad_ids, inverse_id=inverse_id)
+
+    dimacs = dimacs_text(n, clauses)
+    unit_count = n - 1
+    transitivity_count = n * (n - 1) * (n - 2)
+    forbidden_count = len(clauses)
+    variable_count = n * (n - 1) // 2
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "source_certificate": {
+            "path": display_path(certificate, ROOT),
+            "type": raw_payload.get("type"),
+            "status": raw_payload.get("status"),
+            "trust": raw_payload.get("trust"),
+            "solver_result": raw_payload.get("solver_result"),
+            "smt_solver": raw_payload.get("smt_solver"),
+            "forbidden_clause_count": raw_payload.get("forbidden_clause_count"),
+            "pattern": {
+                "name": name,
+                "n": n,
+                "circulant_offsets": offsets,
+            },
+        },
+        "encoding": {
+            "format": "DIMACS CNF",
+            "variable_count": variable_count,
+            "clause_count": unit_count + transitivity_count + forbidden_count,
+            "unit_clause_count": unit_count,
+            "transitivity_clause_count": transitivity_count,
+            "forbidden_order_clause_count": forbidden_count,
+            "rotation_quotient": "label 0 is fixed first by unit clauses",
+            "reversal_quotient": "none",
+            "variable_semantics": (
+                "For 0 <= i < j < n, variable o_i_j is true exactly when "
+                "label i precedes label j in the linear representative order."
+            ),
+            "forbidden_clause_semantics": (
+                "Each stored pair of ordered quadrilaterals contributes one "
+                "six-literal clause forbidding both quadrilateral orders from "
+                "appearing simultaneously."
+            ),
+        },
+        "validation": {
+            "parsed_forbidden_clause_count": len(clauses),
+            "unique_forbidden_clause_count": len(set(clauses)),
+            "all_forbidden_clauses_validate_as_inverse_pairs": True,
+            "dimacs_sha256": hashlib.sha256(dimacs.encode("utf-8")).hexdigest(),
+            "dimacs_line_count": dimacs.count("\n"),
+            "dimacs_header": f"p cnf {variable_count} "
+            f"{unit_count + transitivity_count + forbidden_count}",
+        },
+        "interpretation": (
+            "This artifact provides a deterministic SAT encoding target for "
+            "the stored C19 order clauses. A solver-independent UNSAT result "
+            "still needs a separately checked DRAT/LRAT proof or equivalent "
+            "finite proof replay."
+        ),
+        "provenance": {
+            "generator": "scripts/export_c19_kalmanson_order_cnf.py",
+            "command": DEFAULT_COMMAND,
+        },
+    }
+
+
+def assert_expected(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: {payload.get(key)!r}")
+
+    source = payload.get("source_certificate")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_certificate must be an object")
+    expected_source = {
+        "path": "data/certificates/c19_skew_all_orders_kalmanson_z3.json",
+        "type": "kalmanson_two_order_z3_refinement_v1",
+        "status": "EXACT_ALL_ORDER_TWO_INEQUALITY_KALMANSON_OBSTRUCTION",
+        "trust": "SMT_EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",
+        "solver_result": "unsat",
+        "smt_solver": "z3",
+        "forbidden_clause_count": 7981,
+        "pattern": {
+            "name": "C19_skew",
+            "n": 19,
+            "circulant_offsets": [-8, -3, 5, 9],
+        },
+    }
+    for key, expected in expected_source.items():
+        if source.get(key) != expected:
+            raise AssertionError(f"source_certificate[{key!r}] mismatch")
+
+    encoding = payload.get("encoding")
+    if not isinstance(encoding, Mapping):
+        raise AssertionError("encoding must be an object")
+    expected_encoding = {
+        "format": "DIMACS CNF",
+        "variable_count": 171,
+        "clause_count": 13813,
+        "unit_clause_count": 18,
+        "transitivity_clause_count": 5814,
+        "forbidden_order_clause_count": 7981,
+        "rotation_quotient": "label 0 is fixed first by unit clauses",
+        "reversal_quotient": "none",
+    }
+    for key, expected in expected_encoding.items():
+        if encoding.get(key) != expected:
+            raise AssertionError(f"encoding[{key!r}] mismatch: {encoding.get(key)!r}")
+
+    validation = payload.get("validation")
+    if not isinstance(validation, Mapping):
+        raise AssertionError("validation must be an object")
+    expected_validation = {
+        "parsed_forbidden_clause_count": 7981,
+        "unique_forbidden_clause_count": 7981,
+        "all_forbidden_clauses_validate_as_inverse_pairs": True,
+        "dimacs_sha256": "dd4b8f429fea232bf09ff878342d7a28f4e9b6e743c99cd1b48f681d0f9ec450",
+        "dimacs_line_count": 13817,
+        "dimacs_header": "p cnf 171 13813",
+    }
+    for key, expected in expected_validation.items():
+        if validation.get(key) != expected:
+            raise AssertionError(f"validation[{key!r}] mismatch: {validation.get(key)!r}")
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping) or provenance.get("command") != DEFAULT_COMMAND:
+        raise AssertionError("provenance command changed")
+    for forbidden in (
+        "does not include a DRAT/LRAT proof",
+        "does not prove Erdos Problem #97",
+        "does not claim a counterexample",
+        "does not transfer the obstruction to other patterns",
+    ):
+        if forbidden not in str(payload.get("claim_scope", "")):
+            raise AssertionError(f"claim_scope missing {forbidden!r}")
+
+
+def check_artifact(path: Path, payload: Mapping[str, Any]) -> None:
+    artifact = load_json(path)
+    if artifact != payload:
+        raise AssertionError(f"{display_path(path, ROOT)} does not match regenerated payload")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--certificate", type=Path, default=DEFAULT_CERTIFICATE)
+    parser.add_argument("--out", type=Path, help="write JSON summary to this path")
+    parser.add_argument("--write-cnf", type=Path, help="write DIMACS CNF to this path")
+    parser.add_argument("--check-artifact", type=Path)
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    certificate = args.certificate if args.certificate.is_absolute() else ROOT / args.certificate
+    payload = diagnostic_payload(certificate)
+    if args.assert_expected:
+        assert_expected(payload)
+    if args.check_artifact:
+        artifact = args.check_artifact if args.check_artifact.is_absolute() else ROOT / args.check_artifact
+        check_artifact(artifact, payload)
+    if args.out:
+        out = args.out if args.out.is_absolute() else ROOT / args.out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.write_cnf:
+        raw_payload = load_json(certificate)
+        _, clauses = source_clauses(raw_payload)
+        cnf = dimacs_text(int(raw_payload["pattern"]["n"]), clauses)
+        cnf_path = args.write_cnf if args.write_cnf.is_absolute() else ROOT / args.write_cnf
+        cnf_path.parent.mkdir(parents=True, exist_ok=True)
+        cnf_path.write_text(cnf, encoding="utf-8", newline="\n")
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        encoding = payload["encoding"]
+        validation = payload["validation"]
+        print("C19 Kalmanson order-CNF export")
+        print(f"variables: {encoding['variable_count']}")
+        print(f"clauses: {encoding['clause_count']}")
+        print(f"dimacs sha256: {validation['dimacs_sha256']}")
+        if args.assert_expected:
+            print("OK: C19 order-CNF summary matches expected values")
+        if args.check_artifact:
+            print(f"OK: {display_path(args.check_artifact, ROOT)} matches regenerated payload")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -123,6 +123,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         claim_scope="Structural diagnostic for the C19_skew all-order Z3 clauses only.",
     ),
     AuditCommand(
+        ident="c19_order_cnf_summary",
+        command=(
+            "python",
+            "scripts/export_c19_kalmanson_order_cnf.py",
+            "--assert-expected",
+            "--check-artifact",
+            "reports/c19_kalmanson_order_cnf_summary.json",
+        ),
+        claim_scope=(
+            "Z3-independent DIMACS encoding summary for the stored C19_skew "
+            "order clauses; replay target only, not a solver-independent "
+            "UNSAT proof or proof of Erdos Problem #97."
+        ),
+    ),
+    AuditCommand(
         ident="c13_fixed_order_compact_kalmanson",
         command=(
             "python",

--- a/tests/test_c19_kalmanson_order_cnf.py
+++ b/tests/test_c19_kalmanson_order_cnf.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.export_c19_kalmanson_order_cnf import (
+    DEFAULT_ARTIFACT,
+    assert_expected,
+    before_literal,
+    check_artifact,
+    diagnostic_payload,
+    dimacs_text,
+    pair_variable,
+    source_clauses,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
+
+
+def test_c19_kalmanson_order_cnf_summary_matches_artifact() -> None:
+    payload = diagnostic_payload()
+
+    assert_expected(payload)
+    check_artifact(DEFAULT_ARTIFACT, payload)
+    assert payload["source_certificate"]["pattern"] == {
+        "circulant_offsets": [-8, -3, 5, 9],
+        "n": 19,
+        "name": "C19_skew",
+    }
+    assert payload["encoding"]["variable_count"] == 171
+    assert payload["encoding"]["clause_count"] == 13813
+    assert payload["encoding"]["transitivity_clause_count"] == 5814
+    assert payload["validation"]["dimacs_header"] == "p cnf 171 13813"
+    assert payload["validation"]["dimacs_sha256"] == (
+        "dd4b8f429fea232bf09ff878342d7a28f4e9b6e743c99cd1b48f681d0f9ec450"
+    )
+
+
+def test_c19_kalmanson_order_cnf_literal_mapping() -> None:
+    assert pair_variable(0, 1, 19) == 1
+    assert pair_variable(0, 18, 19) == 18
+    assert pair_variable(1, 2, 19) == 19
+    assert before_literal(0, 18, 19) == 18
+    assert before_literal(18, 0, 19) == -18
+
+
+def test_c19_kalmanson_order_cnf_dimacs_shape() -> None:
+    certificate = json.loads(
+        (ROOT / "data/certificates/c19_skew_all_orders_kalmanson_z3.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    _, clauses = source_clauses(certificate)
+    dimacs = dimacs_text(19, clauses)
+    lines = dimacs.splitlines()
+
+    assert lines[3] == "p cnf 171 13813"
+    assert lines[4] == "1 0"
+    assert lines[21] == "18 0"
+    assert len(lines) == 13817
+
+
+def test_c19_kalmanson_order_cnf_rejects_tampering() -> None:
+    payload = diagnostic_payload()
+    payload["validation"]["dimacs_sha256"] = "0" * 64
+
+    try:
+        assert_expected(payload)
+    except AssertionError as exc:
+        assert "dimacs_sha256" in str(exc)
+    else:  # pragma: no cover - defensive assertion shape
+        raise AssertionError("tampered CNF summary unexpectedly passed")
+
+
+def test_c19_kalmanson_order_cnf_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/export_c19_kalmanson_order_cnf.py",
+            "--assert-expected",
+            "--check-artifact",
+            "reports/c19_kalmanson_order_cnf_summary.json",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "C19_ORDER_CNF_EXPORT_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "EXACT_CERTIFICATE_DIAGNOSTIC"


### PR DESCRIPTION
## What changed

- Added `scripts/export_c19_kalmanson_order_cnf.py`, which validates the stored C19 forbidden ordered-quadrilateral pairs as exact inverse-pair clauses and emits a deterministic DIMACS CNF encoding summary.
- Added the checked summary artifact `reports/c19_kalmanson_order_cnf_summary.json` with 171 variables, 13,813 clauses, and the generated DIMACS SHA256 hash.
- Registered the new generated artifact in `metadata/generated_artifacts.yaml` and added the checker to `scripts/run_artifact_audit.py`.
- Updated the Kalmanson docs, review priorities, and Codex backlog to state that this is a CNF replay target only.
- Added focused artifact tests for the CNF exporter, mapping, artifact comparison, tamper rejection, and CLI path.

## Claim scope and evidence level

This is `EXACT_CERTIFICATE_DIAGNOSTIC` / SAT-encoding infrastructure for the fixed abstract `C19_skew` Kalmanson order clauses only. It does not prove Erdos Problem #97, does not claim a counterexample, does not prove all C19-like patterns are impossible, and does not provide a solver-independent UNSAT proof. The official/global status remains falsifiable/open; the local `n <= 8` source-of-truth result and review-pending `n=9` artifacts are unchanged.

## Commands run

- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --out reports/c19_kalmanson_order_cnf_summary.json`
- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json --json`
- `python -m pytest tests/test_c19_kalmanson_order_cnf.py -q -m artifact` (`5 passed`)
- `python -m pytest tests/test_run_artifact_audit.py tests/test_c19_kalmanson_order_cnf.py -q -m "artifact or not artifact"` (`9 passed`)
- `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
- `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1091 passed, 413 deselected`)

## Artifacts generated or checked

- Generated and checked `reports/c19_kalmanson_order_cnf_summary.json`.
- Checked the source C19 Z3 certificate `data/certificates/c19_skew_all_orders_kalmanson_z3.json`.
- Checked the existing C19 clause diagnostic `reports/c19_kalmanson_z3_clause_diagnostics.json`.
- Updated `metadata/generated_artifacts.yaml` so the new report is covered by artifact provenance and audit-command tests.

## Known limitations / next review steps

- The DIMACS CNF is a replay target, not an UNSAT proof object.
- The next trust-reduction step is to produce and check a DRAT/LRAT proof, or an equivalent finite proof replay, for the exported CNF.
- The result remains scoped to the fixed abstract `C19_skew` selected-witness pattern and does not transfer to arbitrary selected-witness systems.