### PR TITLE
Tag n9 audit assert failure object

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -694,9 +694,9 @@ the Python exception type before returning nonzero under `--check`. Text-mode
 failure rendering also rejects malformed scalar `validation_errors` payloads
 as a single schema problem instead of treating the scalar as multiple errors.
 JSON diagnostics for `--assert-expected` failures also include an
-`assert_expected_failure` object with the assertion stage, Python exception
-type, message, and underlying validation-error count so consumers do not have
-to parse the error string.
+`assert_expected_failure` object with its own schema tag, assertion stage,
+Python exception type, message, and underlying validation-error count so
+consumers do not have to parse the error string.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -55,6 +55,9 @@ from check_relation_skeleton_local_lemma_crosswalk import (  # noqa: E402
 from erdos97.path_display import display_path  # noqa: E402
 
 SCHEMA = "erdos97.n9_vertex_circle_local_lemma_audit_path.v1"
+ASSERT_EXPECTED_FAILURE_SCHEMA = (
+    "erdos97.n9_vertex_circle_local_lemma_audit_path.assert_expected_failure.v1"
+)
 STATUS = "REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 CLAIM_SCOPE = (
@@ -3433,6 +3436,7 @@ def _payload_with_assert_expected_failure(
     updated["validation_status"] = "failed"
     updated["validation_errors"] = errors
     updated["assert_expected_failure"] = {
+        "schema": ASSERT_EXPECTED_FAILURE_SCHEMA,
         "stage": "assert_expected",
         "exception_type": type(exc).__name__,
         "message": str(exc),

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -11,6 +11,7 @@ from scripts.check_artifact_provenance import (
     load_manifest as load_generated_artifact_manifest,
 )
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
+    ASSERT_EXPECTED_FAILURE_SCHEMA,
     CLAIM_SCOPE_GUARDS,
     EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS,
     EXPECTED_HANDOFF_EDGES,
@@ -1412,6 +1413,7 @@ def test_local_lemma_audit_path_cli_json_scalar_validation_errors_shape(
         "assert_expected failed: validation errors: 'malformed contract payload'"
     )
     assert parsed["assert_expected_failure"] == {
+        "schema": ASSERT_EXPECTED_FAILURE_SCHEMA,
         "stage": "assert_expected",
         "exception_type": "AssertionError",
         "message": "validation errors: 'malformed contract payload'",
@@ -1453,6 +1455,10 @@ def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload
         for error in parsed["validation_errors"]
     )
     assert parsed["assert_expected_failure"]["stage"] == "assert_expected"
+    assert (
+        parsed["assert_expected_failure"]["schema"]
+        == ASSERT_EXPECTED_FAILURE_SCHEMA
+    )
     assert parsed["assert_expected_failure"]["exception_type"] == "AssertionError"
     assert parsed["assert_expected_failure"]["message"].startswith(
         "validation errors:"
@@ -1517,6 +1523,7 @@ def test_local_lemma_audit_path_cli_json_generation_failure_returns_payload(
         for error in parsed["validation_errors"]
     )
     assert parsed["assert_expected_failure"] == {
+        "schema": ASSERT_EXPECTED_FAILURE_SCHEMA,
         "stage": "assert_expected",
         "exception_type": "AssertionError",
         "message": (


### PR DESCRIPTION
## What changed

- Added a versioned `schema` field to the `assert_expected_failure` JSON object emitted by `scripts/check_n9_vertex_circle_local_lemma_audit_path.py` when `--assert-expected --json` fails after a diagnostic payload is available.
- Updated regression tests to pin the nested failure-object schema in scalar validation-error and payload-construction failure paths.
- Updated the local-lemma audit-path docs to describe the schema-tagged nested failure diagnostic.

## Claim scope and evidence level

This is a diagnostic/review-support contract change only. It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97. It does not claim a counterexample or alter the official/global falsifiable/open status. Existing review-pending `n=9` scopes remain review-pending.

## Commands run

```bash
python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py
python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q
python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
python scripts/check_text_clean.py
python scripts/check_status_consistency.py
python scripts/check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

## Artifacts generated or checked

- Checked the existing local-lemma audit-path JSON payload with `--check --assert-expected --json`.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps

- This only versions the nested assertion-failure diagnostic object; it does not strengthen any mathematical certificate.
- Continue reviewing the n=9 local-lemma audit path and adjacent handoff contracts before any promotion of review-pending n=9 artifacts.