### PR TITLE
Add n9 audit output contracts

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -645,14 +645,16 @@ exhaustive/local-lemma crosswalk, and relation-skeleton/local-lemma crosswalk
 all agree on the same 12 templates, 16 families, and 184 assignments. Its JSON
 payload now includes explicit layer contracts for schema/status/trust fields,
 layer provenance contracts for generator/command fields, claim-scope guards
-for the non-proof/non-counterexample/global-status disclaimers, and adjacent
+for the non-proof/non-counterexample/global-status disclaimers, output
+contracts for each layer's reviewer-facing summary sections, and adjacent
 handoff checks for each pair of successive layers, so a reviewer can see
 whether any drift starts in a layer identity contract, a provenance contract,
-a claim-scope guard, or at the focused-packet, mini-replay, aggregate,
-exhaustive, or relation-skeleton handoff. It also includes an `input_manifest`
-listing the checked upstream artifact paths, roles, sizes, and SHA256 digests
-used by the combined audit path, plus a manifest-consistency check comparing
-those paths with the artifacts actually referenced by each layer payload:
+a claim-scope guard, an output contract, or at the focused-packet,
+mini-replay, aggregate, exhaustive, or relation-skeleton handoff. It also
+includes an `input_manifest` listing the checked upstream artifact paths,
+roles, sizes, and SHA256 digests used by the combined audit path, plus a
+manifest-consistency check comparing those paths with the artifacts actually
+referenced by each layer payload:
 
 ```bash
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -164,6 +164,89 @@ CLAIM_SCOPE_GUARDS = {
         ("does not prove", "official/global status update"),
     ),
 }
+EXPECTED_LAYER_OUTPUT_CONTRACTS = {
+    "focused_packet_catalog": {
+        "summary_key": "focused_packet_catalog_audit",
+        "required_top_level_keys": ("source_artifacts", "packet_artifacts"),
+        "required_summary_keys": (
+            "packet_count",
+            "template_ids",
+            "covered_family_count",
+            "covered_assignment_count",
+            "packet_records",
+            "status_counts",
+            "status_assignment_counts",
+        ),
+    },
+    "focused_minireplay": {
+        "summary_key": "focused_minireplay_crosswalk",
+        "required_top_level_keys": (),
+        "required_summary_keys": (
+            "minireplay_count",
+            "packet_count",
+            "template_ids",
+            "source_family_count",
+            "source_assignment_count",
+            "records",
+            "status_counts",
+            "status_assignment_counts",
+        ),
+    },
+    "aggregate_simple_replay": {
+        "summary_key": "coverage_summary",
+        "required_top_level_keys": (
+            "source_artifacts",
+            "family_crosswalk",
+            "focused_crosscheck_summary",
+        ),
+        "required_summary_keys": (
+            "expected_family_count",
+            "expected_assignment_count",
+            "matched_family_count",
+            "matched_assignment_count",
+            "self_edge_family_count",
+            "self_edge_assignment_count",
+            "strict_cycle_family_count",
+            "strict_cycle_assignment_count",
+        ),
+    },
+    "exhaustive_local_lemma": {
+        "summary_key": "coverage_summary",
+        "required_top_level_keys": (
+            "source_artifacts",
+            "family_crosswalk",
+            "local_replay_crosswalk_summary",
+        ),
+        "required_summary_keys": (
+            "classification_assignment_count",
+            "exhaustive_frontier_assignment_count",
+            "family_count",
+            "local_matched_assignment_count",
+            "self_edge_assignment_count",
+            "strict_cycle_assignment_count",
+        ),
+    },
+    "relation_skeleton_local_lemma": {
+        "summary_key": "coverage_summary",
+        "required_top_level_keys": (
+            "source_artifacts",
+            "family_crosswalk",
+            "local_replay_crosswalk_summary",
+        ),
+        "required_summary_keys": (
+            "expected_family_count",
+            "expected_assignment_count",
+            "local_family_count",
+            "matched_family_count",
+            "matched_assignment_count",
+            "relation_skeleton_count",
+            "self_edge_family_count",
+            "self_edge_assignment_count",
+            "strict_cycle_family_count",
+            "strict_cycle_assignment_count",
+        ),
+    },
+}
 HANDOFF_COMPARE_KEYS = (
     "template_count",
     "template_ids",
@@ -244,6 +327,7 @@ def local_lemma_audit_path_payload(
     layer_contracts = _layer_contracts(layers, errors)
     layer_provenance = _layer_provenance(layers, errors)
     claim_scope_guards = _claim_scope_guards(layers, errors)
+    layer_output_contracts = _layer_output_contracts(layers, errors)
     layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
     handoff_checks = _handoff_checks(layer_summaries, errors)
     coverage = _coverage_summary(layer_summaries, errors)
@@ -263,6 +347,7 @@ def local_lemma_audit_path_payload(
             "layer_contracts": layer_contracts,
             "layer_provenance": layer_provenance,
             "claim_scope_guards": claim_scope_guards,
+            "layer_output_contracts": layer_output_contracts,
             "handoff_count": len(handoff_checks),
             "handoff_checks": handoff_checks,
             "layers": layer_summaries,
@@ -310,6 +395,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_layer_contracts(payload)
     _assert_expected_layer_provenance(payload)
     _assert_expected_claim_scope_guards(payload)
+    _assert_expected_layer_output_contracts(payload)
     _assert_expected_input_manifest(payload)
     _assert_expected_manifest_consistency(payload)
 
@@ -445,6 +531,37 @@ def _assert_expected_claim_scope_guards(payload: Mapping[str, Any]) -> None:
         for result in results:
             if result.get("status") != "passed":
                 raise AssertionError(f"claim-scope guard result failed: {result!r}")
+
+
+def _assert_expected_layer_output_contracts(payload: Mapping[str, Any]) -> None:
+    audit_path = payload.get("audit_path")
+    if not isinstance(audit_path, Mapping):
+        raise AssertionError("audit_path must be an object")
+    output_contracts = audit_path.get("layer_output_contracts")
+    if not isinstance(output_contracts, list):
+        raise AssertionError("audit_path.layer_output_contracts must be a list")
+    observed_ids = [
+        contract.get("layer_id")
+        for contract in output_contracts
+        if isinstance(contract, Mapping)
+    ]
+    if observed_ids != EXPECTED_LAYER_IDS:
+        raise AssertionError(f"layer output contract ids mismatch: {observed_ids!r}")
+    for contract in output_contracts:
+        if not isinstance(contract, Mapping):
+            raise AssertionError("layer output contract must be an object")
+        layer_id = str(contract.get("layer_id"))
+        expected = _expected_output_contract(layer_id)
+        if contract.get("expected") != expected:
+            raise AssertionError(f"{layer_id} expected output contract mismatch")
+        if contract.get("status") != "passed":
+            raise AssertionError(f"{layer_id} output contract failed: {contract!r}")
+        if contract.get("missing_top_level_keys") != []:
+            raise AssertionError(f"{layer_id} missing top-level output keys")
+        if contract.get("missing_summary_keys") != []:
+            raise AssertionError(f"{layer_id} missing summary output keys")
+        if contract.get("summary_type") != "object":
+            raise AssertionError(f"{layer_id} summary output is not an object")
 
 
 def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
@@ -660,6 +777,65 @@ def _matched_claim_scope_tokens(
         if all(token in lowered for token in tokens):
             return list(tokens)
     return []
+
+
+def _layer_output_contracts(
+    layers: Mapping[str, Mapping[str, Any]],
+    errors: list[str],
+) -> list[dict[str, Any]]:
+    contracts: list[dict[str, Any]] = []
+    for layer_id in EXPECTED_LAYER_IDS:
+        payload = layers[layer_id]
+        expected = _expected_output_contract(layer_id)
+        summary_key = str(expected["summary_key"])
+        summary = payload.get(summary_key)
+        summary_type = "object" if isinstance(summary, Mapping) else type(summary).__name__
+        top_level_keys = set(payload)
+        summary_keys = set(summary) if isinstance(summary, Mapping) else set()
+        missing_top_level_keys = sorted(
+            set(expected["required_top_level_keys"]) - top_level_keys
+        )
+        missing_summary_keys = sorted(
+            set(expected["required_summary_keys"]) - summary_keys
+        )
+        if summary_type != "object":
+            errors.append(f"{layer_id} output summary {summary_key!r} is not an object")
+        if missing_top_level_keys:
+            errors.append(
+                f"{layer_id} output missing top-level keys: {missing_top_level_keys!r}"
+            )
+        if missing_summary_keys:
+            errors.append(
+                f"{layer_id} output missing summary keys: {missing_summary_keys!r}"
+            )
+        contracts.append(
+            {
+                "layer_id": layer_id,
+                "expected": expected,
+                "summary_type": summary_type,
+                "observed_top_level_keys": sorted(top_level_keys),
+                "observed_summary_keys": sorted(summary_keys),
+                "missing_top_level_keys": missing_top_level_keys,
+                "missing_summary_keys": missing_summary_keys,
+                "status": (
+                    "passed"
+                    if summary_type == "object"
+                    and not missing_top_level_keys
+                    and not missing_summary_keys
+                    else "failed"
+                ),
+            }
+        )
+    return contracts
+
+
+def _expected_output_contract(layer_id: str) -> dict[str, Any]:
+    contract = EXPECTED_LAYER_OUTPUT_CONTRACTS[layer_id]
+    return {
+        "summary_key": contract["summary_key"],
+        "required_top_level_keys": list(contract["required_top_level_keys"]),
+        "required_summary_keys": list(contract["required_summary_keys"]),
+    }
 
 
 def _input_manifest() -> dict[str, Any]:
@@ -990,6 +1166,8 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"{_summary_status(payload['audit_path']['layer_provenance'])}",
         "claim-scope guards: "
         f"{_summary_status(payload['audit_path']['claim_scope_guards'])}",
+        "layer output contracts: "
+        f"{_summary_status(payload['audit_path']['layer_output_contracts'])}",
         f"handoffs: {payload['audit_path']['handoff_count']}",
         f"input artifacts: {payload['input_manifest']['artifact_count']}",
         f"manifest consistency: {payload['manifest_consistency']['status']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -11,6 +11,7 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_INPUT_ARTIFACT_COUNT,
     EXPECTED_LAYER_CONTRACTS,
     EXPECTED_LAYER_IDS,
+    EXPECTED_LAYER_OUTPUT_CONTRACTS,
     EXPECTED_LAYER_PROVENANCE,
     assert_expected_local_lemma_audit_path,
     local_lemma_audit_path_payload,
@@ -132,6 +133,24 @@ def test_local_lemma_audit_path_claim_scope_guards() -> None:
         assert [result["guard"] for result in results] == list(CLAIM_SCOPE_GUARDS)
         assert all(result["status"] == "passed" for result in results)
         assert all(result["matched_tokens"] for result in results)
+
+
+def test_local_lemma_audit_path_layer_output_contracts() -> None:
+    payload = local_lemma_audit_path_payload()
+    output_contracts = payload["audit_path"]["layer_output_contracts"]
+
+    assert [contract["layer_id"] for contract in output_contracts] == EXPECTED_LAYER_IDS
+    assert all(contract["status"] == "passed" for contract in output_contracts)
+    for contract in output_contracts:
+        expected = EXPECTED_LAYER_OUTPUT_CONTRACTS[contract["layer_id"]]
+        assert contract["expected"] == {
+            "summary_key": expected["summary_key"],
+            "required_top_level_keys": list(expected["required_top_level_keys"]),
+            "required_summary_keys": list(expected["required_summary_keys"]),
+        }
+        assert contract["summary_type"] == "object"
+        assert contract["missing_top_level_keys"] == []
+        assert contract["missing_summary_keys"] == []
 
 
 def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
@@ -262,6 +281,58 @@ def test_local_lemma_audit_path_global_status_guard_requires_negation() -> None:
     assert focused_guard["missing_guards"] == ["denies_global_status_update"]
     assert any(
         "focused_minireplay claim_scope missing guards" in error
+        for error in payload["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_rejects_missing_output_section() -> None:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    del tampered["family_crosswalk"]
+
+    payload = local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
+    output_contracts = {
+        contract["layer_id"]: contract
+        for contract in payload["audit_path"]["layer_output_contracts"]
+    }
+
+    assert payload["validation_status"] == "failed"
+    aggregate_contract = output_contracts["aggregate_simple_replay"]
+    assert aggregate_contract["status"] == "failed"
+    assert aggregate_contract["missing_top_level_keys"] == ["family_crosswalk"]
+    assert aggregate_contract["missing_summary_keys"] == []
+    assert any(
+        "aggregate_simple_replay output missing top-level keys" in error
+        for error in payload["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_rejects_missing_output_summary_key() -> None:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    del tampered["coverage_summary"]["matched_assignment_count"]
+
+    payload = local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
+    output_contracts = {
+        contract["layer_id"]: contract
+        for contract in payload["audit_path"]["layer_output_contracts"]
+    }
+
+    assert payload["validation_status"] == "failed"
+    aggregate_contract = output_contracts["aggregate_simple_replay"]
+    assert aggregate_contract["status"] == "failed"
+    assert aggregate_contract["missing_top_level_keys"] == []
+    assert aggregate_contract["missing_summary_keys"] == ["matched_assignment_count"]
+    assert any(
+        "aggregate_simple_replay output missing summary keys" in error
         for error in payload["validation_errors"]
     )
 


### PR DESCRIPTION
## What changed
- Added `layer_output_contracts` to the n=9 vertex-circle local-lemma audit-path payload.
- The checker now validates each joined layer exposes its expected reviewer-facing summary section and required output fields.
- Added tests for the passing output-contract table plus missing top-level output and missing summary-key negative cases.
- Updated the local-lemma audit docs to describe the output contract guard.

## Claim scope and evidence level
- Scope is limited to review-pending n=9 vertex-circle local-lemma audit bookkeeping.
- This is a reviewer-facing output-shape guard for existing diagnostic layers.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, the general problem, or any counterexample.

## Commands run
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_n9_vertex_circle_local_lemma_audit_path.py -q -m "artifact or not artifact"`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the in-memory `erdos97.n9_vertex_circle_local_lemma_audit_path.v1` payload with its new `layer_output_contracts` section.
- No stored/generated artifact files were regenerated.

## Known limitations / next review steps
- Output contracts guard payload shape only; they do not review mathematical soundness or independently prove any layer.
- Next useful review step: continue replacing review-pending n=9 stack assumptions with independent local replays or sharper handoff contracts.