### PR TITLE
Expose n9 audit assert failure details

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -693,6 +693,9 @@ fails, the fallback payload records `failure_stage: payload_construction` and
 the Python exception type before returning nonzero under `--check`. Text-mode
 failure rendering also rejects malformed scalar `validation_errors` payloads
 as a single schema problem instead of treating the scalar as multiple errors.
+JSON diagnostics for `--assert-expected` failures also include an
+`assert_expected_failure` object with the assertion stage, Python exception
+type, and message so consumers do not have to parse the error string.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3431,6 +3431,11 @@ def _payload_with_assert_expected_failure(
         errors.append(message)
     updated["validation_status"] = "failed"
     updated["validation_errors"] = errors
+    updated["assert_expected_failure"] = {
+        "stage": "assert_expected",
+        "exception_type": type(exc).__name__,
+        "message": str(exc),
+    }
     return updated
 
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1388,6 +1388,36 @@ def test_local_lemma_audit_path_cli_scalar_validation_errors_stays_textual(
     assert "- m" not in lines
 
 
+def test_local_lemma_audit_path_cli_json_scalar_validation_errors_shape(
+    monkeypatch,
+    capsys,
+) -> None:
+    malformed_payload = local_lemma_audit_path_payload()
+    malformed_payload["validation_status"] = "failed"
+    malformed_payload["validation_errors"] = "malformed contract payload"
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: malformed_payload,
+    )
+
+    assert audit_path_main(["--check", "--assert-expected", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["validation_errors"][0] == "validation_errors is not a list: str"
+    assert parsed["validation_errors"][1] == (
+        "assert_expected failed: validation errors: 'malformed contract payload'"
+    )
+    assert parsed["assert_expected_failure"] == {
+        "stage": "assert_expected",
+        "exception_type": "AssertionError",
+        "message": "validation errors: 'malformed contract payload'",
+    }
+
+
 def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload(
     monkeypatch,
     capsys,
@@ -1420,6 +1450,11 @@ def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload
     assert any(
         error.startswith("assert_expected failed: validation errors:")
         for error in parsed["validation_errors"]
+    )
+    assert parsed["assert_expected_failure"]["stage"] == "assert_expected"
+    assert parsed["assert_expected_failure"]["exception_type"] == "AssertionError"
+    assert parsed["assert_expected_failure"]["message"].startswith(
+        "validation errors:"
     )
 
 
@@ -1477,6 +1512,14 @@ def test_local_lemma_audit_path_cli_json_generation_failure_returns_payload(
         error.startswith("assert_expected failed: validation errors:")
         for error in parsed["validation_errors"]
     )
+    assert parsed["assert_expected_failure"] == {
+        "stage": "assert_expected",
+        "exception_type": "AssertionError",
+        "message": (
+            "validation errors: "
+            "['payload construction failed: malformed audit fixture']"
+        ),
+    }
 
 
 def test_local_lemma_audit_path_cli_layer_failure_summary_marks_layer_side(


### PR DESCRIPTION
## What changed
- Added a structured `assert_expected_failure` object to n=9 local-lemma audit-path JSON diagnostics when `--assert-expected` fails.
- Preserved existing `validation_errors` behavior while exposing assertion stage, Python exception type, and message for JSON consumers.
- Added regression coverage for scalar malformed `validation_errors`, normal contract failure JSON, and payload-construction fallback JSON.
- Documented the JSON diagnostic shape in the n=9 local-lemma audit notes.

## Claim scope and evidence level
- Diagnostic/review support only.
- No general proof is claimed.
- No counterexample is claimed.
- n=9 artifacts remain review-pending.
- Numerical near-misses remain non-counterexamples.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked existing provenance metadata with `scripts/check_artifact_provenance.py`.
- Checked the n=9 local-lemma audit path CLI JSON contract.

## Known limitations / next review steps
- This does not strengthen any n=9 mathematical result.
- The added object describes assertion-stage diagnostic failures only; it does not repair malformed source artifacts.
- Further review can continue tightening audit-path schema and drift-localization contracts.