### PR TITLE
Add localized rich-support counting cap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ verify-n9-review:
 verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
 	$(PYTHON) scripts/check_rich_support_counting_bound.py --check --json
+	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -52,10 +52,15 @@ witness pairs and `binom(n,2)-n` non-edge witness pairs, giving
 
 Consequently, if every center has a rich class of size at least `k`, then
 `n >= binom(k, 2) + 2`. In particular, the all-centers size-five subcase is
-impossible for `n <= 11`; any hypothetical 4-bad nonagon has at least seven
-exact-four centers, any hypothetical 4-bad decagon has at least five, and any
-hypothetical 4-bad hendecagon has at least three. See
-`docs/rich-support-counting-lemma.md`.
+impossible for `n <= 11`; the global pair budget alone gives at least seven
+exact-four centers in a hypothetical 4-bad nonagon, at least five in a
+hypothetical 4-bad decagon, and at least three in a hypothetical 4-bad
+hendecagon. The localized per-label support-pair cap sharpens the nonagon
+case: each witness label can occur in at most four chosen supports, so any
+hypothetical 4-bad nonagon is already forced into the all-exact-four,
+selected-indegree-four support case by counting alone. See
+`docs/rich-support-counting-lemma.md` and
+`docs/localized-rich-support-counting.md`.
 
 ### Lemma: crossing-bisector and sharpened count
 

--- a/STATE.md
+++ b/STATE.md
@@ -251,22 +251,27 @@ all-five-rich subcases: for any same-radius supports `R_i`,
 pair-sharing count is that a hull-edge witness pair can occur in at most one
 support, while a non-edge witness pair can occur in at most two. Hence every
 center having five equidistant witnesses requires `n >= 12`. The same counting
