### PR TITLE
Show n9 audit assert failure schema in text

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -698,7 +698,9 @@ JSON diagnostics for `--assert-expected` failures also include an
 Python exception type, message, and underlying validation-error count so
 consumers do not have to parse the error string. The checker validates that
 nested object contract for schema, exact keys, stage, nonempty text fields, and
-the pre-assertion validation-error count.
+the pre-assertion validation-error count. Text-mode failure summaries mirror
+the nested schema, exception type, and count so reviewers can identify the
+failure contract without switching to JSON.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3451,6 +3451,23 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
         lines.append(f"failure stage: {payload['failure_stage']}")
     if payload.get("exception_type"):
         lines.append(f"exception type: {payload['exception_type']}")
+    assert_expected_failure = payload.get("assert_expected_failure")
+    if isinstance(assert_expected_failure, Mapping):
+        lines.extend(
+            [
+                "assert_expected failure schema: "
+                f"{assert_expected_failure.get('schema')}",
+                "assert_expected failure type: "
+                f"{assert_expected_failure.get('exception_type')}",
+                "assert_expected failure validation errors: "
+                f"{assert_expected_failure.get('validation_error_count')}",
+            ]
+        )
+    elif assert_expected_failure is not None:
+        lines.append(
+            "assert_expected_failure is not an object: "
+            f"{type(assert_expected_failure).__name__}"
+        )
     errors = payload.get("validation_errors", [])
     if not isinstance(errors, list):
         lines.append(f"- validation_errors is not a list: {type(errors).__name__}")

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1402,6 +1402,12 @@ def test_local_lemma_audit_path_cli_assert_expected_failure_stays_textual(
     assert captured.out == ""
     assert "FAILED: local-lemma audit path" in lines
     assert "manifest contract summary: failed" in lines
+    assert (
+        f"assert_expected failure schema: {ASSERT_EXPECTED_FAILURE_SCHEMA}"
+        in lines
+    )
+    assert "assert_expected failure type: AssertionError" in lines
+    assert "assert_expected failure validation errors: 1" in lines
     assert any(
         line.startswith("- assert_expected failed: validation errors:")
         for line in lines


### PR DESCRIPTION
## What changed

- Updated text-mode failure summaries from `scripts/check_n9_vertex_circle_local_lemma_audit_path.py` to include the nested `assert_expected_failure` schema, exception type, and pre-assertion validation-error count when that object is present.
- Added regression coverage for the textual `--assert-expected` failure path.
- Documented that text-mode summaries mirror the nested failure contract fields so reviewers can identify the failure contract without switching to JSON.

## Claim scope and evidence level

This is a diagnostic/review-support contract change only. It does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97. It does not claim a counterexample and does not alter the official/global falsifiable/open status. Existing `n=9` artifacts remain review-pending.

## Commands run

```bash
python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py
python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q
python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
python scripts/check_text_clean.py
python scripts/check_status_consistency.py
python scripts/check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

## Artifacts generated or checked

- Checked the existing local-lemma audit-path JSON payload with `--check --assert-expected --json`.
- No generated certificate artifacts were rewritten.

## Known limitations / next review steps

- This only improves human-readable failure diagnostics; it does not strengthen any mathematical certificate.
- Continue reviewing packet soundness, local-lemma completeness, and frontier coverage as separate review-pending scopes.