### PR TITLE
Add C19 proof tooling probe

### DIFF
--- a/docs/c19-order-cnf-proof-tooling.md
+++ b/docs/c19-order-cnf-proof-tooling.md
@@ -32,6 +32,17 @@ replay certificate.
 
 ## Local Tooling Probe
 
+The reusable local probe is:
+
+```bash
+python scripts/probe_c19_proof_tooling.py --json
+```
+
+It reports executable availability, Python module availability, and whether
+the local environment has at least one supported SAT solver plus one supported
+proof checker for a solver-independent C19 CNF replay. This is still an
+environment diagnostic only.
+
 The local Windows checkout currently has no command-line SAT proof toolchain
 available on `PATH` for this step:
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -373,6 +373,10 @@ Use this queue when no more specific issue is selected.
    gives a standard SAT target for the stored Z3 clauses, but the external
    DRAT/LRAT or equivalent UNSAT replay is still open. The same script can
    round-trip an external CNF file with `--write-cnf` and `--check-cnf`.
+   The local proof-tooling environment probe
+   `python scripts/probe_c19_proof_tooling.py --json` records whether a
+   supported SAT solver/checker pair is available, but this is environment
+   bookkeeping only and not proof evidence.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
    with an independent input-data replay. The current SymPy-free
    `n=8` replay command,
@@ -616,6 +620,7 @@ python scripts/analyze_kalmanson_certificates.py
 python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
 python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json
