### PR TITLE
[codex] Add support saturation obstruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ verify-n9-review:
 verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
 	$(PYTHON) scripts/check_rich_support_counting_bound.py --check --json
+	$(PYTHON) scripts/check_support_saturation_obstruction.py --check --json
 	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -50,18 +50,21 @@ boundary vertices, so that edge pair has capacity one. There are `n` hull-edge
 witness pairs and `binom(n,2)-n` non-edge witness pairs, giving
 `n + 2*(binom(n,2)-n) = n(n-2)` by double-counting.
 
-Consequently, if every center has a rich class of size at least `k`, then
-`n >= binom(k, 2) + 2`. In particular, the all-centers size-five subcase is
-impossible for `n <= 11`; the global pair budget alone gives at least seven
-exact-four centers in a hypothetical 4-bad nonagon, at least five in a
-hypothetical 4-bad decagon, and at least three in a hypothetical 4-bad
-hendecagon. The rich-support checker now also records a nonagon
-profile-deficiency refinement excluding the remaining raw non-exact-four
-profiles by label-deficiency residues. The localized per-label support-pair cap
-gives a second route to the same nonagon conclusion: each witness label can
-occur in at most four chosen supports, so any hypothetical 4-bad nonagon is
-already forced into the all-exact-four, selected-indegree-four support case by
-counting alone. See `docs/rich-support-counting-lemma.md` and
+Consequently, if every center has a rich class of size at least `k`, then the
+edge-sensitive pair count gives `n >= binom(k, 2) + 2`. The
+support-saturation obstruction rules out the equality wall for `k >= 4`, so
+the all-centers size-five subcase is impossible for `n <= 12`; the global pair
+budget alone gives at least seven exact-four centers in a hypothetical 4-bad
+nonagon, at least five in a hypothetical 4-bad decagon, and at least three in a
+hypothetical 4-bad hendecagon. The rich-support checker now also records a
+nonagon profile-deficiency refinement excluding the remaining raw
+non-exact-four profiles by label-deficiency residues. The localized per-label
+support-pair cap gives a second route to the same nonagon conclusion: each
+witness label can occur in at most four chosen supports, so any hypothetical
+4-bad nonagon is already forced into the all-exact-four,
+selected-indegree-four support case by counting alone. See
+`docs/rich-support-counting-lemma.md`,
+`docs/support-saturation-obstruction.md`, and
 `docs/localized-rich-support-counting.md`.
 
 ### Lemma: crossing-bisector and sharpened count

--- a/STATE.md
+++ b/STATE.md
@@ -249,8 +249,9 @@ A sharpened rich-support counting lemma now gives a proof-level shortcut for
 all-five-rich subcases: for any same-radius supports `R_i`,
 `sum_i binom(|R_i|, 2) <= n(n - 2)`. The improvement over the coarse `n(n-1)`
 pair-sharing count is that a hull-edge witness pair can occur in at most one
-support, while a non-edge witness pair can occur in at most two. Hence every
-center having five equidistant witnesses requires `n >= 12`. The same counting
+support, while a non-edge witness pair can occur in at most two. A
+support-saturation obstruction rules out the equality wall, so every center
+having five equidistant witnesses requires `n >= 13`. The same pair-counting
 relaxation says any hypothetical 4-bad decagon has at least five exact-four
 centers and any hypothetical 4-bad hendecagon has at least three. A nonagon
 profile-deficiency refinement in the same checker rules out the remaining raw
@@ -259,7 +260,8 @@ support-pair cap gives a second route to the same sharpened nonagon conclusion:
 any hypothetical 4-bad nonagon is forced into the all-exact-four,
 selected-indegree-four support case by counting alone. This does not prove the
 review-pending exact-four frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97.
-See `docs/rich-support-counting-lemma.md` and
+See `docs/rich-support-counting-lemma.md`,
+`docs/support-saturation-obstruction.md`, and
 `docs/localized-rich-support-counting.md`.
 
 The follow-up mixed rich-support reduction enumerates every four- or

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -99,9 +99,11 @@ polygon boundary at the edge midpoint and can contain at most one further
 boundary vertex, hence at most one center. Double-counting witness pairs inside
 supports gives the displayed inequality.
 
