### PR TITLE
Add C19 proof preflight check

### DIFF
--- a/docs/c19-order-cnf-proof-tooling.md
+++ b/docs/c19-order-cnf-proof-tooling.md
@@ -36,12 +36,17 @@ The reusable local probe is:
 
 ```bash
 python scripts/probe_c19_proof_tooling.py --json
+
+python scripts/probe_c19_proof_tooling.py \
+  --check-c19-cnf-summary \
+  --json
 ```
 
-It reports executable availability, Python module availability, and whether
-the local environment has at least one supported SAT solver plus one supported
-proof checker for a solver-independent C19 CNF replay. This is still an
-environment diagnostic only.
+It reports executable availability, Python module availability, whether the
+stored C19 order-CNF summary still matches the deterministic exporter when
+requested, and whether the local environment has at least one supported SAT
+solver plus one supported proof checker for a solver-independent C19 CNF
+replay. This is still an environment diagnostic only.
 
 The local Windows checkout currently has no command-line SAT proof toolchain
 available on `PATH` for this step:

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -375,7 +375,9 @@ Use this queue when no more specific issue is selected.
    round-trip an external CNF file with `--write-cnf` and `--check-cnf`.
    The local proof-tooling environment probe
    `python scripts/probe_c19_proof_tooling.py --json` records whether a
-   supported SAT solver/checker pair is available, but this is environment
+   supported SAT solver/checker pair is available. With
+   `--check-c19-cnf-summary`, it also checks the stored C19 order-CNF summary
+   against the deterministic exporter, but this is environment/preflight
    bookkeeping only and not proof evidence.
 6. Audit `n=8` class `14` or the review-pending `n=9` vertex-circle checker
    with an independent input-data replay. The current SymPy-free
@@ -621,6 +623,7 @@ python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --j
 python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json
 python scripts/probe_c19_proof_tooling.py --json
+python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json
 ```
 
 Expected artifacts:

--- a/docs/kalmanson-certificate-diagnostics.md
+++ b/docs/kalmanson-certificate-diagnostics.md
@@ -151,10 +151,15 @@ The local proof-tooling environment can be probed with:
 
 ```bash
 python scripts/probe_c19_proof_tooling.py --json
