### PR TITLE
Document C19 CNF proof tooling blocker

### DIFF
--- a/docs/c19-order-cnf-proof-tooling.md
+++ b/docs/c19-order-cnf-proof-tooling.md
@@ -1,0 +1,68 @@
+# C19 Order-CNF Proof Tooling Probe
+
+Status: `TOOLING_BLOCKER_DIAGNOSTIC`.
+
+This note records the local tooling state for turning the checked
+`C19_skew` order-CNF export into a solver-independent proof replay. It is an
+environment and workflow note only. It does not add a mathematical
+obstruction, does not prove Erdos Problem #97, and does not claim a
+counterexample.
+
+## Scope
+
+The relevant checked inputs are:
+
+- `data/certificates/c19_skew_all_orders_kalmanson_z3.json`
+- `reports/c19_kalmanson_order_cnf_summary.json`
+- `scripts/export_c19_kalmanson_order_cnf.py`
+
+The exporter can write and byte-check the DIMACS target:
+
+```bash
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --write-cnf reports/c19_kalmanson_order.cnf
+
+python scripts/export_c19_kalmanson_order_cnf.py \
+  --check-cnf reports/c19_kalmanson_order.cnf
+```
+
+The generated CNF is only a proof target. A solver-independent claim still
+requires a checked proof object such as DRAT, LRAT, or an equivalent finite
+replay certificate.
+
+## Local Tooling Probe
+
+The local Windows checkout currently has no command-line SAT proof toolchain
+available on `PATH` for this step:
+
+```text
+where.exe kissat     -> not found
+where.exe cadical    -> not found
+where.exe drat-trim  -> not found
+where.exe lrat-check -> not found
+```
+
+The Python package probe found:
+
+```text
+pysat False
+z3 True
+```
+
+Thus the current local environment can replay the stored Z3 certificate, but
+it cannot yet generate and independently check a DRAT/LRAT proof for the
+exported CNF.
+
+## Next Step
+
+The next reproducible proof-tooling increment should add one of:
+
+- a checked external SAT proof workflow, for example a pinned `kissat` or
+  `cadical` command plus a pinned DRAT/LRAT checker;
+- a checked proof artifact for `reports/c19_kalmanson_order.cnf`, with the CNF
+  regenerated and byte-checked before proof validation;
+- a pure finite-order proof checker for the stored forbidden clauses that does
+  not call Z3.
+
+Until one of those exists, the C19 all-order obstruction remains a checked Z3
+certificate with a standard CNF replay target, not a solver-independent proof.

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,9 @@ put detailed reconciliation in the canonical synthesis.
   deterministic support diagnostics for the checked C13 and C19 fixed-order
   Kalmanson/Farkas certificates, plus the C19 all-order Z3 clause-template
   diagnostic.
+- [`c19-order-cnf-proof-tooling.md`](c19-order-cnf-proof-tooling.md):
+  local tooling blocker note for turning the C19 order-CNF export into a
+  DRAT/LRAT or equivalent solver-independent proof replay.
 - [`kalmanson-two-order-search.md`](kalmanson-two-order-search.md): exact
   all-cyclic-order two-inequality Kalmanson obstruction for the fixed C13 Sidon
   and C19 skew patterns.


### PR DESCRIPTION
## What changed

- Added `docs/c19-order-cnf-proof-tooling.md`, a local tooling blocker note for turning the checked C19 order-CNF export into a solver-independent DRAT/LRAT or equivalent proof replay.
- Linked the note from `docs/index.md` near the C19 Kalmanson diagnostics and two-order search documentation.

## Claim scope and evidence level

- Documentation/provenance increment only.
- Records local tool availability: no `kissat`, `cadical`, `drat-trim`, or `lrat-check` on PATH for this environment; Python probe found `pysat False` and `z3 True`.
- Does not claim a general proof, a counterexample, or a solver-independent C19 proof.
- Preserves the repo status: global/official problem remains open/falsifiable; `n <= 8` remains repo-local and machine-checked; `n=9` artifacts remain review-pending.

## Commands run

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
- `python -m pytest -q` (`1091 passed, 416 deselected`)

## Artifacts generated or checked

- Checked existing `reports/c19_kalmanson_order_cnf_summary.json` against the deterministic C19 order-CNF exporter.
- No new generated artifacts.

## Known limitations / next review steps

- The note documents a current local blocker rather than removing it.
- A future increment should add a pinned SAT proof workflow, a checked DRAT/LRAT-style proof artifact, or a pure finite-order proof checker that does not call Z3.