-Thus, if every center has a rich distance class of size at least `k`, then
-`n >= binom(k, 2) + 2`. In particular, every-vertex size-five richness is
-impossible for `n <= 11`. Choosing a maximum rich class at each center of a
+Thus, if every center has a rich distance class of size at least `k`, then the
+edge-sensitive pair count gives `n >= binom(k, 2) + 2`. The support-saturation
+obstruction rules out the equality wall for `k >= 4`, improving this to
+`n >= binom(k, 2) + 3`. In particular, every-vertex size-five richness is
+impossible for `n <= 12`. Choosing a maximum rich class at each center of a
 hypothetical 4-bad nonagon also shows that at most two centers can have
 `E(i) >= 5`, so at least seven centers must be exact-four. The same relaxation
 forces at least five exact-four centers for `n=10` and at least three for
@@ -123,12 +125,15 @@ localized budget, so each label occurs in at most four chosen supports. The
 4-bad baseline already needs `36` support occurrences, hence every chosen
 support is exact-four and every label has selected indegree four.
 
-These are support-level counting lemmas only. The profile-deficiency and
-localized routes both reduce hypothetical nonagons to the all-exact-four
-support frontier, but they do not prove the review-pending exact-four
-vertex-circle checker, `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
-`docs/rich-support-counting-lemma.md`, `docs/localized-rich-support-counting.md`,
-and the checkers `scripts/check_rich_support_counting_bound.py` and
+These are support-level counting lemmas only. The saturation obstruction only
+rules out the equality wall, and the profile-deficiency and localized routes
+both reduce hypothetical nonagons to the all-exact-four support frontier. They
+do not prove the review-pending exact-four vertex-circle checker, `n=9`,
+`n=10`, `n=11`, or Erdos Problem #97. See
+`docs/rich-support-counting-lemma.md`, `docs/support-saturation-obstruction.md`,
+`docs/localized-rich-support-counting.md`, and the checkers
+`scripts/check_rich_support_counting_bound.py`,
+`scripts/check_support_saturation_obstruction.py`, and
 `scripts/check_localized_rich_support_counting.py`.
 
 ### Altman diagonal-order sums

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,10 @@ put detailed reconciliation in the canonical synthesis.
   proof-facing edge-sensitive support pair-counting lemma for all-centers large
   rich classes, plus an independent nonagon profile-deficiency refinement; not
   an `n=9`, `n=10`, `n=11`, or global proof.
+- [`support-saturation-obstruction.md`](support-saturation-obstruction.md):
+  equality-wall obstruction strengthening all-centers rich-support thresholds
+  to `n >= binom(k,2)+3` for `k >= 4`; not an `n=9`, `n=10`, `n=11`, or
+  global proof.
 - [`localized-rich-support-counting.md`](localized-rich-support-counting.md):
   proof-facing per-label rich-support occurrence cap reducing hypothetical
   4-bad nonagons to all-exact-four support systems by counting alone.

--- a/docs/localized-rich-support-counting.md
+++ b/docs/localized-rich-support-counting.md
@@ -87,11 +87,16 @@ n = 8: at least 8 exact-four centers; exact-four indegree is forced to be 4
 n = 9: at least 9 exact-four centers; exact-four indegree is forced to be 4
 n = 10: at least 5 exact-four centers by the global pair budget
 n = 11: at least 3 exact-four centers by the global pair budget
-n = 12: no exact-four center is forced by these counting bounds alone
+n = 12: no exact-four center is forced by these two budgets alone
 ```
 
 For `n = 5, 6, 7`, the edge-sensitive global pair budget already rules out
 4-bad supports.
+
+The support-saturation obstruction in `docs/support-saturation-obstruction.md`
+adds a separate equality-wall count: all centers having support size at least
+five is impossible for `n <= 12`. Thus a hypothetical 4-bad dodecagon has at
+least one exact-four center once that equality-wall obstruction is also used.
 
 ## Verification command
 

--- a/docs/n9-all-five-rich-support-obstruction.md
+++ b/docs/n9-all-five-rich-support-obstruction.md
@@ -38,6 +38,13 @@ that midpoint as an endpoint. Therefore
 so `n >= 12`. In particular, the `n=9` all-five-rich support subcase is closed
 by this one-line sharpened pair-sharing count.
 
