### PR TITLE
Cover n9 audit layer failure rollups

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -684,7 +684,9 @@ manifest-side before inspecting the full JSON payload. If validation fails
 after a complete payload is available, the text mode prints those same compact
 summary lines before the detailed validation errors. With `--json`, failed
 runs return the same machine-readable payload, including the rollup fields,
-and exit nonzero when `--check` is supplied.
+and exit nonzero when `--check` is supplied. Regression coverage exercises both
+layer-side and manifest-side contract failures so those two failure classes stay
+separate in text and JSON summaries.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 from scripts.check_artifact_provenance import (
     DEFAULT_MANIFEST as DEFAULT_GENERATED_ARTIFACTS_MANIFEST,
@@ -37,6 +38,19 @@ from scripts.check_n9_vertex_circle_local_lemma_replay_crosswalk import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _layer_contract_trust_tamper_payload() -> dict[str, Any]:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    # Only the in-memory layer payload is tampered; the input manifest and
+    # stored artifacts stay canonical, so this isolates layer-contract failure.
+    tampered["trust"] = "EXACT_OBSTRUCTION"
+    return local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
 
 
 def test_local_lemma_audit_path_counts_and_scope() -> None:
@@ -1309,14 +1323,7 @@ def test_local_lemma_audit_path_cli_layer_failure_summary_marks_layer_side(
     monkeypatch,
     capsys,
 ) -> None:
-    aggregate = load_artifact(DEFAULT_AGGREGATE)
-    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
-    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
-    tampered = json.loads(json.dumps(local_replay))
-    tampered["trust"] = "EXACT_OBSTRUCTION"
-    tampered_payload = local_lemma_audit_path_payload(
-        aggregate_simple_replay_payload=tampered,
-    )
+    tampered_payload = _layer_contract_trust_tamper_payload()
     monkeypatch.setattr(
         "scripts.check_n9_vertex_circle_local_lemma_audit_path."
         "local_lemma_audit_path_payload",
@@ -1341,14 +1348,7 @@ def test_local_lemma_audit_path_cli_json_layer_failure_marks_layer_side(
     monkeypatch,
     capsys,
 ) -> None:
-    aggregate = load_artifact(DEFAULT_AGGREGATE)
-    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
-    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
-    tampered = json.loads(json.dumps(local_replay))
-    tampered["trust"] = "EXACT_OBSTRUCTION"
-    tampered_payload = local_lemma_audit_path_payload(
-        aggregate_simple_replay_payload=tampered,
-    )
+    tampered_payload = _layer_contract_trust_tamper_payload()
     monkeypatch.setattr(
         "scripts.check_n9_vertex_circle_local_lemma_audit_path."
         "local_lemma_audit_path_payload",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1305,6 +1305,85 @@ def test_local_lemma_audit_path_cli_json_failure_includes_contract_rollups(
     )
 
 
+def test_local_lemma_audit_path_cli_layer_failure_summary_marks_layer_side(
+    monkeypatch,
+    capsys,
+) -> None:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    tampered["trust"] = "EXACT_OBSTRUCTION"
+    tampered_payload = local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: tampered_payload,
+    )
+
+    assert audit_path_main(["--check"]) == 1
+
+    captured = capsys.readouterr()
+    lines = captured.err.splitlines()
+    assert captured.out == ""
+    assert "layer contracts: failed" in lines
+    assert "audit contract summary: failed" in lines
+    assert "manifest contract summary: passed" in lines
+    assert any(
+        line.startswith("- aggregate_simple_replay contract mismatch on trust")
+        for line in lines
+    )
+
+
+def test_local_lemma_audit_path_cli_json_layer_failure_marks_layer_side(
+    monkeypatch,
+    capsys,
+) -> None:
+    aggregate = load_artifact(DEFAULT_AGGREGATE)
+    simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)
+    local_replay = local_replay_crosswalk_payload(aggregate, simple_replay)
+    tampered = json.loads(json.dumps(local_replay))
+    tampered["trust"] = "EXACT_OBSTRUCTION"
+    tampered_payload = local_lemma_audit_path_payload(
+        aggregate_simple_replay_payload=tampered,
+    )
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: tampered_payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    layer_contracts = {
+        contract["layer_id"]: contract
+        for contract in parsed["audit_path"]["layer_contracts"]
+    }
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["audit_contract_summary"]["status"] == "failed"
+    assert parsed["audit_contract_summary"]["failed_components"] == [
+        "layer_contracts",
+    ]
+    assert parsed["manifest_contract_summary"]["status"] == "passed"
+    assert layer_contracts["aggregate_simple_replay"]["status"] == "failed"
+    assert layer_contracts["aggregate_simple_replay"]["mismatches"] == [
+        {
+            "key": "trust",
+            "expected": "REVIEW_PENDING_DIAGNOSTIC",
+            "observed": "EXACT_OBSTRUCTION",
+        }
+    ]
+    assert any(
+        "aggregate_simple_replay contract mismatch on trust" in error
+        for error in parsed["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_cli_json() -> None:
     result = subprocess.run(
         [


### PR DESCRIPTION
## What changed
- Added CLI negative-control tests for a layer-side n9 local-lemma audit-path contract failure in both text and `--json` modes.
- Documented that regression coverage now exercises both layer-side and manifest-side contract failure rollups.

## Claim scope and evidence level
- Claim scope is limited to checker failure-path coverage and reviewer-facing documentation.
- No general proof or counterexample is claimed.
- The official/global Erdos #97 status remains open/falsifiable unless manually rechecked.
- Existing `n <= 8` and `n=9` claim scopes are unchanged; `n=9` artifacts remain review-pending.

## Commands run
- `python -m ruff check tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked the existing n9 vertex-circle local-lemma audit-path checker JSON output and failure-rollup tests.

## Known limitations / next review steps
- This does not strengthen n=9 mathematical evidence; it only guards diagnostic behavior for review triage.
- Next review work should continue tightening independent n=9 audit-path contracts and replay checks without promoting claim scope.