### PR TITLE
Add 81:3 post-8 supply-chain accounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_escape_rich_support_csp.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_first_supply_chains.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_second_step_chains.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   and
   [`docs/bootstrap-t12-81-3-first-supply-chains.md`](docs/bootstrap-t12-81-3-first-supply-chains.md),
   then
-  [`docs/bootstrap-t12-81-3-second-step-chains.md`](docs/bootstrap-t12-81-3-second-step-chains.md).
+  [`docs/bootstrap-t12-81-3-second-step-chains.md`](docs/bootstrap-t12-81-3-second-step-chains.md)
+  and its raw-catalogue companion
+  [`docs/bootstrap-t12-81-3-post8-supply-chains.md`](docs/bootstrap-t12-81-3-post8-supply-chains.md).
 - For the source-`81` row-`8` singleton-support audit, where all fixed and
   one-row-drop activation-row survivors keep the original row `8`, read
   [`docs/bootstrap-t12-81-8-singleton-support-audit.md`](docs/bootstrap-t12-81-8-singleton-support-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -661,7 +661,13 @@ bridge. See `docs/bootstrap-t12-81-3-first-supply-chains.md`,
 `data/certificates/bootstrap_t12_81_3_first_supply_chains.json`, and
 `docs/bootstrap-t12-81-3-second-step-chains.md`,
 `scripts/check_bootstrap_t12_81_3_second_step_chains.py`,
-`data/certificates/bootstrap_t12_81_3_second_step_chains.json`.
+`data/certificates/bootstrap_t12_81_3_second_step_chains.json`. The companion
+post-`8` supply-chain accounting packet records the raw denominator for the
+same bounded chain model: `3,918,164,268` support catalogues, `58` initially
+compatible catalogues, `223` selected-search nodes, and no selected-row
+survivor. See `docs/bootstrap-t12-81-3-post8-supply-chains.md`,
+`scripts/check_bootstrap_t12_81_3_post8_supply_chains.py`, and
+`data/certificates/bootstrap_t12_81_3_post8_supply_chains.json`.
 
 The source-`81` row-`8` singleton-support audit probes the other
 relation-sufficient source-`81` row. Center `8` has bootstrap-core witnesses

--- a/STATE.md
+++ b/STATE.md
@@ -425,7 +425,11 @@ center-`6` label-`6` supply support; it finds no surviving chain. This remains
 one-support-per-activated-center proof-mining bookkeeping, not support
 existence, row forcing, `n=9`, or the bridge. See
 `docs/bootstrap-t12-81-3-first-supply-chains.md` and
-`docs/bootstrap-t12-81-3-second-step-chains.md`.
+`docs/bootstrap-t12-81-3-second-step-chains.md`. A companion post-`8`
+supply-chain packet records the raw support-catalogue denominator for the same
+bounded model: `3,918,164,268` support catalogues collapse to `58` initially
+compatible catalogues and zero selected-row completions. See
+`docs/bootstrap-t12-81-3-post8-supply-chains.md`.
 
 A source-`81` row-`8` singleton-support audit now probes the other
 relation-sufficient target in source `81`. It enumerates the nine center-`8`

--- a/data/certificates/bootstrap_t12_81_3_post8_supply_chains.json
+++ b/data/certificates/bootstrap_t12_81_3_post8_supply_chains.json
@@ -1,0 +1,3226 @@
+{
+  "claim_scope": "Post-center-8 supply-chain CSP for the 81:3 pre-3 label-6 escape. It takes the three first-supply-chain prefix survivors as boundary inputs, each starting at center 8, and enumerates every ordered continuation through any subset of the remaining possible intermediate centers [2,5,7] before center 6. Each auxiliary center may use any rich support of size at least four containing at least three already-closed labels; selected rows at auxiliary centers may be 4-subsets of their support or disjoint 4-sets. All support catalogues that pass the row-pair, crossing, witness-pair, and same-center disjointness filters are then searched for selected-row completions. No selected-row survivor is found. This is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "initially_compatible_catalogues": [
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 9,
+      "empty_domain_depth_histogram": {
+        "6": 5,
+        "7": 4
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 21,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "6": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 8,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "4": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 5,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        3,
+        4,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "2": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 3,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 6,
+      "empty_domain_depth_histogram": {
+        "5": 2,
+        "6": 1,
+        "7": 3
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 16,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "6": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 8,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        3,
+        4,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "2": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 1,
+      "intermediate_order": [
+        2
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 3,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        2,
+        4,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "6": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 8,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "6": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 8,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "6": 1,
+        "8": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 11,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "7": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 10,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          2,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          2,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        3,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "1": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 2,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "6": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 8,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 3,
+      "empty_domain_depth_histogram": {
+        "6": 1,
+        "8": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 11,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "6": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 8,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "1": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 2,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "7": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        5
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 10,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          2,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        3,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          2,
+          4,
+          5,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "3": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 2,
+      "intermediate_order": [
+        2,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "7": [
+          2,
+          3,
+          4,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 4,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "8": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          0,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 10,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          0,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          1,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          1,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          1,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 1,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          3,
+          4,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "1": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 2,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        5,
+        7,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 2,
+      "empty_domain_depth_histogram": {
+        "8": 2
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 10,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          3,
+          4,
+          8
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          0,
+          2,
+          5,
+          6
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        1,
+        3,
+        5,
+        8
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "detected_solution_count": 0,
+      "empty_domain_count": 1,
+      "empty_domain_depth_histogram": {
+        "0": 1
+      },
+      "first_step_center": 8,
+      "first_step_support": [
+        0,
+        1,
+        4,
+        7
+      ],
+      "intermediate_center_count": 3,
+      "intermediate_order": [
+        2,
+        5,
+        7
+      ],
+      "intermediate_supports": {
+        "2": [
+          0,
+          4,
+          5,
+          8
+        ],
+        "5": [
+          2,
+          4,
+          7,
+          8
+        ],
+        "7": [
+          1,
+          5,
+          6,
+          8
+        ]
+      },
+      "prefix_survivor_index": 2,
+      "search_node_count": 1,
+      "solution_search_status": "EXHAUSTED_NO_SOLUTION",
+      "supply_center": 6,
+      "supply_support": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center": 3,
+      "target_support": [
+        1,
+        2,
+        4,
+        6
+      ]
+    }
+  ],
+  "interpretation_warnings": [
+    "The packet closes only the finite post-center-8 chain model built on the three stored first-step prefix survivors.",
+    "Intermediate chains use distinct centers from [2,5,7]; length 3 exhausts all possible remaining pre-6 centers in this model.",
+    "The scan uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+    "It does not prove that any audited support exists as a genuine rich distance class.",
+    "It does not model additional simultaneous auxiliary supports beyond the activation chain and target connector support.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "length_summaries": {
+    "0": {
+      "initially_compatible_support_catalogue_count": 0,
+      "initially_incompatible_support_catalogue_count": 228,
+      "intermediate_center_count": 0,
+      "per_intermediate_order": {},
+      "per_prefix_survivor": {},
+      "selected_detected_solution_count": 0,
+      "selected_empty_domain_count": 0,
+      "selected_empty_domain_depth_histogram": {},
+      "selected_search_node_count": 0,
+      "support_catalogue_candidate_count": 228
+    },
+    "1": {
+      "initially_compatible_support_catalogue_count": 14,
+      "initially_incompatible_support_catalogue_count": 80698,
+      "intermediate_center_count": 1,
+      "per_intermediate_order": {
+        "2": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 29,
+          "initial_compatible_count": 14,
+          "search_node_count": 86
+        }
+      },
+      "per_prefix_survivor": {
+        "1": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 16,
+          "initial_compatible_count": 7,
+          "search_node_count": 46
+        },
+        "2": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 13,
+          "initial_compatible_count": 7,
+          "search_node_count": 40
+        }
+      },
+      "selected_detected_solution_count": 0,
+      "selected_empty_domain_count": 29,
+      "selected_empty_domain_depth_histogram": {
+        "0": 2,
+        "2": 2,
+        "3": 5,
+        "4": 1,
+        "5": 2,
+        "6": 10,
+        "7": 7
+      },
+      "selected_search_node_count": 86,
+      "support_catalogue_candidate_count": 80712
+    },
+    "2": {
+      "initially_compatible_support_catalogue_count": 20,
+      "initially_incompatible_support_catalogue_count": 23890732,
+      "intermediate_center_count": 2,
+      "per_intermediate_order": {
+        "2,5": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 22,
+          "initial_compatible_count": 12,
+          "search_node_count": 80
+        },
+        "2,7": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 8,
+          "initial_compatible_count": 8,
+          "search_node_count": 14
+        }
+      },
+      "per_prefix_survivor": {
+        "1": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 15,
+          "initial_compatible_count": 10,
+          "search_node_count": 46
+        },
+        "2": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 15,
+          "initial_compatible_count": 10,
+          "search_node_count": 48
+        }
+      },
+      "selected_detected_solution_count": 0,
+      "selected_empty_domain_count": 30,
+      "selected_empty_domain_depth_histogram": {
+        "0": 8,
+        "1": 2,
+        "3": 2,
+        "6": 10,
+        "7": 4,
+        "8": 4
+      },
+      "selected_search_node_count": 94,
+      "support_catalogue_candidate_count": 23890752
+    },
+    "3": {
+      "initially_compatible_support_catalogue_count": 24,
+      "initially_incompatible_support_catalogue_count": 3894192552,
+      "intermediate_center_count": 3,
+      "per_intermediate_order": {
+        "2,5,7": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 26,
+          "initial_compatible_count": 24,
+          "search_node_count": 43
+        }
+      },
+      "per_prefix_survivor": {
+        "1": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 13,
+          "initial_compatible_count": 12,
+          "search_node_count": 21
+        },
+        "2": {
+          "detected_solution_count": 0,
+          "empty_domain_count": 13,
+          "initial_compatible_count": 12,
+          "search_node_count": 22
+        }
+      },
+      "selected_detected_solution_count": 0,
+      "selected_empty_domain_count": 26,
+      "selected_empty_domain_depth_histogram": {
+        "0": 21,
+        "1": 1,
+        "8": 4
+      },
+      "selected_search_node_count": 43,
+      "support_catalogue_candidate_count": 3894192576
+    }
+  },
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_post8_supply_chains.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_post8_supply_chains.v1",
+  "source_first_supply_chains": {
+    "path": "data/certificates/bootstrap_t12_81_3_first_supply_chains.json",
+    "scan_status": "PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION",
+    "schema": "erdos97.bootstrap_t12_81_3_first_supply_chains.v1",
+    "status": "BOOTSTRAP_T12_81_3_FIRST_SUPPLY_CHAINS_DIAGNOSTIC_ONLY"
+  },
+  "source_second_step_chains": {
+    "path": "data/certificates/bootstrap_t12_81_3_second_step_chains.json",
+    "scan_status": "NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS",
+    "schema": "erdos97.bootstrap_t12_81_3_second_step_chains.v1",
+    "status": "BOOTSTRAP_T12_81_3_SECOND_STEP_CHAINS_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_POST8_SUPPLY_CHAINS_DIAGNOSTIC_ONLY",
+  "summary": {
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "eventual_supply_center": 6,
+    "first_step_center": 8,
+    "initially_compatible_support_catalogue_count_by_length": {
+      "0": 0,
+      "1": 14,
+      "2": 20,
+      "3": 24
+    },
+    "intermediate_center_universe": [
+      2,
+      5,
+      7
+    ],
+    "max_intermediate_center_count": 3,
+    "post_first_step_closure": [
+      0,
+      1,
+      4,
+      8
+    ],
+    "remaining_gap": "Within the same finite support-chain model, the three stored center-8 prefixes no longer leave a longer-chain route to center 6. Any remaining 81:3 escape must use a hypothesis or catalogue outside this audited chain model, such as additional simultaneous rich supports, a different rich-class/minimality forcing step, or geometry not represented by these basic filters.",
+    "scan_status": "NO_POST8_PRE6_SUPPLY_CHAIN_SURVIVORS_UNDER_BASIC_FILTERS",
+    "selected_detected_solution_count_by_length": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0
+    },
+    "selected_empty_domain_count_by_length": {
+      "0": 0,
+      "1": 29,
+      "2": 30,
+      "3": 26
+    },
+    "selected_search_node_count_by_length": {
+      "0": 0,
+      "1": 86,
+      "2": 94,
+      "3": 43
+    },
+    "source_first_supply_survivor_centers": [
+      8
+    ],
+    "source_first_supply_survivor_count": 3,
+    "source_record_ids": [
+      81
+    ],
+    "support_catalogue_candidate_count_by_length": {
+      "0": 228,
+      "1": 80712,
+      "2": 23890752,
+      "3": 3894192576
+    },
+    "target_center": 3,
+    "target_row_key": "81:3",
+    "total_initially_compatible_support_catalogue_count": 58,
+    "total_selected_detected_solution_count": 0,
+    "total_selected_empty_domain_count": 85,
+    "total_selected_search_node_count": 223,
+    "total_support_catalogue_candidate_count": 3918164268
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-post8-supply-chains.md
+++ b/docs/bootstrap-t12-81-3-post8-supply-chains.md
@@ -1,0 +1,101 @@
+# Bootstrap T12 81:3 Post-8 Supply-Chain CSP
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This packet is a catalogue-accounting companion to
+`docs/bootstrap-t12-81-3-second-step-chains.md`, following the source prefix
+packet in `docs/bootstrap-t12-81-3-first-supply-chains.md`. The source packet
+found exactly three basic-filter survivor prefixes, all with center `8` as the
+first activation from the deletion seed `[0,1,4]`, and none of those prefixes
+admitted an immediate center-`6` supply support.
+
+Here the same finite support-chain model is pushed to its natural endpoint
+after center `8`. Before center `6` activates, the only remaining non-seed,
+non-target, non-supply centers are:
+
+```text
+2,5,7
+```
+
+So the checker enumerates every ordered continuation through any subset of
+`[2,5,7]`, then tries center `6`.
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_81_3_post8_supply_chains.json`.
+
+## Scan scope
+
+The scan starts from the three stored center-`8` prefix survivors. At every
+additional intermediate center, the auxiliary rich support may be any support of
+size at least `4` containing at least three already-closed labels. At each
+auxiliary center, the selected row may be any four-subset of the auxiliary
+support or any four-set disjoint from it. Non-auxiliary centers may use any
+selected four-set.
+
+The filters are the same basic finite filters used in the source packet:
+
+```text
+row-pair cap
+witness-pair cap
+two-overlap crossing
+same-center disjointness
+```
+
+The scan does not test Euclidean realizability.
+
+## Result
+
+The post-center-`8` continuation closes under these filters. The companion
+second-step packet records the pruned continuation search; this packet records
+the raw support-catalogue denominator before initial compatibility pruning.
+
+| intermediate centers before `6` | support catalogues | initially compatible | selected-search nodes | empty domains | selected-row survivors |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 0 | 228 | 0 | 0 | 0 | 0 |
+| 1 | 80,712 | 14 | 86 | 29 | 0 |
+| 2 | 23,890,752 | 20 | 94 | 30 | 0 |
+| 3 | 3,894,192,576 | 24 | 43 | 26 | 0 |
+| total | 3,918,164,268 | 58 | 223 | 85 | 0 |
+
+The only initially compatible intermediate orders are:
+
+```text
+length 1: 2
+length 2: 2,5 and 2,7
+length 3: 2,5,7
+```
+
+No initially compatible catalogue admits a selected-row completion.
+
+The checked scan status is:
+
+```text
+NO_POST8_PRE6_SUPPLY_CHAIN_SURVIVORS_UNDER_BASIC_FILTERS
+```
+
+## Interpretation
+
+Within this finite chain model, the three stored center-`8` prefixes no longer
+leave a longer route to center `6`. This is the same closure boundary as the
+second-step packet, with the added raw-catalogue accounting. The remaining
+`81:3` escape must therefore leave this audited model, for example by using
+additional simultaneous rich supports, a different minimality or rich-class
+forcing hypothesis, or geometry not captured by these basic filters.
+
+## What this does not prove
+
+This artifact does not prove row forcing, rich-class existence, `n=9`, the
+bootstrap bridge, or Erdos Problem #97. It is a proof-mining diagnostic for one
+specific `81:3` post-center-`8` label-`6` escape model.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -997,7 +997,11 @@ intermediate centers from `{2,5,7}` after those center-`8` prefixes before one
 center-`6` supply support. It finds no surviving chain under the same basic
 filters. These are bounded proof-mining diagnostics only; they do not prove
 support existence, row forcing, `n=9`, the bootstrap bridge, or Erdos
-Problem #97.
+Problem #97. The companion post-`8` supply-chain accounting packet in
+`docs/bootstrap-t12-81-3-post8-supply-chains.md` records the raw denominator
+for the same bounded model: `3,918,164,268` support catalogues reduce to `58`
+initially compatible catalogues and zero selected-row completions. It has the
+same diagnostic-only claim boundary.
 
 The source-`81` row-`8` singleton-support audit in
 `docs/bootstrap-t12-81-8-singleton-support-audit.md` checks a neighboring

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -352,11 +352,15 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-second-step-chains.md` attacks the bounded
    distinct-intermediate continuation: after those center-`8` prefixes, no
    chain through distinct centers from `{2,5,7}` followed by one center-`6`
-   label-`6` supply support survives the same basic filters. The next useful
-   PR must therefore either handle repeated/multiple supports, introduce a
-   genuine rich-class/minimality hypothesis that forces or excludes such a
-   support, or move to a different bridge target. The source-`81` row-`8`
-   singleton-support audit in
+   label-`6` supply support survives the same basic filters. The post-`8`
+   supply-chain accounting companion in
+   `docs/bootstrap-t12-81-3-post8-supply-chains.md` records the raw
+   denominator behind the same closure: `3,918,164,268` support catalogues
+   reduce to `58` initially compatible catalogues and no selected-row
+   survivor. The next useful PR must therefore either handle repeated/multiple
+   supports, introduce a genuine rich-class/minimality hypothesis that forces
+   or excludes such a support, or move to a different bridge target. The
+   source-`81` row-`8` singleton-support audit in
    `docs/bootstrap-t12-81-8-singleton-support-audit.md` is one such adjacent
    target: it finds no non-original row-`8` activation survivor in the fixed
    source-`81` neighborhood or a one-row-drop relaxation, but still leaves

--- a/docs/index.md
+++ b/docs/index.md
@@ -284,6 +284,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-second-step-chains.md`](bootstrap-t12-81-3-second-step-chains.md):
   distinct-intermediate continuation CSP after the stored center-`8` prefix
   survivors, before testing center-`6` label-`6` supply.
+- [`bootstrap-t12-81-3-post8-supply-chains.md`](bootstrap-t12-81-3-post8-supply-chains.md):
+  raw support-catalogue accounting companion for the same post-center-`8`
+  chain model.
 - [`bootstrap-t12-81-8-singleton-support-audit.md`](bootstrap-t12-81-8-singleton-support-audit.md):
   source-`81` row-`8` singleton-support audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -757,6 +757,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   one-support-per-activated-center continuation model under the same basic
   filters, while leaving repeated/multiple supports, richer catalogues, and
   genuine rich-class forcing open.
+- bootstrap/T12 focused `81:3` post-`8` supply-chain accounting, as recorded
+  in `docs/bootstrap-t12-81-3-post8-supply-chains.md`, giving the raw
+  denominator for the same bounded continuation model: `3,918,164,268`
+  support catalogues, `58` initially compatible catalogues, and zero
+  selected-row survivors.
 - bootstrap/T12 focused `81:8` singleton-support evidence, as recorded in
   `docs/bootstrap-t12-81-8-singleton-support-audit.md`, showing that the fixed
   source-`81` neighborhood and one-row-drop relaxation have no non-original

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -6090,6 +6090,102 @@ artifacts:
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
+
+  - id: bootstrap_t12_81_3_post8_supply_chains
+    path: data/certificates/bootstrap_t12_81_3_post8_supply_chains.json
+    sha256: 69d69309dcbb118b2186f6c4eefa95a79e0d8195a39c5503775723ec941e7488
+    size_bytes: 60584
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_post8_supply_chains.py
+    command: python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_post8_supply_chains.py
+    check_command: python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Post-center-8 raw support-catalogue accounting for the 81:3 pre-3 label-6 escape chain model; starting from the three stored center-8 prefix survivors, every ordered continuation through distinct intermediate centers from {2,5,7} before one center-6 supply support has zero selected-row completions under the same basic filters, but this is not support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_post8_supply_chains.v1
+      status: BOOTSTRAP_T12_81_3_POST8_SUPPLY_CHAINS_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.first_step_center: 8
+      summary.post_first_step_closure:
+        - 0
+        - 1
+        - 4
+        - 8
+      summary.eventual_supply_center: 6
+      summary.target_center: 3
+      summary.intermediate_center_universe:
+        - 2
+        - 5
+        - 7
+      summary.max_intermediate_center_count: 3
+      summary.source_first_supply_survivor_count: 3
+      summary.source_first_supply_survivor_centers:
+        - 8
+      summary.support_catalogue_candidate_count_by_length.0: 228
+      summary.support_catalogue_candidate_count_by_length.1: 80712
+      summary.support_catalogue_candidate_count_by_length.2: 23890752
+      summary.support_catalogue_candidate_count_by_length.3: 3894192576
+      summary.initially_compatible_support_catalogue_count_by_length.0: 0
+      summary.initially_compatible_support_catalogue_count_by_length.1: 14
+      summary.initially_compatible_support_catalogue_count_by_length.2: 20
+      summary.initially_compatible_support_catalogue_count_by_length.3: 24
+      summary.selected_search_node_count_by_length.0: 0
+      summary.selected_search_node_count_by_length.1: 86
+      summary.selected_search_node_count_by_length.2: 94
+      summary.selected_search_node_count_by_length.3: 43
+      summary.selected_detected_solution_count_by_length.0: 0
+      summary.selected_detected_solution_count_by_length.1: 0
+      summary.selected_detected_solution_count_by_length.2: 0
+      summary.selected_detected_solution_count_by_length.3: 0
+      summary.total_support_catalogue_candidate_count: 3918164268
+      summary.total_initially_compatible_support_catalogue_count: 58
+      summary.total_selected_search_node_count: 223
+      summary.total_selected_empty_domain_count: 85
+      summary.total_selected_detected_solution_count: 0
+      summary.scan_status: NO_POST8_PRE6_SUPPLY_CHAIN_SURVIVORS_UNDER_BASIC_FILTERS
+      source_first_supply_chains.schema: erdos97.bootstrap_t12_81_3_first_supply_chains.v1
+      source_first_supply_chains.scan_status: PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION
+      source_second_step_chains.schema: erdos97.bootstrap_t12_81_3_second_step_chains.v1
+      source_second_step_chains.scan_status: NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS
+      provenance.generator: scripts/check_bootstrap_t12_81_3_post8_supply_chains.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich support exists
+      - the 81:3 row is forced
+      - the post8-supply-chain CSP proves genuine rich-class order
+      - the post8-supply-chain CSP proves no pre-3 label-6 supply exists
+      - the post8-supply-chain CSP proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
   - id: bootstrap_t12_81_8_singleton_support_audit
     path: data/certificates/bootstrap_t12_81_8_singleton_support_audit.json
     sha256: daa724c9c566b321310cce08ade6747122a6a0fab1208504995d0ebdcfe96eec

--- a/scripts/check_bootstrap_t12_81_3_post8_supply_chains.py
+++ b/scripts/check_bootstrap_t12_81_3_post8_supply_chains.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 post-center-8 supply-chain CSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_post8_supply_chains import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_post8_supply_chains_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 post-center-8 supply-chain CSP")
+    print(
+        "support-catalogue candidates: "
+        f"{summary['total_support_catalogue_candidate_count']}"
+    )
+    print(
+        "initially compatible catalogues: "
+        f"{summary['total_initially_compatible_support_catalogue_count']}"
+    )
+    print(
+        "selected search nodes: "
+        f"{summary['total_selected_search_node_count']}"
+    )
+    print(
+        "selected-row survivors: "
+        f"{summary['total_selected_detected_solution_count']}"
+    )
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write regenerated payload",
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument(
+        "--assert-expected",
+        action="store_true",
+        help="assert pinned values",
+    )
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_post8_supply_chains_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(
+                f"{artifact} is stale relative to regenerated post8 packet"
+            )
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 post8 artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 post8 expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2129,6 +2129,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_81_3_post8_supply_chains",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_81_3_post8_supply_chains.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Post-center-8 raw catalogue accounting for the 81:3 pre-3 "
+            "label-6 escape chain model; not support existence, row forcing, "
+            "an n=9 proof, a bridge proof, or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_81_8_singleton_support_audit",
         command=(
             "python",

--- a/src/erdos97/bootstrap_t12_81_3_post8_supply_chains.py
+++ b/src/erdos97/bootstrap_t12_81_3_post8_supply_chains.py
@@ -1,0 +1,651 @@
+"""Post-center-8 supply-chain CSP for the bootstrap/T12 81:3 escape.
+
+The first-supply-chain prefix packet leaves three boundary prefixes, all with
+center 8 as the first pre-3 activation from seed [0,1,4].  It also checks that
+none of those prefixes admits an immediate center-6 supply support.
+
+This packet exhausts the finite continuation model after that center-8 step:
+before center 6 activates, the only remaining non-seed, non-target,
+non-supply centers are 2, 5, and 7.  The scan therefore tries every ordered
+subset of [2,5,7] as intermediate activations, then tries center 6.
+
+The search is exact finite incidence/crossing bookkeeping.  It is not a
+Euclidean realizability theorem and not a proof of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from itertools import permutations
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CYCLIC_ORDER,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_escape_rich_support_csp import (
+    _bit_labels,
+    _build_pair_centers,
+    _support_masks_containing,
+    _support_pair_compatible,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import _row_mask
+from erdos97.bootstrap_t12_81_3_first_supply_chains import (
+    DEFAULT_ARTIFACT as FIRST_SUPPLY_ARTIFACT,
+    SCAN_STATUS as FIRST_SUPPLY_SCAN_STATUS,
+    SCHEMA as FIRST_SUPPLY_SCHEMA,
+    STATUS as FIRST_SUPPLY_STATUS,
+    _search_auxiliary_support_catalogue,
+    assert_expected_payload as assert_first_supply_payload,
+    load_artifact as load_first_supply_artifact,
+)
+from erdos97.bootstrap_t12_81_3_second_step_chains import (
+    DEFAULT_ARTIFACT as SECOND_STEP_ARTIFACT,
+    SCAN_STATUS as SECOND_STEP_SCAN_STATUS,
+    SCHEMA as SECOND_STEP_SCHEMA,
+    STATUS as SECOND_STEP_STATUS,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_post8_supply_chains.v1"
+STATUS = "BOOTSTRAP_T12_81_3_POST8_SUPPLY_CHAINS_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_POST8_PRE6_SUPPLY_CHAIN_SURVIVORS_UNDER_BASIC_FILTERS"
+CLAIM_SCOPE = (
+    "Post-center-8 supply-chain CSP for the 81:3 pre-3 label-6 escape. It "
+    "takes the three first-supply-chain prefix survivors as boundary inputs, "
+    "each starting at center 8, and enumerates every ordered continuation "
+    "through any subset of the remaining possible intermediate centers [2,5,7] "
+    "before center 6. Each auxiliary center may use any rich support of size at "
+    "least four containing at least three already-closed labels; selected rows "
+    "at auxiliary centers may be 4-subsets of their support or disjoint 4-sets. "
+    "All support catalogues that pass the row-pair, crossing, witness-pair, "
+    "and same-center disjointness filters are then searched for selected-row "
+    "completions. No selected-row survivor is found. This is not a proof of "
+    "genuine rich-class order, not a proof of row forcing, not a proof of n=9, "
+    "not a proof of the bridge, and not a counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_post8_supply_chains.json"
+)
+FIRST_STEP_CENTER = 8
+POST8_INTERMEDIATE_CENTERS = [2, 5, 7]
+MAX_INTERMEDIATE_CENTER_COUNT = len(POST8_INTERMEDIATE_CENTERS)
+
+
+def _int_list(values: Iterable[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _source_prefix_survivors(
+    first_supply_artifact: Path = FIRST_SUPPLY_ARTIFACT,
+) -> list[dict[str, object]]:
+    source = load_first_supply_artifact(first_supply_artifact)
+    assert_first_supply_payload(source)
+    survivors = source.get("survivors")
+    if not isinstance(survivors, Sequence):
+        raise AssertionError("source first-supply survivors must be a sequence")
+    out: list[dict[str, object]] = []
+    for survivor in survivors:
+        if not isinstance(survivor, Mapping):
+            raise AssertionError("source survivor entries must be mappings")
+        if int(survivor.get("first_step_center", -1)) != FIRST_STEP_CENTER:
+            raise AssertionError("all source survivors should start at center 8")
+        out.append(dict(survivor))
+    return out
+
+
+def _support_options_for_activation(center: int, closure: set[int]) -> list[int]:
+    closure_mask = _row_mask(closure)
+    return [
+        support_mask
+        for support_mask in _support_masks_containing(center, [])
+        if (support_mask & closure_mask).bit_count() >= 3
+    ]
+
+
+def _initial_auxiliary_supports_compatible(
+    auxiliary_supports: Mapping[int, int],
+) -> bool:
+    centers = sorted(auxiliary_supports)
+    for index, center_a in enumerate(centers):
+        for center_b in centers[index + 1 :]:
+            if not _support_pair_compatible(
+                center_a,
+                auxiliary_supports[center_a],
+                center_b,
+                auxiliary_supports[center_b],
+            ):
+                return False
+
+    pair_centers = _build_pair_centers(auxiliary_supports, {})
+    return all(len(centers_for_pair) <= 2 for centers_for_pair in pair_centers.values())
+
+
+def _support_candidate_count_for_order(order: Sequence[int]) -> int:
+    closure = set(TARGET_DELETION_SEED) | {FIRST_STEP_CENTER}
+    count = 1
+    for center in order:
+        count *= len(_support_options_for_activation(center, closure))
+        closure.add(center)
+    count *= len(_support_options_for_activation(SUPPLY_CENTER, closure))
+    return count
+
+
+def _enumerate_initially_compatible_catalogues(
+    prefix: Mapping[str, object],
+    order: Sequence[int],
+) -> list[dict[str, object]]:
+    first_support = _row_mask(
+        _int_list(prefix["first_step_support"])  # type: ignore[index]
+    )
+    target_support = _row_mask(
+        _int_list(prefix["auxiliary_target_support"])  # type: ignore[index]
+    )
+    base_auxiliary = {
+        FIRST_STEP_CENTER: first_support,
+        TARGET_ROW_CENTER: target_support,
+    }
+    if not _initial_auxiliary_supports_compatible(base_auxiliary):
+        raise AssertionError("source prefix support catalogue should be compatible")
+
+    records: list[dict[str, object]] = []
+    initial_closure = set(TARGET_DELETION_SEED) | {FIRST_STEP_CENTER}
+
+    def search_prefix(
+        position: int,
+        auxiliary_supports: dict[int, int],
+        closure: set[int],
+        intermediate_supports: dict[int, int],
+    ) -> None:
+        if position == len(order):
+            for supply_support in _support_options_for_activation(
+                SUPPLY_CENTER,
+                closure,
+            ):
+                next_auxiliary = dict(auxiliary_supports)
+                next_auxiliary[SUPPLY_CENTER] = supply_support
+                if not _initial_auxiliary_supports_compatible(next_auxiliary):
+                    continue
+                records.append(
+                    {
+                        "auxiliary_supports": next_auxiliary,
+                        "intermediate_supports": dict(intermediate_supports),
+                        "supply_support": supply_support,
+                    }
+                )
+            return
+
+        center = int(order[position])
+        for support in _support_options_for_activation(center, closure):
+            next_auxiliary = dict(auxiliary_supports)
+            next_auxiliary[center] = support
+            if not _initial_auxiliary_supports_compatible(next_auxiliary):
+                continue
+            next_intermediate_supports = dict(intermediate_supports)
+            next_intermediate_supports[center] = support
+            next_closure = set(closure)
+            next_closure.add(center)
+            search_prefix(
+                position + 1,
+                next_auxiliary,
+                next_closure,
+                next_intermediate_supports,
+            )
+
+    search_prefix(0, base_auxiliary, initial_closure, {})
+    return records
+
+
+def _order_key(order: Sequence[int]) -> str:
+    return "immediate" if not order else ",".join(str(center) for center in order)
+
+
+def _scan_post8_supply_chains(
+    prefix_survivors: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    length_summaries: dict[str, object] = {}
+    compatible_catalogue_records: list[dict[str, object]] = []
+    summary_counts = {
+        "raw_by_length": {},
+        "initial_compatible_by_length": {},
+        "nodes_by_length": {},
+        "empty_by_length": {},
+        "solutions_by_length": {},
+    }
+
+    for length in range(MAX_INTERMEDIATE_CENTER_COUNT + 1):
+        orders = (
+            [()]
+            if length == 0
+            else list(permutations(POST8_INTERMEDIATE_CENTERS, length))
+        )
+        support_candidate_count = len(prefix_survivors) * sum(
+            _support_candidate_count_for_order(order) for order in orders
+        )
+
+        aggregate: Counter[str] = Counter()
+        empty_depths: Counter[str] = Counter()
+        per_prefix: dict[int, Counter[str]] = defaultdict(Counter)
+        per_order: dict[str, Counter[str]] = defaultdict(Counter)
+
+        for prefix_index, prefix in enumerate(prefix_survivors):
+            for order in orders:
+                compatible_catalogues = _enumerate_initially_compatible_catalogues(
+                    prefix,
+                    order,
+                )
+                for compatible in compatible_catalogues:
+                    auxiliary_supports = compatible["auxiliary_supports"]
+                    if not isinstance(auxiliary_supports, Mapping):
+                        raise AssertionError("auxiliary_supports must be a mapping")
+                    stats = _search_auxiliary_support_catalogue(
+                        auxiliary_supports,
+                        incompatible_status=(
+                            "INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE"
+                        ),
+                    )
+                    aggregate["initial_compatible_count"] += 1
+                    aggregate["search_node_count"] += int(stats["search_node_count"])
+                    aggregate["empty_domain_count"] += int(stats["empty_domain_count"])
+                    aggregate["detected_solution_count"] += int(
+                        stats["detected_solution_count"]
+                    )
+                    aggregate[f"solution_status:{stats['solution_search_status']}"] += 1
+
+                    per_prefix[prefix_index]["initial_compatible_count"] += 1
+                    per_prefix[prefix_index]["search_node_count"] += int(
+                        stats["search_node_count"]
+                    )
+                    per_prefix[prefix_index]["empty_domain_count"] += int(
+                        stats["empty_domain_count"]
+                    )
+                    per_prefix[prefix_index]["detected_solution_count"] += int(
+                        stats["detected_solution_count"]
+                    )
+
+                    key = _order_key(order)
+                    per_order[key]["initial_compatible_count"] += 1
+                    per_order[key]["search_node_count"] += int(
+                        stats["search_node_count"]
+                    )
+                    per_order[key]["empty_domain_count"] += int(
+                        stats["empty_domain_count"]
+                    )
+                    per_order[key]["detected_solution_count"] += int(
+                        stats["detected_solution_count"]
+                    )
+
+                    for depth, count in dict(
+                        stats["empty_domain_depth_histogram"]
+                    ).items():
+                        empty_depths[str(depth)] += int(count)
+
+                    intermediate_supports = compatible["intermediate_supports"]
+                    if not isinstance(intermediate_supports, Mapping):
+                        raise AssertionError("intermediate_supports must be a mapping")
+                    supply_support = int(compatible["supply_support"])
+                    compatible_catalogue_records.append(
+                        {
+                            "intermediate_center_count": length,
+                            "prefix_survivor_index": prefix_index,
+                            "first_step_center": FIRST_STEP_CENTER,
+                            "first_step_support": prefix["first_step_support"],
+                            "target_center": TARGET_ROW_CENTER,
+                            "target_support": prefix["auxiliary_target_support"],
+                            "intermediate_order": list(order),
+                            "intermediate_supports": {
+                                str(center): _bit_labels(int(support))
+                                for center, support in sorted(
+                                    intermediate_supports.items()
+                                )
+                            },
+                            "supply_center": SUPPLY_CENTER,
+                            "supply_support": _bit_labels(supply_support),
+                            "search_node_count": stats["search_node_count"],
+                            "empty_domain_count": stats["empty_domain_count"],
+                            "empty_domain_depth_histogram": stats[
+                                "empty_domain_depth_histogram"
+                            ],
+                            "detected_solution_count": stats[
+                                "detected_solution_count"
+                            ],
+                            "solution_search_status": stats[
+                                "solution_search_status"
+                            ],
+                        }
+                    )
+
+        length_key = str(length)
+        summary_counts["raw_by_length"][length_key] = support_candidate_count
+        summary_counts["initial_compatible_by_length"][length_key] = aggregate[
+            "initial_compatible_count"
+        ]
+        summary_counts["nodes_by_length"][length_key] = aggregate["search_node_count"]
+        summary_counts["empty_by_length"][length_key] = aggregate["empty_domain_count"]
+        summary_counts["solutions_by_length"][length_key] = aggregate[
+            "detected_solution_count"
+        ]
+
+        length_summaries[length_key] = {
+            "intermediate_center_count": length,
+            "support_catalogue_candidate_count": support_candidate_count,
+            "initially_incompatible_support_catalogue_count": (
+                support_candidate_count - aggregate["initial_compatible_count"]
+            ),
+            "initially_compatible_support_catalogue_count": aggregate[
+                "initial_compatible_count"
+            ],
+            "selected_search_node_count": aggregate["search_node_count"],
+            "selected_empty_domain_count": aggregate["empty_domain_count"],
+            "selected_detected_solution_count": aggregate["detected_solution_count"],
+            "selected_empty_domain_depth_histogram": dict(
+                sorted(empty_depths.items(), key=lambda item: int(item[0]))
+            ),
+            "per_prefix_survivor": {
+                str(prefix_index): dict(sorted(counter.items()))
+                for prefix_index, counter in sorted(per_prefix.items())
+            },
+            "per_intermediate_order": {
+                key: dict(sorted(counter.items()))
+                for key, counter in sorted(per_order.items())
+            },
+        }
+
+    return {
+        "length_summaries": length_summaries,
+        "initially_compatible_catalogues": compatible_catalogue_records,
+        "summary_counts": summary_counts,
+    }
+
+
+def build_t12_81_3_post8_supply_chains_payload(
+    first_supply_artifact: Path = FIRST_SUPPLY_ARTIFACT,
+) -> dict[str, object]:
+    """Return the deterministic post-center-8 supply-chain CSP packet."""
+
+    prefix_survivors = _source_prefix_survivors(first_supply_artifact)
+    scan = _scan_post8_supply_chains(prefix_survivors)
+    summary_counts = scan["summary_counts"]
+    if not isinstance(summary_counts, Mapping):
+        raise AssertionError("summary_counts must be a mapping")
+
+    raw_by_length = summary_counts["raw_by_length"]
+    initial_compatible_by_length = summary_counts["initial_compatible_by_length"]
+    nodes_by_length = summary_counts["nodes_by_length"]
+    empty_by_length = summary_counts["empty_by_length"]
+    solutions_by_length = summary_counts["solutions_by_length"]
+
+    if not all(
+        isinstance(value, Mapping)
+        for value in (
+            raw_by_length,
+            initial_compatible_by_length,
+            nodes_by_length,
+            empty_by_length,
+            solutions_by_length,
+        )
+    ):
+        raise AssertionError("summary count fields must be mappings")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            (
+                "The packet closes only the finite post-center-8 chain model "
+                "built on the three stored first-step prefix survivors."
+            ),
+            (
+                "Intermediate chains use distinct centers from [2,5,7]; length "
+                "3 exhausts all possible remaining pre-6 centers in this model."
+            ),
+            (
+                "The scan uses incidence, crossing, pair-cap, and same-center "
+                "disjointness filters only, not Euclidean realizability."
+            ),
+            (
+                "It does not prove that any audited support exists as a genuine "
+                "rich distance class."
+            ),
+            (
+                "It does not model additional simultaneous auxiliary supports "
+                "beyond the activation chain and target connector support."
+            ),
+            (
+                "No n=9 finite-case status, bridge status, official status, or "
+                "counterexample status changes."
+            ),
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "first_step_center": FIRST_STEP_CENTER,
+            "post_first_step_closure": sorted(
+                set(TARGET_DELETION_SEED) | {FIRST_STEP_CENTER}
+            ),
+            "eventual_supply_center": SUPPLY_CENTER,
+            "target_center": TARGET_ROW_CENTER,
+            "intermediate_center_universe": POST8_INTERMEDIATE_CENTERS,
+            "max_intermediate_center_count": MAX_INTERMEDIATE_CENTER_COUNT,
+            "source_first_supply_survivor_count": len(prefix_survivors),
+            "source_first_supply_survivor_centers": sorted(
+                {
+                    int(prefix["first_step_center"])
+                    for prefix in prefix_survivors
+                }
+            ),
+            "support_catalogue_candidate_count_by_length": dict(raw_by_length),
+            "initially_compatible_support_catalogue_count_by_length": dict(
+                initial_compatible_by_length
+            ),
+            "selected_search_node_count_by_length": dict(nodes_by_length),
+            "selected_empty_domain_count_by_length": dict(empty_by_length),
+            "selected_detected_solution_count_by_length": dict(solutions_by_length),
+            "total_support_catalogue_candidate_count": sum(
+                int(value) for value in raw_by_length.values()
+            ),
+            "total_initially_compatible_support_catalogue_count": sum(
+                int(value) for value in initial_compatible_by_length.values()
+            ),
+            "total_selected_search_node_count": sum(
+                int(value) for value in nodes_by_length.values()
+            ),
+            "total_selected_empty_domain_count": sum(
+                int(value) for value in empty_by_length.values()
+            ),
+            "total_selected_detected_solution_count": sum(
+                int(value) for value in solutions_by_length.values()
+            ),
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "Within the same finite support-chain model, the three stored "
+                "center-8 prefixes no longer leave a longer-chain route to "
+                "center 6. Any remaining 81:3 escape must use a hypothesis or "
+                "catalogue outside this audited chain model, such as additional "
+                "simultaneous rich supports, a different rich-class/minimality "
+                "forcing step, or geometry not represented by these basic filters."
+            ),
+        },
+        "length_summaries": scan["length_summaries"],
+        "initially_compatible_catalogues": scan["initially_compatible_catalogues"],
+        "source_first_supply_chains": {
+            "path": FIRST_SUPPLY_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": FIRST_SUPPLY_SCHEMA,
+            "status": FIRST_SUPPLY_STATUS,
+            "scan_status": FIRST_SUPPLY_SCAN_STATUS,
+        },
+        "source_second_step_chains": {
+            "path": SECOND_STEP_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": SECOND_STEP_SCHEMA,
+            "status": SECOND_STEP_STATUS,
+            "scan_status": SECOND_STEP_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_post8_supply_chains.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "first_step_center": FIRST_STEP_CENTER,
+        "post_first_step_closure": [0, 1, 4, 8],
+        "eventual_supply_center": SUPPLY_CENTER,
+        "target_center": TARGET_ROW_CENTER,
+        "intermediate_center_universe": POST8_INTERMEDIATE_CENTERS,
+        "max_intermediate_center_count": 3,
+        "source_first_supply_survivor_count": 3,
+        "source_first_supply_survivor_centers": [8],
+        "support_catalogue_candidate_count_by_length": {
+            "0": 228,
+            "1": 80712,
+            "2": 23890752,
+            "3": 3894192576,
+        },
+        "initially_compatible_support_catalogue_count_by_length": {
+            "0": 0,
+            "1": 14,
+            "2": 20,
+            "3": 24,
+        },
+        "selected_search_node_count_by_length": {
+            "0": 0,
+            "1": 86,
+            "2": 94,
+            "3": 43,
+        },
+        "selected_empty_domain_count_by_length": {
+            "0": 0,
+            "1": 29,
+            "2": 30,
+            "3": 26,
+        },
+        "selected_detected_solution_count_by_length": {
+            "0": 0,
+            "1": 0,
+            "2": 0,
+            "3": 0,
+        },
+        "total_support_catalogue_candidate_count": 3918164268,
+        "total_initially_compatible_support_catalogue_count": 58,
+        "total_selected_search_node_count": 223,
+        "total_selected_empty_domain_count": 85,
+        "total_selected_detected_solution_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    length_summaries = payload.get("length_summaries")
+    if not isinstance(length_summaries, Mapping):
+        raise AssertionError("length_summaries must be a mapping")
+    expected_initial_orders = {
+        "1": {"2": 14},
+        "2": {"2,5": 12, "2,7": 8},
+        "3": {"2,5,7": 24},
+    }
+    for length, expected_orders in expected_initial_orders.items():
+        length_summary = length_summaries.get(length)
+        if not isinstance(length_summary, Mapping):
+            raise AssertionError(f"length {length} summary missing")
+        orders = length_summary.get("per_intermediate_order")
+        if not isinstance(orders, Mapping):
+            raise AssertionError(f"length {length} per-order summary missing")
+        observed = {
+            key: int(value.get("initial_compatible_count", -1))
+            for key, value in orders.items()
+            if isinstance(value, Mapping)
+        }
+        if observed != expected_orders:
+            raise AssertionError(
+                f"length {length} initial-compatible order map is "
+                f"{observed!r}, expected {expected_orders!r}"
+            )
+
+    records = payload.get("initially_compatible_catalogues")
+    if not isinstance(records, Sequence):
+        raise AssertionError("initially_compatible_catalogues must be a sequence")
+    if len(records) != 58:
+        raise AssertionError("expected 58 initially compatible catalogues")
+    if any(
+        isinstance(record, Mapping) and record.get("detected_solution_count") != 0
+        for record in records
+    ):
+        raise AssertionError("no initially compatible catalogue should solve")
+
+    source = payload.get("source_first_supply_chains")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_first_supply_chains must be a mapping")
+    if source.get("schema") != FIRST_SUPPLY_SCHEMA:
+        raise AssertionError("source first-supply schema drifted")
+    if source.get("scan_status") != FIRST_SUPPLY_SCAN_STATUS:
+        raise AssertionError("source first-supply scan status drifted")
+
+    second_step = payload.get("source_second_step_chains")
+    if not isinstance(second_step, Mapping):
+        raise AssertionError("source_second_step_chains must be a mapping")
+    if second_step.get("schema") != SECOND_STEP_SCHEMA:
+        raise AssertionError("source second-step schema drifted")
+    if second_step.get("scan_status") != SECOND_STEP_SCAN_STATUS:
+        raise AssertionError("source second-step scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_post8_supply_chains.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_post8_supply_chains.py
+++ b/tests/test_bootstrap_t12_81_3_post8_supply_chains.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_post8_supply_chains import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_post8_supply_chains_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_post8_supply_chains_payload()
+
+
+def test_81_3_post8_supply_chains_counts_and_scope(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_81_3_POST8_SUPPLY_CHAINS_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "Post-center-8 supply-chain CSP" in claim_scope
+    assert "No selected-row survivor is found" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+
+def test_81_3_post8_supply_chains_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "81:3"
+    assert summary["source_record_ids"] == [81]
+    assert summary["deletion_seed"] == [0, 1, 4]
+    assert summary["first_step_center"] == 8
+    assert summary["post_first_step_closure"] == [0, 1, 4, 8]
+    assert summary["eventual_supply_center"] == 6
+    assert summary["target_center"] == 3
+    assert summary["intermediate_center_universe"] == [2, 5, 7]
+    assert summary["source_first_supply_survivor_count"] == 3
+    assert summary["source_first_supply_survivor_centers"] == [8]
+    assert summary["total_support_catalogue_candidate_count"] == 3_918_164_268
+    assert summary["total_initially_compatible_support_catalogue_count"] == 58
+    assert summary["total_selected_search_node_count"] == 223
+    assert summary["total_selected_empty_domain_count"] == 85
+    assert summary["total_selected_detected_solution_count"] == 0
+    assert summary["scan_status"] == SCAN_STATUS
+
+
+def test_81_3_post8_supply_chains_by_length(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+
+    assert summary["support_catalogue_candidate_count_by_length"] == {
+        "0": 228,
+        "1": 80_712,
+        "2": 23_890_752,
+        "3": 3_894_192_576,
+    }
+    assert summary["initially_compatible_support_catalogue_count_by_length"] == {
+        "0": 0,
+        "1": 14,
+        "2": 20,
+        "3": 24,
+    }
+    assert summary["selected_search_node_count_by_length"] == {
+        "0": 0,
+        "1": 86,
+        "2": 94,
+        "3": 43,
+    }
+    assert summary["selected_detected_solution_count_by_length"] == {
+        "0": 0,
+        "1": 0,
+        "2": 0,
+        "3": 0,
+    }
+
+
+def test_81_3_post8_supply_chains_source_crosswalk(
+    payload: dict[str, object],
+) -> None:
+    source_first = payload["source_first_supply_chains"]
+    source_second = payload["source_second_step_chains"]
+
+    assert source_first["scan_status"] == (
+        "PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION"
+    )
+    assert source_second["scan_status"] == (
+        "NO_DISTINCT_INTERMEDIATE_CENTER8_TO_LABEL6_CHAINS"
+    )
+    records = payload["initially_compatible_catalogues"]
+    assert len(records) == 58
+    assert {tuple(record["intermediate_order"]) for record in records} == {
+        (2,),
+        (2, 5),
+        (2, 7),
+        (2, 5, 7),
+    }
+    assert all(record["detected_solution_count"] == 0 for record in records)
+
+
+def test_81_3_post8_supply_chains_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_81_3_post8_supply_chains_checker_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_post8_supply_chains.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["scan_status"] == SCAN_STATUS
+    assert payload["summary"]["total_selected_detected_solution_count"] == 0
+
+
+def test_81_3_post8_supply_chains_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["total_selected_detected_solution_count"] = 1
+
+    with pytest.raises(AssertionError, match="total_selected_detected_solution_count"):
+        assert_expected_payload(bad)

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -221,6 +221,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -309,6 +309,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_81_3_second_step_chains.py "
         "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py "
+        "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check "


### PR DESCRIPTION
## Summary

Adds a review-pending raw catalogue accounting companion for the existing bootstrap/T12 `81:3` second-step chain closure. The new packet starts from the three stored center-8 first-supply survivor prefixes and records the full support-catalogue denominator for ordered continuations through distinct intermediate centers `{2,5,7}` before one center-6 label-6 supply support.

Recorded funnel:

- raw support catalogues: `3,918,164,268`
- initially compatible support catalogues: `58`
- selected-search nodes: `223`
- selected-row survivors: `0`
- status: `NO_POST8_PRE6_SUPPLY_CHAIN_SURVIVORS_UNDER_BASIC_FILTERS`

This is deliberately framed as a companion accounting artifact for the same bounded model as `bootstrap_t12_81_3_second_step_chains`, not a stronger theorem. No row-forcing theorem, no `n=9` proof, no bridge proof, and no counterexample claim.

## Changes from submitted packet

- Regenerated the stale JSON artifact from the checker on current `main`.
- Removed the standalone metadata snippet and registered the artifact in `metadata/generated_artifacts.yaml`.
- Moved CLI handling into the script wrapper, keeping the `src` module as reusable logic.
- Made the checker read the stored first-supply artifact and cross-reference the merged second-step artifact.
- Added focused slow tests and wired the checker into Makefile/audit registration tests.
- Updated README/index/STATE/RESULTS/claims/backlog/review-priority wording as a scoped companion artifact.

## Validation

- `python -m py_compile src/erdos97/bootstrap_t12_81_3_post8_supply_chains.py scripts/check_bootstrap_t12_81_3_post8_supply_chains.py tests/test_bootstrap_t12_81_3_post8_supply_chains.py`
- `python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --write --assert-expected`
- `python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --check --assert-expected --json`
- `python -m pytest -q -m slow tests/test_bootstrap_t12_81_3_post8_supply_chains.py`
- `python -m pytest -q tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1156 passed, 430 deselected`)

Attempted `wsl.exe -d Ubuntu make PYTHON=python3 verify-bridge-frontier`; local WSL lacks the repo Python deps and fails immediately with `ModuleNotFoundError: No module named 'numpy'` before reaching this checker.