### PR TITLE
[codex] Add n10 q1 rich vertex-circle diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ verify-bridge-frontier:
 verify-n10-review:
 	$(PYTHON) scripts/check_n10_mixed_rich_support_capacity.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_q2_rich_vertex_circle.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n10_q1_rich_vertex_circle.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n10_turn_row0_combined_closure.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1101,6 +1101,14 @@ finite support bookkeeping only, not a proof of `n=10`, not a proof of Erdos
 Problem #97, and not a counterexample. See
 `docs/n10-mixed-rich-support-capacity.md`.
 
+The follow-up rich vertex-circle quotient diagnostics in
+`data/certificates/n10_q2_rich_vertex_circle.json` and
+`data/certificates/n10_q1_rich_vertex_circle.json` close the exactly-two and
+exactly-one size-five layers, respectively. Combined with the support-capacity
+catalogue, this leaves only the all-exact-four `q=0` layer inside the
+four/five support-plus-quotient abstraction. This remains review-pending
+finite bookkeeping only, not an `n=10` proof and not a global status update.
+
 The row-circle Ptolemy diagnostic in
 `docs/row-circle-ptolemy-nlp.md` adds the Ptolemy equality forced by each
 selected witness quadruple being concyclic around its center. It numerically

--- a/STATE.md
+++ b/STATE.md
@@ -724,8 +724,13 @@ two-overlap crossing, and witness-pair capacity filters, all support
 assignments with `q=3,...,7` size-five supports are obstructed; a direct `q=2`
 witness remains, so the bound is sharp for these filters. This says only that
 surviving four/five support assignments have at most two size-five supports.
-It does not prove `n=10`, does not close `q=0,1,2`, and does not change the
-global status. See `docs/n10-mixed-rich-support-capacity.md`.
+Follow-up rich vertex-circle quotient replays close the `q=2` and `q=1`
+layers, so the combined support-plus-quotient abstraction now leaves only the
+all-exact-four `q=0` layer. This is still not a proof of `n=10`, does not close
+that all-exact-four layer, and does not change the global status. See
+`docs/n10-mixed-rich-support-capacity.md`,
+`docs/n10-q2-rich-vertex-circle.md`, and
+`docs/n10-q1-rich-vertex-circle.md`.
 
 ## Best saved near-miss
 