-relaxation says any hypothetical 4-bad nonagon has at least seven exact-four
-centers, any hypothetical 4-bad decagon has at least five, and any hypothetical
-4-bad hendecagon has at least three. This does not replace the mixed support
-catalogues or prove `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
-`docs/rich-support-counting-lemma.md`.
+relaxation says any hypothetical 4-bad decagon has at least five exact-four
+centers and any hypothetical 4-bad hendecagon has at least three. A localized
+per-label support-pair cap sharpens the nonagon case further: any hypothetical
+4-bad nonagon is forced into the all-exact-four, selected-indegree-four support
+case by counting alone. This does not prove the review-pending exact-four
+frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
+`docs/rich-support-counting-lemma.md` and
+`docs/localized-rich-support-counting.md`.
 
 The follow-up mixed rich-support reduction enumerates every four- or
 five-witness support at every center, for `126^9 =
 8,004,512,848,309,157,376` raw assignments. With the same pair/crossing
 filters plus witness-pair capacity, the exact search leaves `184` complete
 assignments, and every one is all-exact-four. There are `0` complete
-assignments containing a size-five support. Repo-locally, any `n=9`
-selected-witness counterexample is therefore reduced to the exact-four
-frontier before vertex-circle replay. This still does not independently prove
-the review-pending exact-four exhaustive checker, prove `n=9`, or give a
-counterexample. See `docs/n9-mixed-rich-support-reduction.md`.
+assignments containing a size-five support. This is now a catalogue regression
+and provenance check for the proof-facing localized count, which already
+reduces any hypothetical `n=9` selected-witness counterexample to the
+exact-four frontier before vertex-circle replay. It still does not
+independently prove the review-pending exact-four exhaustive checker, prove
+`n=9`, or give a counterexample. See
+`docs/n9-mixed-rich-support-reduction.md`.
 
 A mixed-rich/frontier crosswalk now checks that those `184` terminal
 mixed-support assignments are exactly the stored `184` exact-four

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -107,10 +107,25 @@ hypothetical 4-bad nonagon also shows that at most two centers can have
 forces at least five exact-four centers for `n=10` and at least three for
 `n=11`.
 
-This is a support-level counting lemma only. It does not rule out mixed
-exact-four/rich catalogues and does not prove `n=9`, `n=10`, `n=11`, or Erdos
-Problem #97. See `docs/rich-support-counting-lemma.md` and the checker
-`scripts/check_rich_support_counting_bound.py`.
+The companion localized counting cap improves the nonagon conclusion. For each
+fixed witness label `x`,
+
+```text
+sum_{i: x in R_i} (|R_i| - 1) <= 2n - 4.
+```
+
+For `n=9`, every support occurrence contributes at least `3` to its label's
+localized budget, so each label occurs in at most four chosen supports. The
+4-bad baseline already needs `36` support occurrences, hence every chosen
+support is exact-four and every label has selected indegree four.
+
+These are support-level counting lemmas only. They reduce hypothetical
+nonagons to the all-exact-four support frontier, but they do not prove the
+review-pending exact-four vertex-circle checker, `n=9`, `n=10`, `n=11`, or
+Erdos Problem #97. See `docs/rich-support-counting-lemma.md`,
+`docs/localized-rich-support-counting.md`, and the checkers
+`scripts/check_rich_support_counting_bound.py` and
+`scripts/check_localized_rich_support_counting.py`.
 
 ### Altman diagonal-order sums
 
@@ -673,9 +688,10 @@ assignments, all of which use exactly four witnesses at every center. There
 are `0` complete assignments containing a size-five support. Check it with
 `python scripts/check_n9_mixed_rich_support_reduction.py --check --assert-expected --json`.
 
-Repo-locally, this reduces any `n=9` selected-witness counterexample to the
-all-exact-four support frontier before vertex-circle replay: no center may
-have a rich distance class of size at least five. It does not independently
+The localized rich-support count now gives the proof-facing version of this
+nonagon support reduction. The finite mixed catalogue remains useful
+provenance and confirms that the row-pair/crossing/witness-pair abstraction
+lands on the same `184` all-exact-four assignments. It does not independently
 prove the review-pending exact-four vertex-circle exhaustive checker, does not
 prove `n=9`, does not prove Erdos Problem #97, and does not provide a
 counterexample. See `docs/n9-mixed-rich-support-reduction.md`.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -193,14 +193,17 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_all_five_rich_support_obstruction.py --check --assert-expected --json`
    now closes the full `56^9` size-five support assignment space under only
    the two-circle row-pair cap and radical-axis crossing filters. This rules
-   out the all-centers-size-at-least-five support subcase repo-locally, but
-   the next rich-class widening is still the mixed exact-four/size-five
-   catalogue or a bridge hypothesis forcing the exact-four-only center.
+   out the all-centers-size-at-least-five support subcase repo-locally. The
+   localized rich-support counting lemma
+   `python scripts/check_localized_rich_support_counting.py --check --json`
+   now gives a proof-facing shortcut for the nonagon support layer itself:
+   any hypothetical 4-bad nonagon is forced into the all-exact-four,
+   selected-indegree-four support frontier by counting alone.
    The mixed rich-support reduction
    `python scripts/check_n9_mixed_rich_support_reduction.py --check --assert-expected --json`
-   now runs that four/five support catalogue with witness-pair capacity and
-   leaves exactly the `184` all-exact-four assignments. The mixed/frontier
-   crosswalk
+   remains as catalogue provenance for that reduction: it runs the four/five
+   support catalogue with witness-pair capacity and leaves exactly the `184`
+   all-exact-four assignments. The mixed/frontier crosswalk
    `python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json`
    checks that those `184` terminal assignments are exactly the stored
    pre-vertex-circle frontier as a labelled row set. The next useful PR is

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`rich-support-counting-lemma.md`](rich-support-counting-lemma.md):
   proof-facing edge-sensitive support pair-counting lemma for all-centers large
   rich classes; not an `n=9`, `n=10`, `n=11`, or global proof.
+- [`localized-rich-support-counting.md`](localized-rich-support-counting.md):
+  proof-facing per-label rich-support occurrence cap reducing hypothetical
+  4-bad nonagons to all-exact-four support systems by counting alone.
 - [`k4e-kalmanson-stretch-audit.md`](k4e-kalmanson-stretch-audit.md): exact
   fixed-pattern audit extracting `K4-e` stretch relations and combining them
   with Kalmanson inequalities; kills only the displayed `n=10` quotient-level