+The support-saturation obstruction in `docs/support-saturation-obstruction.md`
+goes one step further: the equality wall for all-centers support size `5` is
+also impossible, so every vertex having five equidistant witnesses actually
+requires `n >= 13`. This stronger threshold is not needed for the nonagon
+subcase, but it records why the `n=12` all-five-rich equality case is no
+longer a live support-level boundary.
+
 The checked artifact below is still useful as a generator-independent
 support-catalogue regression: it exercises the explicit five-support option
 catalogue, row-pair cap, and two-overlap crossing rule that are reused in the

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -51,7 +51,8 @@ sum_i binom(|R_i|, 2)
 
 ## Consequences
 
-If every center has a same-radius support of size at least `k`, then
+If every center has a same-radius support of size at least `k`, then the
+edge-sensitive pair count gives
 
 ```text
 n * binom(k, 2) <= n(n - 2),
@@ -63,13 +64,13 @@ so
 n >= binom(k, 2) + 2.
 ```
 
-For `k=4`, this gives the support-level wall `n >= 8`.
+For `k=4`, this gives the pair-counting support-level wall `n >= 8`.
 
-In particular, a strict convex polygon in which every vertex has five
-equidistant witnesses must have `n >= 12`. Thus the `n=9`, `n=10`, and `n=11`
-all-five-rich support subcases are already impossible by this pair-sharing
-count, before using cyclic order, crossing, selected-distance quotienting, or
-vertex-circle pruning.
+In particular, this pair-sharing count gives `n >= 12` for a strict convex
+polygon in which every vertex has five equidistant witnesses. The companion
+support-saturation obstruction rules out the equality wall and improves the
+proof-facing threshold to `n >= 13` for the all-five-rich case. See
+`docs/support-saturation-obstruction.md`.
 
 For a hypothetical 4-bad nonagon, choose a maximum rich support at every
 center, so `|R_i| = E(i) >= 4`. The same inequality gives
