### PR TITLE
Add n9 audit manifest contract summary

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -666,7 +666,8 @@ inputs to `metadata/generated_artifacts.yaml` edit-policy and recheck-command
 entries, a manifest-claim contract for the expected review-pending claim-scope
 guard language on each upstream artifact, plus a manifest-consistency check
 comparing those paths with the artifacts actually referenced by each layer
-payload:
+payload, and a compact manifest-contract summary that reports the pass/fail
+state for all manifest-side contracts in one place:
 
 ```bash
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -85,6 +85,15 @@ EXPECTED_LAYER_IDS = [
 EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
 EXPECTED_HANDOFF_EDGES = list(zip(EXPECTED_LAYER_IDS, EXPECTED_LAYER_IDS[1:]))
 EXPECTED_INPUT_ARTIFACT_COUNT = 32
+EXPECTED_MANIFEST_CONTRACT_IDS = [
+    "manifest_role_contract",
+    "manifest_digest_contract",
+    "manifest_header_contract",
+    "manifest_provenance_contract",
+    "manifest_metadata_contract",
+    "manifest_claim_contract",
+    "manifest_consistency",
+]
 EXPECTED_LAYER_CONTRACTS = {
     "focused_packet_catalog": {
         "schema": "erdos97.n9_vertex_circle_focused_packet_catalog_audit.v1",
@@ -497,6 +506,17 @@ def local_lemma_audit_path_payload(
         claim_payloads=manifest_claim_payloads,
     )
     manifest_consistency = _manifest_consistency(layers, input_manifest, errors)
+    manifest_contract_summary = _manifest_contract_summary(
+        {
+            "manifest_role_contract": manifest_role_contract,
+            "manifest_digest_contract": manifest_digest_contract,
+            "manifest_header_contract": manifest_header_contract,
+            "manifest_provenance_contract": manifest_provenance_contract,
+            "manifest_metadata_contract": manifest_metadata_contract,
+            "manifest_claim_contract": manifest_claim_contract,
+            "manifest_consistency": manifest_consistency,
+        }
+    )
 
     return {
         "schema": SCHEMA,
@@ -527,6 +547,7 @@ def local_lemma_audit_path_payload(
         "manifest_metadata_contract": manifest_metadata_contract,
         "manifest_claim_contract": manifest_claim_contract,
         "manifest_consistency": manifest_consistency,
+        "manifest_contract_summary": manifest_contract_summary,
         "coverage_summary": coverage,
         "validation_status": "passed" if not errors else "failed",
         "validation_errors": errors,
@@ -580,6 +601,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_manifest_metadata_contract(payload)
     _assert_expected_manifest_claim_contract(payload)
     _assert_expected_manifest_consistency(payload)
+    _assert_expected_manifest_contract_summary(payload)
 
     audit_path = payload.get("audit_path")
     if not isinstance(audit_path, Mapping):
@@ -1123,6 +1145,30 @@ def _assert_expected_manifest_consistency(payload: Mapping[str, Any]) -> None:
             raise AssertionError(
                 f"manifest_consistency[{key!r}] mismatch: "
                 f"{consistency.get(key)!r} != {value!r}"
+            )
+
+
+def _assert_expected_manifest_contract_summary(payload: Mapping[str, Any]) -> None:
+    summary = payload.get("manifest_contract_summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("manifest_contract_summary must be an object")
+    expected_statuses = [
+        {"contract_id": contract_id, "status": "passed"}
+        for contract_id in EXPECTED_MANIFEST_CONTRACT_IDS
+    ]
+    expected = {
+        "status": "passed",
+        "contract_count": len(EXPECTED_MANIFEST_CONTRACT_IDS),
+        "passed_contract_count": len(EXPECTED_MANIFEST_CONTRACT_IDS),
+        "failed_contract_count": 0,
+        "failed_contracts": [],
+        "contract_statuses": expected_statuses,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(
+                f"manifest_contract_summary[{key!r}] mismatch: "
+                f"{summary.get(key)!r} != {value!r}"
             )
 
 
@@ -1869,6 +1915,32 @@ def _manifest_role_records(roles_by_path: Mapping[str, list[str]]) -> list[dict[
         {"path": path, "roles": roles_by_path[path]}
         for path in sorted(roles_by_path)
     ]
+
+
+def _manifest_contract_summary(
+    contracts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    contract_statuses: list[dict[str, str]] = []
+    for contract_id in EXPECTED_MANIFEST_CONTRACT_IDS:
+        contract = contracts.get(contract_id)
+        status = contract.get("status") if isinstance(contract, Mapping) else "missing"
+        if not isinstance(status, str):
+            status = "failed"
+        contract_statuses.append({"contract_id": contract_id, "status": status})
+
+    failed_contracts = [
+        item["contract_id"]
+        for item in contract_statuses
+        if item["status"] != "passed"
+    ]
+    return {
+        "status": "passed" if not failed_contracts else "failed",
+        "contract_count": len(contract_statuses),
+        "passed_contract_count": len(contract_statuses) - len(failed_contracts),
+        "failed_contract_count": len(failed_contracts),
+        "failed_contracts": failed_contracts,
+        "contract_statuses": contract_statuses,
+    }
 
 
 def _manifest_digest_contract(
@@ -3201,6 +3273,8 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"manifest metadata: {payload['manifest_metadata_contract']['status']}",
         f"manifest claims: {payload['manifest_claim_contract']['status']}",
         f"manifest consistency: {payload['manifest_consistency']['status']}",
+        "manifest contract summary: "
+        f"{payload['manifest_contract_summary']['status']}",
         f"templates: {coverage['template_count']}",
         f"families: {coverage['family_count']}",
         f"assignments: {coverage['assignment_count']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -18,6 +18,7 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_LAYER_OUTPUT_CONTRACTS,
     EXPECTED_LAYER_PROVENANCE,
     EXPECTED_LAYER_SOURCE_ARTIFACTS,
+    EXPECTED_MANIFEST_CONTRACT_IDS,
     assert_expected_local_lemma_audit_path,
     local_lemma_audit_path_payload,
 )
@@ -277,6 +278,23 @@ def test_local_lemma_audit_path_manifest_consistency() -> None:
     }
 
 
+def test_local_lemma_audit_path_manifest_contract_summary() -> None:
+    payload = local_lemma_audit_path_payload()
+    summary = payload["manifest_contract_summary"]
+
+    assert summary == {
+        "status": "passed",
+        "contract_count": len(EXPECTED_MANIFEST_CONTRACT_IDS),
+        "passed_contract_count": len(EXPECTED_MANIFEST_CONTRACT_IDS),
+        "failed_contract_count": 0,
+        "failed_contracts": [],
+        "contract_statuses": [
+            {"contract_id": contract_id, "status": "passed"}
+            for contract_id in EXPECTED_MANIFEST_CONTRACT_IDS
+        ],
+    }
+
+
 def test_local_lemma_audit_path_rejects_manifest_role_drift() -> None:
     payload = local_lemma_audit_path_payload()
     tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
@@ -289,9 +307,17 @@ def test_local_lemma_audit_path_rejects_manifest_role_drift() -> None:
         input_manifest_payload=tampered_manifest,
     )
     contract = tampered_payload["manifest_role_contract"]
+    summary = tampered_payload["manifest_contract_summary"]
 
     assert tampered_payload["validation_status"] == "failed"
     assert contract["status"] == "failed"
+    assert summary["status"] == "failed"
+    assert summary["contract_count"] == len(EXPECTED_MANIFEST_CONTRACT_IDS)
+    assert summary["passed_contract_count"] == (
+        len(EXPECTED_MANIFEST_CONTRACT_IDS) - 1
+    )
+    assert summary["failed_contract_count"] == 1
+    assert summary["failed_contracts"] == ["manifest_role_contract"]
     assert contract["mismatched_manifest_roles"] == [
         {
             "path": "data/certificates/n9_vertex_circle_local_lemmas.json",


### PR DESCRIPTION
## What changed
- Added an `EXPECTED_MANIFEST_CONTRACT_IDS` contract order for the n=9 local-lemma audit-path checker.
- Added a top-level `manifest_contract_summary` payload that reports pass/fail status, counts, and failed manifest-side contract ids across role, digest, header, provenance, metadata, claim, and manifest/layer consistency checks.
- Added focused tests for the all-pass summary and for a manifest role drift failure appearing in the summary.
- Documented the compact summary in the n=9 vertex-circle local-lemma audit path notes.

## Claim scope and evidence level
- Claim scope remains `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH` / `REVIEW_PENDING_DIAGNOSTIC`.
- This is an auditability/bookkeeping increment only.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97.
- It is not a counterexample and not a global status update.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle local-lemma audit-path JSON payload.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps
- The summary only rolls up existing manifest-side contract statuses; it does not independently validate the mathematical content of the underlying local-lemma packets.
- The n=9 artifacts remain review-pending.