--- a/docs/localized-rich-support-counting.md
+++ b/docs/localized-rich-support-counting.md
@@ -1,0 +1,114 @@
+# Localized rich-support counting cap
+
+Status: `LEMMA` / proof-facing localized counting bound. This note does not
+claim a general proof of Erdos Problem #97 and does not claim a counterexample.
+
+## Setup
+
+Let `V` be the vertex set of a strictly convex `n`-gon in cyclic hull order. For
+each center `i in V`, choose one same-radius support
+
+```text
+R_i subset V \ {i}
+```
+
+meaning that all vertices of `R_i` lie on one circle centered at `i`. The set
+`R_i` may have size larger than four. In a hypothetical 4-bad polygon one may
+choose, for each center, a maximum rich class, so `|R_i| = E(i) >= 4`.
+
+## Localized cap
+
+For each fixed witness label `x`,
+
+```text
+sum_{i : x in R_i} (|R_i| - 1) <= 2n - 4.
+```
+
+Proof: double-count pairs `{x,y}` inside supports. For each `y != x`, every
+center `i` with `{x,y} subset R_i` is equidistant from `x` and `y`, hence lies
+on the perpendicular bisector of segment `xy`.
+
+If `{x,y}` is a hull edge, that perpendicular bisector already meets the
+polygon boundary at the midpoint of the edge. Since it cannot coincide with the
+edge line, it has at most one further intersection point with the boundary of a
+convex polygon, and therefore contains at most one polygon vertex that can serve
+as a center.
+
+If `{x,y}` is not a hull edge, a line contains at most two vertices of a
+strictly convex polygon, so the pair can occur with at most two centers.
+
+There are two hull neighbors of `x` and `n - 3` non-neighbor labels. Thus the
+pair budget incident to `x` is
+
+```text
+2 * 1 + (n - 3) * 2 = 2n - 4.
+```
+
+This proves the displayed inequality.
+
+## Consequence for nonagons
+
+Assume `n = 9` and choose a same-radius support of size at least four at every
+center. Every occurrence `x in R_i` contributes at least `3` to the localized
+sum for `x`, so each label occurs in at most
+
+```text
+floor((2n - 4) / 3) = floor(14 / 3) = 4
+```
+
+supports. Summing over the nine labels gives
+
+```text
+sum_i |R_i| <= 9 * 4 = 36.
+```
+
+But the 4-bad hypothesis gives `sum_i |R_i| >= 9 * 4 = 36`. Hence equality
+holds everywhere:
+
+- every chosen support has size exactly four;
+- every label occurs in exactly four chosen supports.
+
+Therefore any hypothetical 4-bad nonagon is forced into the all-exact-four,
+selected-indegree-four case before using cyclic-order crossing, witness-pair
+capacity, selected-distance quotienting, or vertex-circle pruning.
+
+This strengthens the older support-level counting consequence for `n = 9`,
+which only forced at least seven exact-four centers. It does not prove the
+`n = 9` selected-witness case: the exact-four frontier and its vertex-circle
+obstructions still require the separate review-pending finite-case pipeline.
+
+## Small-n table
+
+Combining the localized occurrence cap with the edge-sensitive global pair
+budget gives this necessary counting summary for hypothetical 4-bad polygons:
+
+```text
+n = 8: at least 8 exact-four centers; exact-four indegree is forced to be 4
+n = 9: at least 9 exact-four centers; exact-four indegree is forced to be 4
+n = 10: at least 5 exact-four centers by the global pair budget
+n = 11: at least 3 exact-four centers by the global pair budget
+n = 12: no exact-four center is forced by these counting bounds alone
+```
+
+For `n = 5, 6, 7`, the edge-sensitive global pair budget already rules out
+4-bad supports.
+
+## Verification command
+
+The helper script
+
+```bash
+python scripts/check_localized_rich_support_counting.py --check --json
+```
+
+checks the localized per-label budget, the `n = 9` all-exact-four consequence,
+and the small `n = 5..12` counting table. It is only a counting-bound checker;
+it is not a realization search and it does not replay the `n = 9` vertex-circle
+frontier.
+
+## Boundary
+
+This lemma is necessary structure only. It rules out mixed exact-four/richer
+support choices for a hypothetical nonagon, but it does not rule out the
+all-exact-four selected-witness frontier by itself. It does not prove `n = 9`,
+`n = 10`, `n = 11`, or Erdos Problem #97.

