### PR TITLE
Count n9 audit assertion validation errors

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -695,7 +695,8 @@ failure rendering also rejects malformed scalar `validation_errors` payloads
 as a single schema problem instead of treating the scalar as multiple errors.
 JSON diagnostics for `--assert-expected` failures also include an
 `assert_expected_failure` object with the assertion stage, Python exception
-type, and message so consumers do not have to parse the error string.
+type, message, and underlying validation-error count so consumers do not have
+to parse the error string.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3426,6 +3426,7 @@ def _payload_with_assert_expected_failure(
         errors = [f"validation_errors is not a list: {type(errors).__name__}"]
     else:
         errors = [str(error) for error in errors]
+    validation_error_count = len(errors)
     message = f"assert_expected failed: {exc}"
     if message not in errors:
         errors.append(message)
@@ -3435,6 +3436,7 @@ def _payload_with_assert_expected_failure(
         "stage": "assert_expected",
         "exception_type": type(exc).__name__,
         "message": str(exc),
+        "validation_error_count": validation_error_count,
     }
     return updated
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1415,6 +1415,7 @@ def test_local_lemma_audit_path_cli_json_scalar_validation_errors_shape(
         "stage": "assert_expected",
         "exception_type": "AssertionError",
         "message": "validation errors: 'malformed contract payload'",
+        "validation_error_count": 1,
     }
 
 
@@ -1456,6 +1457,9 @@ def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload
     assert parsed["assert_expected_failure"]["message"].startswith(
         "validation errors:"
     )
+    assert parsed["assert_expected_failure"]["validation_error_count"] == len(
+        parsed["validation_errors"]
+    ) - 1
 
 
 def test_local_lemma_audit_path_cli_generation_failure_stays_textual(
@@ -1519,6 +1523,7 @@ def test_local_lemma_audit_path_cli_json_generation_failure_returns_payload(
             "validation errors: "
             "['payload construction failed: malformed audit fixture']"
         ),
+        "validation_error_count": 1,
     }
 
 


### PR DESCRIPTION
## What changed
- Added `validation_error_count` to the n=9 local-lemma audit-path `assert_expected_failure` JSON object.
- Kept the count scoped to the underlying validation errors before the appended `assert_expected failed` message.
- Updated regression coverage for scalar malformed errors, normal contract failures, and payload-construction fallback failures.
- Documented the richer JSON diagnostic shape in the n=9 local-lemma audit notes.

## Claim scope and evidence level
- Diagnostic/review support only.
- No general proof is claimed.
- No counterexample is claimed.
- n=9 artifacts remain review-pending.
- Numerical near-misses remain non-counterexamples.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were rewritten.
- Checked existing provenance metadata with `scripts/check_artifact_provenance.py`.
- Checked the n=9 local-lemma audit path CLI JSON contract.

## Known limitations / next review steps
- This does not strengthen any n=9 mathematical result.
- The count is diagnostic metadata only and does not repair malformed source artifacts.
- Further review can continue tightening audit-path schema and drift-localization contracts.