### PR TITLE
[codex] Add nonagon rich-support profile refinement

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -55,11 +55,13 @@ Consequently, if every center has a rich class of size at least `k`, then
 impossible for `n <= 11`; the global pair budget alone gives at least seven
 exact-four centers in a hypothetical 4-bad nonagon, at least five in a
 hypothetical 4-bad decagon, and at least three in a hypothetical 4-bad
-hendecagon. The localized per-label support-pair cap sharpens the nonagon
-case: each witness label can occur in at most four chosen supports, so any
-hypothetical 4-bad nonagon is already forced into the all-exact-four,
-selected-indegree-four support case by counting alone. See
-`docs/rich-support-counting-lemma.md` and
+hendecagon. The rich-support checker now also records a nonagon
+profile-deficiency refinement excluding the remaining raw non-exact-four
+profiles by label-deficiency residues. The localized per-label support-pair cap
+gives a second route to the same nonagon conclusion: each witness label can
+occur in at most four chosen supports, so any hypothetical 4-bad nonagon is
+already forced into the all-exact-four, selected-indegree-four support case by
+counting alone. See `docs/rich-support-counting-lemma.md` and
 `docs/localized-rich-support-counting.md`.
 
 ### Lemma: crossing-bisector and sharpened count

--- a/STATE.md
+++ b/STATE.md
@@ -252,12 +252,14 @@ pair-sharing count is that a hull-edge witness pair can occur in at most one
 support, while a non-edge witness pair can occur in at most two. Hence every
 center having five equidistant witnesses requires `n >= 12`. The same counting
 relaxation says any hypothetical 4-bad decagon has at least five exact-four
-centers and any hypothetical 4-bad hendecagon has at least three. A localized
-per-label support-pair cap sharpens the nonagon case further: any hypothetical
-4-bad nonagon is forced into the all-exact-four, selected-indegree-four support
-case by counting alone. This does not prove the review-pending exact-four
-frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
-`docs/rich-support-counting-lemma.md` and
+centers and any hypothetical 4-bad hendecagon has at least three. A nonagon
+profile-deficiency refinement in the same checker rules out the remaining raw
+size-five and size-six nonagon support-size profiles. The localized per-label
+support-pair cap gives a second route to the same sharpened nonagon conclusion:
+any hypothetical 4-bad nonagon is forced into the all-exact-four,
+selected-indegree-four support case by counting alone. This does not prove the
+review-pending exact-four frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97.
+See `docs/rich-support-counting-lemma.md` and
 `docs/localized-rich-support-counting.md`.
 
 The follow-up mixed rich-support reduction enumerates every four- or

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -107,7 +107,11 @@ hypothetical 4-bad nonagon also shows that at most two centers can have
 forces at least five exact-four centers for `n=10` and at least three for
 `n=11`.
 
-The companion localized counting cap improves the nonagon conclusion. For each
+The profile-deficiency refinement in the same checker rules out the three raw
+nonagon profiles still allowed by the global pair budget, namely `5 4^8`,
+`5^2 4^7`, and `6 4^8`, by comparing pair-capacity slack with the label
+deficiency residues forced by row sizes. The companion localized counting cap
+gives an even shorter per-label route to the same nonagon conclusion. For each
 fixed witness label `x`,
 
 ```text
@@ -119,12 +123,12 @@ localized budget, so each label occurs in at most four chosen supports. The
 4-bad baseline already needs `36` support occurrences, hence every chosen
 support is exact-four and every label has selected indegree four.
 
-These are support-level counting lemmas only. They reduce hypothetical
-nonagons to the all-exact-four support frontier, but they do not prove the
-review-pending exact-four vertex-circle checker, `n=9`, `n=10`, `n=11`, or
-Erdos Problem #97. See `docs/rich-support-counting-lemma.md`,
-`docs/localized-rich-support-counting.md`, and the checkers
-`scripts/check_rich_support_counting_bound.py` and
+These are support-level counting lemmas only. The profile-deficiency and
+localized routes both reduce hypothetical nonagons to the all-exact-four
+support frontier, but they do not prove the review-pending exact-four
+vertex-circle checker, `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
+`docs/rich-support-counting-lemma.md`, `docs/localized-rich-support-counting.md`,
+and the checkers `scripts/check_rich_support_counting_bound.py` and
 `scripts/check_localized_rich_support_counting.py`.
 
 ### Altman diagonal-order sums

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,8 @@ put detailed reconciliation in the canonical synthesis.
   only.
 - [`rich-support-counting-lemma.md`](rich-support-counting-lemma.md):
   proof-facing edge-sensitive support pair-counting lemma for all-centers large