@@ -163,10 +164,11 @@ The helper script
 python scripts/check_rich_support_counting_bound.py --check --json
 ```
 
-checks the threshold `n >= 12` for all-centers size-five support, the small
-`n=8..12` surplus table used above, and the nonagon profile-deficiency
-refinement. It is only a counting-bound checker; it is not a realization
-search.
+checks the pair-counting threshold `n >= 12` for all-centers size-five support,
+the small `n=8..12` surplus table used above, and the nonagon
+profile-deficiency refinement. The companion saturation checker verifies the
+equality-wall upgrade to `n >= 13`. These are counting-bound checkers; they are
+not realization searches.
 
 ## Boundary
 

--- a/docs/support-saturation-obstruction.md
+++ b/docs/support-saturation-obstruction.md
@@ -1,0 +1,177 @@
+# Support-saturation obstruction
+
+Status: `LEMMA` / proof-facing equality-case obstruction. This note does not
+claim a general proof of Erdos Problem #97 and does not claim a counterexample.
+
+This note strengthens the edge-sensitive rich-support count in
+`docs/rich-support-counting-lemma.md` at its equality wall. The counting lemma
+says that, for one same-radius support `R_i` chosen at each center of a strict
+convex `n`-gon,
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 2).
+```
+
+Consequently, if every center has a same-radius support of size at least `k`,
+then pair-counting alone gives
+
+```text
+n >= binom(k, 2) + 2.
+```
+
+The equality case is impossible for `k >= 4`.
+
+## Saturated equality lemma
+
+Let `V = {v_0,...,v_{n-1}}` be the cyclic vertex set of a strictly convex
+polygon, and choose one same-radius support
+
+```text
+R_i subset V \ {v_i}
+```
+
+at every center `v_i`. Suppose `|R_i| >= k >= 4` for every `i` and
+
+```text
+n = binom(k, 2) + 2.
+```
+
+Then no such support system exists.
+
+Equivalently, for every `k >= 4`, any strict convex polygon whose every vertex
+has `k` equidistant witnesses must satisfy
+
+```text
+n >= binom(k, 2) + 3.
+```
+
+## Proof
+
+At the equality wall,
+
+```text
+n * binom(k, 2) = n(n - 2).
+```
+
+Since each support has size at least `k`, the rich-support counting lemma can
+hold only if every support has size exactly `k` and every witness-pair capacity
+is saturated. Thus:
+
+1. every hull-edge witness pair occurs together in exactly one selected
+   support;
+2. every diagonal witness pair occurs together in exactly two selected
+   supports.
+
+The base-apex lemma from `docs/n8-geometric-proof.md` says that, for a fixed
+base pair `{a,b}`, all centers using both witnesses lie on the perpendicular
+bisector of `ab`, with at most one such center on each side of the line `ab`.
+Therefore a saturated diagonal has one selected-support center on each side.
+
+Consider the length-2 diagonal `{v_i,v_{i+2}}`. One side of this diagonal
+contains only `v_{i+1}`. Since the diagonal pair is saturated, `v_{i+1}` is the
+selected-support center on that short side. Hence
+
+```text
+|v_i v_{i+1}| = |v_{i+1} v_{i+2}|.
+```
+
+This holds for all `i`, so all side lengths are equal. Let the common side
+length be `s`.
+
+Let `tau_j in (0,pi)` be the exterior turn angle at `v_j`. For an equilateral
+strict convex polygon,
+
+```text
+|v_{j-1} v_{j+1}| = 2s cos(tau_j / 2).
+```
+
+Thus `|v_{j-1} v_{j+1}| = s` if and only if
+
+```text
+tau_j = 2*pi/3.
+```
+
+Now consider the length-3 diagonal `{v_i,v_{i+3}}`. Its short side contains
+exactly `v_{i+1}` and `v_{i+2}`. Saturation again gives a selected-support
+center on that short side.
+
+If the short-side center is `v_{i+1}`, then
+
+```text
+|v_i v_{i+1}| = |v_{i+1} v_{i+3}|,
+```
+
+so `|v_{i+1} v_{i+3}| = s`, and therefore `tau_{i+2} = 2*pi/3`.
+
+If the short-side center is `v_{i+2}`, then
+
+```text
+|v_i v_{i+2}| = |v_{i+2} v_{i+3}|,
+```
+
+so `|v_i v_{i+2}| = s`, and therefore `tau_{i+1} = 2*pi/3`.
+
+Hence the set
+
+```text
+M = {j : tau_j = 2*pi/3}
+```
+
+hits every adjacent pair of indices in the `n`-cycle. In other words, `M` is a
+vertex cover of the cycle. Since `n = binom(k,2) + 2 >= 8`, every such cover
+has size at least `4`. Therefore
+
+```text
+sum_j tau_j >= 4 * (2*pi/3) = 8*pi/3 > 2*pi,
+```
+
+contradicting the total exterior turn `sum_j tau_j = 2*pi` of a strict convex
+polygon.
+
+Thus the equality wall is impossible.
+
+## Consequences
+
+The pure support count gives `n >= binom(k,2)+2`; the saturated equality lemma
+raises this to
+
+```text
+n >= binom(k, 2) + 3       for k >= 4.
+```
+
+Concrete small thresholds:
+
+```text
+k = 4:  n >= 9
+k = 5:  n >= 13
+k = 6:  n >= 18
+k = 7:  n >= 24
+```
+
+For `k=4`, this recovers the repository's no-bad-octagon obstruction from a
+support-saturation viewpoint. It does not replace the existing `n <= 8`
+selected-witness and geometric proof notes.
+
+For `k=5`, it upgrades the all-five-rich support subcase: pair-counting alone
+left the equality wall `n=12`, but saturation rules out that dodecagon case.
+Thus every vertex having five equidistant witnesses requires `n >= 13`.
+
+## Verification command
+
+The helper script
+
+```bash
+python scripts/check_support_saturation_obstruction.py --check --json
+```
+
+checks the upgraded thresholds and the cycle vertex-cover turn arithmetic. It
+is only an arithmetic checker for the proof note; it is not a realization
+search.
+
+## Boundary
+
+This lemma is only an equality-wall obstruction. It does not rule out mixed
+exact-four and size-five catalogues, does not prove the review-pending `n=9` or
+`n=10` finite-case artifacts, and does not prove Erdos Problem #97.
+For `n=9`, it leaves the existing exact-four frontier and mixed-rich/frontier
+crosswalk as the relevant proof targets.