--- a/data/certificates/n10_q1_rich_vertex_circle.json
+++ b/data/certificates/n10_q1_rich_vertex_circle.json
@@ -1,0 +1,160 @@
+{
+  "claim_scope": "Generator-independent n=10 q=1 four/five rich-support diagnostic. It checks the unique dihedral center-set representative with exactly one size-five support under the row-pair cap, two-overlap crossing, witness-pair capacity, and monotone rich vertex-circle quotient pruning. It finds no clean complete assignment. This does not prove n=10, does not prove Erdos Problem #97, and is not a counterexample.",
+  "filters": [
+    {
+      "meaning": "Two distinct distance circles can share at most two witness vertices.",
+      "name": "row_pair_cap"
+    },
+    {
+      "meaning": "When two rich supports share exactly two witnesses, the center chord and shared-witness chord must cross in the cyclic order.",
+      "name": "two_overlap_crossing"
+    },
+    {
+      "meaning": "Any unordered witness pair can occur together in rich supports at at most two centers.",
+      "name": "witness_pair_capacity"
+    },
+    {
+      "meaning": "For each rich class, union all center-witness distances inside the class and add all nested-interval strict distance inequalities from the full witness set. A self-edge or directed strict cycle is an obstruction.",
+      "name": "rich_vertex_circle_quotient"
+    }
+  ],
+  "interpretation_warnings": [
+    "This is a necessary support/quotient diagnostic only.",
+    "It does not replay turn inequalities, Kalmanson certificates, or Euclidean realizability.",
+    "It leaves the q=0 exact-four support case to stronger filters.",
+    "No n=10 theorem, general proof, or counterexample is claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_n10_q1_rich_vertex_circle.py --write --assert-expected",
+    "generator": "scripts/check_n10_q1_rich_vertex_circle.py",
+    "related_artifacts": [
+      "data/certificates/n10_mixed_rich_support_capacity.json",
+      "data/certificates/n10_q2_rich_vertex_circle.json",
+      "docs/n10-mixed-rich-support-capacity.md",
+      "docs/n10-q2-rich-vertex-circle.md",
+      "src/erdos97/vertex_circle_quotient_replay.py"
+    ]
+  },
+  "representative_results": {
+    "0": {
+      "dead_end_count": 97419,
+      "first_obstruction": {
+        "first_edge": {
+          "inner_class": [
+            0,
+            6
+          ],
+          "inner_interval": [
+            1,
+            3
+          ],
+          "inner_pair": [
+            0,
+            6
+          ],
+          "outer_class": [
+            0,
+            6
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            6,
+            8
+          ],
+          "row": 7,
+          "witness_order": [
+            8,
+            0,
+            2,
+            6
+          ]
+        },
+        "partial_row_count": 4,
+        "partial_rows": {
+          "0": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "6": [
+            0,
+            1,
+            7,
+            9
+          ],
+          "7": [
+            0,
+            2,
+            6,
+            8
+          ],
+          "8": [
+            3,
+            6,
+            7,
+            9
+          ]
+        },
+        "status": "self_edge",
+        "strict_edges_scanned_before_obstruction": 40
+      },
+      "found_clean_complete_assignment": false,
+      "max_depth_reached": 7,
+      "nodes_visited": 362556,
+      "size_five_centers": [
+        0
+      ],
+      "vertex_circle_prune_count": 181302,
+      "vertex_circle_status_counts": {
+        "self_edge": 82444,
+        "strict_cycle": 98858
+      }
+    }
+  },
+  "schema": "erdos97.n10_q1_rich_vertex_circle.v1",
+  "status": "N10_Q1_RICH_VERTEX_CIRCLE_CLOSURE",
+  "summary": {
+    "complete_assignments_found": 0,
+    "max_depth_reached": 7,
+    "max_size_five_centers_surviving_support_plus_vertex_circle_filters": 0,
+    "min_exact_four_only_centers_surviving_support_plus_vertex_circle_filters": 10,
+    "n": 10,
+    "order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9
+    ],
+    "representatives_checked": 1,
+    "size_five_center_count": 1,
+    "support_sizes": [
+      4,
+      5
+    ],
+    "total_dead_end_count": 97419,
+    "total_nodes_visited": 362556,
+    "total_vertex_circle_prune_count": 181302,
+    "vertex_circle_status_counts": {
+      "self_edge": 82444,
+      "strict_cycle": 98858
+    }
+  },
+  "support_rule": {
+    "combined_consequence_note": "The all-exact-four consequence combines this q=1 closure with the existing q=2 rich vertex-circle artifact and the existing n10_mixed_rich_support_capacity artifact, which closes q=3..7 under weaker support filters. This checker itself exhausts exactly the q=1 layer.",
+    "dihedral_reduction": "The natural cyclic order fixes labels 0..9. The single size-five center is reduced by cyclic rotations and reflection; support choices are still labelled for the representative.",
+    "monotonicity_note": "The vertex-circle quotient obstruction is monotone under adding rows: an existing self-edge or strict cycle remains obstructive, possibly after quotient classes merge.",
+    "rule": "Exactly one center is represented by a size-five same-radius support. The other nine centers are represented by exact-four supports."
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -721,9 +721,9 @@ that abstraction.
 
 Repo-locally, any `n=10` four/five support assignment surviving those filters
 has at most `2` size-five supports, hence at least `8` exact-four-only
-centers. This does not close the `q=0`, `q=1`, or `q=2` cases, does not prove
-`n=10`, does not prove Erdos Problem #97, and does not provide a
-counterexample. See `docs/n10-mixed-rich-support-capacity.md`.
+centers. This checker alone does not close the `q=0`, `q=1`, or `q=2` cases,
+does not prove `n=10`, does not prove Erdos Problem #97, and does not provide
+a counterexample. See `docs/n10-mixed-rich-support-capacity.md`.
 
 ### n=10 q=2 rich vertex-circle closure diagnostic
 
@@ -743,6 +743,25 @@ centers. This combined consequence depends on both artifacts; this checker
 itself closes exactly the `q=2` layer. It does not close `q=0` or `q=1`, does
 not prove `n=10`, does not prove Erdos Problem #97, and does not provide a
 counterexample. See `docs/n10-q2-rich-vertex-circle.md`.
+
+### n=10 q=1 rich vertex-circle closure diagnostic
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite support-plus-quotient
+catalogue.
+
+The checker in `scripts/check_n10_q1_rich_vertex_circle.py` exhausts the
+unique dihedral representative with exactly one size-five support under the
+same row-pair cap, two-overlap crossing, and witness-pair capacity filters,
+then adds the rich vertex-circle quotient gate on partial assignments. It
+finds no clean complete `q=1` assignment.
+
+Combined with the earlier `q=2` rich vertex-circle closure and the `q=3,...,7`
+support-capacity closure, this says any `n=10` four/five support assignment
+surviving these support-plus-quotient filters must be all-exact-four at this
+abstraction level. This combined consequence depends on all three artifacts;
+this checker itself closes exactly the `q=1` layer. It does not close `q=0`,
+does not prove `n=10`, does not prove Erdos Problem #97, and does not provide
+a counterexample. See `docs/n10-q1-rich-vertex-circle.md`.
 
 ### n=10 row0 turn plus vertex-circle crosswalk
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -478,6 +478,11 @@ put detailed reconciliation in the canonical synthesis.
   review-pending `n=10` exactly-two-size-five rich-support closure after adding
   the rich vertex-circle quotient; finite support-plus-quotient bookkeeping
   only.
+- [`n10-q1-rich-vertex-circle.md`](n10-q1-rich-vertex-circle.md):
+  review-pending `n=10` exactly-one-size-five rich-support closure after adding
+  the rich vertex-circle quotient; combined with the `q=2` and support-capacity
+  artifacts, this leaves only the all-exact-four `q=0` layer at this
+  abstraction.
 - [`n10-turn-row0-pilot.md`](n10-turn-row0-pilot.md): bounded `n=10`
   row0-index-0 turn-frontier pilot; finite bookkeeping only, not a proof of
   `n=10`.

--- a/docs/n10-mixed-rich-support-capacity.md
+++ b/docs/n10-mixed-rich-support-capacity.md
@@ -80,8 +80,10 @@ sharp for these three necessary filters alone.
 
 A follow-up rich vertex-circle quotient diagnostic,
 `docs/n10-q2-rich-vertex-circle.md`, closes that sharp `q=2` layer after adding
-one stronger quotient filter. The support-capacity artifact here remains only
-the three-filter `q=3,...,7` catalogue.
+one stronger quotient filter. A second quotient replay,
+`docs/n10-q1-rich-vertex-circle.md`, closes the exactly-one-size-five layer.
+The support-capacity artifact here remains only the three-filter `q=3,...,7`
+catalogue.
 
 ## Consequence
 
@@ -98,12 +100,17 @@ that any size-at-least-five rich-class escape must be extremely sparse before
 vertex-circle, Kalmanson, turn, or Euclidean realizability filters are even
 applied.
 
+After the companion `q=2` and `q=1` rich vertex-circle quotient replays, the
+combined support-plus-quotient abstraction leaves only the all-exact-four
+`q=0` layer. That combined statement depends on the separate quotient
+artifacts and is stronger than this support-capacity checker alone.
+
 ## Scope warnings
 
 - This is a necessary support-catalogue diagnostic only.
 - It does not replay vertex-circle, Kalmanson, turn-inequality, or Euclidean
   realizability filters.
-- It leaves the `q=0`, `q=1`, and `q=2` four/five support cases to stronger
-  filters at this support-capacity level.
+- This checker alone leaves the `q=0`, `q=1`, and `q=2` four/five support
+  cases to stronger filters at this support-capacity level.
 - It does not prove `n=10`, does not prove Erdos Problem #97, and does not
   provide a counterexample.

--- a/docs/n10-q1-rich-vertex-circle.md
+++ b/docs/n10-q1-rich-vertex-circle.md
@@ -1,0 +1,104 @@
+# n=10 q=1 rich vertex-circle closure diagnostic
+
+Status: `REVIEW_PENDING_DIAGNOSTIC` / finite support-quotient catalogue.
+
+This note records a small narrowing of the `n=10` four/five rich-support
+abstraction. It is not a proof of `n=10`, not a proof of Erdos Problem #97, and
+not a counterexample.
+
+## Setup
+
+Fix the natural cyclic order on labels `0,1,...,9`. At each center, represent
+one available rich distance class by a support of size `4` or `5`:
+
+- an exact-four class is represented by its four witnesses;
+- a class of size at least five is represented by an arbitrary five-witness
+  sub-support.
+
+The earlier mixed-rich support-capacity diagnostic closes all cases with
+`q=3,...,7` size-five supports under the row-pair cap, two-overlap crossing,
+and witness-pair capacity filters. The follow-up `q=2` rich vertex-circle
+quotient diagnostic closes the `q=2` layer after adding the rich
+vertex-circle quotient gate. The checker recorded here exhausts the remaining
+`q=1` layer with the same support-plus-quotient filters.
+
+For each rich class, the quotient gate unions all center-witness distances in
+the class and adds every nested-interval strict distance inequality from the
+full witness set. A strict self-edge or directed strict cycle obstructs the
+partial assignment; the obstruction is monotone under adding more rows.
+
+## Checked command
+
+```bash
+python scripts/check_n10_q1_rich_vertex_circle.py --write --assert-expected
+python scripts/check_n10_q1_rich_vertex_circle.py --check --assert-expected --json
+```
+
+Artifact:
+
+```text
+data/certificates/n10_q1_rich_vertex_circle.json
+```
+
+## Summary
+
+There is one dihedral representative for the unique size-five center. It is
+represented as center set `[0]`; support choices themselves remain labelled.
+
+```text
+size-five centers  nodes visited  dead ends  vertex-circle prunes  max depth  self-edge prunes  strict-cycle prunes
+[0]                362,556        97,419     181,302               7          82,444            98,858
+```
+
+Aggregate counts:
+
+```text
+representatives checked:        1
+clean complete assignments:     0
+nodes visited:                  362,556
+dead ends:                      97,419
+vertex-circle prunes:           181,302
+self-edge prunes:               82,444
+strict-cycle prunes:            98,858
+maximum search depth reached:   7
+```
+
+The first recorded obstruction is a self-edge after four rows:
+
+```text
+0 -> {1,2,3,4,5}
+6 -> {0,1,7,9}
+7 -> {0,2,6,8}
+8 -> {3,6,7,9}
+```
+
+At row `7`, the witness order is `[8,0,2,6]`; the outer chord `[6,8]`
+strictly contains the inner chord `[0,6]`, and the selected-distance quotient
+has already identified those two ordinary pair distances.
+
+## Consequence
+
+Within the four/five support abstraction, adding the rich vertex-circle
+quotient closes the `q=1` layer. Combined with the existing `q=2` rich
+vertex-circle closure and the existing support-capacity closure for
+`q=3,...,7`, any `n=10` support assignment surviving these filters must be
+all-exact-four at this abstraction level:
+
+```text
+q = 0 only.
+```
+
+Equivalently, this support-plus-quotient layer says that any surviving
+four/five rich-support abstraction has ten exact-four-only centers. The checker
+itself exhausts exactly the `q=1` layer; the `q=2` and `q=3,...,7` parts of the
+combined consequence remain the earlier artifacts.
+
+## Scope warnings
+
+- This is a necessary support/quotient diagnostic only.
+- It does not replay turn inequalities, Kalmanson certificates, or Euclidean
+  realizability.
+- It leaves the `q=0` exact-four case to stronger finite-case or local-lemma
+  filters.
+- It does not prove `n=10`, does not prove Erdos Problem #97, and does not
+  provide a counterexample.

--- a/docs/n10-q2-rich-vertex-circle.md
+++ b/docs/n10-q2-rich-vertex-circle.md
@@ -68,10 +68,15 @@ checker itself exhausts exactly the `q=2` layer; the `q=3,...,7` part of the
 combined consequence remains the earlier
 `n10_mixed_rich_support_capacity` artifact.
 
+The companion `q=1` replay in `docs/n10-q1-rich-vertex-circle.md` closes the
+next layer. Combining all three artifacts leaves only the all-exact-four `q=0`
+layer in this support-plus-quotient abstraction.
+
 ## Scope warnings
 
 - This is a necessary support/quotient diagnostic only.
 - It does not replay turn inequalities, Kalmanson certificates, or Euclidean realizability.
-- It leaves the `q=0` and `q=1` four/five support cases to stronger filters.
+- This checker alone leaves the `q=0` and `q=1` four/five support cases to
+  stronger filters.
 - It does not prove `n=10`, does not prove Erdos Problem #97, and does not
   provide a counterexample.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -4439,6 +4439,50 @@ artifacts:
       - counterexample to Erdos Problem #97
       - general proof of Erdos Problem #97
 
+  - id: n10_q1_rich_vertex_circle
+    path: data/certificates/n10_q1_rich_vertex_circle.json
+    sha256: 4534657681ceddbe8ecafc35cb9f2a9b30cf5d7a78abd14e577bcf0b3334b910
+    size_bytes: 5275
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_n10_q1_rich_vertex_circle.py
+    command: python scripts/check_n10_q1_rich_vertex_circle.py --write --assert-expected
+    checker: scripts/check_n10_q1_rich_vertex_circle.py
+    check_command: python scripts/check_n10_q1_rich_vertex_circle.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Generator-independent n=10 exactly-one-size-five rich-support diagnostic under row-pair cap, two-overlap crossing, witness-pair capacity, and rich vertex-circle quotient filters; finite support-plus-quotient reduction only, not a proof of n=10, not a proof of Erdos Problem #97, and not a counterexample.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n10_q1_rich_vertex_circle.v1
+      status: N10_Q1_RICH_VERTEX_CIRCLE_CLOSURE
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.n: 10
+      summary.support_sizes:
+        - 4
+        - 5
+      summary.size_five_center_count: 1
+      summary.representatives_checked: 1
+      summary.complete_assignments_found: 0
+      summary.total_nodes_visited: 362556
+      summary.total_dead_end_count: 97419
+      summary.total_vertex_circle_prune_count: 181302
+      summary.max_depth_reached: 7
+      summary.vertex_circle_status_counts.self_edge: 82444
+      summary.vertex_circle_status_counts.strict_cycle: 98858
+      summary.max_size_five_centers_surviving_support_plus_vertex_circle_filters: 0
+      summary.min_exact_four_only_centers_surviving_support_plus_vertex_circle_filters: 10
+      provenance.command: python scripts/check_n10_q1_rich_vertex_circle.py --write --assert-expected
+    forbidden_claims:
+      - n=10 is proved
+      - the q=0 case is closed
+      - this checker alone revalidates the q=2 or q=3 through q=7 closures
+      - support-plus-quotient filters prove Euclidean realizability or nonrealizability
+      - source-of-truth strongest result
+      - official/global status update
+      - counterexample to Erdos Problem #97
+      - general proof of Erdos Problem #97
+
   - id: n10_vertex_circle_singleton_slices
     path: data/certificates/n10_vertex_circle_singleton_slices.json
     sha256: 66b1212e6a61a04530d7e2b33afbeafb3039b125a026c94c814c47bbc7cba856

--- a/scripts/check_n10_q1_rich_vertex_circle.py
+++ b/scripts/check_n10_q1_rich_vertex_circle.py
@@ -1,0 +1,832 @@
+#!/usr/bin/env python3
+"""Close the n=10 q=1 four/five rich-support layer by vertex-circle replay.
+
+This review-pending diagnostic extends the n=10 mixed rich-support capacity
+catalogue and the q=2 rich vertex-circle closure.  The support-level checker
+closes q=3..7 size-five supports, and the q=2 rich vertex-circle checker closes
+exactly two size-five supports.  This checker exhausts q=1 under the same
+row-pair cap, two-overlap crossing, and witness-pair capacity filters, while
+adding monotone partial pruning by the rich-class vertex-circle quotient gate.
+
+The result is still only finite support/quotient bookkeeping.  It does not
+prove n=10, does not prove Erdos Problem #97, and does not give a
+counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCHEMA = "erdos97.n10_q1_rich_vertex_circle.v1"
+STATUS = "N10_Q1_RICH_VERTEX_CIRCLE_CLOSURE"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n10_q1_rich_vertex_circle.json"
+N = 10
+ORDER = tuple(range(N))
+SUPPORT_SIZES = (4, 5)
+Q = 1
+
+EXPECTED_REP_SUMMARIES = {
+    "0": {
+        "nodes_visited": 362556,
+        "dead_end_count": 97419,
+        "vertex_circle_prune_count": 181302,
+        "max_depth_reached": 7,
+        "vertex_circle_status_counts": {"self_edge": 82444, "strict_cycle": 98858},
+    },
+}
+EXPECTED_AGGREGATE = {
+    "representatives_checked": 1,
+    "complete_assignments_found": 0,
+    "total_nodes_visited": 362556,
+    "total_dead_end_count": 97419,
+    "total_vertex_circle_prune_count": 181302,
+    "max_depth_reached": 7,
+    "vertex_circle_status_counts": {"self_edge": 82444, "strict_cycle": 98858},
+}
+
+Pair = tuple[int, int]
+PairId = int
+
+ALL_PAIRS: tuple[Pair, ...] = tuple(combinations(range(N), 2))
+PAIR_TO_ID: dict[Pair, PairId] = {pair: idx for idx, pair in enumerate(ALL_PAIRS)}
+PAIR_COUNT = len(ALL_PAIRS)
+
+
+def normalized_pair(left: int, right: int) -> Pair:
+    """Return a sorted non-loop pair."""
+
+    if left == right:
+        raise ValueError("loop pair")
+    return (left, right) if left < right else (right, left)
+
+
+def pair_id(left: int, right: int) -> PairId:
+    """Return the dense id of an unordered pair."""
+
+    return PAIR_TO_ID[normalized_pair(left, right)]
+
+
+def support_mask(support: Sequence[int]) -> int:
+    """Return the bitmask of a support."""
+
+    out = 0
+    for label in support:
+        out |= 1 << int(label)
+    return out
+
+
+def iter_bits(mask: int) -> Iterable[int]:
+    """Yield set-bit indices of a nonnegative integer bitset."""
+
+    while mask:
+        low_bit = mask & -mask
+        yield low_bit.bit_length() - 1
+        mask ^= low_bit
+
+
+def chords_cross_in_natural_order(first: Pair, second: Pair) -> bool:
+    """Return whether two disjoint chords cross in the natural cyclic order."""
+
+    if set(first) & set(second):
+        return False
+    a, b = normalized_pair(*first)
+    c, d = normalized_pair(*second)
+    return (a < c < b) != (a < d < b)
+
+
+def canonical_center_subset(subset: Sequence[int], n: int = N) -> tuple[int, ...]:
+    """Return the dihedral canonical representative of a center subset."""
+
+    raw = set(subset)
+    variants: list[tuple[int, ...]] = []
+    for shift in range(n):
+        variants.append(tuple(sorted((label + shift) % n for label in raw)))
+        variants.append(tuple(sorted((shift - label) % n for label in raw)))
+    return min(variants)
+
+
+def dihedral_representatives(q: int, n: int = N) -> tuple[tuple[int, ...], ...]:
+    """Return dihedral representatives of q-subsets of centers."""
+
+    representatives = {
+        canonical_center_subset(subset, n) for subset in combinations(range(n), q)
+    }
+    return tuple(sorted(representatives))
+
+
+@dataclass(frozen=True)
+class StrictEdgeTemplate:
+    """A row-local nested-interval strict inequality before quotienting."""
+
+    outer_pair_id: PairId
+    inner_pair_id: PairId
+    row: int
+    witness_order: tuple[int, ...]
+    outer_interval: tuple[int, int]
+    inner_interval: tuple[int, int]
+    outer_pair: Pair
+    inner_pair: Pair
+
+
+@dataclass(frozen=True)
+class RowOption:
+    """Precomputed support option for one center and support size."""
+
+    witnesses: tuple[int, ...]
+    mask: int
+    witness_pair_ids: tuple[PairId, ...]
+    center_witness_pair_ids: tuple[PairId, ...]
+    strict_edges: tuple[StrictEdgeTemplate, ...]
+
+
+@dataclass(frozen=True)
+class PreparedCatalogue:
+    options: Mapping[tuple[int, int], tuple[RowOption, ...]]
+    pair_option_bits: Mapping[tuple[int, int], tuple[int, ...]]
+    compatible_option_bits: Mapping[tuple[int, int, int, int], tuple[int, ...]]
+    full_domain: Mapping[tuple[int, int], int]
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    found_clean_complete_assignment: bool
+    nodes_visited: int
+    dead_end_count: int
+    vertex_circle_prune_count: int
+    max_depth_reached: int
+    vertex_circle_status_counts: dict[str, int]
+    first_obstruction: dict[str, object] | None
+
+
+def witness_order_for_row(center: int, witnesses: Sequence[int]) -> tuple[int, ...]:
+    """Return witnesses in boundary order around a convex-hull vertex."""
+
+    return tuple(sorted(witnesses, key=lambda witness: (witness - center) % N))
+
+
+def strict_edges_for_row(
+    center: int,
+    witnesses: Sequence[int],
+) -> tuple[StrictEdgeTemplate, ...]:
+    """Generate row-circle nested interval inequalities for a rich support."""
+
+    ordered = witness_order_for_row(center, witnesses)
+    out: list[StrictEdgeTemplate] = []
+    witness_count = len(ordered)
+    for outer_start in range(witness_count):
+        for outer_end in range(outer_start + 1, witness_count):
+            for inner_start in range(witness_count):
+                for inner_end in range(inner_start + 1, witness_count):
+                    if (outer_start, outer_end) == (inner_start, inner_end):
+                        continue
+                    contains = (
+                        outer_start <= inner_start
+                        and inner_end <= outer_end
+                        and (outer_start < inner_start or inner_end < outer_end)
+                    )
+                    if not contains:
+                        continue
+                    outer_pair = normalized_pair(
+                        ordered[outer_start],
+                        ordered[outer_end],
+                    )
+                    inner_pair = normalized_pair(
+                        ordered[inner_start],
+                        ordered[inner_end],
+                    )
+                    out.append(
+                        StrictEdgeTemplate(
+                            outer_pair_id=PAIR_TO_ID[outer_pair],
+                            inner_pair_id=PAIR_TO_ID[inner_pair],
+                            row=center,
+                            witness_order=ordered,
+                            outer_interval=(outer_start, outer_end),
+                            inner_interval=(inner_start, inner_end),
+                            outer_pair=outer_pair,
+                            inner_pair=inner_pair,
+                        )
+                    )
+    return tuple(out)
+
+
+def prepare_catalogue(n: int = N) -> PreparedCatalogue:
+    """Precompute support options and compatibility bitsets."""
+
+    if n != N:
+        raise ValueError("this checker is specialized to n=10")
+
+    options: dict[tuple[int, int], tuple[RowOption, ...]] = {}
+    pair_option_bits: dict[tuple[int, int], tuple[int, ...]] = {}
+    full_domain: dict[tuple[int, int], int] = {}
+    compatible_option_bits: dict[tuple[int, int, int, int], tuple[int, ...]] = {}
+
+    for center in range(N):
+        labels = tuple(label for label in range(N) if label != center)
+        for support_size in SUPPORT_SIZES:
+            row_options: list[RowOption] = []
+            for row in combinations(labels, support_size):
+                witness_pair_ids = tuple(
+                    pair_id(left, right) for left, right in combinations(row, 2)
+                )
+                center_witness_pair_ids = tuple(
+                    pair_id(center, witness) for witness in row
+                )
+                row_options.append(
+                    RowOption(
+                        witnesses=tuple(row),
+                        mask=support_mask(row),
+                        witness_pair_ids=witness_pair_ids,
+                        center_witness_pair_ids=center_witness_pair_ids,
+                        strict_edges=strict_edges_for_row(center, row),
+                    )
+                )
+            options[(center, support_size)] = tuple(row_options)
+            full_domain[(center, support_size)] = (1 << len(row_options)) - 1
+
+            option_bits = [0] * PAIR_COUNT
+            for row_index, row_option in enumerate(row_options):
+                bit = 1 << row_index
+                for witness_pair_id in row_option.witness_pair_ids:
+                    option_bits[witness_pair_id] |= bit
+            pair_option_bits[(center, support_size)] = tuple(option_bits)
+
+    for left, right in combinations(range(N), 2):
+        for left_size in SUPPORT_SIZES:
+            for right_size in SUPPORT_SIZES:
+                left_to_right: list[int] = []
+                right_to_left = [0] * len(options[(right, right_size)])
+                for left_index, left_option in enumerate(options[(left, left_size)]):
+                    bits = 0
+                    for right_index, right_option in enumerate(
+                        options[(right, right_size)]
+                    ):
+                        intersection_mask = left_option.mask & right_option.mask
+                        intersection_size = intersection_mask.bit_count()
+                        compatible = True
+                        if intersection_size > 2:
+                            compatible = False
+                        elif intersection_size == 2:
+                            shared = [
+                                label
+                                for label in range(N)
+                                if (intersection_mask >> label) & 1
+                            ]
+                            compatible = chords_cross_in_natural_order(
+                                (left, right),
+                                (shared[0], shared[1]),
+                            )
+                        if compatible:
+                            bits |= 1 << right_index
+                            right_to_left[right_index] |= 1 << left_index
+                    left_to_right.append(bits)
+                compatible_option_bits[(left, left_size, right, right_size)] = tuple(
+                    left_to_right
+                )
+                compatible_option_bits[(right, right_size, left, left_size)] = tuple(
+                    right_to_left
+                )
+
+    return PreparedCatalogue(
+        options=options,
+        pair_option_bits=pair_option_bits,
+        compatible_option_bits=compatible_option_bits,
+        full_domain=full_domain,
+    )
+
+
+class UnionFind:
+    """Small deterministic union-find on dense pair ids."""
+
+    def __init__(self, size: int) -> None:
+        self.parent = list(range(size))
+
+    def find(self, item: int) -> int:
+        while self.parent[item] != item:
+            self.parent[item] = self.parent[self.parent[item]]
+            item = self.parent[item]
+        return item
+
+    def union(self, left: int, right: int) -> None:
+        root_left = self.find(left)
+        root_right = self.find(right)
+        if root_left == root_right:
+            return
+        if root_right < root_left:
+            root_left, root_right = root_right, root_left
+        self.parent[root_right] = root_left
+
+
+def selected_rows_to_json(
+    selected: Sequence[tuple[int, int, int, RowOption]],
+) -> dict[str, list[int]]:
+    """Return a stable JSON object for a partial selected rich-row state."""
+
+    return {
+        str(center): list(row_option.witnesses)
+        for center, _support_size, _row_index, row_option in sorted(selected)
+    }
+
+
+def strict_edge_to_json(
+    edge: StrictEdgeTemplate,
+    outer_class: int,
+    inner_class: int,
+) -> dict[str, object]:
+    """Return a JSON-safe strict edge after quotienting."""
+
+    return {
+        "row": edge.row,
+        "witness_order": list(edge.witness_order),
+        "outer_interval": list(edge.outer_interval),
+        "inner_interval": list(edge.inner_interval),
+        "outer_pair": list(edge.outer_pair),
+        "inner_pair": list(edge.inner_pair),
+        "outer_class": list(ALL_PAIRS[outer_class]),
+        "inner_class": list(ALL_PAIRS[inner_class]),
+    }
+
+
+def rich_vertex_circle_status(
+    selected: Sequence[tuple[int, int, int, RowOption]],
+) -> tuple[str, int, dict[str, object] | None]:
+    """Replay the rich vertex-circle quotient gate on a partial assignment.
+
+    Returns ``(status, scanned_strict_edges, first_edge)`` where status is one
+    of ``ok``, ``self_edge``, or ``strict_cycle``.  The replay is intentionally
+    self-contained rather than importing the main quotient helper, so it is a
+    small implementation cross-check of the same quotient semantics.
+    """
+
+    union_find = UnionFind(PAIR_COUNT)
+    for _center, _support_size, _row_index, row_option in selected:
+        base = row_option.center_witness_pair_ids[0]
+        for pair in row_option.center_witness_pair_ids[1:]:
+            union_find.union(base, pair)
+
+    strict_edges: list[tuple[int, int, StrictEdgeTemplate]] = []
+    scanned_edges = 0
+    for _center, _support_size, _row_index, row_option in selected:
+        for edge in row_option.strict_edges:
+            scanned_edges += 1
+            outer_class = union_find.find(edge.outer_pair_id)
+            inner_class = union_find.find(edge.inner_pair_id)
+            if outer_class == inner_class:
+                return (
+                    "self_edge",
+                    scanned_edges,
+                    strict_edge_to_json(edge, outer_class, inner_class),
+                )
+            strict_edges.append((outer_class, inner_class, edge))
+
+    graph: dict[int, list[tuple[int, StrictEdgeTemplate]]] = defaultdict(list)
+    for outer_class, inner_class, edge in strict_edges:
+        graph[outer_class].append((inner_class, edge))
+    for source in graph:
+        graph[source].sort(
+            key=lambda item: (
+                item[0],
+                item[1].row,
+                item[1].outer_pair,
+                item[1].inner_pair,
+            )
+        )
+
+    color: dict[int, int] = {}
+    parent: dict[int, tuple[int, StrictEdgeTemplate] | None] = {}
+
+    def dfs(node: int) -> dict[str, object] | None:
+        color[node] = 1
+        for next_node, edge in graph.get(node, []):
+            next_color = color.get(next_node, 0)
+            if next_color == 0:
+                parent[next_node] = (node, edge)
+                found = dfs(next_node)
+                if found is not None:
+                    return found
+            elif next_color == 1:
+                return strict_edge_to_json(edge, node, next_node)
+        color[node] = 2
+        return None
+
+    for source in sorted(graph):
+        if color.get(source, 0) == 0:
+            parent[source] = None
+            found_cycle_edge = dfs(source)
+            if found_cycle_edge is not None:
+                return "strict_cycle", scanned_edges, found_cycle_edge
+    return "ok", scanned_edges, None
+
+
+def search_size_five_subset(
+    catalogue: PreparedCatalogue,
+    size_five_centers: Sequence[int],
+) -> SearchResult:
+    """Search one dihedral q=1 center-set representative."""
+
+    size_five_set = set(size_five_centers)
+    support_sizes = tuple(5 if center in size_five_set else 4 for center in range(N))
+    domains = tuple(
+        catalogue.full_domain[(center, support_sizes[center])] for center in range(N)
+    )
+    pair_counts = [0] * PAIR_COUNT
+    assigned: list[int | None] = [None] * N
+    selected: list[tuple[int, int, int, RowOption]] = []
+    nodes_visited = 0
+    dead_end_count = 0
+    vertex_circle_prune_count = 0
+    max_depth_reached = 0
+    status_counts: Counter[str] = Counter()
+    first_obstruction: dict[str, object] | None = None
+
+    def recurse(depth: int, assigned_mask: int, current_domains: tuple[int, ...]) -> bool:
+        nonlocal dead_end_count
+        nonlocal first_obstruction
+        nonlocal max_depth_reached
+        nonlocal nodes_visited
+        nonlocal vertex_circle_prune_count
+
+        max_depth_reached = max(max_depth_reached, depth)
+        if depth == N:
+            return True
+
+        best_center: int | None = None
+        best_count: int | None = None
+        for center in range(N):
+            if (assigned_mask >> center) & 1:
+                continue
+            option_count = current_domains[center].bit_count()
+            if best_count is None or option_count < best_count:
+                best_center = center
+                best_count = option_count
+            if option_count == 0:
+                break
+
+        if best_center is None:
+            return True
+        if best_count == 0:
+            dead_end_count += 1
+            return False
+
+        center = best_center
+        center_size = support_sizes[center]
+        for option_index in iter_bits(current_domains[center]):
+            nodes_visited += 1
+            row_option = catalogue.options[(center, center_size)][option_index]
+            newly_saturated: list[PairId] = []
+            for witness_pair_id in row_option.witness_pair_ids:
+                old_count = pair_counts[witness_pair_id]
+                if old_count >= 2:
+                    raise AssertionError("domain allowed an already saturated pair")
+                pair_counts[witness_pair_id] = old_count + 1
+                if old_count + 1 == 2:
+                    newly_saturated.append(witness_pair_id)
+
+            new_domains = list(current_domains)
+            new_domains[center] = 1 << option_index
+            new_assigned_mask = assigned_mask | (1 << center)
+            empty_domain = False
+            for other_center in range(N):
+                if (new_assigned_mask >> other_center) & 1:
+                    continue
+                other_size = support_sizes[other_center]
+                domain = new_domains[other_center]
+                domain &= catalogue.compatible_option_bits[
+                    (center, center_size, other_center, other_size)
+                ][option_index]
+                for pair in newly_saturated:
+                    domain &= ~catalogue.pair_option_bits[(other_center, other_size)][pair]
+                new_domains[other_center] = domain
+                if domain == 0:
+                    empty_domain = True
+                    break
+
+            assigned[center] = option_index
+            selected.append((center, center_size, option_index, row_option))
+            if empty_domain:
+                dead_end_count += 1
+                found = False
+            else:
+                status, scanned_strict_edges, first_edge = rich_vertex_circle_status(
+                    selected
+                )
+                if status != "ok":
+                    vertex_circle_prune_count += 1
+                    status_counts[status] += 1
+                    if first_obstruction is None:
+                        first_obstruction = {
+                            "status": status,
+                            "partial_row_count": len(selected),
+                            "partial_rows": selected_rows_to_json(selected),
+                            "strict_edges_scanned_before_obstruction": (
+                                scanned_strict_edges
+                            ),
+                            "first_edge": first_edge,
+                        }
+                    found = False
+                else:
+                    found = recurse(
+                        depth + 1,
+                        new_assigned_mask,
+                        tuple(new_domains),
+                    )
+            selected.pop()
+            assigned[center] = None
+            for witness_pair_id in row_option.witness_pair_ids:
+                pair_counts[witness_pair_id] -= 1
+            if found:
+                return True
+        return False
+
+    found_clean = recurse(0, 0, domains)
+    return SearchResult(
+        found_clean_complete_assignment=found_clean,
+        nodes_visited=nodes_visited,
+        dead_end_count=dead_end_count,
+        vertex_circle_prune_count=vertex_circle_prune_count,
+        max_depth_reached=max_depth_reached,
+        vertex_circle_status_counts=dict(sorted(status_counts.items())),
+        first_obstruction=first_obstruction,
+    )
+
+
+def representative_key(representative: Sequence[int]) -> str:
+    """Return a compact stable key for a representative."""
+
+    return ",".join(str(item) for item in representative)
+
+
+def search_result_to_json(
+    representative: Sequence[int],
+    result: SearchResult,
+) -> dict[str, object]:
+    """Return a JSON-safe representative search result."""
+
+    return {
+        "size_five_centers": list(representative),
+        "found_clean_complete_assignment": result.found_clean_complete_assignment,
+        "nodes_visited": result.nodes_visited,
+        "dead_end_count": result.dead_end_count,
+        "vertex_circle_prune_count": result.vertex_circle_prune_count,
+        "max_depth_reached": result.max_depth_reached,
+        "vertex_circle_status_counts": result.vertex_circle_status_counts,
+        "first_obstruction": result.first_obstruction,
+    }
+
+
+def run_q1_search() -> dict[str, object]:
+    """Run the complete q=1 search and return deterministic summaries."""
+
+    catalogue = prepare_catalogue(N)
+    representative_results: dict[str, object] = {}
+    aggregate_status_counts: Counter[str] = Counter()
+    total_nodes = 0
+    total_dead_ends = 0
+    total_vertex_prunes = 0
+    max_depth = 0
+    complete_assignments_found = 0
+
+    for representative in dihedral_representatives(Q, N):
+        result = search_size_five_subset(catalogue, representative)
+        key = representative_key(representative)
+        representative_results[key] = search_result_to_json(representative, result)
+        total_nodes += result.nodes_visited
+        total_dead_ends += result.dead_end_count
+        total_vertex_prunes += result.vertex_circle_prune_count
+        max_depth = max(max_depth, result.max_depth_reached)
+        if result.found_clean_complete_assignment:
+            complete_assignments_found += 1
+        aggregate_status_counts.update(result.vertex_circle_status_counts)
+
+    return {
+        "representative_results": representative_results,
+        "summary": {
+            "representatives_checked": len(representative_results),
+            "complete_assignments_found": complete_assignments_found,
+            "total_nodes_visited": total_nodes,
+            "total_dead_end_count": total_dead_ends,
+            "total_vertex_circle_prune_count": total_vertex_prunes,
+            "max_depth_reached": max_depth,
+            "vertex_circle_status_counts": dict(sorted(aggregate_status_counts.items())),
+        },
+    }
+
+
+def build_payload() -> dict[str, object]:
+    """Build the checked artifact payload."""
+
+    search = run_q1_search()
+    summary = search["summary"]
+    assert isinstance(summary, Mapping)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Generator-independent n=10 q=1 four/five rich-support diagnostic. "
+            "It checks the unique dihedral center-set representative with exactly "
+            "one size-five support under the row-pair cap, two-overlap crossing, "
+            "witness-pair capacity, and monotone rich vertex-circle quotient "
+            "pruning. It finds no clean complete assignment. This does not prove "
+            "n=10, does not prove Erdos Problem #97, and is not a counterexample."
+        ),
+        "summary": {
+            "n": N,
+            "order": list(ORDER),
+            "support_sizes": list(SUPPORT_SIZES),
+            "size_five_center_count": Q,
+            **summary,
+            "max_size_five_centers_surviving_support_plus_vertex_circle_filters": 0,
+            "min_exact_four_only_centers_surviving_support_plus_vertex_circle_filters": 10,
+        },
+        "representative_results": search["representative_results"],
+        "filters": [
+            {
+                "name": "row_pair_cap",
+                "meaning": (
+                    "Two distinct distance circles can share at most two witness "
+                    "vertices."
+                ),
+            },
+            {
+                "name": "two_overlap_crossing",
+                "meaning": (
+                    "When two rich supports share exactly two witnesses, the "
+                    "center chord and shared-witness chord must cross in the "
+                    "cyclic order."
+                ),
+            },
+            {
+                "name": "witness_pair_capacity",
+                "meaning": (
+                    "Any unordered witness pair can occur together in rich "
+                    "supports at at most two centers."
+                ),
+            },
+            {
+                "name": "rich_vertex_circle_quotient",
+                "meaning": (
+                    "For each rich class, union all center-witness distances "
+                    "inside the class and add all nested-interval strict "
+                    "distance inequalities from the full witness set. A self-edge "
+                    "or directed strict cycle is an obstruction."
+                ),
+            },
+        ],
+        "support_rule": {
+            "rule": (
+                "Exactly one center is represented by a size-five same-radius "
+                "support. The other nine centers are represented by exact-four "
+                "supports."
+            ),
+            "dihedral_reduction": (
+                "The natural cyclic order fixes labels 0..9. The single "
+                "size-five center is reduced by cyclic rotations and reflection; "
+                "support choices are still labelled for the representative."
+            ),
+            "monotonicity_note": (
+                "The vertex-circle quotient obstruction is monotone under adding "
+                "rows: an existing self-edge or strict cycle remains obstructive, "
+                "possibly after quotient classes merge."
+            ),
+            "combined_consequence_note": (
+                "The all-exact-four consequence combines this q=1 closure with "
+                "the existing q=2 rich vertex-circle artifact and the existing "
+                "n10_mixed_rich_support_capacity artifact, which closes q=3..7 "
+                "under weaker support filters. This checker itself exhausts "
+                "exactly the q=1 layer."
+            ),
+        },
+        "interpretation_warnings": [
+            "This is a necessary support/quotient diagnostic only.",
+            "It does not replay turn inequalities, Kalmanson certificates, or Euclidean realizability.",
+            "It leaves the q=0 exact-four support case to stronger filters.",
+            "No n=10 theorem, general proof, or counterexample is claimed.",
+        ],
+        "provenance": {
+            "generator": "scripts/check_n10_q1_rich_vertex_circle.py",
+            "command": (
+                "python scripts/check_n10_q1_rich_vertex_circle.py "
+                "--write --assert-expected"
+            ),
+            "related_artifacts": [
+                "data/certificates/n10_mixed_rich_support_capacity.json",
+                "data/certificates/n10_q2_rich_vertex_circle.json",
+                "docs/n10-mixed-rich-support-capacity.md",
+                "docs/n10-q2-rich-vertex-circle.md",
+                "src/erdos97/vertex_circle_quotient_replay.py",
+            ],
+        },
+    }
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert stable expected q=1 closure counts."""
+
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("status") != STATUS:
+        raise AssertionError(f"unexpected status: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        raise AssertionError(f"unexpected trust: {payload.get('trust')!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary is missing")
+    for key, expected in EXPECTED_AGGREGATE.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {summary.get(key)!r}, expected {expected!r}"
+            )
+    max_survivors = "max_size_five_centers_surviving_support_plus_vertex_circle_filters"
+    min_exact_four = "min_exact_four_only_centers_surviving_support_plus_vertex_circle_filters"
+    if summary.get(max_survivors) != 0:
+        raise AssertionError("expected no surviving size-five center")
+    if summary.get(min_exact_four) != 10:
+        raise AssertionError("expected all ten centers to be exact-four-only")
+
+    representative_results = payload.get("representative_results")
+    if not isinstance(representative_results, Mapping):
+        raise AssertionError("representative_results is missing")
+    for key, expected_items in EXPECTED_REP_SUMMARIES.items():
+        item = representative_results.get(key)
+        if not isinstance(item, Mapping):
+            raise AssertionError(f"missing representative {key}")
+        if item.get("found_clean_complete_assignment") is not False:
+            raise AssertionError(f"representative {key} unexpectedly has a clean assignment")
+        for expected_key, expected in expected_items.items():
+            if item.get(expected_key) != expected:
+                raise AssertionError(
+                    f"representative {key} key {expected_key!r} is "
+                    f"{item.get(expected_key)!r}, expected {expected!r}"
+                )
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    """Compare a checked artifact with a freshly built payload."""
+
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_summary(payload: Mapping[str, object]) -> None:
+    """Print a compact human-readable summary."""
+
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=10 q=1 rich vertex-circle closure diagnostic")
+    print(f"claim scope: {payload['claim_scope']}")
+    print(f"representatives checked: {summary['representatives_checked']}")
+    print(f"clean complete assignments found: {summary['complete_assignments_found']}")
+    print(
+        "max size-five centers surviving support + vertex-circle filters: "
+        f"{summary['max_size_five_centers_surviving_support_plus_vertex_circle_filters']}"
+    )
+    print(
+        "minimum exact-four-only centers after this filter layer: "
+        f"{summary['min_exact_four_only_centers_surviving_support_plus_vertex_circle_filters']}"
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the artifact")
+    parser.add_argument("--check", action="store_true", help="compare the artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true", help="print full JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload()
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2565,6 +2565,24 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n10_q1_rich_vertex_circle",
+        command=(
+            "python",
+            "scripts/check_n10_q1_rich_vertex_circle.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Generator-independent n=10 exactly-one-size-five rich-support "
+            "diagnostic under row-pair cap, two-overlap crossing, "
+            "witness-pair capacity, and rich vertex-circle quotient filters; "
+            "finite support-plus-quotient reduction only, not a proof of "
+            "n=10, not a proof of Erdos Problem #97, and not a "
+            "counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="n10_turn_row0_pilot",
         command=(
             "python",

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -291,6 +291,10 @@ def test_verify_n10_review_includes_turn_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_n10_q1_rich_vertex_circle.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_n10_turn_row0_pilot.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_n10_q1_rich_vertex_circle.py
+++ b/tests/test_n10_q1_rich_vertex_circle.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from erdos97.vertex_circle_quotient_replay import (
+    RichClassRow,
+    replay_vertex_circle_rich_quotient,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.slow
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n10_q1_rich_vertex_circle import (  # noqa: E402
+    N,
+    ORDER,
+    assert_expected_payload,
+    build_payload,
+    dihedral_representatives,
+)
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, Any]:
+    return build_payload()
+
+
+def test_dihedral_representatives_are_pinned() -> None:
+    assert dihedral_representatives(1, N) == ((0,),)
+
+
+def test_expected_payload_counts(payload: dict[str, Any]) -> None:
+    assert_expected_payload(payload)
+
+    summary = payload["summary"]
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert summary["complete_assignments_found"] == 0
+    assert summary["total_nodes_visited"] == 362556
+    assert (
+        summary["max_size_five_centers_surviving_support_plus_vertex_circle_filters"]
+        == 0
+    )
+    assert (
+        summary["min_exact_four_only_centers_surviving_support_plus_vertex_circle_filters"]
+        == 10
+    )
+
+
+def test_first_obstruction_matches_shared_rich_replay(payload: dict[str, Any]) -> None:
+    representative_results = payload["representative_results"]
+    obstruction = representative_results["0"]["first_obstruction"]
+    partial_rows = obstruction["partial_rows"]
+
+    rows = [
+        RichClassRow(center=int(center), witnesses=tuple(witnesses))
+        for center, witnesses in sorted(partial_rows.items())
+    ]
+    result = replay_vertex_circle_rich_quotient(N, ORDER, rows)
+
+    assert result.status == obstruction["status"]
+    assert result.obstructed

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -973,6 +973,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n10_q1_rich_vertex_circle.py --check "
+        "--assert-expected --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n10_mixed_rich_support_capacity.py --check "
         "--assert-expected --json"
@@ -982,6 +987,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_n10_q2_rich_vertex_circle.py --check "
+        "--assert-expected --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n10_q1_rich_vertex_circle.py --check "
+        "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n10_q1_rich_vertex_circle.py --check "
         "--assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n10_turn_row0_pilot.py --check "


### PR DESCRIPTION
## Summary

Adds a review-pending `n=10` exactly-one-size-five rich-support vertex-circle diagnostic. The checker exhausts the unique dihedral representative with `q=1`, applies the row-pair cap, two-overlap crossing, witness-pair capacity, and rich vertex-circle quotient gate, and records zero clean complete assignments.

This wires the generated certificate into the artifact metadata, audit runner, `verify-n10-review`, and the claim/result ledgers. The combined wording stays scoped: together with the existing q=2 quotient closure and q=3..7 support-capacity closure, the four/five support-plus-quotient abstraction leaves only the all-exact-four q=0 layer. It does not prove n=10, Erdos Problem #97, or a counterexample.

## Validation

- `python scripts/check_n10_q1_rich_vertex_circle.py --check --assert-expected --json`
- `python -m py_compile scripts/check_n10_q1_rich_vertex_circle.py tests/test_n10_q1_rich_vertex_circle.py`
- `python -m pytest -q -m slow tests/test_n10_q1_rich_vertex_circle.py`
- `python -m pytest -q tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- Manual `verify-n10-review` commands, because `make` is not installed in this Windows shell:
  - `python scripts/check_n10_mixed_rich_support_capacity.py --check --assert-expected --json`
  - `python scripts/check_n10_q2_rich_vertex_circle.py --check --assert-expected --json`
  - `python scripts/check_n10_q1_rich_vertex_circle.py --check --assert-expected --json`
  - `python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json`
  - `python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json`
  - `python scripts/check_n10_turn_row0_combined_closure.py --check --assert-expected --json`
  - `python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json`
  - `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125`
  - `python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json`