### PR TITLE
[codex] Add C19 CNF roundtrip check

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -371,7 +371,8 @@ Use this queue when no more specific issue is selected.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external
-   DRAT/LRAT or equivalent UNSAT replay is still open.
+   DRAT/LRAT or equivalent UNSAT replay is still open. The same script can
+   round-trip an external CNF file with `--write-cnf` and `--check-cnf`.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
    with an independent input-data replay. The current SymPy-free
    `n=8` replay command,

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -132,6 +132,16 @@ then encodes the rotation-fixed cyclic-order problem with pair-precedence
 variables, label-0 unit clauses, transitivity clauses, and the 7,981 stored
 forbidden-order clauses. The checked summary records the DIMACS header
 `p cnf 171 13813` and a deterministic SHA256 hash for the generated text.
+For external SAT-proof experiments, write and round-trip check the concrete CNF
+file with:
+
+```bash
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --write-cnf reports/c19_kalmanson_order.cnf
+
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --check-cnf reports/c19_kalmanson_order.cnf
+```
 
 This is a replay target for a future DRAT/LRAT or equivalent proof artifact.
 It is not a solver-independent UNSAT proof by itself, and it does not alter the

--- a/docs/kalmanson-two-order-search.md
+++ b/docs/kalmanson-two-order-search.md
@@ -126,6 +126,16 @@ of the DIMACS text. This is a Z3-independent representation only; it is not yet
 a solver-independent UNSAT proof because no DRAT/LRAT or equivalent proof
 object is checked.
 
+The same script can write and recheck the generated DIMACS file byte-for-byte:
+
+```bash
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --write-cnf reports/c19_kalmanson_order.cnf
+
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --check-cnf reports/c19_kalmanson_order.cnf
+```
+
 ## Reproduction
 
 Regenerate the artifact:

--- a/scripts/export_c19_kalmanson_order_cnf.py
+++ b/scripts/export_c19_kalmanson_order_cnf.py
@@ -356,11 +356,32 @@ def check_artifact(path: Path, payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"{display_path(path, ROOT)} does not match regenerated payload")
 
 
+def dimacs_from_certificate(certificate: Path) -> str:
+    raw_payload = load_json(certificate)
+    if not isinstance(raw_payload, dict):
+        raise TypeError("source certificate must be a JSON object")
+    pattern, clauses = source_clauses(raw_payload)
+    return dimacs_text(int(pattern["n"]), clauses)
+
+
+def check_cnf(path: Path, expected_dimacs: str) -> None:
+    actual = path.read_bytes()
+    expected = expected_dimacs.encode("utf-8")
+    if actual != expected:
+        actual_hash = hashlib.sha256(actual).hexdigest()
+        expected_hash = hashlib.sha256(expected).hexdigest()
+        raise AssertionError(
+            f"{display_path(path, ROOT)} does not match generated DIMACS "
+            f"(actual {actual_hash}, expected {expected_hash})"
+        )
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--certificate", type=Path, default=DEFAULT_CERTIFICATE)
     parser.add_argument("--out", type=Path, help="write JSON summary to this path")
     parser.add_argument("--write-cnf", type=Path, help="write DIMACS CNF to this path")
+    parser.add_argument("--check-cnf", type=Path, help="compare this DIMACS file to generated text")
     parser.add_argument("--check-artifact", type=Path)
     parser.add_argument("--assert-expected", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -384,13 +405,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             encoding="utf-8",
             newline="\n",
         )
+    if args.write_cnf or args.check_cnf:
+        cnf = dimacs_from_certificate(certificate)
     if args.write_cnf:
-        raw_payload = load_json(certificate)
-        _, clauses = source_clauses(raw_payload)
-        cnf = dimacs_text(int(raw_payload["pattern"]["n"]), clauses)
         cnf_path = args.write_cnf if args.write_cnf.is_absolute() else ROOT / args.write_cnf
         cnf_path.parent.mkdir(parents=True, exist_ok=True)
         cnf_path.write_text(cnf, encoding="utf-8", newline="\n")
+    if args.check_cnf:
+        cnf_path = args.check_cnf if args.check_cnf.is_absolute() else ROOT / args.check_cnf
+        check_cnf(cnf_path, cnf)
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
@@ -404,6 +427,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("OK: C19 order-CNF summary matches expected values")
         if args.check_artifact:
             print(f"OK: {display_path(args.check_artifact, ROOT)} matches regenerated payload")
+        if args.check_cnf:
+            print(f"OK: {display_path(args.check_cnf, ROOT)} matches generated DIMACS")
     return 0
 
 

