### PR TITLE
Cover n9 audit JSON failure payload

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -682,7 +682,9 @@ summary includes both `audit contract summary` and `manifest contract summary`
 lines so reviewers can quickly see whether a failure is layer-side or
 manifest-side before inspecting the full JSON payload. If validation fails
 after a complete payload is available, the text mode prints those same compact
-summary lines before the detailed validation errors.
+summary lines before the detailed validation errors. With `--json`, failed
+runs return the same machine-readable payload, including the rollup fields,
+and exit nonzero when `--check` is supplied.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1264,6 +1264,47 @@ def test_local_lemma_audit_path_cli_failure_summary_includes_contract_rollups(
     assert "manifest contract summary: failed" in lines
 
 
+def test_local_lemma_audit_path_cli_json_failure_includes_contract_rollups(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
+    for artifact in tampered_manifest["artifacts"]:
+        if artifact["path"] == "data/certificates/n9_vertex_circle_local_lemmas.json":
+            artifact["roles"] = ["aggregate/simple replay aggregate source"]
+            break
+    tampered_payload = local_lemma_audit_path_payload(
+        input_manifest_payload=tampered_manifest,
+    )
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: tampered_payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["audit_contract_summary"]["status"] == "failed"
+    assert parsed["audit_contract_summary"]["failed_components"] == [
+        "manifest_contracts",
+    ]
+    assert parsed["manifest_role_contract"]["status"] == "failed"
+    assert parsed["manifest_contract_summary"]["status"] == "failed"
+    assert parsed["manifest_contract_summary"]["failed_contracts"] == [
+        "manifest_role_contract",
+    ]
+    assert any(
+        "input_manifest role mismatch on "
+        "data/certificates/n9_vertex_circle_local_lemmas.json" in error
+        for error in parsed["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_cli_json() -> None:
     result = subprocess.run(
         [


### PR DESCRIPTION
## What changed
- Added a regression test for `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --json` when manifest-role validation fails after a complete payload is available.
- Documented that failed JSON runs keep the machine-readable rollup fields while exiting nonzero under `--check`.

## Claim scope and evidence level
- Claim scope is limited to checker/CLI behavior and documentation for review triage.
- No general proof or counterexample is claimed.
- The official/global Erdos #97 status remains open/falsifiable unless manually rechecked.
- Existing `n <= 8` and `n=9` claim scopes are unchanged; `n=9` artifacts remain review-pending.

## Commands run
- `python -m ruff check tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked the existing n9 vertex-circle local-lemma audit-path checker in text and JSON modes.

## Known limitations / next review steps
- This does not strengthen the n=9 mathematical evidence; it only improves failure-path coverage for machine-readable audit diagnostics.
- Next review work should continue tightening independent audit contracts and replay coverage for n=9 packets.