--- a/scripts/check_rich_support_counting_bound.py
+++ b/scripts/check_rich_support_counting_bound.py
@@ -54,7 +54,7 @@ def pair_budget(n: int) -> int:
 
 
 def all_centers_min_n(k: int) -> int:
-    """Smallest n not ruled out when every center has support size at least k."""
+    """Smallest n not ruled out by pair counting alone for support size k."""
 
     if k < 0:
         raise ValueError("k must be nonnegative")
@@ -390,7 +390,10 @@ def main() -> int:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:
         print(f"schema: {summary['schema']}")
-        print("all centers with size >=5 requires n >=", all_centers_min_n(5))
+        print(
+            "pair-counting alone: all centers with size >=5 requires n >=",
+            all_centers_min_n(5),
+        )
         n9_refinement = summary["n9_profile_deficiency_refinement"]
         print(
             "n=9 refined support-size profiles:",

--- a/scripts/check_support_saturation_obstruction.py
+++ b/scripts/check_support_saturation_obstruction.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Check the support-saturation equality-wall obstruction.
+
+This standalone checker records the arithmetic consequences of the lemma in
+docs/support-saturation-obstruction.md.  It does not verify Euclidean
+realizability, run a search, or prove Erdos Problem #97.
+
+The proof-facing claim is:
+
+    If every center of a strict convex n-gon has a same-radius support of size
+    at least k >= 4, then n >= binom(k, 2) + 3.
+
+Pair-counting alone gives binom(k,2)+2; the equality wall is ruled out by the
+support-saturation/turn-cover argument.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from math import comb
+from typing import Any
+
+SCHEMA = "erdos97.support_saturation_obstruction.v1"
+TRUST = "LEMMA"
+
+
+def pair_counting_wall(k: int) -> int:
+    """Smallest n not ruled out by pair-counting alone."""
+
+    if k < 0:
+        raise ValueError("k must be nonnegative")
+    return comb(k, 2) + 2
+
+
+def saturation_improved_wall(k: int) -> int:
+    """Smallest n not ruled out after excluding the saturated equality wall."""
+
+    if k < 0:
+        raise ValueError("k must be nonnegative")
+    if k < 4:
+        raise ValueError("the saturation obstruction is used here only for k >= 4")
+    return pair_counting_wall(k) + 1
+
+
+def min_vertex_cover_size_cycle(n: int) -> int:
+    """Minimum vertex-cover size of the n-cycle."""
+
+    if n < 3:
+        raise ValueError("cycle size must be at least 3")
+    return (n + 1) // 2
+
+
+def forced_turn_units_pi_over_3(n: int) -> int:
+    """Lower bound on total forced turn in units of pi/3.
+
+    Every forced exterior turn contributes 2*pi/3, and the forced turn set is a
+    vertex cover of the n-cycle.
+    """
+
+    return 2 * min_vertex_cover_size_cycle(n)
+
+
+def turn_cover_contradiction(n: int) -> bool:
+    """Return whether the turn-cover lower bound exceeds total turn 2*pi."""
+
+    # Total turn 2*pi is 6 units of pi/3.
+    return forced_turn_units_pi_over_3(n) > 6
+
+
+def threshold_row(k: int) -> dict[str, Any]:
+    """Return a checked threshold row for support size k."""
+
+    n0 = pair_counting_wall(k)
+    return {
+        "k": k,
+        "pair_counting_wall_n": n0,
+        "saturation_improved_min_n": saturation_improved_wall(k),
+        "equality_wall_has_n_at_least_8": n0 >= 8,
+        "cycle_vertex_cover_size_at_wall": min_vertex_cover_size_cycle(n0),
+        "forced_turn_lower_bound_units_pi_over_3": forced_turn_units_pi_over_3(n0),
+        "total_turn_units_pi_over_3": 6,
+        "equality_wall_ruled_out_by_turn_cover": turn_cover_contradiction(n0),
+    }
+
+
+def build_summary(min_k: int = 4, max_k: int = 8) -> dict[str, Any]:
+    """Build a stable JSON summary for the saturation obstruction."""
+
+    if min_k < 4:
+        raise ValueError("min_k must be at least 4")
+    if max_k < min_k:
+        raise ValueError("max_k must be at least min_k")
+    return {
+        "schema": SCHEMA,
+        "status": "PROVED_EQUALITY_WALL_OBSTRUCTION",
+        "trust": TRUST,
+        "claim_scope": (
+            "Equality-wall obstruction for the edge-sensitive rich-support "
+            "count. It upgrades all-centers support-size thresholds by one at "
+            "k >= 4, but does not prove n=9, n=10, n=11, or Erdos Problem #97."
+        ),
+        "lemma": (
+            "If every center has a same-radius support of size at least k >= 4, "
+            "then n >= binom(k,2)+3."
+        ),
+        "proof_accounting": {
+            "pair_counting_wall": "n = binom(k,2)+2",
+            "equality_forces": (
+                "all supports have size exactly k and every hull-edge/nonedge "
+                "witness-pair capacity is saturated"
+            ),
+            "length_2_diagonal_step": "short-side apex saturation forces all side lengths equal",
+            "length_3_diagonal_step": (
+                "short-side apex saturation forces exterior turns equal to 2*pi/3 "
+                "to hit every adjacent pair"
+            ),
+            "turn_contradiction": "a cycle vertex cover of forced 2*pi/3 turns exceeds total turn 2*pi",
+        },
+        "threshold_rows": [threshold_row(k) for k in range(min_k, max_k + 1)],
+    }
+
+
+def check_expected(summary: dict[str, Any]) -> None:
+    """Check the default small threshold table."""
+
+    rows = {row["k"]: row for row in summary["threshold_rows"]}
+    expected = {
+        4: (8, 9, 4, 8),
+        5: (12, 13, 6, 12),
+        6: (17, 18, 9, 18),
+        7: (23, 24, 12, 24),
+        8: (30, 31, 15, 30),
+    }
+    for k, (counting_wall, improved, cover_size, turn_units) in expected.items():
+        row = rows[k]
+        got = (
+            row["pair_counting_wall_n"],
+            row["saturation_improved_min_n"],
+            row["cycle_vertex_cover_size_at_wall"],
+            row["forced_turn_lower_bound_units_pi_over_3"],
+        )
+        want = (counting_wall, improved, cover_size, turn_units)
+        if got != want:
+            raise AssertionError(f"k={k}: got {got}, expected {want}")
+        if not row["equality_wall_has_n_at_least_8"]:
+            raise AssertionError(f"k={k}: equality wall should have n >= 8")
+        if not row["equality_wall_ruled_out_by_turn_cover"]:
+            raise AssertionError(f"k={k}: expected turn-cover contradiction")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-k", type=int, default=4)
+    parser.add_argument("--max-k", type=int, default=8)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="assert expected default thresholds",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    summary = build_summary(args.min_k, args.max_k)
+    if args.check:
+        if (args.min_k, args.max_k) != (4, 8):
+            raise SystemExit("--check is only defined for the default k range")
+        check_expected(summary)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"schema: {summary['schema']}")
+        for row in summary["threshold_rows"]:
+            print(
+                f"k={row['k']}: pair-counting wall n="
+                f"{row['pair_counting_wall_n']} is saturated-obstructed; "
+                f"improved minimum n={row['saturation_improved_min_n']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1555,6 +1555,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="support_saturation_obstruction",
+        command=(
+            "python",
+            "scripts/check_support_saturation_obstruction.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Proof-facing equality-wall obstruction for the edge-sensitive "
+            "rich-support count; upgrades all-centers support-size thresholds "
+            "by one for k >= 4, but is not a proof of n=9, not a proof of "
+            "n=10, not a proof of n=11, not a proof of Erdos Problem #97, "
+            "and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="localized_rich_support_counting",
         command=(
             "python",

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -125,6 +125,7 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
     expected_chain = [
         "python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json",
         "python scripts/check_rich_support_counting_bound.py --check --json",
+        "python scripts/check_support_saturation_obstruction.py --check --json",
         "python scripts/check_localized_rich_support_counting.py --check --json",
         (
             "python scripts/check_bootstrap_core_crosswalk.py "

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -257,12 +257,26 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_localized_rich_support_counting.py --check --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_support_saturation_obstruction.py --check --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check "
         "--assert-expected --json"
     ) < ordered_command_texts.index(
         "python scripts/check_bridge_lemma_frontier.py --check "
         "--assert-expected --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_rich_support_counting_bound.py --check --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_support_saturation_obstruction.py --check --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_support_saturation_obstruction.py --check --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_localized_rich_support_counting.py --check --json"
     )
     bootstrap_bridge_commands = (
         "python scripts/check_bootstrap_core_crosswalk.py --check "

--- a/tests/test_support_saturation_obstruction.py
+++ b/tests/test_support_saturation_obstruction.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_support_saturation_obstruction import (  # noqa: E402
+    build_summary,
+    check_expected,
+    forced_turn_units_pi_over_3,
+    min_vertex_cover_size_cycle,
+    pair_counting_wall,
+    saturation_improved_wall,
+    turn_cover_contradiction,
+)
+
+
+def test_support_saturation_expected_summary() -> None:
+    summary = build_summary()
+
+    check_expected(summary)
+    rows = {row["k"]: row for row in summary["threshold_rows"]}
+    assert summary["trust"] == "LEMMA"
+    assert rows[4]["pair_counting_wall_n"] == 8
+    assert rows[4]["saturation_improved_min_n"] == 9
+    assert rows[5]["pair_counting_wall_n"] == 12
+    assert rows[5]["saturation_improved_min_n"] == 13
+    assert rows[7]["cycle_vertex_cover_size_at_wall"] == 12
+    assert rows[7]["forced_turn_lower_bound_units_pi_over_3"] == 24
+
+
+def test_support_saturation_helpers() -> None:
+    assert pair_counting_wall(4) == 8
+    assert pair_counting_wall(5) == 12
+    assert saturation_improved_wall(4) == 9
+    assert saturation_improved_wall(5) == 13
+    assert min_vertex_cover_size_cycle(8) == 4
+    assert min_vertex_cover_size_cycle(9) == 5
+    assert forced_turn_units_pi_over_3(8) == 8
+    assert turn_cover_contradiction(8)
+
+
+def test_support_saturation_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_support_saturation_obstruction.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "erdos97.support_saturation_obstruction.v1"
+    assert payload["status"] == "PROVED_EQUALITY_WALL_OBSTRUCTION"
+    assert payload["threshold_rows"][0]["k"] == 4
+    assert payload["threshold_rows"][1]["saturation_improved_min_n"] == 13


### PR DESCRIPTION
## Summary

Adds a proof-facing support-saturation equality-wall obstruction. The existing edge-sensitive rich-support count gives `n >= binom(k,2)+2` for all-centers support size at least `k`; this note/checker rules out the equality wall for `k >= 4`, improving the threshold to `n >= binom(k,2)+3`.

The main repo-facing consequence is that every vertex having five equidistant witnesses now requires `n >= 13`, closing the all-five-rich dodecagon equality wall. The change updates the rich-support, localized-counting, all-five-rich, claim, state, result, index, bridge target, and artifact-audit surfaces while keeping the scope explicit: this is an equality-wall support lemma only and does not prove `n=9`, `n=10`, `n=11`, Erdos Problem #97, or a counterexample.

## Validation

- `python scripts/check_support_saturation_obstruction.py --check --json`
- `python scripts/check_rich_support_counting_bound.py --check --json`
- `python scripts/check_localized_rich_support_counting.py --check --json`
- `python -m pytest -q tests/test_support_saturation_obstruction.py tests/test_rich_support_counting_bound.py tests/test_localized_rich_support_counting.py`
- `python -m pytest -q tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `$env:PYTHONPYCACHEPREFIX=$env:TEMP; python -m py_compile scripts/check_support_saturation_obstruction.py tests/test_support_saturation_obstruction.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check .`
- `git diff --check`
- `python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json`
- `python -m pytest -q`