+
+python scripts/probe_c19_proof_tooling.py \
+  --check-c19-cnf-summary \
+  --json
 ```
 
-That probe reports local solver/checker availability only. It is not a proof
-replay and does not promote the all-order Z3 certificate to a
+That probe reports local solver/checker availability and can preflight the
+stored C19 order-CNF summary against the deterministic exporter. It is not a
+proof replay and does not promote the all-order Z3 certificate to a
 solver-independent proof object.
 
 ## C13/C19 Inverse-Pair Template Diagnostic

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -512,8 +512,10 @@ Review checklist:
   target and checked summary hash for that replay, but no DRAT/LRAT or
   equivalent proof object is checked yet;
 - `scripts/probe_c19_proof_tooling.py --json` records whether the local
-  environment has a supported SAT proof solver/checker pair, but it is an
-  environment diagnostic only and not proof evidence;
+  environment has a supported SAT proof solver/checker pair, and
+  `--check-c19-cnf-summary` also checks the stored CNF summary against the
+  deterministic exporter, but this is still an environment/preflight
+  diagnostic only and not proof evidence;
 - an UNSAT core alone is not treated as a proof object unless a separate
   checker verifies it;
 - the claim remains scoped to the fixed abstract `C19_skew` selected-witness

--- a/scripts/probe_c19_proof_tooling.py
+++ b/scripts/probe_c19_proof_tooling.py
@@ -16,6 +16,18 @@ from pathlib import Path
 from typing import Any
 
 
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from export_c19_kalmanson_order_cnf import (  # noqa: E402
+    assert_expected as assert_c19_cnf_expected,
+)
+from export_c19_kalmanson_order_cnf import check_artifact as check_c19_cnf  # noqa: E402
+from export_c19_kalmanson_order_cnf import diagnostic_payload  # noqa: E402
+
+DEFAULT_C19_CNF_SUMMARY = ROOT / "reports" / "c19_kalmanson_order_cnf_summary.json"
 DEFAULT_COMMANDS = ("kissat", "cadical", "drat-trim", "lrat-check")
 DEFAULT_MODULES = ("pysat", "z3")
 SAT_SOLVER_COMMANDS = ("kissat", "cadical")
@@ -57,12 +69,44 @@ def _module_payload(
     return modules
 
 
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def c19_cnf_summary_payload(artifact: Path) -> dict[str, Any]:
+    payload = diagnostic_payload()
+    try:
+        assert_c19_cnf_expected(payload)
+        check_c19_cnf(artifact, payload)
+    except (AssertionError, OSError, json.JSONDecodeError) as exc:
+        return {
+            "checked": True,
+            "ok": False,
+            "artifact": _display_path(artifact),
+            "error": str(exc),
+        }
+
+    return {
+        "checked": True,
+        "ok": True,
+        "artifact": _display_path(artifact),
+        "variables": payload["encoding"]["variable_count"],
+        "clauses": payload["encoding"]["clause_count"],
+        "dimacs_sha256": payload["validation"]["dimacs_sha256"],
+    }
+
+
 def tooling_probe(
     *,
     command_names: Sequence[str] = DEFAULT_COMMANDS,
     module_names: Sequence[str] = DEFAULT_MODULES,
     required_commands: Sequence[str] = (),
     required_modules: Sequence[str] = (),
+    check_c19_cnf_summary: bool = False,
+    c19_cnf_summary_artifact: Path = DEFAULT_C19_CNF_SUMMARY,
     which: Callable[[str], str | None] = shutil.which,
     find_spec: Callable[[str], Any] = importlib.util.find_spec,
 ) -> dict[str, Any]:
@@ -102,6 +146,11 @@ def tooling_probe(
         ],
         "commands": commands,
         "python_modules": modules,
+        "c19_cnf_summary": (
+            c19_cnf_summary_payload(c19_cnf_summary_artifact)
+            if check_c19_cnf_summary
+            else {"checked": False}
+        ),
         "requirements": {
             "missing_commands": missing_commands,
             "missing_modules": missing_modules,
@@ -124,8 +173,13 @@ def tooling_probe(
 
 def print_human(payload: dict[str, Any]) -> None:
     replay = payload["requirements"]["c19_solver_independent_replay"]
+    c19_cnf = payload["c19_cnf_summary"]
     print("C19 proof tooling probe")
     print(f"status: {payload['status']}")
+    if c19_cnf["checked"]:
+        print(f"C19 CNF summary checked: {c19_cnf['ok']}")
+        if not c19_cnf["ok"]:
+            print(f"C19 CNF summary error: {c19_cnf['error']}")
     print(f"solver-independent replay ready: {replay['ready']}")
     if replay["missing_groups"]:
         print("missing toolchain groups: " + ", ".join(replay["missing_groups"]))
@@ -175,6 +229,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "supported proof checker are found"
         ),
     )
+    parser.add_argument(
+        "--check-c19-cnf-summary",
+        action="store_true",
+        help="check the stored C19 order-CNF summary before reporting tooling",
+    )
+    parser.add_argument(
+        "--c19-cnf-summary-artifact",
+        type=Path,
+        default=DEFAULT_C19_CNF_SUMMARY,
+        help="C19 order-CNF summary artifact to check",
+    )
     return parser.parse_args(argv)
 
 
@@ -185,6 +250,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         module_names=(*DEFAULT_MODULES, *args.module),
         required_commands=args.require_command,
         required_modules=args.require_module,
+        check_c19_cnf_summary=args.check_c19_cnf_summary,
+        c19_cnf_summary_artifact=args.c19_cnf_summary_artifact,
     )
 
     if args.out:
@@ -208,8 +275,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "missing_groups"
             ]
         )
+    c19_cnf_failed = (
+        payload["c19_cnf_summary"]["checked"] and not payload["c19_cnf_summary"]["ok"]
+    )
+    if c19_cnf_failed:
+        print("C19 CNF summary check failed", file=sys.stderr)
     if missing:
         print("required proof tooling is not available", file=sys.stderr)
+    if missing or c19_cnf_failed:
         return 1
     return 0
 

--- a/tests/test_c19_proof_tooling_probe.py
+++ b/tests/test_c19_proof_tooling_probe.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-from scripts.probe_c19_proof_tooling import tooling_probe
+from scripts.probe_c19_proof_tooling import c19_cnf_summary_payload, tooling_probe
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -80,6 +80,34 @@ def test_probe_cli_json_is_claim_neutral() -> None:
         "proves_c19_order_cnf_unsat": False,
         "proves_erdos97": False,
     }
+    assert payload["c19_cnf_summary"] == {"checked": False}
+
+
+def test_probe_can_check_c19_cnf_summary() -> None:
+    payload = tooling_probe(check_c19_cnf_summary=True)
+
+    assert payload["c19_cnf_summary"] == {
+        "checked": True,
+        "ok": True,
+        "artifact": "reports/c19_kalmanson_order_cnf_summary.json",
+        "variables": 171,
+        "clauses": 13813,
+        "dimacs_sha256": (
+            "dd4b8f429fea232bf09ff878342d7a28f4e9b6e743c99cd1b48f681d0f9ec450"
+        ),
+    }
+
+
+def test_probe_reports_bad_c19_cnf_summary_without_traceback(tmp_path: Path) -> None:
+    bad_artifact = tmp_path / "bad_c19_summary.json"
+    bad_artifact.write_text("{}\n", encoding="utf-8")
+
+    payload = c19_cnf_summary_payload(bad_artifact)
+
+    assert payload["checked"] is True
+    assert payload["ok"] is False
+    assert payload["artifact"] == str(bad_artifact)
+    assert "does not match regenerated payload" in payload["error"]
 
 
 def test_probe_cli_requirement_failure_is_explicit() -> None:
@@ -126,3 +154,51 @@ def test_probe_cli_dotted_missing_module_still_emits_json() -> None:
     assert payload["python_modules"]["erdos97_definitely_missing_parent.child"] == {
         "found": False
     }
+
+
+def test_probe_cli_c19_cnf_summary_preflight() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/probe_c19_proof_tooling.py",
+            "--check-c19-cnf-summary",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["c19_cnf_summary"]["ok"] is True
+    assert payload["c19_cnf_summary"]["artifact"] == (
+        "reports/c19_kalmanson_order_cnf_summary.json"
+    )
+
+
+def test_probe_cli_bad_c19_cnf_summary_fails_with_json(tmp_path: Path) -> None:
+    bad_artifact = tmp_path / "bad_c19_summary.json"
+    bad_artifact.write_text("{}\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/probe_c19_proof_tooling.py",
+            "--check-c19-cnf-summary",
+            "--c19-cnf-summary-artifact",
+            str(bad_artifact),
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert "C19 CNF summary check failed" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["c19_cnf_summary"]["ok"] is False


### PR DESCRIPTION
## What changed

- Extended `scripts/probe_c19_proof_tooling.py` with `--check-c19-cnf-summary`, which checks the stored C19 order-CNF summary against the deterministic exporter before reporting local proof-tool availability.
- Added JSON-stable failure handling for a bad CNF summary artifact.
- Expanded focused tests for the preflight happy path and bad-artifact failure path.
- Updated C19 proof-tooling, Kalmanson diagnostics, review-priority, and backlog docs with the preflight command.

## Claim scope and evidence level

- Reproducibility/preflight tooling only.
- The new check validates that the stored C19 order-CNF summary still matches the deterministic exporter; it does not validate a DRAT/LRAT proof object.
- It does not prove the C19 order CNF UNSAT, prove Erdos Problem #97, or claim a counterexample.
- Preserves the repo status: global/official problem remains open/falsifiable; `n <= 8` remains repo-local and machine-checked; `n=9` artifacts remain review-pending.

## Commands run

- `python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json`
- `python -m pytest tests/test_c19_proof_tooling_probe.py -q` (`10 passed`)
- `python -m ruff check scripts/probe_c19_proof_tooling.py tests/test_c19_proof_tooling_probe.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
- `python -m pytest -q` (`1101 passed, 416 deselected`)

## Artifacts generated or checked

- Checked existing `reports/c19_kalmanson_order_cnf_summary.json` through both the exporter command and the new preflight option.
- No new generated artifacts were committed.

## Known limitations / next review steps

- This still does not install or pin SAT proof tools.
- A future increment must add a pinned SAT solver/checker workflow and a checked proof object before any solver-independent C19 UNSAT proof claim is available.