### PR TITLE
Mark n9 audit payload construction failures

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -688,7 +688,9 @@ and exit nonzero when `--check` is supplied. Regression coverage exercises both
 layer-side and manifest-side contract failures so those two failure classes stay
 separate in text and JSON summaries. When `--assert-expected` is also supplied,
 an expected-shape failure is recorded in `validation_errors` instead of
-replacing the JSON diagnostic with a traceback.
+replacing the JSON diagnostic with a traceback. If payload construction itself
+fails, the fallback payload records `failure_stage: payload_construction` and
+the Python exception type before returning nonzero under `--check`.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3389,9 +3389,27 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
         lines.extend(summary_lines(payload))
     except (KeyError, TypeError):
         pass
+    if payload.get("failure_stage"):
+        lines.append(f"failure stage: {payload['failure_stage']}")
+    if payload.get("exception_type"):
+        lines.append(f"exception type: {payload['exception_type']}")
     for error in payload.get("validation_errors", []):
         lines.append(f"- {error}")
     return lines
+
+
+def _payload_with_generation_failure(exc: Exception) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "validation_status": "failed",
+        "validation_errors": [f"payload construction failed: {exc}"],
+        "failure_stage": "payload_construction",
+        "exception_type": type(exc).__name__,
+        "provenance": dict(PROVENANCE),
+    }
 
 
 def _payload_with_assert_expected_failure(
@@ -3422,15 +3440,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         payload = local_lemma_audit_path_payload()
     except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-        payload = {
-            "schema": SCHEMA,
-            "status": STATUS,
-            "trust": TRUST,
-            "claim_scope": CLAIM_SCOPE,
-            "validation_status": "failed",
-            "validation_errors": [str(exc)],
-            "provenance": dict(PROVENANCE),
-        }
+        payload = _payload_with_generation_failure(exc)
 
     assert_expected_failed = False
     if args.assert_expected:

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1386,6 +1386,62 @@ def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload
     )
 
 
+def test_local_lemma_audit_path_cli_generation_failure_stays_textual(
+    monkeypatch,
+    capsys,
+) -> None:
+    def raise_payload_error() -> None:
+        raise ValueError("malformed audit fixture")
+
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        raise_payload_error,
+    )
+
+    assert audit_path_main(["--check"]) == 1
+
+    captured = capsys.readouterr()
+    lines = captured.err.splitlines()
+    assert captured.out == ""
+    assert lines == [
+        "FAILED: local-lemma audit path",
+        "failure stage: payload_construction",
+        "exception type: ValueError",
+        "- payload construction failed: malformed audit fixture",
+    ]
+
+
+def test_local_lemma_audit_path_cli_json_generation_failure_returns_payload(
+    monkeypatch,
+    capsys,
+) -> None:
+    def raise_payload_error() -> None:
+        raise ValueError("malformed audit fixture")
+
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        raise_payload_error,
+    )
+
+    assert audit_path_main(["--check", "--assert-expected", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["failure_stage"] == "payload_construction"
+    assert parsed["exception_type"] == "ValueError"
+    assert parsed["validation_errors"][0] == (
+        "payload construction failed: malformed audit fixture"
+    )
+    assert any(
+        error.startswith("assert_expected failed: validation errors:")
+        for error in parsed["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_cli_layer_failure_summary_marks_layer_side(
     monkeypatch,
     capsys,


### PR DESCRIPTION
## What changed
- Added an explicit fallback payload for n=9 local-lemma audit path payload-construction failures.
- Included `failure_stage: payload_construction` and `exception_type` in JSON/text diagnostics for malformed outer payload failures.
- Added CLI regression coverage for text and JSON modes, including `--assert-expected` behavior.
- Documented the fallback diagnostic shape in the n=9 local-lemma audit notes.

## Claim scope and evidence level
- Diagnostic/review support only.
- No general proof is claimed.
- No counterexample is claimed.
- n=9 artifacts remain review-pending.
- Numerical near-misses remain non-counterexamples.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked existing provenance metadata with `scripts/check_artifact_provenance.py`.
- Checked the n=9 local-lemma audit path CLI JSON contract.

## Known limitations / next review steps
- This does not strengthen any n=9 mathematical result.
- The fallback only preserves diagnostics after payload-construction exceptions; it does not repair malformed source artifacts.
- Next review can continue tightening n=9 audit-path failure contracts and cross-check coverage.