### PR TITLE
Add n9 audit CLI failure summary

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -680,7 +680,9 @@ python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert
 Without `--json`, the same checker prints the compact text summary. That
 summary includes both `audit contract summary` and `manifest contract summary`
 lines so reviewers can quickly see whether a failure is layer-side or
-manifest-side before inspecting the full JSON payload.
+manifest-side before inspecting the full JSON payload. If validation fails
+after a complete payload is available, the text mode prints those same compact
+summary lines before the detailed validation errors.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3383,6 +3383,17 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def failure_lines(payload: Mapping[str, Any]) -> list[str]:
+    lines = ["FAILED: local-lemma audit path"]
+    try:
+        lines.extend(summary_lines(payload))
+    except (KeyError, TypeError):
+        pass
+    for error in payload.get("validation_errors", []):
+        lines.append(f"- {error}")
+    return lines
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit path")
@@ -3414,9 +3425,8 @@ def main(argv: list[str] | None = None) -> int:
             print(line)
         print("OK: local-lemma audit path checks passed")
     else:
-        print("FAILED: local-lemma audit path", file=sys.stderr)
-        for error in payload.get("validation_errors", []):
-            print(f"- {error}", file=sys.stderr)
+        for line in failure_lines(payload):
+            print(line, file=sys.stderr)
 
     if args.check and payload.get("validation_status") != "passed":
         return 1

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -21,7 +21,9 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_LAYER_SOURCE_ARTIFACTS,
     EXPECTED_MANIFEST_CONTRACT_IDS,
     assert_expected_local_lemma_audit_path,
+    failure_lines,
     local_lemma_audit_path_payload,
+    main as audit_path_main,
     summary_lines,
 )
 from scripts.check_n9_vertex_circle_focused_minireplay_crosswalk import (
@@ -1202,6 +1204,64 @@ def test_local_lemma_audit_path_cli_text_summary_includes_contract_rollups() -> 
     assert "validation: passed" in lines
     assert "audit contract summary: passed" in lines
     assert "manifest contract summary: passed" in lines
+
+
+def test_local_lemma_audit_path_failure_lines_include_contract_rollups() -> None:
+    payload = local_lemma_audit_path_payload()
+    tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
+    for artifact in tampered_manifest["artifacts"]:
+        if artifact["path"] == "data/certificates/n9_vertex_circle_local_lemmas.json":
+            artifact["roles"] = ["aggregate/simple replay aggregate source"]
+            break
+
+    tampered_payload = local_lemma_audit_path_payload(
+        input_manifest_payload=tampered_manifest,
+    )
+    lines = failure_lines(tampered_payload)
+
+    assert lines[0] == "FAILED: local-lemma audit path"
+    assert "validation: failed" in lines
+    assert "audit contract summary: failed" in lines
+    assert "manifest roles: failed" in lines
+    assert "manifest contract summary: failed" in lines
+    assert any(
+        line.startswith(
+            "- input_manifest role mismatch on "
+            "data/certificates/n9_vertex_circle_local_lemmas.json"
+        )
+        for line in lines
+    )
+
+
+def test_local_lemma_audit_path_cli_failure_summary_includes_contract_rollups(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
+    for artifact in tampered_manifest["artifacts"]:
+        if artifact["path"] == "data/certificates/n9_vertex_circle_local_lemmas.json":
+            artifact["roles"] = ["aggregate/simple replay aggregate source"]
+            break
+    tampered_payload = local_lemma_audit_path_payload(
+        input_manifest_payload=tampered_manifest,
+    )
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: tampered_payload,
+    )
+
+    assert audit_path_main(["--check"]) == 1
+
+    captured = capsys.readouterr()
+    lines = captured.err.splitlines()
+    assert captured.out == ""
+    assert "FAILED: local-lemma audit path" in lines
+    assert "validation: failed" in lines
+    assert "audit contract summary: failed" in lines
+    assert "manifest roles: failed" in lines
+    assert "manifest contract summary: failed" in lines
 
 
 def test_local_lemma_audit_path_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Added a `failure_lines()` helper for the n=9 local-lemma audit-path checker.
- Text-mode failures now print the compact audit-path summary when a complete failed payload is available, then print validation errors.
- Added focused tests for the failure summary helper and for the CLI failure path via a manifest-role drift payload.
- Documented that text-mode failures include the compact rollups before detailed errors when possible.

## Claim scope and evidence level
- Claim scope remains `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH` / `REVIEW_PENDING_DIAGNOSTIC`.
- This is a reviewer-triage and reproducibility increment only.
- It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97.
- It is not a counterexample and not a global status update.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle local-lemma audit-path text summary and JSON payload.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps
- The failure summary is a display aid over existing contract checks; it does not independently validate the mathematical soundness of the underlying local-lemma packets.
- The n=9 artifacts remain review-pending.