### PR TITLE
Add 81:3 second-step chain diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_trigger_uniqueness.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_first_supply_chains.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_81_3_second_step_chains.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   then
   [`docs/bootstrap-t12-81-3-escape-rich-support-csp.md`](docs/bootstrap-t12-81-3-escape-rich-support-csp.md),
   and
-  [`docs/bootstrap-t12-81-3-first-supply-chains.md`](docs/bootstrap-t12-81-3-first-supply-chains.md).
+  [`docs/bootstrap-t12-81-3-first-supply-chains.md`](docs/bootstrap-t12-81-3-first-supply-chains.md),
+  then
+  [`docs/bootstrap-t12-81-3-second-step-chains.md`](docs/bootstrap-t12-81-3-second-step-chains.md).
 - For the source-`81` row-`8` singleton-support audit, where all fixed and
   one-row-drop activation-row survivors keep the original row `8`, read
   [`docs/bootstrap-t12-81-8-singleton-support-audit.md`](docs/bootstrap-t12-81-8-singleton-support-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -646,6 +646,23 @@ forcing, `n=9`, or the bootstrap bridge. See
 `scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py`, and
 `data/certificates/bootstrap_t12_81_3_escape_rich_support_csp.json`.
 
+The first-supply-chain prefix CSP then lets the first pre-`3` activation after
+seed `[0,1,4]` occur at any non-seed, non-`3` center. Among `4650`
+first-step/support-prefix pairs, exact backtracking leaves exactly three
+basic-filter prefix survivors, all starting at center `8`, and no immediate
+center-`6` label-`6` supply extension. The second-step-chain continuation CSP
+then tests distinct intermediate centers from `{2,5,7}` after those center-`8`
+prefixes before one center-`6` label-`6` supply support. It prunes `4112`
+support prefixes, tests `9528` label-`6` supply catalogues, searches `58` of
+them, and finds no surviving chain. These remain bounded proof-mining
+diagnostics, not support existence, row forcing, `n=9`, or the bootstrap
+bridge. See `docs/bootstrap-t12-81-3-first-supply-chains.md`,
+`scripts/check_bootstrap_t12_81_3_first_supply_chains.py`,
+`data/certificates/bootstrap_t12_81_3_first_supply_chains.json`, and
+`docs/bootstrap-t12-81-3-second-step-chains.md`,
+`scripts/check_bootstrap_t12_81_3_second_step_chains.py`,
+`data/certificates/bootstrap_t12_81_3_second_step_chains.json`.
+
 The source-`81` row-`8` singleton-support audit probes the other
 relation-sufficient source-`81` row. Center `8` has bootstrap-core witnesses
 `[0,2]` and singleton support labels `5` and `6`; the audit enumerates the

--- a/STATE.md
+++ b/STATE.md
@@ -415,6 +415,18 @@ does not prove the supports exist, row forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-3-trigger-uniqueness.md`, plus
 `docs/bootstrap-t12-81-3-escape-rich-support-csp.md`.
 
+The first-supply-chain and second-step-chain packets now push that same
+`81:3` escape model through the next bounded continuation layers. The
+first-supply-chain scan leaves exactly three basic-filter prefix survivors,
+all first activating center `8`, and no immediate center-`6` label-`6` supply
+extension. The second-step-chain scan then lets distinct intermediate centers
+from `{2,5,7}` activate after those center-`8` prefixes before testing one
+center-`6` label-`6` supply support; it finds no surviving chain. This remains
+one-support-per-activated-center proof-mining bookkeeping, not support
+existence, row forcing, `n=9`, or the bridge. See
+`docs/bootstrap-t12-81-3-first-supply-chains.md` and
+`docs/bootstrap-t12-81-3-second-step-chains.md`.
+
 A source-`81` row-`8` singleton-support audit now probes the other
 relation-sufficient target in source `81`. It enumerates the nine center-`8`
 rows containing bootstrap-core witnesses `[0,2]` and one singleton support

--- a/data/certificates/bootstrap_t12_81_3_second_step_chains.json
+++ b/data/certificates/bootstrap_t12_81_3_second_step_chains.json
@@ -1,0 +1,278 @@
+{
+  "chain_scan": {
+    "aggregate": {
+      "detected_solution_count": 0,
+      "empty_domain_count": 85,
+      "initial_auxiliary_catalogue_incompatible_count": 9470,
+      "initial_auxiliary_catalogue_searched_count": 58,
+      "label_6_supply_candidate_count": 9528,
+      "search_node_count": 223,
+      "support_prefix_pruned_count": 4112
+    },
+    "per_chain_length": {
+      "0": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 0,
+        "initial_auxiliary_catalogue_incompatible_count": 228,
+        "initial_auxiliary_catalogue_searched_count": 0,
+        "label_6_supply_candidate_count": 228,
+        "search_node_count": 0,
+        "support_prefix_pruned_count": 0
+      },
+      "1": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 29,
+        "initial_auxiliary_catalogue_incompatible_count": 694,
+        "initial_auxiliary_catalogue_searched_count": 14,
+        "label_6_supply_candidate_count": 708,
+        "search_node_count": 86,
+        "support_prefix_pruned_count": 678
+      },
+      "2": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 30,
+        "initial_auxiliary_catalogue_incompatible_count": 2052,
+        "initial_auxiliary_catalogue_searched_count": 20,
+        "label_6_supply_candidate_count": 2072,
+        "search_node_count": 94,
+        "support_prefix_pruned_count": 1402
+      },
+      "3": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 26,
+        "initial_auxiliary_catalogue_incompatible_count": 6496,
+        "initial_auxiliary_catalogue_searched_count": 24,
+        "label_6_supply_candidate_count": 6520,
+        "search_node_count": 43,
+        "support_prefix_pruned_count": 2032
+      }
+    },
+    "per_source_prefix": {
+      "0": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 0,
+        "initial_auxiliary_catalogue_incompatible_count": 76,
+        "initial_auxiliary_catalogue_searched_count": 0,
+        "label_6_supply_candidate_count": 76,
+        "search_node_count": 0,
+        "support_prefix_pruned_count": 228
+      },
+      "1": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 44,
+        "initial_auxiliary_catalogue_incompatible_count": 4697,
+        "initial_auxiliary_catalogue_searched_count": 29,
+        "label_6_supply_candidate_count": 4726,
+        "search_node_count": 113,
+        "support_prefix_pruned_count": 1942
+      },
+      "2": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 41,
+        "initial_auxiliary_catalogue_incompatible_count": 4697,
+        "initial_auxiliary_catalogue_searched_count": 29,
+        "label_6_supply_candidate_count": 4726,
+        "search_node_count": 110,
+        "support_prefix_pruned_count": 1942
+      }
+    },
+    "per_terminal_intermediate_center": {
+      "2": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 29,
+        "initial_auxiliary_catalogue_incompatible_count": 694,
+        "initial_auxiliary_catalogue_searched_count": 14,
+        "label_6_supply_candidate_count": 708,
+        "search_node_count": 86
+      },
+      "5": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 22,
+        "initial_auxiliary_catalogue_incompatible_count": 2120,
+        "initial_auxiliary_catalogue_searched_count": 12,
+        "label_6_supply_candidate_count": 2132,
+        "search_node_count": 80
+      },
+      "7": {
+        "detected_solution_count": 0,
+        "empty_domain_count": 34,
+        "initial_auxiliary_catalogue_incompatible_count": 6428,
+        "initial_auxiliary_catalogue_searched_count": 32,
+        "label_6_supply_candidate_count": 6460,
+        "search_node_count": 57
+      }
+    },
+    "survivors": []
+  },
+  "claim_scope": "Distinct-intermediate continuation CSP for the 81:3 pre-3 label-6 escape. It treats the three stored center-8 prefix survivors from the first-supply-chain packet as inputs, allows a chain of distinct intermediate centers from {2,5,7}, gives each intermediate center one rich support containing at least three labels already in the closure, and then asks whether center 6 can supply label 6 through one support before the stored connector-avoiding center-3 support. Exact backtracking finds no surviving chain under the same basic filters used by the source packet. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This packet starts only from the three stored center-8 survivor prefixes in the first-supply-chain artifact.",
+    "Intermediate centers are distinct labels from {2,5,7}; each gets one auxiliary support.",
+    "Support activation means the support contains at least three labels from the current closure.",
+    "The scan uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_second_step_chains.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_second_step_chains.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_second_step_chains.v1",
+  "source_first_supply_chains": {
+    "path": "data/certificates/bootstrap_t12_81_3_first_supply_chains.json",
+    "scan_status": "PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION",
+    "schema": "erdos97.bootstrap_t12_81_3_first_supply_chains.v1",
+    "status": "BOOTSTRAP_T12_81_3_FIRST_SUPPLY_CHAINS_DIAGNOSTIC_ONLY"
+  },
+  "source_prefix_survivors": [
+    {
+      "auxiliary_target_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "auxiliary_target_support_size": 4,
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        5
+      ],
+      "first_step_support_size": 4,
+      "source_prefix_survivor_index": 0,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "auxiliary_target_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "first_step_support_size": 4,
+      "source_prefix_survivor_index": 1,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "auxiliary_target_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "auxiliary_target_support_size": 4,
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "first_step_support_size": 4,
+      "source_prefix_survivor_index": 2,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    }
+  ],
+  "status": "BOOTSTRAP_T12_81_3_SECOND_STEP_CHAINS_DIAGNOSTIC_ONLY",
+  "summary": {
+    "connector_pair": [
+      0,
+      1
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "detected_solution_count": 0,
+    "empty_domain_count": 85,
+    "eventual_supply_label": 6,
+    "first_step_center": 8,
+    "initial_auxiliary_catalogue_incompatible_count": 9470,
+    "initial_auxiliary_catalogue_searched_count": 58,
+    "intermediate_centers_after_center8": [
+      2,
+      5,
+      7
+    ],
+    "label_6_supply_candidate_count": 9528,
+    "max_distinct_intermediate_chain_length": 3,
+    "remaining_gap": "No chain remains in this distinct-intermediate, one-support-per-center model after the stored center-8 prefix survivors. Repeated or multiple rich supports at one center, richer catalogues not represented by a single support per activated center, a theorem forcing genuine rich-class order, and other bridge targets remain open.",
+    "scan_status": "NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS",
+    "search_node_count": 223,
+    "source_prefix_survivor_count": 3,
+    "source_record_ids": [
+      81
+    ],
+    "support_prefix_pruned_count": 4112,
+    "surviving_chain_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "support_generation": {
+    "base_closure_after_center_8": [
+      0,
+      1,
+      4,
+      8
+    ],
+    "center_6_supply_support_count_from_base_closure": 76,
+    "intermediate_centers_after_center8": [
+      2,
+      5,
+      7
+    ],
+    "intermediate_support_count_by_center_from_base_closure": {
+      "2": 76,
+      "5": 76,
+      "7": 76
+    },
+    "labels": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ]
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-second-step-chains.md
+++ b/docs/bootstrap-t12-81-3-second-step-chains.md
@@ -1,0 +1,132 @@
+# Bootstrap T12 81:3 Second-Step Chain CSP
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet is the next audit after
+`docs/bootstrap-t12-81-3-first-supply-chains.md`. That earlier packet found
+exactly three basic-filter survivor prefixes. All three begin by activating
+center `8` from seed `[0,1,4]`, and none admits an immediate center-`6`
+label-`6` supply support.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_second_step_chains.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_second_step_chains.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_second_step_chains.json`.
+
+## Scan Scope
+
+The deletion seed remains:
+
+```text
+[0,1,4]
+```
+
+The source prefixes are the three stored center-`8` survivor prefixes from
+`data/certificates/bootstrap_t12_81_3_first_supply_chains.json`.
+After center `8`, the active closure is:
+
+```text
+[0,1,4,8]
+```
+
+The possible distinct intermediate centers before center `6` are:
+
+```text
+2,5,7
+```
+
+For each ordered chain of distinct intermediate centers, each intermediate
+center receives one auxiliary support. A support is allowed exactly when it has
+size at least `4`, excludes its own center, and contains at least three labels
+from the current active closure. The active closure is then enlarged by the new
+center label.
+
+After any chain length `0` through `3`, center `6` receives one candidate
+label-`6` supply support using the same activation rule. The stored
+connector-avoiding center-`3` support from the source prefix is kept fixed.
+
+The checker uses the same basic filters as the previous support CSP:
+
+```text
+row-pair cap
+witness-pair cap
+two-overlap crossing
+same-center disjointness
+```
+
+It does not test Euclidean realizability.
+
+## Result
+
+The distinct-intermediate continuation scan closes this bounded model. It finds
+no full selected-row assignment for any ordered chain of distinct intermediate
+centers from `{2,5,7}` before center `6` supplies label `6`.
+
+The deterministic scan summary is:
+
+```text
+source center-8 prefixes: 3
+intermediate centers after center 8: 2,5,7
+maximum distinct intermediate chain length: 3
+support prefixes pruned before label-6 supply: 4112
+label-6 supply catalogues tested: 9528
+initially incompatible label-6 catalogues: 9470
+searched label-6 catalogues: 58
+search nodes: 223
+empty domains: 85
+detected solutions: 0
+surviving chains: 0
+```
+
+By chain length, the label-`6` supply catalogue counts are:
+
+```text
+length 0: 228 tested, 228 initially incompatible, 0 searched
+length 1: 708 tested, 694 initially incompatible, 14 searched
+length 2: 2072 tested, 2052 initially incompatible, 20 searched
+length 3: 6520 tested, 6496 initially incompatible, 24 searched
+```
+
+The checked scan status is:
+
+```text
+NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS
+```
+
+## Interpretation
+
+This narrows the previous remaining escape. The earlier boundary case was:
+
+```text
+seed [0,1,4]
+  -> center 8 first
+  -> some longer chain before center 6
+  -> center 6 supplies label 6
+  -> center 3 activates through a connector-avoiding support
+```
+
+Within the bounded model where every post-`8` intermediate activation uses a
+new center from `{2,5,7}` and exactly one auxiliary support at that center, no
+such chain survives the same basic filters.
+
+The remaining escape is now outside this distinct-intermediate,
+one-support-per-center model. Examples still not ruled out here include
+repeated or multiple rich supports at one center, richer catalogues not
+represented by a single support per activated center, or a future
+minimal/rich-class theorem that changes which supports must be considered.
+
+## What This Does Not Prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a proof-mining diagnostic for one
+specific `81:3` pre-`3` label-`6` escape model.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -986,6 +986,19 @@ filters. This remains a finite proof-mining diagnostic only, not a proof of
 support existence, row forcing, `n=9`, the bootstrap bridge, or Erdos Problem
 #97.
 
+The first-supply-chain prefix CSP in
+`docs/bootstrap-t12-81-3-first-supply-chains.md` lets any non-seed, non-`3`
+center activate first after seed `[0,1,4]` before checking center-`6` label-`6`
+supply. Exact backtracking leaves exactly three basic-filter prefix survivors,
+all with first activation at center `8`, and no immediate center-`6` label-`6`
+supply extension. The second-step-chain continuation in
+`docs/bootstrap-t12-81-3-second-step-chains.md` then allows distinct
+intermediate centers from `{2,5,7}` after those center-`8` prefixes before one
+center-`6` supply support. It finds no surviving chain under the same basic
+filters. These are bounded proof-mining diagnostics only; they do not prove
+support existence, row forcing, `n=9`, the bootstrap bridge, or Erdos
+Problem #97.
+
 The source-`81` row-`8` singleton-support audit in
 `docs/bootstrap-t12-81-8-singleton-support-audit.md` checks a neighboring
 relation-sufficient row target. It enumerates the nine center-`8` rows that

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -348,10 +348,15 @@ Use this queue when no more specific issue is selected.
    auxiliary first steps: among `4650` first-step/support-prefix pairs it finds
    exactly three basic-filter survivor prefixes, all starting at center `8`,
    and none of those admits an immediate center-`6` label-`6` supply support.
-   The next useful PR must therefore either attack longer chains after the
-   center-`8` prefix survivors, introduce a genuine rich-class/minimality
-   hypothesis that forces or excludes such a support, or move to a different
-   bridge target. The source-`81` row-`8` singleton-support audit in
+   The second-step-chain CSP in
+   `docs/bootstrap-t12-81-3-second-step-chains.md` attacks the bounded
+   distinct-intermediate continuation: after those center-`8` prefixes, no
+   chain through distinct centers from `{2,5,7}` followed by one center-`6`
+   label-`6` supply support survives the same basic filters. The next useful
+   PR must therefore either handle repeated/multiple supports, introduce a
+   genuine rich-class/minimality hypothesis that forces or excludes such a
+   support, or move to a different bridge target. The source-`81` row-`8`
+   singleton-support audit in
    `docs/bootstrap-t12-81-8-singleton-support-audit.md` is one such adjacent
    target: it finds no non-original row-`8` activation survivor in the fixed
    source-`81` neighborhood or a one-row-drop relaxation, but still leaves

--- a/docs/index.md
+++ b/docs/index.md
@@ -281,6 +281,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-first-supply-chains.md`](bootstrap-t12-81-3-first-supply-chains.md):
   first-step prefix CSP allowing any non-seed, non-`3` center to activate
   first before testing immediate label-`6` supply extensions.
+- [`bootstrap-t12-81-3-second-step-chains.md`](bootstrap-t12-81-3-second-step-chains.md):
+  distinct-intermediate continuation CSP after the stored center-`8` prefix
+  survivors, before testing center-`6` label-`6` supply.
 - [`bootstrap-t12-81-8-singleton-support-audit.md`](bootstrap-t12-81-8-singleton-support-audit.md):
   source-`81` row-`8` singleton-support audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -750,6 +750,13 @@ condition that the surviving multi-block family does not automatically satisfy:
   extension for those prefixes. The remaining target is a longer center-`8`
   chain audit or a minimal/rich-class hypothesis that rules out those boundary
   prefixes.
+- bootstrap/T12 focused `81:3` second-step-chain evidence, as recorded in
+  `docs/bootstrap-t12-81-3-second-step-chains.md`, testing distinct
+  intermediate centers from `{2,5,7}` after the three stored center-`8`
+  prefixes and before center `6` supplies label `6`. This closes that bounded
+  one-support-per-activated-center continuation model under the same basic
+  filters, while leaving repeated/multiple supports, richer catalogues, and
+  genuine rich-class forcing open.
 - bootstrap/T12 focused `81:8` singleton-support evidence, as recorded in
   `docs/bootstrap-t12-81-8-singleton-support-audit.md`, showing that the fixed
   source-`81` neighborhood and one-row-drop relaxation have no non-original

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -6009,6 +6009,87 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_81_3_second_step_chains
+    path: data/certificates/bootstrap_t12_81_3_second_step_chains.json
+    sha256: d83f3791b8062f070f09e173dbaf3116fdf6e6cd26c573e57095c790373e3392
+    size_bytes: 8981
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_second_step_chains.py
+    command: python scripts/check_bootstrap_t12_81_3_second_step_chains.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_second_step_chains.py
+    check_command: python scripts/check_bootstrap_t12_81_3_second_step_chains.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Distinct-intermediate continuation CSP for the 81:3 pre-3 label-6 escape; starting from the three stored center-8 prefix survivors, no chain of distinct intermediate centers from {2,5,7} followed by one center-6 supply support survives the same basic filters, but this is not support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_second_step_chains.v1
+      status: BOOTSTRAP_T12_81_3_SECOND_STEP_CHAINS_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.target_center: 3
+      summary.first_step_center: 8
+      summary.eventual_supply_label: 6
+      summary.source_prefix_survivor_count: 3
+      summary.intermediate_centers_after_center8:
+        - 2
+        - 5
+        - 7
+      summary.max_distinct_intermediate_chain_length: 3
+      summary.support_prefix_pruned_count: 4112
+      summary.label_6_supply_candidate_count: 9528
+      summary.initial_auxiliary_catalogue_incompatible_count: 9470
+      summary.initial_auxiliary_catalogue_searched_count: 58
+      summary.search_node_count: 223
+      summary.empty_domain_count: 85
+      summary.detected_solution_count: 0
+      summary.surviving_chain_count: 0
+      summary.scan_status: NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS
+      chain_scan.aggregate.detected_solution_count: 0
+      chain_scan.per_chain_length.0.label_6_supply_candidate_count: 228
+      chain_scan.per_chain_length.1.initial_auxiliary_catalogue_searched_count: 14
+      chain_scan.per_chain_length.2.initial_auxiliary_catalogue_searched_count: 20
+      chain_scan.per_chain_length.3.initial_auxiliary_catalogue_searched_count: 24
+      source_first_supply_chains.schema: erdos97.bootstrap_t12_81_3_first_supply_chains.v1
+      source_first_supply_chains.scan_status: PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION
+      provenance.generator: scripts/check_bootstrap_t12_81_3_second_step_chains.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_second_step_chains.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich support exists
+      - the 81:3 row is forced
+      - the second-step-chain CSP proves genuine rich-class order
+      - the second-step-chain CSP proves no pre-3 label-6 supply exists
+      - the second-step-chain CSP proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
   - id: bootstrap_t12_81_8_singleton_support_audit
     path: data/certificates/bootstrap_t12_81_8_singleton_support_audit.json
     sha256: daa724c9c566b321310cce08ade6747122a6a0fab1208504995d0ebdcfe96eec

--- a/scripts/check_bootstrap_t12_81_3_second_step_chains.py
+++ b/scripts/check_bootstrap_t12_81_3_second_step_chains.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 second-step chain CSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_second_step_chains import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_second_step_chains_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 second-step distinct-chain CSP")
+    print(f"source center-8 prefixes: {summary['source_prefix_survivor_count']}")
+    print(
+        "label-6 supply candidates: "
+        f"{summary['label_6_supply_candidate_count']}"
+    )
+    print(f"support prefixes pruned: {summary['support_prefix_pruned_count']}")
+    print(f"searched catalogues: {summary['initial_auxiliary_catalogue_searched_count']}")
+    print(f"survivors: {summary['surviving_chain_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_second_step_chains_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 second-step chain artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 second-step chain expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2113,6 +2113,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_81_3_second_step_chains",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_81_3_second_step_chains.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Distinct-intermediate continuation CSP for the 81:3 pre-3 "
+            "label-6 escape after the center-8 prefix survivors; not support "
+            "existence, row forcing, an n=9 proof, a bridge proof, or a "
+            "counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_81_8_singleton_support_audit",
         command=(
             "python",

--- a/src/erdos97/bootstrap_t12_81_3_second_step_chains.py
+++ b/src/erdos97/bootstrap_t12_81_3_second_step_chains.py
@@ -1,0 +1,648 @@
+"""Distinct-intermediate chain CSP for the bootstrap/T12 81:3 escape.
+
+The first-supply-chain packet leaves exactly three basic-filter survivor
+prefixes.  All of them start by activating center 8 from deletion seed
+[0, 1, 4], and none admits an immediate center-6 supply support.
+
+This packet asks the next finite question: after one of those stored center-8
+prefixes, can a chain of distinct intermediate centers from {2, 5, 7} appear
+before center 6 supplies label 6?  Each intermediate center gets one auxiliary
+rich support containing at least three labels already in the closure.  Center 6
+then gets one supply support containing at least three labels from the final
+closure.  The center-3 connector-avoiding support is the one stored in the
+source prefix.
+
+The search uses the same exact incidence/crossing bookkeeping filters as the
+first-supply-chain packet.  It is not a Euclidean realizability theorem and not
+a proof of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_escape_rich_support_csp import (
+    _bit_labels,
+    _build_pair_centers,
+    _support_pair_compatible,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import LABELS, _row_mask
+from erdos97.bootstrap_t12_81_3_first_supply_chains import (
+    DEFAULT_ARTIFACT as FIRST_SUPPLY_ARTIFACT,
+    SCAN_STATUS as FIRST_SUPPLY_SCAN_STATUS,
+    SCHEMA as FIRST_SUPPLY_SCHEMA,
+    STATUS as FIRST_SUPPLY_STATUS,
+    _search_auxiliary_support_catalogue,
+    assert_expected_payload as assert_first_supply_payload,
+    load_artifact as load_first_supply_artifact,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_second_step_chains.v1"
+STATUS = "BOOTSTRAP_T12_81_3_SECOND_STEP_CHAINS_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS"
+CLAIM_SCOPE = (
+    "Distinct-intermediate continuation CSP for the 81:3 pre-3 label-6 "
+    "escape. It treats the three stored center-8 prefix survivors from the "
+    "first-supply-chain packet as inputs, allows a chain of distinct "
+    "intermediate centers from {2,5,7}, gives each intermediate center one "
+    "rich support containing at least three labels already in the closure, and "
+    "then asks whether center 6 can supply label 6 through one support before "
+    "the stored connector-avoiding center-3 support. Exact backtracking finds "
+    "no surviving chain under the same basic filters used by the source "
+    "packet. This is not a proof of genuine rich-class order, not a proof of "
+    "row forcing, not a proof of n=9, not a proof of the bridge, and not a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_second_step_chains.json"
+)
+FIRST_STEP_CENTER = 8
+MAX_DISTINCT_INTERMEDIATE_CHAIN_LENGTH = 3
+INTERMEDIATE_CENTERS_AFTER_CENTER8 = [
+    label
+    for label in CYCLIC_ORDER
+    if label
+    not in set(TARGET_DELETION_SEED)
+    | {FIRST_STEP_CENTER, TARGET_ROW_CENTER, SUPPLY_CENTER}
+]
+
+AGGREGATE_COUNTER_KEYS = (
+    "support_prefix_pruned_count",
+    "label_6_supply_candidate_count",
+    "initial_auxiliary_catalogue_incompatible_count",
+    "initial_auxiliary_catalogue_searched_count",
+    "search_node_count",
+    "empty_domain_count",
+    "detected_solution_count",
+)
+TERMINAL_COUNTER_KEYS = tuple(
+    key for key in AGGREGATE_COUNTER_KEYS if key != "support_prefix_pruned_count"
+)
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _counter_dict(
+    counter: Counter[str],
+    *,
+    keys: Sequence[str] = AGGREGATE_COUNTER_KEYS,
+) -> dict[str, int]:
+    return {key: int(counter.get(key, 0)) for key in keys}
+
+
+def _support_masks_meeting_activation(
+    center: int,
+    activation_labels: Sequence[int],
+) -> list[int]:
+    activation_mask = _row_mask(activation_labels)
+    universe = [label for label in CYCLIC_ORDER if label != center]
+    masks: list[int] = []
+    for support_size in range(4, len(universe) + 1):
+        for support in combinations(universe, support_size):
+            support_mask = _row_mask(support)
+            if (support_mask & activation_mask).bit_count() >= 3:
+                masks.append(support_mask)
+    return masks
+
+
+def _auxiliary_support_catalogue_compatible(
+    auxiliary_supports: Mapping[int, int],
+) -> bool:
+    centers = sorted(auxiliary_supports)
+    for index, center_a in enumerate(centers):
+        for center_b in centers[index + 1 :]:
+            if not _support_pair_compatible(
+                center_a,
+                auxiliary_supports[center_a],
+                center_b,
+                auxiliary_supports[center_b],
+            ):
+                return False
+
+    pair_centers = _build_pair_centers(auxiliary_supports, {})
+    return all(len(centers_for_pair) <= 2 for centers_for_pair in pair_centers.values())
+
+
+def _source_prefix_survivors(
+    first_supply_artifact: Path = FIRST_SUPPLY_ARTIFACT,
+) -> list[dict[str, object]]:
+    payload = load_first_supply_artifact(first_supply_artifact)
+    assert_first_supply_payload(payload)
+    survivors = payload.get("survivors")
+    if not isinstance(survivors, Sequence):
+        raise AssertionError("first-supply-chain survivors must be a sequence")
+
+    records: list[dict[str, object]] = []
+    for index, survivor in enumerate(survivors):
+        if not isinstance(survivor, Mapping):
+            raise AssertionError("first-supply-chain survivor records must be mappings")
+        first_center = int(survivor.get("first_step_center", -1))
+        if first_center != FIRST_STEP_CENTER:
+            raise AssertionError("second-step scan expects only center-8 prefixes")
+        first_support = _int_list(survivor["first_step_support"])
+        target_support = _int_list(survivor["auxiliary_target_support"])
+        records.append(
+            {
+                "source_prefix_survivor_index": index,
+                "first_step_center": first_center,
+                "first_step_support": first_support,
+                "first_step_support_size": len(first_support),
+                "auxiliary_target_support": target_support,
+                "auxiliary_target_support_size": len(target_support),
+                "target_center_activation_triple": _int_list(
+                    survivor["target_center_activation_triple"]
+                ),
+                "target_center_forbidden_connector_endpoint": int(
+                    survivor["target_center_forbidden_connector_endpoint"]
+                ),
+            }
+        )
+    return records
+
+
+def _increment_search_counters(
+    counters: Sequence[Counter[str]],
+    stats: Mapping[str, object],
+) -> None:
+    for counter in counters:
+        counter["label_6_supply_candidate_count"] += 1
+        if stats["initial_status"] == "INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE":
+            counter["initial_auxiliary_catalogue_incompatible_count"] += 1
+        else:
+            counter["initial_auxiliary_catalogue_searched_count"] += 1
+        counter["search_node_count"] += int(stats["search_node_count"])
+        counter["empty_domain_count"] += int(stats["empty_domain_count"])
+        counter["detected_solution_count"] += int(stats["detected_solution_count"])
+
+
+def _scan_distinct_intermediate_chains(
+    source_prefixes: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    aggregate: Counter[str] = Counter()
+    per_chain_length: dict[str, Counter[str]] = {
+        str(length): Counter()
+        for length in range(MAX_DISTINCT_INTERMEDIATE_CHAIN_LENGTH + 1)
+    }
+    per_source_prefix: dict[str, Counter[str]] = {
+        str(index): Counter() for index in range(len(source_prefixes))
+    }
+    per_terminal_center: dict[str, Counter[str]] = {
+        str(center): Counter() for center in INTERMEDIATE_CENTERS_AFTER_CENTER8
+    }
+    survivors: list[dict[str, object]] = []
+
+    def scan_label_6_supply(
+        *,
+        source_prefix_index: int,
+        chain: Sequence[tuple[int, int]],
+        auxiliary_supports: Mapping[int, int],
+        active_labels: Sequence[int],
+    ) -> None:
+        chain_length = len(chain)
+        chain_key = str(chain_length)
+        source_key = str(source_prefix_index)
+        terminal_key = str(chain[-1][0]) if chain else None
+        for supply_support in _support_masks_meeting_activation(
+            SUPPLY_CENTER,
+            active_labels,
+        ):
+            full_auxiliary_supports = dict(auxiliary_supports)
+            full_auxiliary_supports[SUPPLY_CENTER] = supply_support
+            stats = _search_auxiliary_support_catalogue(
+                full_auxiliary_supports,
+                incompatible_status="INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE",
+            )
+            counters = [aggregate, per_chain_length[chain_key], per_source_prefix[source_key]]
+            if terminal_key is not None:
+                counters.append(per_terminal_center[terminal_key])
+            _increment_search_counters(counters, stats)
+
+            if int(stats["detected_solution_count"]):
+                survivors.append(
+                    {
+                        "source_prefix_survivor_index": source_prefix_index,
+                        "intermediate_chain": [
+                            {"center": center, "support": _bit_labels(support)}
+                            for center, support in chain
+                        ],
+                        "label_6_supply_support": _bit_labels(supply_support),
+                        **stats,
+                    }
+                )
+
+    def extend_chain(
+        *,
+        source_prefix_index: int,
+        chain: list[tuple[int, int]],
+        remaining_centers: Sequence[int],
+        auxiliary_supports: Mapping[int, int],
+        active_labels: Sequence[int],
+    ) -> None:
+        scan_label_6_supply(
+            source_prefix_index=source_prefix_index,
+            chain=chain,
+            auxiliary_supports=auxiliary_supports,
+            active_labels=active_labels,
+        )
+        if len(chain) >= MAX_DISTINCT_INTERMEDIATE_CHAIN_LENGTH:
+            return
+
+        next_chain_length = len(chain) + 1
+        chain_key = str(next_chain_length)
+        source_key = str(source_prefix_index)
+        for center in remaining_centers:
+            for support in _support_masks_meeting_activation(center, active_labels):
+                next_auxiliary_supports = dict(auxiliary_supports)
+                next_auxiliary_supports[center] = support
+                if not _auxiliary_support_catalogue_compatible(next_auxiliary_supports):
+                    aggregate["support_prefix_pruned_count"] += 1
+                    per_chain_length[chain_key]["support_prefix_pruned_count"] += 1
+                    per_source_prefix[source_key]["support_prefix_pruned_count"] += 1
+                    continue
+                next_active_labels = sorted(set(active_labels) | {center})
+                next_remaining = [
+                    next_center
+                    for next_center in remaining_centers
+                    if next_center != center
+                ]
+                extend_chain(
+                    source_prefix_index=source_prefix_index,
+                    chain=[*chain, (center, support)],
+                    remaining_centers=next_remaining,
+                    auxiliary_supports=next_auxiliary_supports,
+                    active_labels=next_active_labels,
+                )
+
+    for prefix in source_prefixes:
+        source_prefix_index = int(prefix["source_prefix_survivor_index"])
+        first_support = _row_mask(_int_list(prefix["first_step_support"]))
+        target_support = _row_mask(_int_list(prefix["auxiliary_target_support"]))
+        base_auxiliary_supports = {
+            FIRST_STEP_CENTER: first_support,
+            TARGET_ROW_CENTER: target_support,
+        }
+        if not _auxiliary_support_catalogue_compatible(base_auxiliary_supports):
+            raise AssertionError("stored first-supply prefix is internally incompatible")
+        extend_chain(
+            source_prefix_index=source_prefix_index,
+            chain=[],
+            remaining_centers=INTERMEDIATE_CENTERS_AFTER_CENTER8,
+            auxiliary_supports=base_auxiliary_supports,
+            active_labels=sorted(set(TARGET_DELETION_SEED) | {FIRST_STEP_CENTER}),
+        )
+
+    return {
+        "aggregate": _counter_dict(aggregate),
+        "per_chain_length": {
+            key: _counter_dict(counter)
+            for key, counter in sorted(per_chain_length.items())
+        },
+        "per_source_prefix": {
+            key: _counter_dict(counter)
+            for key, counter in sorted(per_source_prefix.items())
+        },
+        "per_terminal_intermediate_center": {
+            key: _counter_dict(counter, keys=TERMINAL_COUNTER_KEYS)
+            for key, counter in sorted(per_terminal_center.items())
+        },
+        "survivors": survivors,
+    }
+
+
+def _support_generation_summary() -> dict[str, object]:
+    base_closure = sorted(set(TARGET_DELETION_SEED) | {FIRST_STEP_CENTER})
+    support_counts_by_center = {
+        str(center): len(_support_masks_meeting_activation(center, base_closure))
+        for center in INTERMEDIATE_CENTERS_AFTER_CENTER8
+    }
+    return {
+        "base_closure_after_center_8": base_closure,
+        "intermediate_centers_after_center8": INTERMEDIATE_CENTERS_AFTER_CENTER8,
+        "intermediate_support_count_by_center_from_base_closure": (
+            support_counts_by_center
+        ),
+        "center_6_supply_support_count_from_base_closure": len(
+            _support_masks_meeting_activation(SUPPLY_CENTER, base_closure)
+        ),
+        "labels": LABELS,
+    }
+
+
+def build_t12_81_3_second_step_chains_payload(
+    first_supply_artifact: Path = FIRST_SUPPLY_ARTIFACT,
+) -> dict[str, object]:
+    """Return the deterministic second-step chain CSP packet."""
+
+    source_prefixes = _source_prefix_survivors(first_supply_artifact)
+    scan = _scan_distinct_intermediate_chains(source_prefixes)
+    aggregate = scan["aggregate"]
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("aggregate must be a mapping")
+    survivors = scan["survivors"]
+    if not isinstance(survivors, Sequence):
+        raise AssertionError("survivors must be a sequence")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            (
+                "This packet starts only from the three stored center-8 "
+                "survivor prefixes in the first-supply-chain artifact."
+            ),
+            (
+                "Intermediate centers are distinct labels from {2,5,7}; "
+                "each gets one auxiliary support."
+            ),
+            (
+                "Support activation means the support contains at least "
+                "three labels from the current closure."
+            ),
+            (
+                "The scan uses incidence, crossing, pair-cap, and same-center "
+                "disjointness filters only, not Euclidean realizability."
+            ),
+            (
+                "No n=9 finite-case status, bridge status, official status, "
+                "or counterexample status changes."
+            ),
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "target_center": TARGET_ROW_CENTER,
+            "first_step_center": FIRST_STEP_CENTER,
+            "eventual_supply_label": SUPPLY_CENTER,
+            "source_prefix_survivor_count": len(source_prefixes),
+            "intermediate_centers_after_center8": INTERMEDIATE_CENTERS_AFTER_CENTER8,
+            "max_distinct_intermediate_chain_length": (
+                MAX_DISTINCT_INTERMEDIATE_CHAIN_LENGTH
+            ),
+            "support_prefix_pruned_count": aggregate["support_prefix_pruned_count"],
+            "label_6_supply_candidate_count": aggregate[
+                "label_6_supply_candidate_count"
+            ],
+            "initial_auxiliary_catalogue_incompatible_count": aggregate[
+                "initial_auxiliary_catalogue_incompatible_count"
+            ],
+            "initial_auxiliary_catalogue_searched_count": aggregate[
+                "initial_auxiliary_catalogue_searched_count"
+            ],
+            "search_node_count": aggregate["search_node_count"],
+            "empty_domain_count": aggregate["empty_domain_count"],
+            "detected_solution_count": aggregate["detected_solution_count"],
+            "surviving_chain_count": len(survivors),
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "No chain remains in this distinct-intermediate, one-support-"
+                "per-center model after the stored center-8 prefix survivors. "
+                "Repeated or multiple rich supports at one center, richer "
+                "catalogues not represented by a single support per activated "
+                "center, a theorem forcing genuine rich-class order, and other "
+                "bridge targets remain open."
+            ),
+        },
+        "support_generation": _support_generation_summary(),
+        "source_prefix_survivors": source_prefixes,
+        "chain_scan": scan,
+        "source_first_supply_chains": {
+            "path": FIRST_SUPPLY_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": FIRST_SUPPLY_SCHEMA,
+            "status": FIRST_SUPPLY_STATUS,
+            "scan_status": FIRST_SUPPLY_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_second_step_chains.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_second_step_chains.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "target_center": TARGET_ROW_CENTER,
+        "first_step_center": FIRST_STEP_CENTER,
+        "eventual_supply_label": SUPPLY_CENTER,
+        "source_prefix_survivor_count": 3,
+        "intermediate_centers_after_center8": [2, 5, 7],
+        "max_distinct_intermediate_chain_length": 3,
+        "support_prefix_pruned_count": 4112,
+        "label_6_supply_candidate_count": 9528,
+        "initial_auxiliary_catalogue_incompatible_count": 9470,
+        "initial_auxiliary_catalogue_searched_count": 58,
+        "search_node_count": 223,
+        "empty_domain_count": 85,
+        "detected_solution_count": 0,
+        "surviving_chain_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    support_generation = payload.get("support_generation")
+    if not isinstance(support_generation, Mapping):
+        raise AssertionError("support_generation must be a mapping")
+    if support_generation.get("base_closure_after_center_8") != [0, 1, 4, 8]:
+        raise AssertionError("base closure after center 8 drifted")
+    if support_generation.get("center_6_supply_support_count_from_base_closure") != 76:
+        raise AssertionError("center-6 base-closure supply count drifted")
+
+    expected_per_chain_length = {
+        "0": {
+            "support_prefix_pruned_count": 0,
+            "label_6_supply_candidate_count": 228,
+            "initial_auxiliary_catalogue_incompatible_count": 228,
+            "initial_auxiliary_catalogue_searched_count": 0,
+            "search_node_count": 0,
+            "empty_domain_count": 0,
+            "detected_solution_count": 0,
+        },
+        "1": {
+            "support_prefix_pruned_count": 678,
+            "label_6_supply_candidate_count": 708,
+            "initial_auxiliary_catalogue_incompatible_count": 694,
+            "initial_auxiliary_catalogue_searched_count": 14,
+            "search_node_count": 86,
+            "empty_domain_count": 29,
+            "detected_solution_count": 0,
+        },
+        "2": {
+            "support_prefix_pruned_count": 1402,
+            "label_6_supply_candidate_count": 2072,
+            "initial_auxiliary_catalogue_incompatible_count": 2052,
+            "initial_auxiliary_catalogue_searched_count": 20,
+            "search_node_count": 94,
+            "empty_domain_count": 30,
+            "detected_solution_count": 0,
+        },
+        "3": {
+            "support_prefix_pruned_count": 2032,
+            "label_6_supply_candidate_count": 6520,
+            "initial_auxiliary_catalogue_incompatible_count": 6496,
+            "initial_auxiliary_catalogue_searched_count": 24,
+            "search_node_count": 43,
+            "empty_domain_count": 26,
+            "detected_solution_count": 0,
+        },
+    }
+    chain_scan = payload.get("chain_scan")
+    if not isinstance(chain_scan, Mapping):
+        raise AssertionError("chain_scan must be a mapping")
+    if chain_scan.get("per_chain_length") != expected_per_chain_length:
+        raise AssertionError("per-chain-length counts drifted")
+
+    expected_per_source_prefix = {
+        "0": {
+            "support_prefix_pruned_count": 228,
+            "label_6_supply_candidate_count": 76,
+            "initial_auxiliary_catalogue_incompatible_count": 76,
+            "initial_auxiliary_catalogue_searched_count": 0,
+            "search_node_count": 0,
+            "empty_domain_count": 0,
+            "detected_solution_count": 0,
+        },
+        "1": {
+            "support_prefix_pruned_count": 1942,
+            "label_6_supply_candidate_count": 4726,
+            "initial_auxiliary_catalogue_incompatible_count": 4697,
+            "initial_auxiliary_catalogue_searched_count": 29,
+            "search_node_count": 113,
+            "empty_domain_count": 44,
+            "detected_solution_count": 0,
+        },
+        "2": {
+            "support_prefix_pruned_count": 1942,
+            "label_6_supply_candidate_count": 4726,
+            "initial_auxiliary_catalogue_incompatible_count": 4697,
+            "initial_auxiliary_catalogue_searched_count": 29,
+            "search_node_count": 110,
+            "empty_domain_count": 41,
+            "detected_solution_count": 0,
+        },
+    }
+    if chain_scan.get("per_source_prefix") != expected_per_source_prefix:
+        raise AssertionError("per-source-prefix counts drifted")
+
+    expected_per_terminal_center = {
+        "2": {
+            "label_6_supply_candidate_count": 708,
+            "initial_auxiliary_catalogue_incompatible_count": 694,
+            "initial_auxiliary_catalogue_searched_count": 14,
+            "search_node_count": 86,
+            "empty_domain_count": 29,
+            "detected_solution_count": 0,
+        },
+        "5": {
+            "label_6_supply_candidate_count": 2132,
+            "initial_auxiliary_catalogue_incompatible_count": 2120,
+            "initial_auxiliary_catalogue_searched_count": 12,
+            "search_node_count": 80,
+            "empty_domain_count": 22,
+            "detected_solution_count": 0,
+        },
+        "7": {
+            "label_6_supply_candidate_count": 6460,
+            "initial_auxiliary_catalogue_incompatible_count": 6428,
+            "initial_auxiliary_catalogue_searched_count": 32,
+            "search_node_count": 57,
+            "empty_domain_count": 34,
+            "detected_solution_count": 0,
+        },
+    }
+    if (
+        chain_scan.get("per_terminal_intermediate_center")
+        != expected_per_terminal_center
+    ):
+        raise AssertionError("per-terminal-center counts drifted")
+    if chain_scan.get("survivors") != []:
+        raise AssertionError("distinct-intermediate chain survivors must be empty")
+
+    source_prefixes = payload.get("source_prefix_survivors")
+    if not isinstance(source_prefixes, Sequence) or len(source_prefixes) != 3:
+        raise AssertionError("expected three source prefix survivors")
+    if {
+        tuple(record.get("first_step_support", []))
+        for record in source_prefixes
+        if isinstance(record, Mapping)
+    } != {(0, 1, 4, 5), (0, 1, 4, 7)}:
+        raise AssertionError("source first-step support set drifted")
+
+    source = payload.get("source_first_supply_chains")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_first_supply_chains must be a mapping")
+    if source.get("schema") != FIRST_SUPPLY_SCHEMA:
+        raise AssertionError("source first-supply schema drifted")
+    if source.get("scan_status") != FIRST_SUPPLY_SCAN_STATUS:
+        raise AssertionError("source first-supply scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_second_step_chains.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_second_step_chains.py
+++ b/tests/test_bootstrap_t12_81_3_second_step_chains.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_second_step_chains import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_second_step_chains_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_second_step_chains_payload()
+
+
+def test_81_3_second_step_chains_counts_and_scope(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_SECOND_STEP_CHAINS_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Distinct-intermediate continuation CSP" in claim_scope
+    assert "no surviving chain" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_second_step_chains_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["connector_pair"] == [0, 1]
+    assert summary["target_center"] == 3
+    assert summary["first_step_center"] == 8
+    assert summary["eventual_supply_label"] == 6
+    assert summary["source_prefix_survivor_count"] == 3
+    assert summary["intermediate_centers_after_center8"] == [2, 5, 7]
+    assert summary["max_distinct_intermediate_chain_length"] == 3
+    assert summary["support_prefix_pruned_count"] == 4112
+    assert summary["label_6_supply_candidate_count"] == 9528
+    assert summary["initial_auxiliary_catalogue_incompatible_count"] == 9470
+    assert summary["initial_auxiliary_catalogue_searched_count"] == 58
+    assert summary["search_node_count"] == 223
+    assert summary["empty_domain_count"] == 85
+    assert summary["detected_solution_count"] == 0
+    assert summary["surviving_chain_count"] == 0
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_second_step_chains_by_length(payload: dict[str, object]) -> None:
+    chain_scan = payload["chain_scan"]
+    per_length = chain_scan["per_chain_length"]
+
+    assert per_length["0"]["label_6_supply_candidate_count"] == 228
+    assert per_length["0"]["initial_auxiliary_catalogue_searched_count"] == 0
+    assert per_length["1"]["label_6_supply_candidate_count"] == 708
+    assert per_length["1"]["initial_auxiliary_catalogue_searched_count"] == 14
+    assert per_length["2"]["label_6_supply_candidate_count"] == 2072
+    assert per_length["2"]["initial_auxiliary_catalogue_searched_count"] == 20
+    assert per_length["3"]["label_6_supply_candidate_count"] == 6520
+    assert per_length["3"]["initial_auxiliary_catalogue_searched_count"] == 24
+    assert all(record["detected_solution_count"] == 0 for record in per_length.values())
+
+
+def test_81_3_second_step_chains_source_prefixes(
+    payload: dict[str, object],
+) -> None:
+    source_prefixes = payload["source_prefix_survivors"]
+
+    assert len(source_prefixes) == 3
+    assert {record["first_step_center"] for record in source_prefixes} == {8}
+    assert {
+        tuple(record["first_step_support"]) for record in source_prefixes
+    } == {(0, 1, 4, 5), (0, 1, 4, 7)}
+    assert {
+        tuple(record["auxiliary_target_support"]) for record in source_prefixes
+    } == {(1, 4, 6, 8), (0, 2, 4, 6), (1, 2, 4, 6)}
+
+    chain_scan = payload["chain_scan"]
+    assert chain_scan["survivors"] == []
+
+
+def test_81_3_second_step_chains_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_second_step_chains_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_second_step_chains.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["surviving_chain_count"] == 0
+
+
+def test_81_3_second_step_chains_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["surviving_chain_count"] = 1
+
+    with pytest.raises(AssertionError, match="surviving_chain_count"):
+        assert_expected_payload(bad)

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -217,6 +217,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_bootstrap_t12_81_3_second_step_chains.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -307,6 +307,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_81_3_first_supply_chains.py "
         "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_81_3_second_step_chains.py "
+        "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check "


### PR DESCRIPTION
## Summary

Adds a review-pending bootstrap/T12 `81:3` second-step chain CSP diagnostic. The new packet starts from the three stored center-8 first-supply survivor prefixes, allows distinct intermediate centers from `{2,5,7}`, and checks whether one center-6 label-6 supply support can follow under the same basic filters.

Result recorded by the generated artifact:

- support prefixes pruned before label-6 supply: `4112`
- label-6 supply catalogues tested: `9528`
- searched label-6 catalogues: `58`
- search nodes: `223`
- surviving chains: `0`
- status: `NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS`

This stays scoped as `REVIEW_PENDING_DIAGNOSTIC`: no row-forcing theorem, no `n=9` proof, no bridge proof, and no counterexample claim.

## Validation

- `python scripts/check_bootstrap_t12_81_3_second_step_chains.py --write --assert-expected`
- `python scripts/check_bootstrap_t12_81_3_second_step_chains.py --check --assert-expected --json`
- `python -m pytest -q -m slow tests/test_bootstrap_t12_81_3_second_step_chains.py`
- `python -m pytest -q tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1156 passed, 423 deselected`)

Attempted `make verify-bridge-frontier`; local PowerShell has no `make`. WSL has `make`, but lacks the repo Python deps (`ModuleNotFoundError: numpy`), so the Makefile artifact target could not be run locally in this environment.