### PR TITLE
Validate n9 audit assert failure schema

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -696,7 +696,9 @@ as a single schema problem instead of treating the scalar as multiple errors.
 JSON diagnostics for `--assert-expected` failures also include an
 `assert_expected_failure` object with its own schema tag, assertion stage,
 Python exception type, message, and underlying validation-error count so
-consumers do not have to parse the error string.
+consumers do not have to parse the error string. The checker validates that
+nested object contract for schema, exact keys, stage, nonempty text fields, and
+the pre-assertion validation-error count.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -58,6 +58,15 @@ SCHEMA = "erdos97.n9_vertex_circle_local_lemma_audit_path.v1"
 ASSERT_EXPECTED_FAILURE_SCHEMA = (
     "erdos97.n9_vertex_circle_local_lemma_audit_path.assert_expected_failure.v1"
 )
+ASSERT_EXPECTED_FAILURE_KEYS = frozenset(
+    {
+        "schema",
+        "stage",
+        "exception_type",
+        "message",
+        "validation_error_count",
+    }
+)
 STATUS = "REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 CLAIM_SCOPE = (
@@ -3331,6 +3340,52 @@ def _string_list(value: Any) -> list[str]:
     return [str(item) for item in value]
 
 
+def assert_expected_failure_contract_errors(
+    record: Any,
+    *,
+    expected_validation_error_count: int | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(record, Mapping):
+        return [f"assert_expected_failure must be an object: {type(record).__name__}"]
+
+    observed_keys = set(record)
+    missing = sorted(ASSERT_EXPECTED_FAILURE_KEYS - observed_keys)
+    unexpected = sorted(observed_keys - ASSERT_EXPECTED_FAILURE_KEYS)
+    if missing:
+        errors.append(f"assert_expected_failure missing keys: {missing!r}")
+    if unexpected:
+        errors.append(f"assert_expected_failure unexpected keys: {unexpected!r}")
+    if record.get("schema") != ASSERT_EXPECTED_FAILURE_SCHEMA:
+        errors.append(
+            "assert_expected_failure schema mismatch: "
+            f"{record.get('schema')!r}"
+        )
+    if record.get("stage") != "assert_expected":
+        errors.append(f"assert_expected_failure stage mismatch: {record.get('stage')!r}")
+    for key in ("exception_type", "message"):
+        value = record.get(key)
+        if not isinstance(value, str) or not value:
+            errors.append(f"assert_expected_failure {key} must be a nonempty string")
+    validation_error_count = record.get("validation_error_count")
+    if not isinstance(validation_error_count, int) or isinstance(
+        validation_error_count,
+        bool,
+    ):
+        errors.append("assert_expected_failure validation_error_count must be an int")
+    elif validation_error_count < 0:
+        errors.append("assert_expected_failure validation_error_count must be nonnegative")
+    elif (
+        expected_validation_error_count is not None
+        and validation_error_count != expected_validation_error_count
+    ):
+        errors.append(
+            "assert_expected_failure validation_error_count mismatch: "
+            f"expected {expected_validation_error_count}, got {validation_error_count}"
+        )
+    return errors
+
+
 def _summary_status(items: Any) -> str:
     if not isinstance(items, list):
         return "failed"
@@ -3435,13 +3490,20 @@ def _payload_with_assert_expected_failure(
         errors.append(message)
     updated["validation_status"] = "failed"
     updated["validation_errors"] = errors
-    updated["assert_expected_failure"] = {
+    failure_record = {
         "schema": ASSERT_EXPECTED_FAILURE_SCHEMA,
         "stage": "assert_expected",
         "exception_type": type(exc).__name__,
         "message": str(exc),
         "validation_error_count": validation_error_count,
     }
+    updated["assert_expected_failure"] = failure_record
+    errors.extend(
+        assert_expected_failure_contract_errors(
+            failure_record,
+            expected_validation_error_count=validation_error_count,
+        )
+    )
     return updated
 
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -11,6 +11,7 @@ from scripts.check_artifact_provenance import (
     load_manifest as load_generated_artifact_manifest,
 )
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
+    ASSERT_EXPECTED_FAILURE_KEYS,
     ASSERT_EXPECTED_FAILURE_SCHEMA,
     CLAIM_SCOPE_GUARDS,
     EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS,
@@ -22,6 +23,7 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_LAYER_PROVENANCE,
     EXPECTED_LAYER_SOURCE_ARTIFACTS,
     EXPECTED_MANIFEST_CONTRACT_IDS,
+    assert_expected_failure_contract_errors,
     assert_expected_local_lemma_audit_path,
     failure_lines,
     local_lemma_audit_path_payload,
@@ -1260,6 +1262,46 @@ def test_local_lemma_audit_path_failure_lines_reject_scalar_errors() -> None:
         "FAILED: local-lemma audit path",
         "- validation_errors is not a list: str",
     ]
+
+
+def test_local_lemma_audit_path_assert_expected_failure_contract_errors() -> None:
+    valid_record = {
+        "schema": ASSERT_EXPECTED_FAILURE_SCHEMA,
+        "stage": "assert_expected",
+        "exception_type": "AssertionError",
+        "message": "validation errors: []",
+        "validation_error_count": 0,
+    }
+    assert set(valid_record) == ASSERT_EXPECTED_FAILURE_KEYS
+    assert (
+        assert_expected_failure_contract_errors(
+            valid_record,
+            expected_validation_error_count=0,
+        )
+        == []
+    )
+
+    tampered_record = dict(valid_record)
+    tampered_record.pop("schema")
+    tampered_record["stage"] = "payload_construction"
+    tampered_record["validation_error_count"] = True
+    tampered_record["extra"] = "surprise"
+
+    errors = assert_expected_failure_contract_errors(
+        tampered_record,
+        expected_validation_error_count=2,
+    )
+    assert "assert_expected_failure missing keys: ['schema']" in errors
+    assert "assert_expected_failure unexpected keys: ['extra']" in errors
+    assert "assert_expected_failure schema mismatch: None" in errors
+    assert (
+        "assert_expected_failure stage mismatch: 'payload_construction'"
+        in errors
+    )
+    assert (
+        "assert_expected_failure validation_error_count must be an int"
+        in errors
+    )
 
 
 def test_local_lemma_audit_path_cli_failure_summary_includes_contract_rollups(


### PR DESCRIPTION
## What changed

- Added `assert_expected_failure_contract_errors`, a small validator for the nested `assert_expected_failure` JSON diagnostic emitted by the n=9 local-lemma audit-path checker.
- Pinned the nested failure-object key set, schema, stage, nonempty text fields, and nonnegative integer pre-assertion validation-error count.
- Wired the validator into the failure-payload construction path and added a regression covering both valid and malformed nested records.
- Updated the local-lemma audit-path documentation to describe the nested contract validation.

## Claim scope and evidence level

This is a diagnostic/review-support contract change only. It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97. It does not claim a counterexample and does not alter the official/global falsifiable/open status. Existing `n=9` artifacts remain review-pending.

## Commands run

```bash
python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py
python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q
python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
python scripts/check_text_clean.py
python scripts/check_status_consistency.py
python scripts/check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

## Artifacts generated or checked

- Checked the existing local-lemma audit-path JSON payload with `--check --assert-expected --json`.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps

- This only validates the diagnostic failure object shape; it does not strengthen any mathematical certificate.
- Continue reviewing the n=9 local-lemma audit path, adjacent handoff contracts, and packet soundness separately before any promotion of review-pending n=9 artifacts.