### PR TITLE
Add n9 audit claim-scope guards

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -644,14 +644,15 @@ mini-replay crosswalk, aggregate/simple replay crosswalk,
 exhaustive/local-lemma crosswalk, and relation-skeleton/local-lemma crosswalk
 all agree on the same 12 templates, 16 families, and 184 assignments. Its JSON
 payload now includes explicit layer contracts for schema/status/trust fields,
-layer provenance contracts for generator/command fields, and adjacent handoff
-checks for each pair of successive layers, so a reviewer can see whether any
-drift starts in a layer identity contract, a provenance contract, or at the
-focused-packet, mini-replay, aggregate, exhaustive, or relation-skeleton
-handoff. It also includes an `input_manifest` listing the checked upstream
-artifact paths, roles, sizes, and SHA256 digests used by the combined audit
-path, plus a manifest-consistency check comparing those paths with the
-artifacts actually referenced by each layer payload:
+layer provenance contracts for generator/command fields, claim-scope guards
+for the non-proof/non-counterexample/global-status disclaimers, and adjacent
+handoff checks for each pair of successive layers, so a reviewer can see
+whether any drift starts in a layer identity contract, a provenance contract,
+a claim-scope guard, or at the focused-packet, mini-replay, aggregate,
+exhaustive, or relation-skeleton handoff. It also includes an `input_manifest`
+listing the checked upstream artifact paths, roles, sizes, and SHA256 digests
+used by the combined audit path, plus a manifest-consistency check comparing
+those paths with the artifacts actually referenced by each layer payload:
 
 ```bash
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -152,6 +152,18 @@ EXPECTED_LAYER_PROVENANCE = {
         ),
     },
 }
+CLAIM_SCOPE_GUARDS = {
+    "mentions_n9_scope": (("n=9",),),
+    "denies_proof": (("does not prove",), ("not a proof",)),
+    "denies_counterexample": (
+        ("not a counterexample",),
+        ("does not prove", "counterexample"),
+    ),
+    "denies_global_status_update": (
+        ("not a global status update",),
+        ("official/global status update",),
+    ),
+}
 HANDOFF_COMPARE_KEYS = (
     "template_count",
     "template_ids",
@@ -231,6 +243,7 @@ def local_lemma_audit_path_payload(
     _append_layer_expected_errors(errors, layers)
     layer_contracts = _layer_contracts(layers, errors)
     layer_provenance = _layer_provenance(layers, errors)
+    claim_scope_guards = _claim_scope_guards(layers, errors)
     layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
     handoff_checks = _handoff_checks(layer_summaries, errors)
     coverage = _coverage_summary(layer_summaries, errors)
@@ -249,6 +262,7 @@ def local_lemma_audit_path_payload(
             "layer_ids": [summary["layer_id"] for summary in layer_summaries],
             "layer_contracts": layer_contracts,
             "layer_provenance": layer_provenance,
+            "claim_scope_guards": claim_scope_guards,
             "handoff_count": len(handoff_checks),
             "handoff_checks": handoff_checks,
             "layers": layer_summaries,
@@ -295,6 +309,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")
     _assert_expected_layer_contracts(payload)
     _assert_expected_layer_provenance(payload)
+    _assert_expected_claim_scope_guards(payload)
     _assert_expected_input_manifest(payload)
     _assert_expected_manifest_consistency(payload)
 
@@ -401,6 +416,35 @@ def _assert_expected_layer_provenance(payload: Mapping[str, Any]) -> None:
             raise AssertionError(f"{layer_id} observed provenance mismatch")
         if check.get("status") != "passed" or check.get("mismatches") != []:
             raise AssertionError(f"{layer_id} provenance failed: {check!r}")
+
+
+def _assert_expected_claim_scope_guards(payload: Mapping[str, Any]) -> None:
+    audit_path = payload.get("audit_path")
+    if not isinstance(audit_path, Mapping):
+        raise AssertionError("audit_path must be an object")
+    guard_checks = audit_path.get("claim_scope_guards")
+    if not isinstance(guard_checks, list):
+        raise AssertionError("audit_path.claim_scope_guards must be a list")
+    observed_ids = [
+        check.get("layer_id")
+        for check in guard_checks
+        if isinstance(check, Mapping)
+    ]
+    if observed_ids != EXPECTED_LAYER_IDS:
+        raise AssertionError(f"claim-scope guard ids mismatch: {observed_ids!r}")
+    for check in guard_checks:
+        if not isinstance(check, Mapping):
+            raise AssertionError("claim-scope guard check must be an object")
+        if check.get("status") != "passed" or check.get("missing_guards") != []:
+            raise AssertionError(f"claim-scope guard failed: {check!r}")
+        results = check.get("guard_results")
+        if not isinstance(results, list):
+            raise AssertionError("claim-scope guard_results must be a list")
+        if [result.get("guard") for result in results] != list(CLAIM_SCOPE_GUARDS):
+            raise AssertionError(f"claim-scope guard order mismatch: {results!r}")
+        for result in results:
+            if result.get("status") != "passed":
+                raise AssertionError(f"claim-scope guard result failed: {result!r}")
 
 
 def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
@@ -570,6 +614,52 @@ def _provenance_contract(provenance: Any) -> dict[str, Any]:
         "generator": provenance.get("generator"),
         "command": provenance.get("command"),
     }
+
+
+def _claim_scope_guards(
+    layers: Mapping[str, Mapping[str, Any]],
+    errors: list[str],
+) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for layer_id in EXPECTED_LAYER_IDS:
+        claim_scope = str(layers[layer_id].get("claim_scope", ""))
+        guard_results = []
+        missing_guards = []
+        for guard, alternatives in CLAIM_SCOPE_GUARDS.items():
+            matched_tokens = _matched_claim_scope_tokens(claim_scope, alternatives)
+            status = "passed" if matched_tokens else "failed"
+            if not matched_tokens:
+                missing_guards.append(guard)
+            guard_results.append(
+                {
+                    "guard": guard,
+                    "status": status,
+                    "matched_tokens": matched_tokens,
+                    "accepted_token_sets": [list(tokens) for tokens in alternatives],
+                }
+            )
+        if missing_guards:
+            errors.append(f"{layer_id} claim_scope missing guards: {missing_guards!r}")
+        checks.append(
+            {
+                "layer_id": layer_id,
+                "status": "passed" if not missing_guards else "failed",
+                "missing_guards": missing_guards,
+                "guard_results": guard_results,
+            }
+        )
+    return checks
+
+
+def _matched_claim_scope_tokens(
+    claim_scope: str,
+    alternatives: tuple[tuple[str, ...], ...],
+) -> list[str]:
+    lowered = claim_scope.lower()
+    for tokens in alternatives:
+        if all(token in lowered for token in tokens):
+            return list(tokens)
+    return []
 
 
 def _input_manifest() -> dict[str, Any]:
@@ -898,6 +988,8 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"{_summary_status(payload['audit_path']['layer_contracts'])}",
         "layer provenance: "
         f"{_summary_status(payload['audit_path']['layer_provenance'])}",
+        "claim-scope guards: "
+        f"{_summary_status(payload['audit_path']['claim_scope_guards'])}",
         f"handoffs: {payload['audit_path']['handoff_count']}",
         f"input artifacts: {payload['input_manifest']['artifact_count']}",
         f"manifest consistency: {payload['manifest_consistency']['status']}",

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -161,7 +161,7 @@ CLAIM_SCOPE_GUARDS = {
     ),
     "denies_global_status_update": (
         ("not a global status update",),
-        ("official/global status update",),
+        ("does not prove", "official/global status update"),
     ),
 }
 HANDOFF_COMPARE_KEYS = (

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
+    CLAIM_SCOPE_GUARDS,
     EXPECTED_HANDOFF_EDGES,
     EXPECTED_INPUT_ARTIFACT_COUNT,
     EXPECTED_LAYER_CONTRACTS,
@@ -119,6 +120,20 @@ def test_local_lemma_audit_path_layer_provenance() -> None:
         assert check["observed"] == expected
 
 
+def test_local_lemma_audit_path_claim_scope_guards() -> None:
+    payload = local_lemma_audit_path_payload()
+    guard_checks = payload["audit_path"]["claim_scope_guards"]
+
+    assert [check["layer_id"] for check in guard_checks] == EXPECTED_LAYER_IDS
+    assert all(check["status"] == "passed" for check in guard_checks)
+    assert all(check["missing_guards"] == [] for check in guard_checks)
+    for check in guard_checks:
+        results = check["guard_results"]
+        assert [result["guard"] for result in results] == list(CLAIM_SCOPE_GUARDS)
+        assert all(result["status"] == "passed" for result in results)
+        assert all(result["matched_tokens"] for result in results)
+
+
 def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
     focused_minireplay = focused_minireplay_crosswalk_payload()
     tampered = json.loads(json.dumps(focused_minireplay))
@@ -198,6 +213,31 @@ def test_local_lemma_audit_path_rejects_layer_provenance_drift() -> None:
     ]
     assert any(
         "aggregate_simple_replay provenance mismatch on command" in error
+        for error in payload["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_rejects_claim_scope_guard_drift() -> None:
+    focused_minireplay = focused_minireplay_crosswalk_payload()
+    tampered = json.loads(json.dumps(focused_minireplay))
+    tampered["claim_scope"] = "This packet audit discusses n=9."
+
+    payload = local_lemma_audit_path_payload(focused_minireplay_payload=tampered)
+    guard_checks = {
+        check["layer_id"]: check
+        for check in payload["audit_path"]["claim_scope_guards"]
+    }
+
+    assert payload["validation_status"] == "failed"
+    focused_guard = guard_checks["focused_minireplay"]
+    assert focused_guard["status"] == "failed"
+    assert focused_guard["missing_guards"] == [
+        "denies_proof",
+        "denies_counterexample",
+        "denies_global_status_update",
+    ]
+    assert any(
+        "focused_minireplay claim_scope missing guards" in error
         for error in payload["validation_errors"]
     )
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -242,6 +242,30 @@ def test_local_lemma_audit_path_rejects_claim_scope_guard_drift() -> None:
     )
 
 
+def test_local_lemma_audit_path_global_status_guard_requires_negation() -> None:
+    focused_minireplay = focused_minireplay_crosswalk_payload()
+    tampered = json.loads(json.dumps(focused_minireplay))
+    tampered["claim_scope"] = (
+        "This is not a proof of n=9, not a counterexample, and this is an "
+        "official/global status update."
+    )
+
+    payload = local_lemma_audit_path_payload(focused_minireplay_payload=tampered)
+    guard_checks = {
+        check["layer_id"]: check
+        for check in payload["audit_path"]["claim_scope_guards"]
+    }
+
+    assert payload["validation_status"] == "failed"
+    focused_guard = guard_checks["focused_minireplay"]
+    assert focused_guard["status"] == "failed"
+    assert focused_guard["missing_guards"] == ["denies_global_status_update"]
+    assert any(
+        "focused_minireplay claim_scope missing guards" in error
+        for error in payload["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_layer_summaries() -> None:
     payload = local_lemma_audit_path_payload()
     by_layer = {item["layer_id"]: item for item in payload["audit_path"]["layers"]}


### PR DESCRIPTION
## What changed
- Added `claim_scope_guards` to the n=9 vertex-circle local-lemma audit-path payload.
- The checker now verifies each joined layer still carries n=9 scope text plus proof/counterexample/global-status disclaimers.
- Added tests for the passing guard table and a tampered claim-scope negative case.
- Updated the local-lemma audit docs to describe the guard alongside layer contracts, provenance contracts, handoffs, and the input manifest.

## Claim scope and evidence level
- Scope is limited to review-pending n=9 vertex-circle local-lemma audit bookkeeping.
- This is a claim-discipline guard for existing diagnostic layers.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, the general problem, or any counterexample.

## Commands run
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_n9_vertex_circle_local_lemma_audit_path.py -q -m "artifact or not artifact"`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the in-memory `erdos97.n9_vertex_circle_local_lemma_audit_path.v1` payload with its new `claim_scope_guards` section.
- No stored/generated artifact files were regenerated.

## Known limitations / next review steps
- The guard checks explicit non-overclaiming language only; it does not review mathematical soundness or independently prove any layer.
- Next useful review step: continue tightening review-pending n=9 layers with independent local replays or sharper handoff contracts.