### PR TITLE
Cover n9 audit text summary rollups

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -677,6 +677,11 @@ contracts into a single reviewer-facing pass/fail table:
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 ```
 
+Without `--json`, the same checker prints the compact text summary. That
+summary includes both `audit contract summary` and `manifest contract summary`
+lines so reviewers can quickly see whether a failure is layer-side or
+manifest-side before inspecting the full JSON payload.
+
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier
 coverage, `n=9`, or Erdos Problem #97.

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -22,6 +22,7 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_MANIFEST_CONTRACT_IDS,
     assert_expected_local_lemma_audit_path,
     local_lemma_audit_path_payload,
+    summary_lines,
 )
 from scripts.check_n9_vertex_circle_focused_minireplay_crosswalk import (
     focused_minireplay_crosswalk_payload,
@@ -1147,6 +1148,60 @@ def test_local_lemma_audit_path_rejects_local_replay_drift() -> None:
         in error
         for error in payload["validation_errors"]
     )
+
+
+def test_local_lemma_audit_path_summary_lines_include_contract_rollups() -> None:
+    payload = local_lemma_audit_path_payload()
+    lines = summary_lines(payload)
+
+    expected_lines = [
+        "validation: passed",
+        "layer contracts: passed",
+        "layer provenance: passed",
+        "layer source artifacts: passed",
+        "claim-scope guards: passed",
+        "layer output contracts: passed",
+        "layer input contracts: passed",
+        "focused minireplay record paths: passed",
+        "audit contract summary: passed",
+        "manifest roles: passed",
+        "manifest digests: passed",
+        "manifest headers: passed",
+        "manifest provenance: passed",
+        "manifest metadata: passed",
+        "manifest claims: passed",
+        "manifest consistency: passed",
+        "manifest contract summary: passed",
+    ]
+
+    for line in expected_lines:
+        assert line in lines
+    assert lines.index("audit contract summary: passed") < lines.index(
+        "input artifacts: 32"
+    )
+    assert lines.index("manifest contract summary: passed") > lines.index(
+        "manifest consistency: passed"
+    )
+
+
+def test_local_lemma_audit_path_cli_text_summary_includes_contract_rollups() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
+            "--check",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    lines = result.stdout.splitlines()
+    assert "validation: passed" in lines
+    assert "audit contract summary: passed" in lines
+    assert "manifest contract summary: passed" in lines
 
 
 def test_local_lemma_audit_path_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Added direct test coverage for `summary_lines()` in the n=9 local-lemma audit-path checker.
- Added a non-JSON CLI smoke test to ensure the compact text summary includes both `audit contract summary` and `manifest contract summary` rollups.
- Documented the plain-text summary mode for reviewers.

## Claim scope and evidence level
- Claim scope remains `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH` / `REVIEW_PENDING_DIAGNOSTIC`.
- This is a reproducibility and reviewer-triage test/documentation increment only.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97.
- It is not a counterexample and not a global status update.

## Commands run
- `python -m ruff check tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle local-lemma audit-path text summary and JSON payload.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps
- The text summary remains a reviewer convenience over existing contract checks; it does not independently validate the mathematical soundness of the underlying local-lemma packets.
- The n=9 artifacts remain review-pending.