### PR TITLE
Add n9 audit contract validation summary

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -667,7 +667,11 @@ entries, a manifest-claim contract for the expected review-pending claim-scope
 guard language on each upstream artifact, plus a manifest-consistency check
 comparing those paths with the artifacts actually referenced by each layer
 payload, and a compact manifest-contract summary that reports the pass/fail
-state for all manifest-side contracts in one place:
+state for all manifest-side contracts in one place. It also emits an
+audit-contract summary that rolls up the layer contracts, layer provenance,
+source-artifact contracts, claim-scope guards, output and input contracts,
+focused minireplay record-path contract, adjacent handoff checks, and manifest
+contracts into a single reviewer-facing pass/fail table:
 
 ```bash
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -94,6 +94,17 @@ EXPECTED_MANIFEST_CONTRACT_IDS = [
     "manifest_claim_contract",
     "manifest_consistency",
 ]
+EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS = [
+    "layer_contracts",
+    "layer_provenance",
+    "layer_source_artifact_contracts",
+    "claim_scope_guards",
+    "layer_output_contracts",
+    "layer_input_contracts",
+    "focused_minireplay_record_path_contract",
+    "handoff_checks",
+    "manifest_contracts",
+]
 EXPECTED_LAYER_CONTRACTS = {
     "focused_packet_catalog": {
         "schema": "erdos97.n9_vertex_circle_focused_packet_catalog_audit.v1",
@@ -517,6 +528,19 @@ def local_lemma_audit_path_payload(
             "manifest_consistency": manifest_consistency,
         }
     )
+    audit_contract_summary = _audit_contract_summary(
+        {
+            "layer_contracts": layer_contracts,
+            "layer_provenance": layer_provenance,
+            "layer_source_artifact_contracts": layer_source_artifact_contracts,
+            "claim_scope_guards": claim_scope_guards,
+            "layer_output_contracts": layer_output_contracts,
+            "layer_input_contracts": layer_input_contracts,
+            "focused_minireplay_record_path_contract": focused_record_path_contract,
+            "handoff_checks": handoff_checks,
+            "manifest_contracts": manifest_contract_summary,
+        }
+    )
 
     return {
         "schema": SCHEMA,
@@ -539,6 +563,7 @@ def local_lemma_audit_path_payload(
             "handoff_checks": handoff_checks,
             "layers": layer_summaries,
         },
+        "audit_contract_summary": audit_contract_summary,
         "input_manifest": input_manifest,
         "manifest_role_contract": manifest_role_contract,
         "manifest_digest_contract": manifest_digest_contract,
@@ -602,6 +627,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_manifest_claim_contract(payload)
     _assert_expected_manifest_consistency(payload)
     _assert_expected_manifest_contract_summary(payload)
+    _assert_expected_audit_contract_summary(payload)
 
     audit_path = payload.get("audit_path")
     if not isinstance(audit_path, Mapping):
@@ -1168,6 +1194,30 @@ def _assert_expected_manifest_contract_summary(payload: Mapping[str, Any]) -> No
         if summary.get(key) != value:
             raise AssertionError(
                 f"manifest_contract_summary[{key!r}] mismatch: "
+                f"{summary.get(key)!r} != {value!r}"
+            )
+
+
+def _assert_expected_audit_contract_summary(payload: Mapping[str, Any]) -> None:
+    summary = payload.get("audit_contract_summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("audit_contract_summary must be an object")
+    expected_statuses = [
+        {"component_id": component_id, "status": "passed"}
+        for component_id in EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS
+    ]
+    expected = {
+        "status": "passed",
+        "component_count": len(EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS),
+        "passed_component_count": len(EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS),
+        "failed_component_count": 0,
+        "failed_components": [],
+        "component_statuses": expected_statuses,
+    }
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise AssertionError(
+                f"audit_contract_summary[{key!r}] mismatch: "
                 f"{summary.get(key)!r} != {value!r}"
             )
 
@@ -1941,6 +1991,47 @@ def _manifest_contract_summary(
         "failed_contracts": failed_contracts,
         "contract_statuses": contract_statuses,
     }
+
+
+def _audit_contract_summary(components: Mapping[str, Any]) -> dict[str, Any]:
+    component_statuses: list[dict[str, str]] = []
+    for component_id in EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS:
+        component_statuses.append(
+            {
+                "component_id": component_id,
+                "status": _contract_component_status(components.get(component_id)),
+            }
+        )
+
+    failed_components = [
+        item["component_id"]
+        for item in component_statuses
+        if item["status"] != "passed"
+    ]
+    return {
+        "status": "passed" if not failed_components else "failed",
+        "component_count": len(component_statuses),
+        "passed_component_count": len(component_statuses) - len(failed_components),
+        "failed_component_count": len(failed_components),
+        "failed_components": failed_components,
+        "component_statuses": component_statuses,
+    }
+
+
+def _contract_component_status(component: Any) -> str:
+    if isinstance(component, Mapping):
+        status = component.get("status")
+        return status if isinstance(status, str) else "failed"
+    if isinstance(component, list):
+        return (
+            "passed"
+            if all(
+                isinstance(item, Mapping) and item.get("status") == "passed"
+                for item in component
+            )
+            else "failed"
+        )
+    return "failed"
 
 
 def _manifest_digest_contract(
@@ -3265,6 +3356,7 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         "focused minireplay record paths: "
         f"{payload['audit_path']['focused_minireplay_record_path_contract']['status']}",
         f"handoffs: {payload['audit_path']['handoff_count']}",
+        f"audit contract summary: {payload['audit_contract_summary']['status']}",
         f"input artifacts: {payload['input_manifest']['artifact_count']}",
         f"manifest roles: {payload['manifest_role_contract']['status']}",
         f"manifest digests: {payload['manifest_digest_contract']['status']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -11,6 +11,7 @@ from scripts.check_artifact_provenance import (
 )
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     CLAIM_SCOPE_GUARDS,
+    EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS,
     EXPECTED_HANDOFF_EDGES,
     EXPECTED_INPUT_ARTIFACT_COUNT,
     EXPECTED_LAYER_CONTRACTS,
@@ -295,6 +296,23 @@ def test_local_lemma_audit_path_manifest_contract_summary() -> None:
     }
 
 
+def test_local_lemma_audit_path_audit_contract_summary() -> None:
+    payload = local_lemma_audit_path_payload()
+    summary = payload["audit_contract_summary"]
+
+    assert summary == {
+        "status": "passed",
+        "component_count": len(EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS),
+        "passed_component_count": len(EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS),
+        "failed_component_count": 0,
+        "failed_components": [],
+        "component_statuses": [
+            {"component_id": component_id, "status": "passed"}
+            for component_id in EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS
+        ],
+    }
+
+
 def test_local_lemma_audit_path_rejects_manifest_role_drift() -> None:
     payload = local_lemma_audit_path_payload()
     tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
@@ -308,6 +326,7 @@ def test_local_lemma_audit_path_rejects_manifest_role_drift() -> None:
     )
     contract = tampered_payload["manifest_role_contract"]
     summary = tampered_payload["manifest_contract_summary"]
+    audit_summary = tampered_payload["audit_contract_summary"]
 
     assert tampered_payload["validation_status"] == "failed"
     assert contract["status"] == "failed"
@@ -318,6 +337,9 @@ def test_local_lemma_audit_path_rejects_manifest_role_drift() -> None:
     )
     assert summary["failed_contract_count"] == 1
     assert summary["failed_contracts"] == ["manifest_role_contract"]
+    assert audit_summary["status"] == "failed"
+    assert audit_summary["failed_component_count"] == 1
+    assert audit_summary["failed_components"] == ["manifest_contracts"]
     assert contract["mismatched_manifest_roles"] == [
         {
             "path": "data/certificates/n9_vertex_circle_local_lemmas.json",
@@ -857,9 +879,13 @@ def test_local_lemma_audit_path_rejects_layer_contract_drift() -> None:
         contract["layer_id"]: contract
         for contract in payload["audit_path"]["layer_contracts"]
     }
+    summary = payload["audit_contract_summary"]
 
     assert payload["validation_status"] == "failed"
     assert contracts["aggregate_simple_replay"]["status"] == "failed"
+    assert summary["status"] == "failed"
+    assert summary["failed_component_count"] == 1
+    assert summary["failed_components"] == ["layer_contracts"]
     assert contracts["aggregate_simple_replay"]["mismatches"] == [
         {
             "key": "trust",


### PR DESCRIPTION
## What changed
- Added `EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS` for the n=9 local-lemma audit-path checker.
- Added a top-level `audit_contract_summary` that rolls up layer contracts, layer provenance, source-artifact contracts, claim-scope guards, output and input contracts, the focused minireplay record-path contract, adjacent handoff checks, and the manifest contract summary.
- Added focused tests for the all-pass rollup, manifest-side failure propagation, and layer-contract failure propagation.
- Documented the new reviewer-facing rollup in the local-lemma audit-path notes.

## Claim scope and evidence level
- Claim scope remains `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH` / `REVIEW_PENDING_DIAGNOSTIC`.
- This is a reproducibility and triage improvement only.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97.
- It is not a counterexample and not a global status update.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle local-lemma audit-path JSON payload.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps
- The summary only reports the status of existing contract checks; it does not independently validate the mathematical soundness of the underlying local-lemma packets.
- The n=9 artifacts remain review-pending.