--- a/tests/test_c19_kalmanson_order_cnf.py
+++ b/tests/test_c19_kalmanson_order_cnf.py
@@ -11,8 +11,10 @@ from scripts.export_c19_kalmanson_order_cnf import (
     DEFAULT_ARTIFACT,
     assert_expected,
     before_literal,
+    check_cnf,
     check_artifact,
     diagnostic_payload,
+    dimacs_from_certificate,
     dimacs_text,
     pair_variable,
     source_clauses,
@@ -51,19 +53,37 @@ def test_c19_kalmanson_order_cnf_literal_mapping() -> None:
 
 
 def test_c19_kalmanson_order_cnf_dimacs_shape() -> None:
-    certificate = json.loads(
-        (ROOT / "data/certificates/c19_skew_all_orders_kalmanson_z3.json").read_text(
-            encoding="utf-8"
-        )
-    )
+    certificate_path = ROOT / "data/certificates/c19_skew_all_orders_kalmanson_z3.json"
+    certificate = json.loads(certificate_path.read_text(encoding="utf-8"))
     _, clauses = source_clauses(certificate)
-    dimacs = dimacs_text(19, clauses)
+    dimacs = dimacs_from_certificate(certificate_path)
     lines = dimacs.splitlines()
 
+    assert dimacs == dimacs_text(19, clauses)
     assert lines[3] == "p cnf 171 13813"
     assert lines[4] == "1 0"
     assert lines[21] == "18 0"
     assert len(lines) == 13817
+
+
+def test_c19_kalmanson_order_cnf_roundtrip_file(tmp_path: Path) -> None:
+    certificate = ROOT / "data/certificates/c19_skew_all_orders_kalmanson_z3.json"
+    cnf_path = tmp_path / "c19.cnf"
+    cnf_path.write_text(dimacs_from_certificate(certificate), encoding="utf-8", newline="\n")
+
+    check_cnf(cnf_path, dimacs_from_certificate(certificate))
+
+
+def test_c19_kalmanson_order_cnf_rejects_tampered_cnf(tmp_path: Path) -> None:
+    cnf_path = tmp_path / "bad.cnf"
+    cnf_path.write_text("p cnf 1 0\n", encoding="utf-8", newline="\n")
+
+    try:
+        check_cnf(cnf_path, "p cnf 1 1\n1 0\n")
+    except AssertionError as exc:
+        assert "does not match generated DIMACS" in str(exc)
+    else:  # pragma: no cover - defensive assertion shape
+        raise AssertionError("tampered CNF unexpectedly passed")
 
 
 def test_c19_kalmanson_order_cnf_rejects_tampering() -> None:
@@ -99,3 +119,39 @@ def test_c19_kalmanson_order_cnf_cli_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["status"] == "C19_ORDER_CNF_EXPORT_DIAGNOSTIC_ONLY"
     assert payload["trust"] == "EXACT_CERTIFICATE_DIAGNOSTIC"
+
+
+def test_c19_kalmanson_order_cnf_cli_write_and_check_cnf(tmp_path: Path) -> None:
+    cnf_path = tmp_path / "c19.cnf"
+
+    write_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/export_c19_kalmanson_order_cnf.py",
+            "--write-cnf",
+            str(cnf_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert write_result.returncode == 0
+    assert write_result.stderr == ""
+    assert cnf_path.exists()
+
+    check_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/export_c19_kalmanson_order_cnf.py",
+            "--check-cnf",
+            str(cnf_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert check_result.returncode == 0
+    assert check_result.stderr == ""
+    assert "matches generated DIMACS" in check_result.stdout


### PR DESCRIPTION
## What changed

- Added `--check-cnf` to `scripts/export_c19_kalmanson_order_cnf.py` so a DIMACS file written by `--write-cnf` can be checked byte-for-byte against the deterministic exporter.
- Factored CNF generation into `dimacs_from_certificate` and added `check_cnf` with SHA256 diagnostics on mismatch.
- Expanded artifact tests to cover the round-trip helper, tampered CNF rejection, and CLI `--write-cnf`/`--check-cnf` flow.
- Updated the C19 Kalmanson docs and backlog to show the external CNF write/check workflow.

## Claim scope and evidence level

This remains `EXACT_CERTIFICATE_DIAGNOSTIC` infrastructure for the fixed abstract `C19_skew` Kalmanson order clauses only. It makes the DIMACS replay target easier to use and verify locally, but it does not provide a DRAT/LRAT proof, does not prove solver-independent UNSAT, does not prove Erdos Problem #97, and does not claim a counterexample. The official/global status and all finite-case source-of-truth scopes are unchanged.

## Commands run

- `python -m ruff check scripts/export_c19_kalmanson_order_cnf.py tests/test_c19_kalmanson_order_cnf.py`
- `python -m pytest tests/test_c19_kalmanson_order_cnf.py -q -m artifact` (`8 passed`)
- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat`
- `python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json`
- `python -m pytest -q` (`1091 passed, 416 deselected`)

## Artifacts generated or checked

No checked-in artifact was regenerated. The existing `reports/c19_kalmanson_order_cnf_summary.json`, source C19 Z3 certificate, and C19 clause diagnostic were checked as inputs. The new `--write-cnf`/`--check-cnf` path is tested with temporary files rather than checking in the large DIMACS file.

## Known limitations / next review steps

- This still does not check an UNSAT proof object.
- The next step remains generating and validating a DRAT/LRAT proof, or an equivalent finite proof replay, for the exported CNF.
- The result remains scoped to fixed abstract `C19_skew` and does not transfer to arbitrary selected-witness systems.