-  rich classes; not an `n=9`, `n=10`, `n=11`, or global proof.
+  rich classes, plus an independent nonagon profile-deficiency refinement; not
+  an `n=9`, `n=10`, `n=11`, or global proof.
 - [`localized-rich-support-counting.md`](localized-rich-support-counting.md):
   proof-facing per-label rich-support occurrence cap reducing hypothetical
   4-bad nonagons to all-exact-four support systems by counting alone.

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -82,6 +82,64 @@ Since any center with `E(i) >= 5` costs at least `binom(5,2)-binom(4,2)=4`,
 at most two centers can have `E(i) >= 5`. Equivalently, any hypothetical 4-bad
 nonagon has at least seven exact-four centers.
 
+### Nonagon profile-deficiency refinement
+
+The raw nonagon pair budget permits only four sorted support-size profiles for
+a 4-bad nonagon:
+
+```text
+4^9,
+5 4^8,
+5^2 4^7,
+6 4^8.
+```
+
+The last three are impossible by a vertex-deficiency refinement of the same
+counting argument. For a label `a`, let `m_ab` be the number of supports
+containing the witness pair `{a,b}`, and let `c_ab` be the pair capacity: `1`
+for hull edges and `2` for non-edges. In a nonagon,
+
+```text
+sum_b c_ab = 2*1 + 6*2 = 14.
+```
+
+Define the label deficiency
+
+```text
+D_a = 14 - sum_{i : a in R_i} (|R_i| - 1).
+```
+
+Because `m_ab <= c_ab` for every pair, `D_a >= 0`, and
+
+```text
+sum_a D_a = 2 * (unused pair-capacity slack).
+```
+
+Now compare this required total deficiency with the congruence forced by row
+sizes. Exact-four rows contribute `3` to the weighted degree of any label they
+contain; size-five rows contribute `4`; size-six rows contribute `5`.
+
+- For profile `5 4^8`, the pair slack is `5`, so `sum_a D_a = 10`. The five
+  labels in the size-five row have weighted degree congruent to `1 mod 3`, so
+  each has deficiency at least `1`; the other four labels have weighted degree
+  congruent to `0 mod 3`, so each has deficiency at least `2`. Hence
+  `sum_a D_a >= 5*1 + 4*2 = 13`, contradiction.
+- For profile `5^2 4^7`, the pair slack is `1`, so `sum_a D_a = 2`. Starting
+  from the exact-four residue lower bound `2` at each of nine labels, the ten
+  size-five witness incidences can lower the total deficiency by at most `10`,
+  leaving `sum_a D_a >= 18 - 10 = 8`, contradiction.
+- For profile `6 4^8`, the pair slack is `0`, so `sum_a D_a = 0`. The six
+  labels in the size-six row can have deficiency `0`, but the three labels
+  outside that support still have exact-four residue deficiency at least `2`,
+  giving `sum_a D_a >= 6`, contradiction.
+
+Therefore any hypothetical 4-bad nonagon has `E(i)=4` at every center.
+Choosing one maximum support per center gives nine exact-four selected rows.
+For each label, the same deficiency count then forces selected indegree exactly
+`4`. This profile-deficiency refinement is an independent count-level
+cross-check of the localized per-label cap below; neither route proves the
+review-pending exact-four vertex-circle frontier.
+
 The corresponding necessary counting relaxation gives at least five exact-four
 centers in any hypothetical 4-bad decagon and at least three exact-four centers
 in any hypothetical 4-bad hendecagon.