--- a/docs/n9-all-five-rich-support-obstruction.md
+++ b/docs/n9-all-five-rich-support-obstruction.md
@@ -89,7 +89,10 @@ This does not enumerate mixed exact-four and size-five rich catalogues. It
 does not prove `n=9`, does not prove the adaptive radius-blocker bridge, does
 not prove Erdos Problem #97, and does not provide a counterexample.
 
-The next useful bridge target is the mixed catalogue. The sharpened
-rich-support counting lemma now forces at least seven exact-four centers in
-any `n=9` selected-witness counterexample before any mixed-catalogue or
-vertex-circle machinery is used.
+The sharpened global rich-support counting lemma already rules out the
+all-five-rich nonagon subcase. The localized rich-support counting lemma goes
+further: any hypothetical `n=9` selected-witness counterexample is forced into
+the all-exact-four, selected-indegree-four support frontier before any
+mixed-catalogue or vertex-circle machinery is used. The next useful bridge
+target is therefore the exact-four frontier itself or reusable local lemmas
+that replace parts of its review-pending vertex-circle replay.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -653,12 +653,16 @@ condition that the surviving multi-block family does not automatically satisfy:
   packet family and closes the full `56^9` size-five support assignment space
   using only the two-circle row-pair cap and radical-axis crossing filters.
   This rules out the all-centers-size-at-least-five `n=9` support subcase
-  repo-locally, but it still does not cover mixed exact-four/size-five
-  catalogues, prove `n=9`, or prove the adaptive blocker bridge.
+  repo-locally. The localized rich-support counting lemma recorded in
+  `docs/localized-rich-support-counting.md` now sharpens the support bridge:
+  any hypothetical 4-bad nonagon is forced into the all-exact-four,
+  selected-indegree-four support frontier by counting alone. This still does
+  not prove `n=9` or prove the adaptive blocker bridge.
 - the generator-independent mixed rich-support reduction recorded in
   `docs/n9-mixed-rich-support-reduction.md`, which closes the four/five
   support catalogue under the same pair/crossing filters plus witness-pair
-  capacity. It leaves exactly `184` complete assignments and all are
+  capacity. It is now catalogue provenance for the localized counting
+  shortcut: it leaves exactly `184` complete assignments and all are
   all-exact-four. The mixed/frontier crosswalk recorded in
   `docs/n9-mixed-rich-frontier-crosswalk.md` checks that those `184` terminal
   assignments are exactly the stored pre-vertex-circle frontier as a labelled

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -86,6 +86,12 @@ The corresponding necessary counting relaxation gives at least five exact-four
 centers in any hypothetical 4-bad decagon and at least three exact-four centers
 in any hypothetical 4-bad hendecagon.
 
+The companion localized counting lemma strengthens the `n=9` consequence: by
+counting support pairs incident to each fixed witness label, a hypothetical
+4-bad nonagon is forced into the all-exact-four, selected-indegree-four support
+case before any mixed-support catalogue or vertex-circle replay. See
+`docs/localized-rich-support-counting.md`.
+
 The same count also gives a short support-level exclusion of `n <= 7`: a 4-bad
 `n`-gon would require `6n <= n(n-2)`, hence `n >= 8`. This agrees with the
 repository's separate sharpened incidence and geometric proof-note routes; the
@@ -105,10 +111,11 @@ not a realization search.
 
 ## Boundary
 
