### PR TITLE
Harden n9 audit failure-line rendering

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -690,7 +690,9 @@ separate in text and JSON summaries. When `--assert-expected` is also supplied,
 an expected-shape failure is recorded in `validation_errors` instead of
 replacing the JSON diagnostic with a traceback. If payload construction itself
 fails, the fallback payload records `failure_stage: payload_construction` and
-the Python exception type before returning nonzero under `--check`.
+the Python exception type before returning nonzero under `--check`. Text-mode
+failure rendering also rejects malformed scalar `validation_errors` payloads
+as a single schema problem instead of treating the scalar as multiple errors.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3393,7 +3393,11 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
         lines.append(f"failure stage: {payload['failure_stage']}")
     if payload.get("exception_type"):
         lines.append(f"exception type: {payload['exception_type']}")
-    for error in payload.get("validation_errors", []):
+    errors = payload.get("validation_errors", [])
+    if not isinstance(errors, list):
+        lines.append(f"- validation_errors is not a list: {type(errors).__name__}")
+        return lines
+    for error in errors:
         lines.append(f"- {error}")
     return lines
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1247,6 +1247,20 @@ def test_local_lemma_audit_path_failure_lines_include_contract_rollups() -> None
     )
 
 
+def test_local_lemma_audit_path_failure_lines_reject_scalar_errors() -> None:
+    lines = failure_lines(
+        {
+            "validation_status": "failed",
+            "validation_errors": "malformed contract payload",
+        }
+    )
+
+    assert lines == [
+        "FAILED: local-lemma audit path",
+        "- validation_errors is not a list: str",
+    ]
+
+
 def test_local_lemma_audit_path_cli_failure_summary_includes_contract_rollups(
     monkeypatch,
     capsys,
@@ -1349,6 +1363,29 @@ def test_local_lemma_audit_path_cli_assert_expected_failure_stays_textual(
         line.startswith("- assert_expected failed: validation errors:")
         for line in lines
     )
+
+
+def test_local_lemma_audit_path_cli_scalar_validation_errors_stays_textual(
+    monkeypatch,
+    capsys,
+) -> None:
+    malformed_payload = local_lemma_audit_path_payload()
+    malformed_payload["validation_status"] = "failed"
+    malformed_payload["validation_errors"] = "malformed contract payload"
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: malformed_payload,
+    )
+
+    assert audit_path_main(["--check"]) == 1
+
+    captured = capsys.readouterr()
+    lines = captured.err.splitlines()
+    assert captured.out == ""
+    assert "validation: failed" in lines
+    assert "- validation_errors is not a list: str" in lines
+    assert "- m" not in lines
 
 
 def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload(


### PR DESCRIPTION
## What changed
- Hardened the n=9 local-lemma audit-path text failure renderer against malformed scalar `validation_errors` payloads.
- Added direct and CLI regression coverage so scalar `validation_errors` is reported as one schema-shape problem instead of character-by-character error lines.
- Documented the failure-rendering contract in the local-lemma audit notes.

## Claim scope and evidence level
- Diagnostic/review support only.
- No general proof is claimed.
- No counterexample is claimed.
- n=9 artifacts remain review-pending.
- Numerical near-misses remain non-counterexamples.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked existing provenance metadata with `scripts/check_artifact_provenance.py`.
- Checked the n=9 local-lemma audit path CLI JSON contract.

## Known limitations / next review steps
- This does not strengthen any n=9 mathematical result.
- The change only hardens text-mode diagnostic rendering for malformed payloads.
- Further review can continue tightening audit-path schema and drift-localization contracts.