### PR TITLE
Add focused minireplay record-path contracts

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -649,14 +649,16 @@ metadata contracts for declared path/role/schema/status/trust fields,
 claim-scope guards for the non-proof/non-counterexample/global-status
 disclaimers, output contracts for each layer's reviewer-facing summary
 sections, per-layer input contracts for the expected upstream artifact paths,
-and adjacent handoff checks for each pair of successive layers, so a reviewer
-can see whether any drift starts in a layer identity contract, a provenance
-contract, a source-artifact contract, a claim-scope guard, an output contract,
-an input contract, or at the focused-packet, mini-replay, aggregate,
-exhaustive, or relation-skeleton handoff. It also includes an `input_manifest`
-listing the checked upstream artifact paths, roles, sizes, and SHA256 digests
-used by the combined audit path, plus a manifest-consistency check comparing
-those paths with the artifacts actually referenced by each layer payload:
+a focused minireplay record-path contract for the per-template packet and
+mini-replay paths, and adjacent handoff checks for each pair of successive
+layers, so a reviewer can see whether any drift starts in a layer identity
+contract, a provenance contract, a source-artifact contract, a claim-scope
+guard, an output contract, an input contract, a focused record-path contract,
+or at the focused-packet, mini-replay, aggregate, exhaustive, or
+relation-skeleton handoff. It also includes an `input_manifest` listing the
+checked upstream artifact paths, roles, sizes, and SHA256 digests used by the
+combined audit path, plus a manifest-consistency check comparing those paths
+with the artifacts actually referenced by each layer payload:
 
 ```bash
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -449,6 +449,9 @@ def local_lemma_audit_path_payload(
     claim_scope_guards = _claim_scope_guards(layers, errors)
     layer_output_contracts = _layer_output_contracts(layers, errors)
     layer_input_contracts = _layer_input_contracts(layers, errors)
+    focused_record_path_contract = _focused_minireplay_record_path_contract(
+        layers["focused_minireplay"], errors
+    )
     layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
     handoff_checks = _handoff_checks(layer_summaries, errors)
     coverage = _coverage_summary(layer_summaries, errors)
@@ -471,6 +474,7 @@ def local_lemma_audit_path_payload(
             "claim_scope_guards": claim_scope_guards,
             "layer_output_contracts": layer_output_contracts,
             "layer_input_contracts": layer_input_contracts,
+            "focused_minireplay_record_path_contract": focused_record_path_contract,
             "handoff_count": len(handoff_checks),
             "handoff_checks": handoff_checks,
             "layers": layer_summaries,
@@ -521,6 +525,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_claim_scope_guards(payload)
     _assert_expected_layer_output_contracts(payload)
     _assert_expected_layer_input_contracts(payload)
+    _assert_expected_focused_minireplay_record_path_contract(payload)
     _assert_expected_input_manifest(payload)
     _assert_expected_manifest_consistency(payload)
 
@@ -771,6 +776,44 @@ def _assert_expected_layer_input_contracts(payload: Mapping[str, Any]) -> None:
             raise AssertionError(f"{layer_id} missing input paths")
         if contract.get("unexpected_input_paths") != []:
             raise AssertionError(f"{layer_id} unexpected input paths")
+
+
+def _assert_expected_focused_minireplay_record_path_contract(
+    payload: Mapping[str, Any],
+) -> None:
+    audit_path = payload.get("audit_path")
+    if not isinstance(audit_path, Mapping):
+        raise AssertionError("audit_path must be an object")
+    contract = audit_path.get("focused_minireplay_record_path_contract")
+    if not isinstance(contract, Mapping):
+        raise AssertionError(
+            "audit_path.focused_minireplay_record_path_contract must be an object"
+        )
+    expected = _expected_focused_minireplay_records()
+    if contract.get("records_type") != "list":
+        raise AssertionError("focused minireplay records must be a list")
+    if contract.get("expected_record_count") != len(expected):
+        raise AssertionError("focused minireplay expected record count mismatch")
+    if contract.get("observed_record_count") != len(expected):
+        raise AssertionError("focused minireplay observed record count mismatch")
+    if contract.get("expected_records") != expected:
+        raise AssertionError("focused minireplay expected records mismatch")
+    if contract.get("observed_records") != expected:
+        raise AssertionError("focused minireplay observed records mismatch")
+    if contract.get("status") != "passed":
+        raise AssertionError(
+            f"focused minireplay record-path contract failed: {contract!r}"
+        )
+    for key in (
+        "missing_template_ids",
+        "unexpected_template_ids",
+        "duplicate_template_ids",
+        "mismatched_record_paths",
+    ):
+        if contract.get(key) != []:
+            raise AssertionError(f"focused minireplay {key} is not empty")
+    if contract.get("malformed_record_count") != 0:
+        raise AssertionError("focused minireplay malformed records")
 
 
 def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
@@ -1260,6 +1303,148 @@ def _artifact_path_key(path: Path) -> str:
     return display_path(path.resolve(), ROOT).replace("\\", "/")
 
 
+def _focused_minireplay_record_path_contract(
+    focused_minireplay: Mapping[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    expected = _expected_focused_minireplay_records()
+    summary = focused_minireplay.get("focused_minireplay_crosswalk")
+    records = summary.get("records", []) if isinstance(summary, Mapping) else []
+    records_type = "list" if isinstance(records, list) else type(records).__name__
+    observed, malformed_count = _observed_focused_minireplay_records(records)
+    expected_by_template = {record["template_id"]: record for record in expected}
+    observed_by_template = {record["template_id"]: record for record in observed}
+    observed_template_ids = [record["template_id"] for record in observed]
+    duplicate_template_ids = sorted(
+        {
+            template_id
+            for template_id in observed_template_ids
+            if observed_template_ids.count(template_id) > 1
+        }
+    )
+    missing = sorted(set(expected_by_template) - set(observed_by_template))
+    unexpected = sorted(set(observed_by_template) - set(expected_by_template))
+    mismatches = _focused_minireplay_record_path_mismatches(
+        expected_by_template,
+        observed_by_template,
+    )
+    bad_records_type = records_type != "list"
+
+    if bad_records_type:
+        errors.append(f"focused_minireplay records has type {records_type}")
+    if malformed_count:
+        errors.append(f"focused_minireplay has {malformed_count} malformed records")
+    if duplicate_template_ids:
+        errors.append(
+            f"focused_minireplay duplicate template ids: {duplicate_template_ids!r}"
+        )
+    if missing:
+        errors.append(f"focused_minireplay missing record templates: {missing!r}")
+    if unexpected:
+        errors.append(
+            f"focused_minireplay unexpected record templates: {unexpected!r}"
+        )
+    for mismatch in mismatches:
+        errors.append(
+            f"focused_minireplay record path mismatch on "
+            f"{mismatch['template_id']} {mismatch['key']}: "
+            f"{mismatch['observed']!r} != {mismatch['expected']!r}"
+        )
+
+    return {
+        "records_type": records_type,
+        "expected_record_count": len(expected),
+        "observed_record_count": len(observed),
+        "expected_records": expected,
+        "observed_records": _sort_focused_minireplay_records(observed),
+        "missing_template_ids": missing,
+        "unexpected_template_ids": unexpected,
+        "duplicate_template_ids": duplicate_template_ids,
+        "mismatched_record_paths": mismatches,
+        "malformed_record_count": malformed_count,
+        "status": (
+            "passed"
+            if not (
+                bad_records_type
+                or malformed_count
+                or duplicate_template_ids
+                or missing
+                or unexpected
+                or mismatches
+            )
+            else "failed"
+        ),
+    }
+
+
+def _expected_focused_minireplay_records() -> list[dict[str, str]]:
+    return [
+        {
+            "template_id": template_id,
+            "source_packet_path": _artifact_path_key(DEFAULT_PACKET_PATHS[template_id]),
+            "minireplay_path": _artifact_path_key(DEFAULT_MINIREPLAY_PATHS[template_id]),
+        }
+        for template_id in EXPECTED_TEMPLATE_IDS
+    ]
+
+
+def _observed_focused_minireplay_records(
+    records: Any,
+) -> tuple[list[dict[str, str]], int]:
+    if not isinstance(records, list):
+        return [], 0
+    observed: list[dict[str, str]] = []
+    malformed_count = 0
+    for record in records:
+        if not isinstance(record, Mapping):
+            malformed_count += 1
+            continue
+        template_id = record.get("template_id")
+        source_packet_path = record.get("source_packet_path")
+        minireplay_path = record.get("minireplay_path")
+        if not all(
+            isinstance(value, str)
+            for value in (template_id, source_packet_path, minireplay_path)
+        ):
+            malformed_count += 1
+            continue
+        observed.append(
+            {
+                "template_id": template_id,
+                "source_packet_path": source_packet_path,
+                "minireplay_path": minireplay_path,
+            }
+        )
+    return _sort_focused_minireplay_records(observed), malformed_count
+
+
+def _focused_minireplay_record_path_mismatches(
+    expected_by_template: Mapping[str, Mapping[str, str]],
+    observed_by_template: Mapping[str, Mapping[str, str]],
+) -> list[dict[str, str]]:
+    mismatches: list[dict[str, str]] = []
+    for template_id in sorted(set(expected_by_template) & set(observed_by_template)):
+        expected = expected_by_template[template_id]
+        observed = observed_by_template[template_id]
+        for key in ("source_packet_path", "minireplay_path"):
+            if observed.get(key) != expected.get(key):
+                mismatches.append(
+                    {
+                        "template_id": template_id,
+                        "key": key,
+                        "expected": expected[key],
+                        "observed": observed[key],
+                    }
+                )
+    return mismatches
+
+
+def _sort_focused_minireplay_records(
+    records: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    return sorted(records, key=lambda record: record["template_id"])
+
+
 def _input_manifest() -> dict[str, Any]:
     entries: dict[str, dict[str, Any]] = {}
 
@@ -1594,6 +1779,8 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"{_summary_status(payload['audit_path']['layer_output_contracts'])}",
         "layer input contracts: "
         f"{_summary_status(payload['audit_path']['layer_input_contracts'])}",
+        "focused minireplay record paths: "
+        f"{payload['audit_path']['focused_minireplay_record_path_contract']['status']}",
         f"handoffs: {payload['audit_path']['handoff_count']}",
         f"input artifacts: {payload['input_manifest']['artifact_count']}",
         f"manifest consistency: {payload['manifest_consistency']['status']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -201,6 +201,32 @@ def test_local_lemma_audit_path_layer_input_contracts() -> None:
         assert contract["unexpected_input_paths"] == []
 
 
+def test_local_lemma_audit_path_focused_minireplay_record_path_contract() -> None:
+    payload = local_lemma_audit_path_payload()
+    contract = payload["audit_path"]["focused_minireplay_record_path_contract"]
+    by_template = {
+        record["template_id"]: record for record in contract["observed_records"]
+    }
+
+    assert contract["status"] == "passed"
+    assert contract["records_type"] == "list"
+    assert contract["expected_record_count"] == 12
+    assert contract["observed_record_count"] == 12
+    assert contract["expected_records"] == contract["observed_records"]
+    assert contract["missing_template_ids"] == []
+    assert contract["unexpected_template_ids"] == []
+    assert contract["duplicate_template_ids"] == []
+    assert contract["mismatched_record_paths"] == []
+    assert contract["malformed_record_count"] == 0
+    assert by_template["T01"] == {
+        "template_id": "T01",
+        "source_packet_path": (
+            "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json"
+        ),
+        "minireplay_path": "data/certificates/n9_t01_self_edge_minireplay.json",
+    }
+
+
 def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
     focused_minireplay = focused_minireplay_crosswalk_payload()
     tampered = json.loads(json.dumps(focused_minireplay))
@@ -217,12 +243,22 @@ def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
         for contract in payload["audit_path"]["layer_input_contracts"]
     }
     focused_contract = input_contracts["focused_minireplay"]
+    record_contract = payload["audit_path"]["focused_minireplay_record_path_contract"]
 
     assert payload["validation_status"] == "failed"
     assert focused_contract["status"] == "failed"
     assert focused_contract["missing_input_paths"] == [original_path]
     assert focused_contract["unexpected_input_paths"] == [
         "data/certificates/unmanifested_minireplay.json"
+    ]
+    assert record_contract["status"] == "failed"
+    assert record_contract["mismatched_record_paths"] == [
+        {
+            "template_id": "T01",
+            "key": "minireplay_path",
+            "expected": original_path,
+            "observed": "data/certificates/unmanifested_minireplay.json",
+        }
     ]
     assert payload["manifest_consistency"]["status"] == "failed"
     assert payload["manifest_consistency"]["missing_from_manifest"] == [
@@ -234,6 +270,26 @@ def test_local_lemma_audit_path_rejects_unmanifested_layer_path() -> None:
     )
     assert any(
         "input_manifest missing layer-referenced paths" in error
+        for error in payload["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_rejects_malformed_record_path() -> None:
+    focused_minireplay = focused_minireplay_crosswalk_payload()
+    tampered = json.loads(json.dumps(focused_minireplay))
+    tampered["focused_minireplay_crosswalk"]["records"][0][
+        "source_packet_path"
+    ] = ["not", "string"]
+
+    payload = local_lemma_audit_path_payload(focused_minireplay_payload=tampered)
+    record_contract = payload["audit_path"]["focused_minireplay_record_path_contract"]
+
+    assert payload["validation_status"] == "failed"
+    assert record_contract["status"] == "failed"
+    assert record_contract["malformed_record_count"] == 1
+    assert record_contract["missing_template_ids"] == ["T01"]
+    assert any(
+        "focused_minireplay has 1 malformed records" in error
         for error in payload["validation_errors"]
     )
 


### PR DESCRIPTION
## What changed
- Add a `focused_minireplay_record_path_contract` section to the n=9 local-lemma audit-path checker.
- Check the 12 focused minireplay records against the expected template id, source packet path, and mini-replay path table.
- Validate the new record-path contract in `--assert-expected` mode and include its status in summary output.
- Add tests for the passing record-path table, a tampered minireplay path, and a malformed non-string record path.
- Update the n=9 local-lemma documentation to describe the focused record-path drift-localization check.

## Claim scope and evidence level
- Evidence level: reproducible review-pending audit-path diagnostic.
- This checks per-template focused minireplay bookkeeping only; it does not independently verify packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, or Erdos Problem #97.
- This is not a counterexample and does not update the official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest tests/test_run_artifact_audit.py tests/test_n9_vertex_circle_local_lemma_audit_path.py -q -m "artifact or not artifact"`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the generated n=9 local-lemma audit-path JSON payload without writing stored artifacts.
- No generated artifact files were changed.

## Known limitations / next review steps
- The new contract localizes record-path drift in the focused minireplay layer; it does not audit the mathematical truth of the upstream packet or minireplay artifacts.
- Independent packet soundness and the review-pending exhaustive brancher remain future review targets.