-This lemma does not rule out mixed exact-four and size-five catalogues. For
-`n=9`, it narrows such a catalogue by forcing at least seven exact-four centers,
-but it does not replace the review-pending exact-four frontier or the mixed
-support crosswalk. The existing `n=9` all-five-rich checker remains useful as a
-crossing-aware support-catalogue regression and as provenance for the richer
-support-search machinery, but the all-five-rich subcase itself is already
-closed by the edge-sensitive count.
+This global pair-counting lemma alone does not rule out mixed exact-four and
+size-five catalogues. For `n=9`, the localized companion lemma rules out that
+mixed support layer by counting alone, reducing hypothetical nonagons to the
+all-exact-four support frontier. It still does not replace the review-pending
+exact-four vertex-circle checker. The existing `n=9` all-five-rich and mixed
+support checkers remain useful as crossing-aware catalogue regressions and as
+provenance for the richer support-search machinery, but their nonagon support
+reduction is now preceded by this proof-facing count.

--- a/scripts/check_localized_rich_support_counting.py
+++ b/scripts/check_localized_rich_support_counting.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Check the localized rich-support counting cap for Erdos Problem #97.
+
+For any choice of same-radius supports R_i in a strict convex n-gon, the
+localized pair-sharing cap says that each fixed witness label x satisfies
+
+    sum_{i: x in R_i} (|R_i| - 1) <= 2n - 4.
+
+The proof counts support pairs {x,y}.  The two hull-neighbor pairs incident to
+x have capacity one, and the remaining n-3 pairs have capacity two.  This
+standalone checker records small-n consequences, especially that a hypothetical
+4-bad nonagon is forced into the all-exact-four, selected-indegree-four case by
+counting alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from math import comb
+from typing import Any
+
+SCHEMA = "erdos97.localized_rich_support_counting.v1"
+TRUST = "LEMMA"
+
+
+def edge_sensitive_pair_budget(n: int) -> int:
+    """Global support-pair budget from hull-edge/nonedge pair capacities."""
+
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    if n == 0:
+        return 0
+    return max(0, n + 2 * (comb(n, 2) - n))
+
+
+def localized_pair_budget_per_label(n: int) -> int:
+    """Incident support-pair budget for one fixed witness label."""
+
+    if n < 3:
+        raise ValueError("n must be at least 3")
+    return 2 + 2 * (n - 3)
+
+
+def all_centers_min_support_threshold(k: int) -> int:
+    """Smallest n not ruled out when every center has support size at least k."""
+
+    if k < 0:
+        raise ValueError("k must be nonnegative")
+    return comb(k, 2) + 2
+
+
+def max_non_exact_centers_by_global_pair_budget(n: int) -> int:
+    """Maximum number of size-at-least-five centers allowed by global pair count."""
+
+    baseline = n * comb(4, 2)
+    budget = edge_sensitive_pair_budget(n)
+    if baseline > budget:
+        return -1
+    extra_pair_budget = budget - baseline
+    # The cheapest non-exact-four center has size five and costs 10-6 = 4
+    # additional support-pair incidences.
+    return min(n, extra_pair_budget // (comb(5, 2) - comb(4, 2)))
+
+
+def max_non_exact_centers_by_local_occurrence_budget(n: int) -> int:
+    """Maximum number of size-at-least-five centers allowed by local occurrence caps.
+
+    For 4-bad supports, every occurrence x in R_i contributes at least three to
+    the localized budget at x.  Hence each label occurs in at most
+    floor((2n-4)/3) supports.  A non-exact-four support has at least one more
+    occurrence than an exact-four support.
+    """
+
+    baseline = 4 * n
+    per_label_occurrence_cap = localized_pair_budget_per_label(n) // 3
+    total_occurrence_cap = n * per_label_occurrence_cap
+    if baseline > total_occurrence_cap:
+        return -1
+    return min(n, total_occurrence_cap - baseline)
+
+
+def row_summary(n: int) -> dict[str, Any]:
+    """Return a stable JSON row for one n."""
+
+    if n < 5:
+        raise ValueError("n must be at least 5")
+
+    baseline_pair_demand = n * comb(4, 2)
+    global_pair_budget = edge_sensitive_pair_budget(n)
+    four_bad_ruled_out = baseline_pair_demand > global_pair_budget
+    localized_budget = localized_pair_budget_per_label(n)
+    occurrence_cap_per_label = localized_budget // 3
+    total_occurrence_cap = n * occurrence_cap_per_label
+
+    row: dict[str, Any] = {
+        "n": n,
+        "global_edge_sensitive_pair_budget": global_pair_budget,
+        "baseline_pair_demand_for_E_ge_4": baseline_pair_demand,
+        "localized_pair_budget_per_label": localized_budget,
+        "max_support_occurrences_per_label_if_E_ge_4": occurrence_cap_per_label,
+        "total_support_occurrence_cap_if_E_ge_4": total_occurrence_cap,
+        "four_bad_ruled_out_by_global_pair_counting": four_bad_ruled_out,
+    }
+
+    if four_bad_ruled_out:
+        row.update(
+            {
+                "global_extra_pair_budget_over_exact_four": None,
+                "local_extra_occurrence_budget_over_exact_four": None,
+                "max_non_exact_four_centers_by_global_pair_budget": None,
+                "max_non_exact_four_centers_by_local_occurrence_budget": None,
+                "max_non_exact_four_centers_by_best_counting_bound": None,
+                "min_exact_four_centers_by_best_counting_bound": None,
+                "all_centers_forced_exact_four_by_localized_counting": None,
+                "exact_four_selected_indegree_forced_regular_by_localized_counting": None,
+            }
+        )
+        return row
+
+    global_max = max_non_exact_centers_by_global_pair_budget(n)
+    local_max = max_non_exact_centers_by_local_occurrence_budget(n)
+    best_max = min(global_max, local_max)
+    row.update(
+        {
+            "global_extra_pair_budget_over_exact_four": global_pair_budget - baseline_pair_demand,
+            "local_extra_occurrence_budget_over_exact_four": total_occurrence_cap - 4 * n,
+            "max_non_exact_four_centers_by_global_pair_budget": global_max,
+            "max_non_exact_four_centers_by_local_occurrence_budget": local_max,
+            "max_non_exact_four_centers_by_best_counting_bound": best_max,
+            "min_exact_four_centers_by_best_counting_bound": n - best_max,
+            "all_centers_forced_exact_four_by_localized_counting": local_max == 0,
+            # If all supports have size exactly four, the same per-label cap
+            # forces selected indegree <= floor((2n-4)/3).  Since the average
+            # selected indegree is four, regularity follows exactly when this
+            # cap is four.
+            "exact_four_selected_indegree_forced_regular_by_localized_counting": (
+                occurrence_cap_per_label == 4
+            ),
+        }
+    )
+    return row
+
+
+def build_summary(min_n: int = 5, max_n: int = 12) -> dict[str, Any]:
+    """Build the checker summary."""
+
+    return {
+        "schema": SCHEMA,
+        "status": "PROVED_LOCALIZED_COUNTING_LEMMA",
+        "trust": TRUST,
+        "claim_scope": (
+            "Necessary localized rich-support counting only.  The n=9 consequence "
+            "forces hypothetical 4-bad nonagons into the all-exact-four, "
+            "selected-indegree-four case, but does not prove n=9 or Erdos #97."
+        ),
+        "lemma": (
+            "For every fixed witness label x, "
+            "sum_{i: x in R_i} (|R_i|-1) <= 2n-4."
+        ),
+        "capacity_accounting_per_label": {
+            "hull_neighbor_pairs_incident_to_x": "2 pairs, capacity 1 each",
+            "non_neighbor_pairs_incident_to_x": "n-3 pairs, capacity 2 each",
+            "total_capacity": "2 + 2*(n-3) = 2n-4",
+        },
+        "all_centers_min_support_thresholds": {
+            str(k): all_centers_min_support_threshold(k) for k in range(4, 8)
+        },
+        "rows": [row_summary(n) for n in range(min_n, max_n + 1)],
+        "n9_consequence": {
+            "all_centers_exact_four": True,
+            "selected_indegree_per_label": 4,
+            "reason": (
+                "For n=9, each label occurs in at most floor(14/3)=4 supports, "
+                "so total support occurrences are at most 36; the 4-bad baseline "
+                "already requires 36 occurrences."
+            ),
+        },
+    }
+
+
+def check_expected(summary: dict[str, Any]) -> None:
+    """Check the small-n consequences intended for the repository note."""
+
+    thresholds = summary["all_centers_min_support_thresholds"]
+    expected_thresholds = {"4": 8, "5": 12, "6": 17, "7": 23}
+    if thresholds != expected_thresholds:
+        raise AssertionError(f"got thresholds {thresholds}, expected {expected_thresholds}")
+
+    rows = {row["n"]: row for row in summary["rows"]}
+    for n in (5, 6, 7):
+        if not rows[n]["four_bad_ruled_out_by_global_pair_counting"]:
+            raise AssertionError(f"n={n}: expected four-bad supports to be ruled out")
+
+    expected = {
+        8: (0, 8, True, True),
+        9: (0, 9, True, True),
+        10: (5, 5, False, False),
+        11: (8, 3, False, False),
+        12: (12, 0, False, False),
+    }
+    for n, (max_non_exact, min_exact, forced_exact, forced_regular) in expected.items():
+        row = rows[n]
+        got = (
+            row["max_non_exact_four_centers_by_best_counting_bound"],
+            row["min_exact_four_centers_by_best_counting_bound"],
+            row["all_centers_forced_exact_four_by_localized_counting"],
+            row["exact_four_selected_indegree_forced_regular_by_localized_counting"],
+        )
+        want = (max_non_exact, min_exact, forced_exact, forced_regular)
+        if got != want:
+            raise AssertionError(f"n={n}: got {got}, expected {want}")
+
+    n9 = rows[9]
+    if n9["total_support_occurrence_cap_if_E_ge_4"] != 36:
+        raise AssertionError("n=9 should have total support occurrence cap 36")
+    if not summary["n9_consequence"]["all_centers_exact_four"]:
+        raise AssertionError("n=9 consequence should force exact-four supports")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-n", type=int, default=5)
+    parser.add_argument("--max-n", type=int, default=12)
+    parser.add_argument("--check", action="store_true", help="assert expected small-n consequences")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    summary = build_summary(args.min_n, args.max_n)
+    if args.check:
+        if (args.min_n, args.max_n) != (5, 12):
+            raise SystemExit("--check is only defined for the default n range")
+        check_expected(summary)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"schema: {summary['schema']}")
+        for row in summary["rows"]:
+            n = row["n"]
+            if row["four_bad_ruled_out_by_global_pair_counting"]:
+                print(f"n={n}: four-bad supports ruled out by global pair counting")
+            else:
+                print(
+                    f"n={n}: min exact-four centers by best count = "
+                    f"{row['min_exact_four_centers_by_best_counting_bound']}; "
+                    f"localized exact-four forced = "
+                    f"{row['all_centers_forced_exact_four_by_localized_counting']}"
+                )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1554,6 +1554,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="localized_rich_support_counting",
+        command=(
+            "python",
+            "scripts/check_localized_rich_support_counting.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Proof-facing localized rich-support occurrence-counting lemma "
+            "and small-n consequences; reduces hypothetical 4-bad nonagons "
+            "to all-exact-four support systems but is not a proof of n=9, "
+            "not a proof of Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="radius_blocker_vertex_circle_pilot",
         command=(
             "python",

--- a/tests/test_localized_rich_support_counting.py
+++ b/tests/test_localized_rich_support_counting.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_localized_rich_support_counting import (  # noqa: E402
+    build_summary,
+    check_expected,
+    localized_pair_budget_per_label,
+    max_non_exact_centers_by_global_pair_budget,
+    max_non_exact_centers_by_local_occurrence_budget,
+)
+
+
+def test_localized_counting_expected_summary() -> None:
+    summary = build_summary()
+    check_expected(summary)
+
+    assert summary["schema"] == "erdos97.localized_rich_support_counting.v1"
+    assert summary["trust"] == "LEMMA"
+    assert "does not prove n=9" in summary["claim_scope"]
+    assert summary["n9_consequence"] == {
+        "all_centers_exact_four": True,
+        "selected_indegree_per_label": 4,
+        "reason": (
+            "For n=9, each label occurs in at most floor(14/3)=4 supports, "
+            "so total support occurrences are at most 36; the 4-bad baseline "
+            "already requires 36 occurrences."
+        ),
+    }
+
+
+def test_localized_counting_rows() -> None:
+    rows = {row["n"]: row for row in build_summary()["rows"]}
+
+    assert rows[8]["max_non_exact_four_centers_by_best_counting_bound"] == 0
+    assert rows[8]["min_exact_four_centers_by_best_counting_bound"] == 8
+    assert rows[8]["exact_four_selected_indegree_forced_regular_by_localized_counting"]
+
+    assert rows[9]["max_non_exact_four_centers_by_best_counting_bound"] == 0
+    assert rows[9]["min_exact_four_centers_by_best_counting_bound"] == 9
+    assert rows[9]["total_support_occurrence_cap_if_E_ge_4"] == 36
+    assert rows[9]["max_non_exact_four_centers_by_global_pair_budget"] == 2
+    assert rows[9]["max_non_exact_four_centers_by_local_occurrence_budget"] == 0
+    assert rows[9]["exact_four_selected_indegree_forced_regular_by_localized_counting"]
+
+    assert rows[10]["max_non_exact_four_centers_by_best_counting_bound"] == 5
+    assert rows[11]["max_non_exact_four_centers_by_best_counting_bound"] == 8
+
+
+def test_localized_counting_helpers() -> None:
+    assert localized_pair_budget_per_label(8) == 12
+    assert localized_pair_budget_per_label(9) == 14
+    assert max_non_exact_centers_by_global_pair_budget(9) == 2
+    assert max_non_exact_centers_by_local_occurrence_budget(9) == 0
+
+    with pytest.raises(ValueError, match="at least 3"):
+        localized_pair_budget_per_label(2)
+
+
+def test_localized_counting_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_localized_rich_support_counting.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["schema"] == "erdos97.localized_rich_support_counting.v1"
+    assert payload["n9_consequence"]["all_centers_exact_four"] is True

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -124,6 +124,8 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
     commands = _make_target_commands("verify-bridge-frontier")
     expected_chain = [
         "python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json",
+        "python scripts/check_rich_support_counting_bound.py --check --json",
+        "python scripts/check_localized_rich_support_counting.py --check --json",
         (
             "python scripts/check_bootstrap_core_crosswalk.py "
             "--check --assert-expected --json"

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -253,6 +253,10 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_localized_rich_support_counting.py --check --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check "
         "--assert-expected --json"


### PR DESCRIPTION
## Summary

Adds a proof-facing localized rich-support occurrence cap:

```text
sum_{i: x in R_i} (|R_i| - 1) <= 2n - 4
```

for each fixed witness label `x`. The checker records the small-n consequences, especially that a hypothetical 4-bad nonagon is forced into the all-exact-four, selected-indegree-four support case by counting alone.

This PR also updates the existing rich-support counting note and ledgers so the older mixed four/five support catalogue is framed as catalogue provenance rather than the shortest route to the nonagon support reduction. It does not prove the review-pending exact-four vertex-circle frontier, `n=9`, `n=10`, `n=11`, or Erdős #97, and it does not change the global/open status.

## Local validation

- `python scripts/check_localized_rich_support_counting.py --check --json`
- `python -m pytest -q tests/test_localized_rich_support_counting.py tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python -m py_compile scripts/check_localized_rich_support_counting.py tests/test_localized_rich_support_counting.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`