+python scripts/probe_c19_proof_tooling.py --json
 ```
 
 Expected artifacts:
@@ -636,6 +641,9 @@ Expected artifacts:
   `reports/c19_kalmanson_order_cnf_summary.json`, kept separate from any
   solver-independent UNSAT proof claim until a DRAT/LRAT or equivalent proof
   artifact is checked.
+- optional local proof-tooling environment probes such as
+  `scripts/probe_c19_proof_tooling.py`, kept separate from mathematical
+  evidence and from any solver-independent proof claim.
 
 Acceptance criteria:
 

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -147,6 +147,16 @@ This is a replay target for a future DRAT/LRAT or equivalent proof artifact.
 It is not a solver-independent UNSAT proof by itself, and it does not alter the
 fixed-pattern scope of the C19 obstruction.
 
+The local proof-tooling environment can be probed with:
+
+```bash
+python scripts/probe_c19_proof_tooling.py --json
+```
+
+That probe reports local solver/checker availability only. It is not a proof
+replay and does not promote the all-order Z3 certificate to a
+solver-independent proof object.
+
 ## C13/C19 Inverse-Pair Template Diagnostic
 
 The coefficient-template diagnostic

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -511,6 +511,9 @@ Review checklist:
 - `scripts/export_c19_kalmanson_order_cnf.py` now provides the DIMACS CNF
   target and checked summary hash for that replay, but no DRAT/LRAT or
   equivalent proof object is checked yet;
+- `scripts/probe_c19_proof_tooling.py --json` records whether the local
+  environment has a supported SAT proof solver/checker pair, but it is an
+  environment diagnostic only and not proof evidence;
 - an UNSAT core alone is not treated as a proof object unless a separate
   checker verifies it;
 - the claim remains scoped to the fixed abstract `C19_skew` selected-witness

--- a/scripts/probe_c19_proof_tooling.py
+++ b/scripts/probe_c19_proof_tooling.py
@@ -49,7 +49,11 @@ def _module_payload(
 ) -> dict[str, dict[str, bool]]:
     modules: dict[str, dict[str, bool]] = {}
     for name in module_names:
-        modules[name] = {"found": find_spec(name) is not None}
+        try:
+            found = find_spec(name) is not None
+        except (ImportError, AttributeError, ValueError):
+            found = False
+        modules[name] = {"found": found}
     return modules
 
 

--- a/scripts/probe_c19_proof_tooling.py
+++ b/scripts/probe_c19_proof_tooling.py
@@ -1,0 +1,214 @@
+"""Probe local tooling for C19 order-CNF proof replay experiments.
+
+This is an environment diagnostic only. It does not check a mathematical
+certificate, prove UNSAT, or alter the status of any Erdos Problem #97 claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_COMMANDS = ("kissat", "cadical", "drat-trim", "lrat-check")
+DEFAULT_MODULES = ("pysat", "z3")
+SAT_SOLVER_COMMANDS = ("kissat", "cadical")
+PROOF_CHECKER_COMMANDS = ("drat-trim", "lrat-check")
+
+
+def dedupe(items: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return tuple(result)
+
+
+def _command_payload(
+    command_names: Sequence[str],
+    which: Callable[[str], str | None],
+) -> dict[str, dict[str, str | bool | None]]:
+    commands: dict[str, dict[str, str | bool | None]] = {}
+    for name in command_names:
+        path = which(name)
+        commands[name] = {"found": path is not None, "path": path}
+    return commands
+
+
+def _module_payload(
+    module_names: Sequence[str],
+    find_spec: Callable[[str], Any],
+) -> dict[str, dict[str, bool]]:
+    modules: dict[str, dict[str, bool]] = {}
+    for name in module_names:
+        modules[name] = {"found": find_spec(name) is not None}
+    return modules
+
+
+def tooling_probe(
+    *,
+    command_names: Sequence[str] = DEFAULT_COMMANDS,
+    module_names: Sequence[str] = DEFAULT_MODULES,
+    required_commands: Sequence[str] = (),
+    required_modules: Sequence[str] = (),
+    which: Callable[[str], str | None] = shutil.which,
+    find_spec: Callable[[str], Any] = importlib.util.find_spec,
+) -> dict[str, Any]:
+    command_names = dedupe((*command_names, *required_commands))
+    module_names = dedupe((*module_names, *required_modules))
+    commands = _command_payload(command_names, which)
+    modules = _module_payload(module_names, find_spec)
+
+    solver_found = [
+        name for name in SAT_SOLVER_COMMANDS if commands.get(name, {}).get("found")
+    ]
+    checker_found = [
+        name for name in PROOF_CHECKER_COMMANDS if commands.get(name, {}).get("found")
+    ]
+    missing_commands = [
+        name for name in required_commands if not commands[name]["found"]
+    ]
+    missing_modules = [name for name in required_modules if not modules[name]["found"]]
+    missing_toolchain_groups: list[str] = []
+    if not solver_found:
+        missing_toolchain_groups.append("sat_solver_with_proof_logging")
+    if not checker_found:
+        missing_toolchain_groups.append("proof_checker")
+
+    return {
+        "status": "C19_PROOF_TOOLING_ENVIRONMENT_DIAGNOSTIC_ONLY",
+        "claim_scope": {
+            "changes_mathematical_status": False,
+            "proves_c19_order_cnf_unsat": False,
+            "proves_erdos97": False,
+            "counterexample_claimed": False,
+        },
+        "checked_inputs": [
+            "data/certificates/c19_skew_all_orders_kalmanson_z3.json",
+            "reports/c19_kalmanson_order_cnf_summary.json",
+            "scripts/export_c19_kalmanson_order_cnf.py",
+        ],
+        "commands": commands,
+        "python_modules": modules,
+        "requirements": {
+            "missing_commands": missing_commands,
+            "missing_modules": missing_modules,
+            "c19_solver_independent_replay": {
+                "ready": not missing_toolchain_groups,
+                "accepted_solver_commands": list(SAT_SOLVER_COMMANDS),
+                "accepted_checker_commands": list(PROOF_CHECKER_COMMANDS),
+                "found_solver_commands": solver_found,
+                "found_checker_commands": checker_found,
+                "missing_groups": missing_toolchain_groups,
+            },
+        },
+        "next_steps": [
+            "pin a SAT solver that can emit a checkable proof",
+            "pin a DRAT/LRAT or equivalent proof checker",
+            "byte-check the generated C19 DIMACS before validating any proof object",
+        ],
+    }
+
+
+def print_human(payload: dict[str, Any]) -> None:
+    replay = payload["requirements"]["c19_solver_independent_replay"]
+    print("C19 proof tooling probe")
+    print(f"status: {payload['status']}")
+    print(f"solver-independent replay ready: {replay['ready']}")
+    if replay["missing_groups"]:
+        print("missing toolchain groups: " + ", ".join(replay["missing_groups"]))
+    print("commands:")
+    for name, row in payload["commands"].items():
+        marker = row["path"] if row["found"] else "not found"
+        print(f"  {name}: {marker}")
+    print("python modules:")
+    for name, row in payload["python_modules"].items():
+        print(f"  {name}: {row['found']}")
+    print("claim scope: environment diagnostic only")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--out", type=Path, help="write the stable JSON payload")
+    parser.add_argument(
+        "--command",
+        action="append",
+        default=[],
+        help="extra executable name to include in the probe",
+    )
+    parser.add_argument(
+        "--module",
+        action="append",
+        default=[],
+        help="extra Python module name to include in the probe",
+    )
+    parser.add_argument(
+        "--require-command",
+        action="append",
+        default=[],
+        help="return nonzero if this executable is not found",
+    )
+    parser.add_argument(
+        "--require-module",
+        action="append",
+        default=[],
+        help="return nonzero if this Python module is not importable",
+    )
+    parser.add_argument(
+        "--require-c19-proof-toolchain",
+        action="store_true",
+        help=(
+            "return nonzero unless at least one supported SAT solver and one "
+            "supported proof checker are found"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = tooling_probe(
+        command_names=(*DEFAULT_COMMANDS, *args.command),
+        module_names=(*DEFAULT_MODULES, *args.module),
+        required_commands=args.require_command,
+        required_modules=args.require_module,
+    )
+
+    if args.out:
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_human(payload)
+
+    missing = (
+        payload["requirements"]["missing_commands"]
+        or payload["requirements"]["missing_modules"]
+    )
+    if args.require_c19_proof_toolchain:
+        missing = (
+            missing
+            or payload["requirements"]["c19_solver_independent_replay"][
+                "missing_groups"
+            ]
+        )
+    if missing:
+        print("required proof tooling is not available", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_c19_proof_tooling_probe.py
+++ b/tests/test_c19_proof_tooling_probe.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.probe_c19_proof_tooling import tooling_probe
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_probe_reports_missing_toolchain_groups_with_mocked_lookup() -> None:
+    def fake_which(name: str) -> str | None:
+        return {"kissat": "/opt/kissat/bin/kissat"}.get(name)
+
+    def fake_find_spec(name: str) -> object | None:
+        return SimpleNamespace(name=name) if name == "z3" else None
+
+    payload = tooling_probe(which=fake_which, find_spec=fake_find_spec)
+
+    assert payload["status"] == "C19_PROOF_TOOLING_ENVIRONMENT_DIAGNOSTIC_ONLY"
+    assert not payload["claim_scope"]["changes_mathematical_status"]
+    assert payload["commands"]["kissat"]["found"]
+    assert not payload["commands"]["drat-trim"]["found"]
+    assert payload["python_modules"]["z3"]["found"]
+    assert not payload["python_modules"]["pysat"]["found"]
+    replay = payload["requirements"]["c19_solver_independent_replay"]
+    assert replay["ready"] is False
+    assert replay["found_solver_commands"] == ["kissat"]
+    assert replay["missing_groups"] == ["proof_checker"]
+
+
+def test_probe_reports_ready_with_mocked_solver_and_checker() -> None:
+    def fake_which(name: str) -> str | None:
+        return {
+            "cadical": "C:/sat/cadical.exe",
+            "lrat-check": "C:/sat/lrat-check.exe",
+        }.get(name)
+
+    payload = tooling_probe(which=fake_which, find_spec=lambda _name: None)
+
+    replay = payload["requirements"]["c19_solver_independent_replay"]
+    assert replay["ready"] is True
+    assert replay["found_solver_commands"] == ["cadical"]
+    assert replay["found_checker_commands"] == ["lrat-check"]
+    assert replay["missing_groups"] == []
+
+
+def test_probe_cli_json_is_claim_neutral() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/probe_c19_proof_tooling.py", "--json"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "C19_PROOF_TOOLING_ENVIRONMENT_DIAGNOSTIC_ONLY"
+    assert payload["claim_scope"] == {
+        "changes_mathematical_status": False,
+        "counterexample_claimed": False,
+        "proves_c19_order_cnf_unsat": False,
+        "proves_erdos97": False,
+    }
+
+
+def test_probe_cli_requirement_failure_is_explicit() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/probe_c19_proof_tooling.py",
+            "--require-command",
+            "erdos97-definitely-missing-proof-tool",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert "required proof tooling is not available" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["requirements"]["missing_commands"] == [
+        "erdos97-definitely-missing-proof-tool"
+    ]

--- a/tests/test_c19_proof_tooling_probe.py
+++ b/tests/test_c19_proof_tooling_probe.py
@@ -49,6 +49,18 @@ def test_probe_reports_ready_with_mocked_solver_and_checker() -> None:
     assert replay["missing_groups"] == []
 
 
+def test_probe_treats_missing_dotted_module_parent_as_not_found() -> None:
+    def raising_find_spec(_name: str) -> object | None:
+        raise ModuleNotFoundError("missing parent")
+
+    payload = tooling_probe(
+        module_names=("missing_parent.child",),
+        find_spec=raising_find_spec,
+    )
+
+    assert payload["python_modules"]["missing_parent.child"] == {"found": False}
+
+
 def test_probe_cli_json_is_claim_neutral() -> None:
     result = subprocess.run(
         [sys.executable, "scripts/probe_c19_proof_tooling.py", "--json"],
@@ -91,3 +103,26 @@ def test_probe_cli_requirement_failure_is_explicit() -> None:
     assert payload["requirements"]["missing_commands"] == [
         "erdos97-definitely-missing-proof-tool"
     ]
+
+
+def test_probe_cli_dotted_missing_module_still_emits_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/probe_c19_proof_tooling.py",
+            "--module",
+            "erdos97_definitely_missing_parent.child",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["python_modules"]["erdos97_definitely_missing_parent.child"] == {
+        "found": False
+    }


### PR DESCRIPTION
## What changed

- Added `scripts/probe_c19_proof_tooling.py`, a reusable environment probe for C19 order-CNF proof replay tooling.
- Added focused tests for mocked solver/checker/module availability, dotted missing-module handling, and CLI behavior.
- Updated C19 proof-tooling, Kalmanson diagnostics, review-priority, and backlog docs to reference the probe.

## Claim scope and evidence level

- Environment diagnostic and reproducibility tooling only.
- The probe reports local executable/module availability and whether a supported SAT proof solver/checker pair is present.
- It does not replay a proof object, prove the C19 order CNF UNSAT, prove Erdos Problem #97, or claim a counterexample.
- Preserves the repo status: global/official problem remains open/falsifiable; `n <= 8` remains repo-local and machine-checked; `n=9` artifacts remain review-pending.

## Commands run

- `python scripts/probe_c19_proof_tooling.py --json`
- `python scripts/probe_c19_proof_tooling.py --module erdos97_definitely_missing_parent.child --json`
- `python -m pytest tests/test_c19_proof_tooling_probe.py -q` (`6 passed`)
- `python -m ruff check scripts/probe_c19_proof_tooling.py tests/test_c19_proof_tooling_probe.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
- `python -m pytest -q` (`1097 passed, 416 deselected`)

## Artifacts generated or checked

- Checked existing `reports/c19_kalmanson_order_cnf_summary.json` against the deterministic C19 order-CNF exporter.
- No new generated artifacts were committed.

## Known limitations / next review steps

- The probe confirms availability only; it does not install, pin, or run SAT proof tools.
- A future proof-tooling increment still needs a pinned SAT solver, a pinned proof checker, and a checked DRAT/LRAT or equivalent proof artifact for the generated CNF.