### PR TITLE
Add n9 audit layer contracts

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -643,8 +643,9 @@ one chain. It checks that the focused packet/catalog audit, focused
 mini-replay crosswalk, aggregate/simple replay crosswalk,
 exhaustive/local-lemma crosswalk, and relation-skeleton/local-lemma crosswalk
 all agree on the same 12 templates, 16 families, and 184 assignments. Its JSON
-payload now includes explicit adjacent handoff checks for each pair of
-successive layers, so a reviewer can see whether any drift starts at the
+payload now includes explicit layer contracts for schema/status/trust fields
+and adjacent handoff checks for each pair of successive layers, so a reviewer
+can see whether any drift starts in a layer identity contract or at the
 focused-packet, mini-replay, aggregate, exhaustive, or relation-skeleton
 handoff. It also includes an `input_manifest` listing the checked upstream
 artifact paths, roles, sizes, and SHA256 digests used by the combined audit

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -81,6 +81,38 @@ EXPECTED_LAYER_IDS = [
 EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
 EXPECTED_HANDOFF_EDGES = list(zip(EXPECTED_LAYER_IDS, EXPECTED_LAYER_IDS[1:]))
 EXPECTED_INPUT_ARTIFACT_COUNT = 32
+EXPECTED_LAYER_CONTRACTS = {
+    "focused_packet_catalog": {
+        "schema": "erdos97.n9_vertex_circle_focused_packet_catalog_audit.v1",
+        "status": "REVIEW_PENDING_FOCUSED_PACKET_CATALOG_AUDIT",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "validation_status": "passed",
+    },
+    "focused_minireplay": {
+        "schema": "erdos97.n9_vertex_circle_focused_minireplay_crosswalk.v1",
+        "status": "REVIEW_PENDING_FOCUSED_MINIREPLAY_CROSSWALK",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "validation_status": "passed",
+    },
+    "aggregate_simple_replay": {
+        "schema": "erdos97.n9_vertex_circle_local_lemma_replay_crosswalk.v1",
+        "status": "REVIEW_PENDING_PACKET_AUDIT",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "validation_status": "passed",
+    },
+    "exhaustive_local_lemma": {
+        "schema": "erdos97.n9_vertex_circle_exhaustive_local_lemma_crosswalk.v1",
+        "status": "REVIEW_PENDING_PACKET_AUDIT",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "validation_status": "passed",
+    },
+    "relation_skeleton_local_lemma": {
+        "schema": "erdos97.relation_skeleton_local_lemma_crosswalk.v1",
+        "status": "REVIEW_PENDING_PACKET_AUDIT",
+        "trust": "REVIEW_PENDING_DIAGNOSTIC",
+        "validation_status": "passed",
+    },
+}
 HANDOFF_COMPARE_KEYS = (
     "template_count",
     "template_ids",
@@ -158,6 +190,7 @@ def local_lemma_audit_path_payload(
 
     errors: list[str] = []
     _append_layer_expected_errors(errors, layers)
+    layer_contracts = _layer_contracts(layers, errors)
     layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
     handoff_checks = _handoff_checks(layer_summaries, errors)
     coverage = _coverage_summary(layer_summaries, errors)
@@ -174,6 +207,7 @@ def local_lemma_audit_path_payload(
         "audit_path": {
             "layer_count": len(layer_summaries),
             "layer_ids": [summary["layer_id"] for summary in layer_summaries],
+            "layer_contracts": layer_contracts,
             "handoff_count": len(handoff_checks),
             "handoff_checks": handoff_checks,
             "layers": layer_summaries,
@@ -218,6 +252,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
             raise AssertionError(f"claim_scope missing {required!r}")
     if payload.get("validation_status") != "passed":
         raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
+    _assert_expected_layer_contracts(payload)
     _assert_expected_input_manifest(payload)
     _assert_expected_manifest_consistency(payload)
 
@@ -270,6 +305,33 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
             )
     if coverage.get("template_ids") != EXPECTED_TEMPLATE_IDS:
         raise AssertionError(f"template ids mismatch: {coverage.get('template_ids')!r}")
+
+
+def _assert_expected_layer_contracts(payload: Mapping[str, Any]) -> None:
+    audit_path = payload.get("audit_path")
+    if not isinstance(audit_path, Mapping):
+        raise AssertionError("audit_path must be an object")
+    contracts = audit_path.get("layer_contracts")
+    if not isinstance(contracts, list):
+        raise AssertionError("audit_path.layer_contracts must be a list")
+    observed_ids = [
+        contract.get("layer_id")
+        for contract in contracts
+        if isinstance(contract, Mapping)
+    ]
+    if observed_ids != EXPECTED_LAYER_IDS:
+        raise AssertionError(f"layer contract ids mismatch: {observed_ids!r}")
+    for contract in contracts:
+        if not isinstance(contract, Mapping):
+            raise AssertionError("layer contract must be an object")
+        layer_id = str(contract.get("layer_id"))
+        expected = EXPECTED_LAYER_CONTRACTS[layer_id]
+        if contract.get("expected") != expected:
+            raise AssertionError(f"{layer_id} expected contract mismatch")
+        if contract.get("observed") != expected:
+            raise AssertionError(f"{layer_id} observed contract mismatch")
+        if contract.get("status") != "passed" or contract.get("mismatches") != []:
+            raise AssertionError(f"{layer_id} contract failed: {contract!r}")
 
 
 def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
@@ -352,6 +414,47 @@ def _append_layer_expected_errors(
             assert_functions[layer_id](layers[layer_id])
         except (AssertionError, KeyError, TypeError, ValueError) as exc:
             errors.append(f"{layer_id} expected-check failed: {exc}")
+
+
+def _layer_contracts(
+    layers: Mapping[str, Mapping[str, Any]],
+    errors: list[str],
+) -> list[dict[str, Any]]:
+    contracts: list[dict[str, Any]] = []
+    for layer_id in EXPECTED_LAYER_IDS:
+        payload = layers[layer_id]
+        expected = EXPECTED_LAYER_CONTRACTS[layer_id]
+        observed = {
+            "schema": payload.get("schema"),
+            "status": payload.get("status"),
+            "trust": payload.get("trust"),
+            "validation_status": payload.get("validation_status"),
+        }
+        mismatches = []
+        for key, expected_value in expected.items():
+            observed_value = observed.get(key)
+            if observed_value != expected_value:
+                mismatches.append(
+                    {
+                        "key": key,
+                        "expected": expected_value,
+                        "observed": observed_value,
+                    }
+                )
+                errors.append(
+                    f"{layer_id} contract mismatch on {key}: "
+                    f"{observed_value!r} != {expected_value!r}"
+                )
+        contracts.append(
+            {
+                "layer_id": layer_id,
+                "expected": dict(expected),
+                "observed": observed,
+                "status": "passed" if not mismatches else "failed",
+                "mismatches": mismatches,
+            }
+        )
+    return contracts
 
 
 def _input_manifest() -> dict[str, Any]:
@@ -663,6 +766,12 @@ def _string_list(value: Any) -> list[str]:
     return [str(item) for item in value]
 
 
+def _summary_status(items: Any) -> str:
+    if not isinstance(items, list):
+        return "failed"
+    return "passed" if all(item.get("status") == "passed" for item in items) else "failed"
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     coverage = payload["coverage_summary"]
     return [
@@ -670,6 +779,8 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"status: {payload['status']}",
         f"validation: {payload['validation_status']}",
         f"layers: {coverage['layer_count']}",
+        "layer contracts: "
+        f"{_summary_status(payload['audit_path']['layer_contracts'])}",
         f"handoffs: {payload['audit_path']['handoff_count']}",
         f"input artifacts: {payload['input_manifest']['artifact_count']}",
         f"manifest consistency: {payload['manifest_consistency']['status']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_HANDOFF_EDGES,
     EXPECTED_INPUT_ARTIFACT_COUNT,
+    EXPECTED_LAYER_CONTRACTS,
     EXPECTED_LAYER_IDS,
     assert_expected_local_lemma_audit_path,
     local_lemma_audit_path_payload,
@@ -91,6 +92,19 @@ def test_local_lemma_audit_path_manifest_consistency() -> None:
     }
 
 
+def test_local_lemma_audit_path_layer_contracts() -> None:
+    payload = local_lemma_audit_path_payload()
+    contracts = payload["audit_path"]["layer_contracts"]
+
+    assert [contract["layer_id"] for contract in contracts] == EXPECTED_LAYER_IDS
+    assert all(contract["status"] == "passed" for contract in contracts)
+    assert all(contract["mismatches"] == [] for contract in contracts)
+    for contract in contracts:
+        expected = EXPECTED_LAYER_CONTRACTS[contract["layer_id"]]
+        assert contract["expected"] == expected
+        assert contract["observed"] == expected
+
+
 def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
     focused_minireplay = focused_minireplay_crosswalk_payload()
     tampered = json.loads(json.dumps(focused_minireplay))
@@ -107,6 +121,36 @@ def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
     ]
     assert any(
         "input_manifest missing layer-referenced paths" in error
+        for error in payload["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_rejects_layer_contract_drift() -> None:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    tampered["trust"] = "EXACT_OBSTRUCTION"
+
+    payload = local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
+    contracts = {
+        contract["layer_id"]: contract
+        for contract in payload["audit_path"]["layer_contracts"]
+    }
+
+    assert payload["validation_status"] == "failed"
+    assert contracts["aggregate_simple_replay"]["status"] == "failed"
+    assert contracts["aggregate_simple_replay"]["mismatches"] == [
+        {
+            "key": "trust",
+            "expected": "REVIEW_PENDING_DIAGNOSTIC",
+            "observed": "EXACT_OBSTRUCTION",
+        }
+    ]
+    assert any(
+        "aggregate_simple_replay contract mismatch on trust" in error
         for error in payload["validation_errors"]
     )
 


### PR DESCRIPTION
## What changed
- Added explicit `layer_contracts` to the n=9 vertex-circle local-lemma audit-path payload.
- The checker now validates each audit layer's schema, review-pending status, trust label, and validation status before count handoffs.
- Added tests for the passing contract table and a trust-drift negative case.
- Updated the local-lemma audit docs to describe the layer identity contract guard.

## Claim scope and evidence level
- Scope is limited to review-pending n=9 vertex-circle local-lemma audit bookkeeping.
- This is a reproducibility/reviewer-facing contract check for existing diagnostic layers.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, the general problem, or any counterexample.

## Commands run
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_n9_vertex_circle_local_lemma_audit_path.py -q -m "artifact or not artifact"`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the in-memory `erdos97.n9_vertex_circle_local_lemma_audit_path.v1` payload with its new `layer_contracts` section.
- No stored/generated artifact files were regenerated.

## Known limitations / next review steps
- Layer contracts guard metadata/status drift only; they do not review the mathematical soundness of each layer.
- Next useful review step: continue replacing review-pending n=9 stack assumptions with independent local replays or sharper contract checks.