@@ -105,17 +163,19 @@ The helper script
 python scripts/check_rich_support_counting_bound.py --check --json
 ```
 
-checks the threshold `n >= 12` for all-centers size-five support and the small
-`n=8..12` surplus table used above. It is only a counting-bound checker; it is
-not a realization search.
+checks the threshold `n >= 12` for all-centers size-five support, the small
+`n=8..12` surplus table used above, and the nonagon profile-deficiency
+refinement. It is only a counting-bound checker; it is not a realization
+search.
 
 ## Boundary
 
 This global pair-counting lemma alone does not rule out mixed exact-four and
-size-five catalogues. For `n=9`, the localized companion lemma rules out that
-mixed support layer by counting alone, reducing hypothetical nonagons to the
-all-exact-four support frontier. It still does not replace the review-pending
-exact-four vertex-circle checker. The existing `n=9` all-five-rich and mixed
-support checkers remain useful as crossing-aware catalogue regressions and as
+size-five catalogues. For `n=9`, the profile-deficiency refinement above and
+the localized companion lemma both rule out that mixed support layer by
+counting alone, reducing hypothetical nonagons to the all-exact-four support
+frontier. This still does not replace the review-pending exact-four
+vertex-circle checker. The existing `n=9` all-five-rich and mixed support
+checkers remain useful as crossing-aware catalogue regressions and as
 provenance for the richer support-search machinery, but their nonagon support
-reduction is now preceded by this proof-facing count.
+reduction is now preceded by these proof-facing counts.

--- a/scripts/check_rich_support_counting_bound.py
+++ b/scripts/check_rich_support_counting_bound.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 
 import argparse
 import json
+from itertools import combinations
 from math import comb
 from typing import Any
 
-SCHEMA = "erdos97.rich_support_counting_bound.v2"
+SCHEMA = "erdos97.rich_support_counting_bound.v3"
 TRUST = "LEMMA"
 
 
@@ -58,6 +59,50 @@ def all_centers_min_n(k: int) -> int:
     if k < 0:
         raise ValueError("k must be nonnegative")
     return comb(k, 2) + 2
+
+
+def support_profile_pair_cost(profile: list[int] | tuple[int, ...]) -> int:
+    """Return sum binom(size, 2) for a support-size profile."""
+
+    if any(size < 0 for size in profile):
+        raise ValueError("support sizes must be nonnegative")
+    return sum(comb(size, 2) for size in profile)
+
+
+def counting_feasible_support_profiles(
+    n: int,
+    min_size: int = 4,
+) -> list[tuple[int, ...]]:
+    """Enumerate sorted support-size profiles allowed by the pair budget.
+
+    The output is a pure counting relaxation: it records only profiles
+    ``s_0 <= ... <= s_{n-1}`` with ``min_size <= s_i < n`` and
+    ``sum_i binom(s_i, 2) <= n(n-2)``. It does not check row-intersection,
+    cyclic-order, or vertex-circle constraints.
+    """
+
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if min_size < 0 or min_size >= n:
+        raise ValueError("min_size must satisfy 0 <= min_size < n")
+
+    budget = pair_budget(n)
+    profiles: list[tuple[int, ...]] = []
+
+    def visit(start_size: int, remaining: int, used: int, profile: list[int]) -> None:
+        if remaining == 0:
+            profiles.append(tuple(profile))
+            return
+        for size in range(start_size, n):
+            new_used = used + comb(size, 2)
+            # Profiles are nondecreasing, so every remaining size is at least this size.
+            min_completion = new_used + (remaining - 1) * comb(size, 2)
+            if min_completion > budget:
+                break
+            visit(size, remaining - 1, new_used, [*profile, size])
+
+    visit(min_size, n, 0, [])
+    return profiles
 
 
 def max_total_support_size(n: int, min_size: int = 4) -> tuple[int, list[int]]:
@@ -109,6 +154,92 @@ def max_non_exact_four_centers(n: int) -> int:
     return min(n, extra_budget // (comb(5, 2) - comb(4, 2)))
 
 
+def _n9_vertex_deficiency_floor(rich_increment: int) -> int:
+    """Minimum possible pair-capacity deficiency for one nonagon label."""
+
+    if rich_increment < 0:
+        raise ValueError("rich_increment must be nonnegative")
+    if rich_increment > 14:
+        raise ValueError("rich_increment exceeds the nonagon label-pair capacity")
+    return (14 - rich_increment) % 3
+
+
+def _min_n9_vertex_deficiency_from_profile(profile: tuple[int, ...]) -> int:
+    """Relaxedly minimize total nonagon vertex deficiency for one size profile."""
+
+    if len(profile) != 9:
+        raise ValueError("n=9 profile must have exactly nine support sizes")
+    if any(size < 4 or size >= 9 for size in profile):
+        raise ValueError("n=9 support sizes must satisfy 4 <= size < 9")
+
+    states: set[tuple[int, ...]] = {tuple([0] * 9)}
+    for size in profile:
+        increment = size - 4
+        if increment == 0:
+            continue
+        next_states: set[tuple[int, ...]] = set()
+        for state in states:
+            for witnesses in combinations(range(9), size):
+                updated = list(state)
+                for vertex in witnesses:
+                    updated[vertex] += increment
+                next_states.add(tuple(sorted(updated)))
+        states = next_states
+
+    return min(
+        sum(_n9_vertex_deficiency_floor(increment) for increment in state)
+        for state in states
+    )
+
+
+def n9_profile_deficiency_refinement() -> dict[str, Any]:
+    """Return the nonagon profile refinement beyond the raw pair budget."""
+
+    profiles = counting_feasible_support_profiles(9, min_size=4)
+    rows: list[dict[str, Any]] = []
+    for profile in profiles:
+        pair_cost_value = support_profile_pair_cost(profile)
+        pair_slack = pair_budget(9) - pair_cost_value
+        required_vertex_deficiency = 2 * pair_slack
+        min_vertex_deficiency = _min_n9_vertex_deficiency_from_profile(profile)
+        excluded = min_vertex_deficiency > required_vertex_deficiency
+        rows.append(
+            {
+                "profile": list(profile),
+                "pair_cost": pair_cost_value,
+                "pair_slack": pair_slack,
+                "required_total_vertex_deficiency": required_vertex_deficiency,
+                "minimum_total_vertex_deficiency_from_weighting": min_vertex_deficiency,
+                "status": (
+                    "EXCLUDED_BY_VERTEX_DEFICIENCY"
+                    if excluded
+                    else "NOT_EXCLUDED_BY_THIS_REFINEMENT"
+                ),
+            }
+        )
+
+    remaining = [
+        row["profile"] for row in rows if row["status"] == "NOT_EXCLUDED_BY_THIS_REFINEMENT"
+    ]
+    return {
+        "claim": (
+            "In a hypothetical 4-bad nonagon, every maximum same-radius support "
+            "has size exactly 4; the raw size-five and size-six profiles are "
+            "excluded by pair-slack/vertex-deficiency counting."
+        ),
+        "pair_capacity_degree_per_label": 14,
+        "raw_counting_feasible_profile_count": len(rows),
+        "profiles": rows,
+        "remaining_profiles_after_refinement": remaining,
+        "consequence": (
+            "The only remaining support-size profile is [4]*9. Therefore a "
+            "4-bad nonagon, if it exists, is an exact-four selected-witness "
+            "object at every center; applying the same weighted-degree cap then "
+            "forces every witness label to have selected indegree 4."
+        ),
+    }
+
+
 def row_summary(n: int) -> dict[str, Any]:
     """Return the counting-bound row for one n."""
 
@@ -151,6 +282,14 @@ def row_summary(n: int) -> dict[str, Any]:
             "min_centers_with_E_equal_4_by_counting": max(0, n - max_non_exact),
         }
     )
+    if n == 9:
+        row.update(
+            {
+                "n9_max_support_size_after_vertex_deficiency_refinement": 4,
+                "n9_all_centers_exact_four_after_vertex_deficiency_refinement": True,
+                "n9_selected_indegree_for_exact_four_profile": 4,
+            }
+        )
     return row
 
 
@@ -163,8 +302,9 @@ def build_summary(min_n: int = 5, max_n: int = 12) -> dict[str, Any]:
         "trust": TRUST,
         "claim_scope": (
             "Proof-facing edge-sensitive rich-support pair-counting lemma only. "
-            "It records necessary support-size consequences and does not prove "
-            "n=9, n=10, n=11, or Erdos Problem #97."
+            "It records necessary support-size consequences and the n=9 "
+            "vertex-deficiency profile refinement; it does not prove n=9, n=10, "
+            "n=11, or Erdos Problem #97."
         ),
         "lemma": (
             "For same-radius supports R_i in a strict convex n-gon, "
@@ -179,6 +319,7 @@ def build_summary(min_n: int = 5, max_n: int = 12) -> dict[str, Any]:
         "all_centers_min_support_thresholds": {
             str(k): all_centers_min_n(k) for k in range(4, 8)
         },
+        "n9_profile_deficiency_refinement": n9_profile_deficiency_refinement(),
         "rows": [row_summary(n) for n in range(min_n, max_n + 1)],
     }
 
@@ -217,6 +358,20 @@ def check_expected(summary: dict[str, Any]) -> None:
                 f"n={n}: expected edge-sensitive pair-counting to rule out four-bad supports"
             )
 
+    refinement = summary["n9_profile_deficiency_refinement"]
+    remaining = refinement["remaining_profiles_after_refinement"]
+    if remaining != [[4, 4, 4, 4, 4, 4, 4, 4, 4]]:
+        raise AssertionError(f"unexpected n=9 refined profiles: {remaining}")
+    statuses = {tuple(row["profile"]): row["status"] for row in refinement["profiles"]}
+    expected_statuses = {
+        (4, 4, 4, 4, 4, 4, 4, 4, 4): "NOT_EXCLUDED_BY_THIS_REFINEMENT",
+        (4, 4, 4, 4, 4, 4, 4, 4, 5): "EXCLUDED_BY_VERTEX_DEFICIENCY",
+        (4, 4, 4, 4, 4, 4, 4, 5, 5): "EXCLUDED_BY_VERTEX_DEFICIENCY",
+        (4, 4, 4, 4, 4, 4, 4, 4, 6): "EXCLUDED_BY_VERTEX_DEFICIENCY",
+    }
+    if statuses != expected_statuses:
+        raise AssertionError(f"unexpected n=9 profile statuses: {statuses}")
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -236,6 +391,11 @@ def main() -> int:
     else:
         print(f"schema: {summary['schema']}")
         print("all centers with size >=5 requires n >=", all_centers_min_n(5))
+        n9_refinement = summary["n9_profile_deficiency_refinement"]
+        print(
+            "n=9 refined support-size profiles:",
+            n9_refinement["remaining_profiles_after_refinement"],
+        )
         for row in summary["rows"]:
             if row["four_bad_ruled_out_by_edge_sensitive_pair_counting"]:
                 print(f"n={row['n']}: four-bad supports ruled out by edge-sensitive pair-counting")

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1548,9 +1548,10 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
         claim_scope=(
             "Proof-facing edge-sensitive rich-support pair-counting lemma "
-            "and small-n consequences; not a proof of n=9, not a proof of "
-            "n=10, not a proof of n=11, not a proof of Erdos Problem #97, "
-            "and not a counterexample."
+            "and small-n consequences, including the n=9 profile-deficiency "
+            "refinement; not a proof of n=9, not a proof of n=10, not a "
+            "proof of n=11, not a proof of Erdos Problem #97, and not a "
+            "counterexample."
         ),
     ),
     AuditCommand(

--- a/tests/test_rich_support_counting_bound.py
+++ b/tests/test_rich_support_counting_bound.py
@@ -15,9 +15,12 @@ from check_rich_support_counting_bound import (  # noqa: E402
     build_summary,
     check_expected,
     coarse_pair_budget,
+    counting_feasible_support_profiles,
     edge_sensitive_pair_budget,
     max_non_exact_four_centers,
+    n9_profile_deficiency_refinement,
     row_summary,
+    support_profile_pair_cost,
 )
 
 
@@ -30,6 +33,9 @@ def test_rich_support_counting_expected_summary() -> None:
     assert summary["all_centers_min_support_thresholds"]["5"] == 12
     assert rows[9]["max_centers_with_E_at_least_5_by_counting"] == 2
     assert rows[9]["min_centers_with_E_equal_4_by_counting"] == 7
+    assert rows[9]["n9_max_support_size_after_vertex_deficiency_refinement"] == 4
+    assert rows[9]["n9_all_centers_exact_four_after_vertex_deficiency_refinement"] is True
+    assert rows[9]["n9_selected_indegree_for_exact_four_profile"] == 4
     assert rows[10]["max_centers_with_E_at_least_5_by_counting"] == 5
     assert rows[10]["min_centers_with_E_equal_4_by_counting"] == 5
     assert rows[11]["min_centers_with_E_equal_4_by_counting"] == 3
@@ -46,6 +52,7 @@ def test_rich_support_counting_threshold_helpers() -> None:
     assert max_non_exact_four_centers(9) == 2
     assert max_non_exact_four_centers(10) == 5
     assert max_non_exact_four_centers(11) == 8
+    assert support_profile_pair_cost((4, 4, 4, 4, 4, 4, 4, 4, 6)) == 63
 
 
 def test_rich_support_counting_rows() -> None:
@@ -61,8 +68,45 @@ def test_rich_support_counting_rows() -> None:
     assert row9["edge_sensitive_pair_budget"] == 63
     assert row9["coarse_pair_budget"] == 72
     assert row9["max_total_support_size_given_E_ge_4"] == 38
+    assert row9["n9_max_support_size_after_vertex_deficiency_refinement"] == 4
     assert row10["edge_sensitive_pair_budget"] == 80
     assert row10["max_total_support_size_given_E_ge_4"] == 45
+
+
+def test_n9_profile_deficiency_refinement() -> None:
+    raw_profiles = counting_feasible_support_profiles(9)
+    assert raw_profiles == [
+        (4, 4, 4, 4, 4, 4, 4, 4, 4),
+        (4, 4, 4, 4, 4, 4, 4, 4, 5),
+        (4, 4, 4, 4, 4, 4, 4, 4, 6),
+        (4, 4, 4, 4, 4, 4, 4, 5, 5),
+    ]
+
+    refinement = n9_profile_deficiency_refinement()
+    rows = {tuple(row["profile"]): row for row in refinement["profiles"]}
+
+    exact_four = rows[(4, 4, 4, 4, 4, 4, 4, 4, 4)]
+    assert exact_four["pair_slack"] == 9
+    assert exact_four["required_total_vertex_deficiency"] == 18
+    assert exact_four["minimum_total_vertex_deficiency_from_weighting"] == 18
+    assert exact_four["status"] == "NOT_EXCLUDED_BY_THIS_REFINEMENT"
+
+    one_size_five = rows[(4, 4, 4, 4, 4, 4, 4, 4, 5)]
+    assert one_size_five["required_total_vertex_deficiency"] == 10
+    assert one_size_five["minimum_total_vertex_deficiency_from_weighting"] == 13
+    assert one_size_five["status"] == "EXCLUDED_BY_VERTEX_DEFICIENCY"
+
+    one_size_six = rows[(4, 4, 4, 4, 4, 4, 4, 4, 6)]
+    assert one_size_six["required_total_vertex_deficiency"] == 0
+    assert one_size_six["minimum_total_vertex_deficiency_from_weighting"] == 6
+    assert one_size_six["status"] == "EXCLUDED_BY_VERTEX_DEFICIENCY"
+
+    two_size_five = rows[(4, 4, 4, 4, 4, 4, 4, 5, 5)]
+    assert two_size_five["required_total_vertex_deficiency"] == 2
+    assert two_size_five["minimum_total_vertex_deficiency_from_weighting"] == 8
+    assert two_size_five["status"] == "EXCLUDED_BY_VERTEX_DEFICIENCY"
+
+    assert refinement["remaining_profiles_after_refinement"] == [[4] * 9]
 
 
 def test_rich_support_counting_cli_json() -> None:
@@ -80,7 +124,11 @@ def test_rich_support_counting_cli_json() -> None:
     )
 
     payload = json.loads(result.stdout)
-    assert payload["schema"] == "erdos97.rich_support_counting_bound.v2"
+    assert payload["schema"] == "erdos97.rich_support_counting_bound.v3"
     assert payload["status"] == "PROVED_COUNTING_LEMMA"
     assert payload["rows"][4]["n"] == 9
     assert payload["rows"][4]["min_centers_with_E_equal_4_by_counting"] == 7
+    assert payload["rows"][4]["n9_max_support_size_after_vertex_deficiency_refinement"] == 4
+    assert payload["n9_profile_deficiency_refinement"]["remaining_profiles_after_refinement"] == [
+        [4] * 9
+    ]


### PR DESCRIPTION
## Summary

Adds a v3 refinement to the rich-support counting checker. The existing edge-sensitive pair budget already forced at least seven exact-four centers in a hypothetical 4-bad nonagon, and the localized per-label cap already forced the all-exact-four selected-indegree-four support case. This PR records an independent count-level cross-check inside the main rich-support checker: the raw nonagon profiles `5 4^8`, `5^2 4^7`, and `6 4^8` are excluded by comparing pair-capacity slack with vertex-deficiency residues, leaving only `4^9`.

The docs and claim ledgers are updated to present this as a support-level refinement alongside the localized cap. It does not prove the review-pending exact-four frontier, `n=9`, `n=10`, `n=11`, Erdos Problem #97, or a counterexample.

## Validation

- `python scripts/check_rich_support_counting_bound.py --check --json`
- `python -m pytest -q tests/test_rich_support_counting_bound.py`
- `$env:PYTHONPYCACHEPREFIX=$env:TEMP; python -m py_compile scripts/check_rich_support_counting_bound.py tests/test_rich_support_counting_bound.py`
- `python -m ruff check scripts/check_rich_support_counting_bound.py tests/test_rich_support_counting_bound.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_localized_rich_support_counting.py --check --json`
- `python -m pytest -q tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`