### PR TITLE
Preserve n9 audit JSON assert failures

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -686,7 +686,9 @@ summary lines before the detailed validation errors. With `--json`, failed
 runs return the same machine-readable payload, including the rollup fields,
 and exit nonzero when `--check` is supplied. Regression coverage exercises both
 layer-side and manifest-side contract failures so those two failure classes stay
-separate in text and JSON summaries.
+separate in text and JSON summaries. When `--assert-expected` is also supplied,
+an expected-shape failure is recorded in `validation_errors` instead of
+replacing the JSON diagnostic with a traceback.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3394,6 +3394,24 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
     return lines
 
 
+def _payload_with_assert_expected_failure(
+    payload: Mapping[str, Any],
+    exc: Exception,
+) -> dict[str, Any]:
+    updated = dict(payload)
+    errors = payload.get("validation_errors", [])
+    if not isinstance(errors, list):
+        errors = [f"validation_errors is not a list: {type(errors).__name__}"]
+    else:
+        errors = [str(error) for error in errors]
+    message = f"assert_expected failed: {exc}"
+    if message not in errors:
+        errors.append(message)
+    updated["validation_status"] = "failed"
+    updated["validation_errors"] = errors
+    return updated
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit path")
@@ -3414,8 +3432,13 @@ def main(argv: list[str] | None = None) -> int:
             "provenance": dict(PROVENANCE),
         }
 
+    assert_expected_failed = False
     if args.assert_expected:
-        assert_expected_local_lemma_audit_path(payload)
+        try:
+            assert_expected_local_lemma_audit_path(payload)
+        except (AssertionError, KeyError, TypeError, ValueError) as exc:
+            assert_expected_failed = True
+            payload = _payload_with_assert_expected_failure(payload, exc)
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -3428,6 +3451,8 @@ def main(argv: list[str] | None = None) -> int:
         for line in failure_lines(payload):
             print(line, file=sys.stderr)
 
+    if assert_expected_failed:
+        return 1
     if args.check and payload.get("validation_status") != "passed":
         return 1
     return 0

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1319,6 +1319,73 @@ def test_local_lemma_audit_path_cli_json_failure_includes_contract_rollups(
     )
 
 
+def test_local_lemma_audit_path_cli_assert_expected_failure_stays_textual(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
+    for artifact in tampered_manifest["artifacts"]:
+        if artifact["path"] == "data/certificates/n9_vertex_circle_local_lemmas.json":
+            artifact["roles"] = ["aggregate/simple replay aggregate source"]
+            break
+    tampered_payload = local_lemma_audit_path_payload(
+        input_manifest_payload=tampered_manifest,
+    )
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: tampered_payload,
+    )
+
+    assert audit_path_main(["--check", "--assert-expected"]) == 1
+
+    captured = capsys.readouterr()
+    lines = captured.err.splitlines()
+    assert captured.out == ""
+    assert "FAILED: local-lemma audit path" in lines
+    assert "manifest contract summary: failed" in lines
+    assert any(
+        line.startswith("- assert_expected failed: validation errors:")
+        for line in lines
+    )
+
+
+def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    tampered_manifest = json.loads(json.dumps(payload["input_manifest"]))
+    for artifact in tampered_manifest["artifacts"]:
+        if artifact["path"] == "data/certificates/n9_vertex_circle_local_lemmas.json":
+            artifact["roles"] = ["aggregate/simple replay aggregate source"]
+            break
+    tampered_payload = local_lemma_audit_path_payload(
+        input_manifest_payload=tampered_manifest,
+    )
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: tampered_payload,
+    )
+
+    assert audit_path_main(["--check", "--assert-expected", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["manifest_contract_summary"]["status"] == "failed"
+    assert parsed["audit_contract_summary"]["failed_components"] == [
+        "manifest_contracts",
+    ]
+    assert any(
+        error.startswith("assert_expected failed: validation errors:")
+        for error in parsed["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_cli_layer_failure_summary_marks_layer_side(
     monkeypatch,
     capsys,


### PR DESCRIPTION
## What changed
- Updated the n9 local-lemma audit-path CLI so `--assert-expected` failures are recorded in the payload `validation_errors` instead of replacing JSON diagnostics with a traceback.
- Added text and JSON negative-control tests for `--check --assert-expected` failure output.
- Documented the reviewer-facing failure-mode behavior.

## Claim scope and evidence level
- Claim scope is limited to CLI failure diagnostics for the review-pending n9 local-lemma audit path.
- No general proof or counterexample is claimed.
- The official/global Erdos #97 status remains open/falsifiable unless manually rechecked.
- Existing `n <= 8` and `n=9` claim scopes are unchanged; `n=9` artifacts remain review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked the existing n9 vertex-circle local-lemma audit-path checker in normal JSON mode and added in-process failure diagnostics coverage.

## Known limitations / next review steps
- This does not strengthen n=9 mathematical evidence; it only makes failing diagnostics machine-readable for review.
- Next review work should continue independent n9 audit-path checks and replay-contract tightening without promoting claim scope.