### PR TITLE
[codex] Add 81:3 chain closure CSP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_second_supply_chains.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_second_step_chains.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_3_post8_supply_chains.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_singleton_support_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_81_8_full_neighborhood_vertex_circle.py --check --assert-expected --json

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ This repository is a public research log and reproducibility workspace for Erdő
   then
   [`docs/bootstrap-t12-81-3-second-step-chains.md`](docs/bootstrap-t12-81-3-second-step-chains.md)
   and its raw-catalogue companion
-  [`docs/bootstrap-t12-81-3-post8-supply-chains.md`](docs/bootstrap-t12-81-3-post8-supply-chains.md).
+  [`docs/bootstrap-t12-81-3-post8-supply-chains.md`](docs/bootstrap-t12-81-3-post8-supply-chains.md),
+  plus the ordered sequential closure replay in
+  [`docs/bootstrap-t12-81-3-chain-closure-csp.md`](docs/bootstrap-t12-81-3-chain-closure-csp.md).
 - For the source-`81` row-`8` singleton-support audit, where all fixed and
   one-row-drop activation-row survivors keep the original row `8`, read
   [`docs/bootstrap-t12-81-8-singleton-support-audit.md`](docs/bootstrap-t12-81-8-singleton-support-audit.md).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -685,6 +685,16 @@ compatible catalogues, `223` selected-search nodes, and no selected-row
 survivor. See `docs/bootstrap-t12-81-3-post8-supply-chains.md`,
 `scripts/check_bootstrap_t12_81_3_post8_supply_chains.py`, and
 `data/certificates/bootstrap_t12_81_3_post8_supply_chains.json`.
+The ordered chain-closure CSP then tests every eligible sequential activation
+from closure `[0,1,4]`, holding center `3` back and requiring each new support
+to contain at least three currently closed labels. It checks `5916` candidate
+extensions, leaves four non-supply prefix survivors, and finds zero
+center-`6` supply-chain survivors. This closes only the sequential
+support-chain model, not repeated or multiple rich supports and not any
+genuine rich-class/minimality bridge. See
+`docs/bootstrap-t12-81-3-chain-closure-csp.md`,
+`scripts/check_bootstrap_t12_81_3_chain_closure_csp.py`, and
+`data/certificates/bootstrap_t12_81_3_chain_closure_csp.json`.
 
 The source-`81` row-`8` singleton-support audit probes the other
 relation-sufficient source-`81` row. Center `8` has bootstrap-core witnesses

--- a/STATE.md
+++ b/STATE.md
@@ -444,6 +444,14 @@ supply-chain packet records the raw support-catalogue denominator for the same
 bounded model: `3,918,164,268` support catalogues collapse to `58` initially
 compatible catalogues and zero selected-row completions. See
 `docs/bootstrap-t12-81-3-post8-supply-chains.md`.
+An ordered chain-closure CSP then lets any eligible not-yet-closed center in
+`[2,5,6,7,8]` activate as long as its support contains at least three
+currently closed labels, while holding center `3` back. It checks `5916`
+candidate extensions, leaves four non-supply prefixes, and finds no surviving
+prefix whose next activated center is `6`. This closes only the audited
+sequential support-chain model; repeated or multiple rich supports and any
+future minimality/rich-class bridge hypothesis remain outside the model. See
+`docs/bootstrap-t12-81-3-chain-closure-csp.md`.
 
 A source-`81` row-`8` singleton-support audit now probes the other
 relation-sufficient target in source `81`. It enumerates the nine center-`8`

--- a/data/certificates/bootstrap_t12_81_3_chain_closure_csp.json
+++ b/data/certificates/bootstrap_t12_81_3_chain_closure_csp.json
@@ -1,0 +1,649 @@
+{
+  "chain_scan": {
+    "aggregate": {
+      "candidate_extension_count": 5916,
+      "detected_solution_count": 4,
+      "empty_domain_count": 5498,
+      "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 5213,
+      "initial_status:SEARCH_EXHAUSTED": 703,
+      "search_node_count": 9214,
+      "solution_search_status:EXHAUSTED_NO_SOLUTION": 699,
+      "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 5213,
+      "solution_search_status:STOPPED_AFTER_FIRST_SOLUTION": 4
+    },
+    "candidate_extension_depth_histogram": {
+      "1": 4650,
+      "2": 912,
+      "3": 354
+    },
+    "empty_domain_depth_histogram": {
+      "0": 424,
+      "1": 86,
+      "2": 434,
+      "3": 1108,
+      "4": 1700,
+      "5": 1106,
+      "6": 340,
+      "7": 165,
+      "8": 135
+    },
+    "per_activation_center": {
+      "2": {
+        "candidate_extension_count": 1158,
+        "detected_solution_count": 1,
+        "empty_domain_count": 135,
+        "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 1152,
+        "initial_status:SEARCH_EXHAUSTED": 6,
+        "prefix_survivor_count": 1,
+        "search_node_count": 303,
+        "solution_search_status:EXHAUSTED_NO_SOLUTION": 5,
+        "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 1152,
+        "solution_search_status:STOPPED_AFTER_FIRST_SOLUTION": 1
+      },
+      "5": {
+        "candidate_extension_count": 1276,
+        "detected_solution_count": 0,
+        "empty_domain_count": 1147,
+        "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 1121,
+        "initial_status:SEARCH_EXHAUSTED": 155,
+        "search_node_count": 1832,
+        "solution_search_status:EXHAUSTED_NO_SOLUTION": 155,
+        "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 1121
+      },
+      "6": {
+        "candidate_extension_count": 1276,
+        "detected_solution_count": 0,
+        "empty_domain_count": 1280,
+        "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 1043,
+        "initial_status:SEARCH_EXHAUSTED": 233,
+        "search_node_count": 2203,
+        "solution_search_status:EXHAUSTED_NO_SOLUTION": 233,
+        "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 1043
+      },
+      "7": {
+        "candidate_extension_count": 1276,
+        "detected_solution_count": 0,
+        "empty_domain_count": 943,
+        "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 1121,
+        "initial_status:SEARCH_EXHAUSTED": 155,
+        "search_node_count": 1508,
+        "solution_search_status:EXHAUSTED_NO_SOLUTION": 155,
+        "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 1121
+      },
+      "8": {
+        "candidate_extension_count": 930,
+        "detected_solution_count": 3,
+        "empty_domain_count": 1993,
+        "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 776,
+        "initial_status:SEARCH_EXHAUSTED": 154,
+        "prefix_survivor_count": 3,
+        "search_node_count": 3368,
+        "solution_search_status:EXHAUSTED_NO_SOLUTION": 151,
+        "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 776,
+        "solution_search_status:STOPPED_AFTER_FIRST_SOLUTION": 3
+      }
+    },
+    "prefix_survivor_depth_histogram": {
+      "1": 3,
+      "2": 1
+    },
+    "search_state_depth_histogram": {
+      "0": 30,
+      "1": 3,
+      "2": 1
+    }
+  },
+  "claim_scope": "Ordered chain-closure CSP for the 81:3 pre-3 label-6 escape. Starting from deletion seed [0,1,4], with the center-3 connector-avoiding support fixed as in the rich-support CSP, each later auxiliary support must be centered at a not-yet-closed non-seed/non-3 label and must contain at least three currently closed labels. The scan follows every exact incidence/crossing-compatible prefix and finds no surviving prefix whose next activated center is 6. This closes only the sequential support-chain model; it is not a proof of genuine rich-class order, not a proof of row forcing, not a proof of n=9, not a proof of the bridge, and not a counterexample.",
+  "interpretation_warnings": [
+    "This CSP audits a sequential support-chain model, not a full arbitrary rich-class catalogue.",
+    "The target center 3 is held back; the eventual pre-3 supply target is center/label 6.",
+    "A next support is eligible only when it contains at least three currently closed labels.",
+    "The scan uses incidence, crossing, pair-cap, and same-center disjointness filters only, not Euclidean realizability.",
+    "No n=9 finite-case status, bridge status, official status, or counterexample status changes."
+  ],
+  "prefix_survivors": [
+    {
+      "chain": [
+        {
+          "activation_trigger_pool": [
+            0,
+            1,
+            4
+          ],
+          "center": 8,
+          "support": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "support_size": 4
+        }
+      ],
+      "chain_centers": [
+        8
+      ],
+      "chain_length": 1,
+      "connector_index": 0,
+      "connector_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "empty_domain_count": 46,
+      "first_solution_selected_rows": {
+        "0": [
+          [
+            1,
+            2,
+            6,
+            8
+          ]
+        ],
+        "1": [
+          [
+            0,
+            2,
+            5,
+            7
+          ]
+        ],
+        "2": [
+          [
+            1,
+            3,
+            4,
+            8
+          ]
+        ],
+        "3": [
+          [
+            0,
+            2,
+            4,
+            6
+          ]
+        ],
+        "4": [
+          [
+            2,
+            3,
+            5,
+            8
+          ]
+        ],
+        "5": [
+          [
+            1,
+            3,
+            6,
+            7
+          ]
+        ],
+        "6": [
+          [
+            4,
+            5,
+            7,
+            8
+          ]
+        ],
+        "7": [
+          [
+            0,
+            3,
+            5,
+            6
+          ]
+        ],
+        "8": [
+          [
+            0,
+            1,
+            4,
+            7
+          ]
+        ]
+      },
+      "max_depth": 9,
+      "search_node_count": 94,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "chain": [
+        {
+          "activation_trigger_pool": [
+            0,
+            1,
+            4
+          ],
+          "center": 8,
+          "support": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "support_size": 4
+        },
+        {
+          "activation_trigger_pool": [
+            0,
+            1,
+            4,
+            8
+          ],
+          "center": 2,
+          "support": [
+            1,
+            3,
+            4,
+            8
+          ],
+          "support_size": 4
+        }
+      ],
+      "chain_centers": [
+        8,
+        2
+      ],
+      "chain_length": 2,
+      "connector_index": 0,
+      "connector_support": [
+        0,
+        2,
+        4,
+        6
+      ],
+      "empty_domain_count": 16,
+      "first_solution_selected_rows": {
+        "0": [
+          [
+            1,
+            2,
+            6,
+            8
+          ]
+        ],
+        "1": [
+          [
+            0,
+            2,
+            5,
+            7
+          ]
+        ],
+        "2": [
+          [
+            1,
+            3,
+            4,
+            8
+          ]
+        ],
+        "3": [
+          [
+            0,
+            2,
+            4,
+            6
+          ]
+        ],
+        "4": [
+          [
+            2,
+            3,
+            5,
+            8
+          ]
+        ],
+        "5": [
+          [
+            1,
+            3,
+            6,
+            7
+          ]
+        ],
+        "6": [
+          [
+            4,
+            5,
+            7,
+            8
+          ]
+        ],
+        "7": [
+          [
+            0,
+            3,
+            5,
+            6
+          ]
+        ],
+        "8": [
+          [
+            0,
+            1,
+            4,
+            7
+          ]
+        ]
+      },
+      "max_depth": 9,
+      "search_node_count": 38,
+      "target_center_activation_triple": [
+        0,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 1
+    },
+    {
+      "chain": [
+        {
+          "activation_trigger_pool": [
+            0,
+            1,
+            4
+          ],
+          "center": 8,
+          "support": [
+            0,
+            1,
+            4,
+            7
+          ],
+          "support_size": 4
+        }
+      ],
+      "chain_centers": [
+        8
+      ],
+      "chain_length": 1,
+      "connector_index": 15,
+      "connector_support": [
+        1,
+        2,
+        4,
+        6
+      ],
+      "empty_domain_count": 36,
+      "first_solution_selected_rows": {
+        "0": [
+          [
+            1,
+            3,
+            6,
+            8
+          ]
+        ],
+        "1": [
+          [
+            0,
+            2,
+            4,
+            8
+          ]
+        ],
+        "2": [
+          [
+            1,
+            3,
+            5,
+            7
+          ]
+        ],
+        "3": [
+          [
+            1,
+            2,
+            4,
+            6
+          ]
+        ],
+        "4": [
+          [
+            2,
+            3,
+            5,
+            8
+          ]
+        ],
+        "5": [
+          [
+            0,
+            3,
+            6,
+            7
+          ]
+        ],
+        "6": [
+          [
+            4,
+            5,
+            7,
+            8
+          ]
+        ],
+        "7": [
+          [
+            0,
+            2,
+            5,
+            6
+          ]
+        ],
+        "8": [
+          [
+            0,
+            1,
+            4,
+            7
+          ]
+        ]
+      },
+      "max_depth": 9,
+      "search_node_count": 74,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    },
+    {
+      "chain": [
+        {
+          "activation_trigger_pool": [
+            0,
+            1,
+            4
+          ],
+          "center": 8,
+          "support": [
+            0,
+            1,
+            4,
+            5
+          ],
+          "support_size": 4
+        }
+      ],
+      "chain_centers": [
+        8
+      ],
+      "chain_length": 1,
+      "connector_index": 18,
+      "connector_support": [
+        1,
+        4,
+        6,
+        8
+      ],
+      "empty_domain_count": 4,
+      "first_solution_selected_rows": {
+        "0": [
+          [
+            1,
+            2,
+            6,
+            7
+          ]
+        ],
+        "1": [
+          [
+            0,
+            2,
+            5,
+            8
+          ]
+        ],
+        "2": [
+          [
+            0,
+            3,
+            4,
+            7
+          ]
+        ],
+        "3": [
+          [
+            1,
+            4,
+            6,
+            8
+          ]
+        ],
+        "4": [
+          [
+            1,
+            3,
+            5,
+            7
+          ]
+        ],
+        "5": [
+          [
+            0,
+            2,
+            3,
+            6
+          ]
+        ],
+        "6": [
+          [
+            2,
+            4,
+            7,
+            8
+          ]
+        ],
+        "7": [
+          [
+            3,
+            5,
+            6,
+            8
+          ]
+        ],
+        "8": [
+          [
+            0,
+            1,
+            4,
+            5
+          ]
+        ]
+      },
+      "max_depth": 9,
+      "search_node_count": 18,
+      "target_center_activation_triple": [
+        1,
+        4,
+        6
+      ],
+      "target_center_forbidden_connector_endpoint": 0
+    }
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_81_3_chain_closure_csp.py"
+  },
+  "schema": "erdos97.bootstrap_t12_81_3_chain_closure_csp.v1",
+  "source_first_supply_chains": {
+    "path": "data/certificates/bootstrap_t12_81_3_first_supply_chains.json",
+    "scan_status": "PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION",
+    "schema": "erdos97.bootstrap_t12_81_3_first_supply_chains.v1",
+    "status": "BOOTSTRAP_T12_81_3_FIRST_SUPPLY_CHAINS_DIAGNOSTIC_ONLY"
+  },
+  "status": "BOOTSTRAP_T12_81_3_CHAIN_CLOSURE_CSP_DIAGNOSTIC_ONLY",
+  "summary": {
+    "activation_centers": [
+      2,
+      5,
+      6,
+      7,
+      8
+    ],
+    "candidate_extension_count": 5916,
+    "candidate_extension_depth_histogram": {
+      "1": 4650,
+      "2": 912,
+      "3": 354
+    },
+    "connector_pair": [
+      0,
+      1
+    ],
+    "connector_support_count": 30,
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "deletion_seed": [
+      0,
+      1,
+      4
+    ],
+    "detected_solution_count": 4,
+    "empty_domain_count": 5498,
+    "eventual_supply_label": 6,
+    "initial_auxiliary_support_catalogue_incompatible_count": 5213,
+    "initial_auxiliary_support_catalogue_searched_count": 703,
+    "prefix_survivor_count": 4,
+    "prefix_survivor_depth_histogram": {
+      "1": 3,
+      "2": 1
+    },
+    "remaining_gap": "This rules out only the audited sequential support-chain model. It does not prove that genuine rich-class catalogues must expose supports in this order, and it does not prove row forcing, n=9, the bridge, or Erdos Problem #97.",
+    "scan_status": "NO_LABEL_6_SUPPLY_CHAIN_SURVIVORS_IN_SEQUENTIAL_SUPPORT_MODEL",
+    "search_node_count": 9214,
+    "search_state_depth_histogram": {
+      "0": 30,
+      "1": 3,
+      "2": 1
+    },
+    "source_record_ids": [
+      81
+    ],
+    "supply_chain_survivor_count": 0,
+    "target_center": 3,
+    "target_row_key": "81:3"
+  },
+  "supply_chain_survivors": [],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/bootstrap-t12-81-3-chain-closure-csp.md
+++ b/docs/bootstrap-t12-81-3-chain-closure-csp.md
@@ -1,0 +1,65 @@
+# Bootstrap T12 81:3 ordered chain-closure CSP
+
+Status: diagnostic bookkeeping only; not mathematical evidence for a general theorem.
+
+This note follows up `docs/bootstrap-t12-81-3-first-supply-chains.md`.  The
+first-supply packet leaves three first-step prefix survivors, all beginning at
+center `8`, and shows that none admits an immediate center-`6` label-`6` supply
+support.  The ordered chain-closure CSP asks the next finite question: after a
+surviving prefix, can any longer sequence of basic support activations reach
+center `6` before the target center `3`?
+
+## Model
+
+The closure starts with the deletion seed `[0,1,4]`.  The center-`3`
+connector-avoiding support is one of the same supports used by the rich-support
+CSP: it contains `[0,4,6]` while avoiding `1`, or contains `[1,4,6]` while
+avoiding `0`.  Center `3` is then held back as the eventual connector target.
+
+A next auxiliary support may be centered at any not-yet-closed label in
+`[2,5,6,7,8]`; it must contain at least three currently closed labels.  For
+each candidate support catalogue, the checker reuses the same exact row-pair,
+witness-pair, crossing, and same-center disjointness filters as the
+rich-support and first-supply packets.  A prefix is followed only when the
+catalogue still has a complete selected-row assignment under those filters.
+
+Run:
+
+```bash
+python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --assert-expected --json
+```
+
+## Result
+
+The scan checks `5,916` candidate chain extensions:
+
+| depth | candidate extensions |
+|---:|---:|
+| 1 | 4,650 |
+| 2 | 912 |
+| 3 | 354 |
+
+Only four non-supply prefixes survive the basic filters:
+
+| connector support at center 3 | chain centers | chain supports |
+|---|---|---|
+| `[0,2,4,6]` | `[8]` | `[[0,1,4,7]]` |
+| `[0,2,4,6]` | `[8,2]` | `[[0,1,4,7], [1,3,4,8]]` |
+| `[1,2,4,6]` | `[8]` | `[[0,1,4,7]]` |
+| `[1,4,6,8]` | `[8]` | `[[0,1,4,5]]` |
+
+No surviving prefix has next activated center `6`.  In aggregate, the checker
+records `9,214` search nodes, `5,498` empty domains, `5,213` initially
+incompatible catalogues, `703` searched catalogues, four stopped-after-first
+prefix solutions, and zero supply-chain survivors.
+
+## Interpretation
+
+This closes the current longer-chain diagnostic inside the sequential
+support-chain model: the only extra branch beyond the old first-step packet is
+`8 -> 2`, and that branch still cannot reach center `6` under the same filters.
+
+The remaining gap is unchanged in scope.  This does not prove that genuine
+rich-class catalogues must expose supports in this sequential model; it does
+not prove row forcing, `n=9`, the bridge, or Erdos Problem #97; and it is not a
+counterexample.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1050,6 +1050,15 @@ Problem #97. The companion post-`8` supply-chain accounting packet in
 for the same bounded model: `3,918,164,268` support catalogues reduce to `58`
 initially compatible catalogues and zero selected-row completions. It has the
 same diagnostic-only claim boundary.
+The ordered chain-closure CSP in
+`docs/bootstrap-t12-81-3-chain-closure-csp.md` then follows every eligible
+sequential activation from closure `[0,1,4]`, with center `3` held back and
+each new support containing at least three currently closed labels. It checks
+`5916` candidate extensions, leaves four non-supply prefixes, and finds no
+surviving prefix whose next activated center is `6`. This closes only the
+audited sequential support-chain model; it does not prove support existence,
+row forcing, genuine rich-class order, `n=9`, the bootstrap bridge, or Erdos
+Problem #97.
 
 The source-`81` row-`8` singleton-support audit in
 `docs/bootstrap-t12-81-8-singleton-support-audit.md` checks a neighboring

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -365,7 +365,11 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-post8-supply-chains.md` records the raw
    denominator behind the same closure: `3,918,164,268` support catalogues
    reduce to `58` initially compatible catalogues and no selected-row
-   survivor. The next useful PR must therefore either handle repeated/multiple
+   survivor. The ordered chain-closure CSP in
+   `docs/bootstrap-t12-81-3-chain-closure-csp.md` then checks `5916`
+   sequential support-chain extensions from closure `[0,1,4]`; it leaves four
+   non-supply prefixes and no surviving prefix whose next activated center is
+   `6`. The next useful PR must therefore either handle repeated/multiple
    supports, introduce a genuine rich-class/minimality hypothesis that forces
    or excludes such a support, or move to a different bridge target. The
    source-`81` row-`8` singleton-support audit in

--- a/docs/index.md
+++ b/docs/index.md
@@ -298,6 +298,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-post8-supply-chains.md`](bootstrap-t12-81-3-post8-supply-chains.md):
   raw support-catalogue accounting companion for the same post-center-`8`
   chain model.
+- [`bootstrap-t12-81-3-chain-closure-csp.md`](bootstrap-t12-81-3-chain-closure-csp.md):
+  ordered sequential support-chain closure CSP showing that no surviving
+  prefix can activate center `6` under the same basic filters.
 - [`bootstrap-t12-81-8-singleton-support-audit.md`](bootstrap-t12-81-8-singleton-support-audit.md):
   source-`81` row-`8` singleton-support audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -6322,6 +6322,94 @@ artifacts:
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
+
+  - id: bootstrap_t12_81_3_chain_closure_csp
+    path: data/certificates/bootstrap_t12_81_3_chain_closure_csp.json
+    sha256: a9f51dac0824a8aaedc8d040850611cef65c9c8f6ff20183c87070fe598c310e
+    size_bytes: 14027
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_81_3_chain_closure_csp.py
+    command: python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_81_3_chain_closure_csp.py
+    check_command: python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Ordered chain-closure CSP for the 81:3 pre-3 label-6 escape; starting from closure [0,1,4], with center 3 held back, every eligible sequential support-chain activation leaves no surviving prefix whose next activated center is 6, but this is not support existence, not row forcing, not genuine rich-class order, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_81_3_chain_closure_csp.v1
+      status: BOOTSTRAP_T12_81_3_CHAIN_CLOSURE_CSP_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "81:3"
+      summary.source_record_ids:
+        - 81
+      summary.cyclic_order:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.deletion_seed:
+        - 0
+        - 1
+        - 4
+      summary.connector_pair:
+        - 0
+        - 1
+      summary.target_center: 3
+      summary.eventual_supply_label: 6
+      summary.activation_centers:
+        - 2
+        - 5
+        - 6
+        - 7
+        - 8
+      summary.connector_support_count: 30
+      summary.candidate_extension_count: 5916
+      summary.candidate_extension_depth_histogram.1: 4650
+      summary.candidate_extension_depth_histogram.2: 912
+      summary.candidate_extension_depth_histogram.3: 354
+      summary.search_state_depth_histogram.0: 30
+      summary.search_state_depth_histogram.1: 3
+      summary.search_state_depth_histogram.2: 1
+      summary.search_node_count: 9214
+      summary.empty_domain_count: 5498
+      summary.initial_auxiliary_support_catalogue_incompatible_count: 5213
+      summary.initial_auxiliary_support_catalogue_searched_count: 703
+      summary.detected_solution_count: 4
+      summary.prefix_survivor_count: 4
+      summary.prefix_survivor_depth_histogram.1: 3
+      summary.prefix_survivor_depth_histogram.2: 1
+      summary.supply_chain_survivor_count: 0
+      summary.scan_status: NO_LABEL_6_SUPPLY_CHAIN_SURVIVORS_IN_SEQUENTIAL_SUPPORT_MODEL
+      chain_scan.aggregate.detected_solution_count: 4
+      chain_scan.per_activation_center.6.detected_solution_count: 0
+      source_first_supply_chains.schema: erdos97.bootstrap_t12_81_3_first_supply_chains.v1
+      source_first_supply_chains.scan_status: PREFIX_SURVIVORS_FOUND_BUT_NO_IMMEDIATE_LABEL6_SUPPLY_EXTENSION
+      provenance.generator: scripts/check_bootstrap_t12_81_3_chain_closure_csp.py
+      provenance.command: python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - the 81:3 rich support exists
+      - the 81:3 row is forced
+      - the chain-closure CSP proves genuine rich-class order
+      - the chain-closure CSP proves no pre-3 label-6 supply exists
+      - the chain-closure CSP proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_81_8_singleton_support_audit
     path: data/certificates/bootstrap_t12_81_8_singleton_support_audit.json
     sha256: daa724c9c566b321310cce08ade6747122a6a0fab1208504995d0ebdcfe96eec

--- a/scripts/check_bootstrap_t12_81_3_chain_closure_csp.py
+++ b/scripts/check_bootstrap_t12_81_3_chain_closure_csp.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 81:3 ordered chain-closure CSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.bootstrap_t12_81_3_chain_closure_csp import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    assert_expected_payload,
+    build_t12_81_3_chain_closure_csp_payload,
+    load_artifact,
+)
+
+
+def write_artifact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def print_summary(payload: dict[str, object]) -> None:
+    summary = payload["summary"]
+    if not isinstance(summary, dict):
+        raise AssertionError("summary must be a mapping")
+    print("bootstrap / T12 81:3 ordered chain-closure CSP")
+    print(f"candidate extensions: {summary['candidate_extension_count']}")
+    print(f"search nodes: {summary['search_node_count']}")
+    print(f"prefix survivors: {summary['prefix_survivor_count']}")
+    print(f"supply-chain survivors: {summary['supply_chain_survivor_count']}")
+    print(f"scan status: {summary['scan_status']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path to check or write",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare artifact to regenerated payload",
+    )
+    parser.add_argument("--write", action="store_true", help="write regenerated payload")
+    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
+    args = parser.parse_args()
+
+    generated = build_t12_81_3_chain_closure_csp_payload()
+    payload = generated
+    artifact = args.artifact
+    if not artifact.is_absolute():
+        artifact = ROOT / artifact
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{artifact} is stale relative to regenerated packet")
+        payload = stored
+
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.write:
+        write_artifact(artifact, generated)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_summary(payload)
+        if args.check:
+            print("OK: stored bootstrap/T12 81:3 chain-closure artifact matches")
+        if args.assert_expected:
+            print("OK: bootstrap/T12 81:3 chain-closure expectations verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2192,6 +2192,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_81_3_chain_closure_csp",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_81_3_chain_closure_csp.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Ordered chain-closure CSP for the 81:3 pre-3 label-6 escape; "
+            "leaves four non-supply prefixes and no surviving prefix whose "
+            "next activated center is 6, but is not support existence, row "
+            "forcing, genuine rich-class order, an n=9 proof, a bridge proof, "
+            "or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_81_8_singleton_support_audit",
         command=(
             "python",

--- a/src/erdos97/bootstrap_t12_81_3_chain_closure_csp.py
+++ b/src/erdos97/bootstrap_t12_81_3_chain_closure_csp.py
@@ -1,0 +1,468 @@
+"""Ordered chain-closure CSP for the bootstrap/T12 81:3 escape.
+
+The first-supply-chain packet leaves three first-step prefix survivors, all
+starting at center 8, and proves no survivor admits an immediate center-6
+label-6 supply support.  This packet follows those prefix survivors as ordered
+support chains: the closure starts at the deletion seed [0,1,4], every next
+activation support must contain at least three currently closed labels, center 3
+is held back as the connector target, and center 6 is the eventual label-6
+supply target.
+
+The search is exact finite incidence/crossing bookkeeping.  It is not a
+Euclidean realizability theorem and not a proof of the bootstrap bridge.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from erdos97.bootstrap_t12_81_3_escape_candidates import (
+    CONNECTOR_PAIR,
+    CYCLIC_ORDER,
+    SUPPLY_CENTER,
+)
+from erdos97.bootstrap_t12_81_3_escape_rich_support_csp import (
+    _bit_labels,
+    _connector_support_records,
+)
+from erdos97.bootstrap_t12_81_3_escape_two_row_drop import _row_mask
+from erdos97.bootstrap_t12_81_3_first_supply_chains import (
+    DEFAULT_ARTIFACT as FIRST_SUPPLY_ARTIFACT,
+    SCAN_STATUS as FIRST_SUPPLY_SCAN_STATUS,
+    SCHEMA as FIRST_SUPPLY_SCHEMA,
+    STATUS as FIRST_SUPPLY_STATUS,
+    _search_auxiliary_support_catalogue,
+)
+from erdos97.bootstrap_t12_81_3_order_escape import (
+    TARGET_DELETION_SEED,
+    TARGET_ROW_CENTER,
+    TARGET_ROW_KEY,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_81_3_chain_closure_csp.v1"
+STATUS = "BOOTSTRAP_T12_81_3_CHAIN_CLOSURE_CSP_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "NO_LABEL_6_SUPPLY_CHAIN_SURVIVORS_IN_SEQUENTIAL_SUPPORT_MODEL"
+CLAIM_SCOPE = (
+    "Ordered chain-closure CSP for the 81:3 pre-3 label-6 escape. Starting "
+    "from deletion seed [0,1,4], with the center-3 connector-avoiding support "
+    "fixed as in the rich-support CSP, each later auxiliary support must be "
+    "centered at a not-yet-closed non-seed/non-3 label and must contain at "
+    "least three currently closed labels. The scan follows every exact "
+    "incidence/crossing-compatible prefix and finds no surviving prefix whose "
+    "next activated center is 6. This closes only the sequential support-chain "
+    "model; it is not a proof of genuine rich-class order, not a proof of row "
+    "forcing, not a proof of n=9, not a proof of the bridge, and not a "
+    "counterexample."
+)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = (
+    REPO_ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_81_3_chain_closure_csp.json"
+)
+ACTIVATION_CENTERS = [
+    label
+    for label in CYCLIC_ORDER
+    if label not in set(TARGET_DELETION_SEED) | {TARGET_ROW_CENTER}
+]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _activation_support_masks(center: int, closure: Iterable[int]) -> list[int]:
+    """Return rich-support masks at ``center`` using at least 3 closed labels."""
+
+    closure_set = set(closure)
+    universe = [label for label in CYCLIC_ORDER if label != center]
+    support_masks: list[int] = []
+    for mask in range(1 << len(universe)):
+        support = [label for bit, label in enumerate(universe) if mask & (1 << bit)]
+        if len(support) < 4:
+            continue
+        if len(closure_set & set(support)) < 3:
+            continue
+        support_masks.append(_row_mask(support))
+    return sorted(support_masks, key=lambda value: (value.bit_count(), _bit_labels(value)))
+
+
+def _compact_chain(
+    chain: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    compact: list[dict[str, object]] = []
+    for step in chain:
+        compact.append(
+            {
+                "center": int(step["center"]),
+                "support": list(step["support"]),
+                "support_size": int(step["support_size"]),
+                "activation_trigger_pool": list(step["activation_trigger_pool"]),
+            }
+        )
+    return compact
+
+
+def _chain_centers(chain: Sequence[Mapping[str, object]]) -> list[int]:
+    return [int(step["center"]) for step in chain]
+
+
+def _scan_chains() -> dict[str, object]:
+    connector_records = _connector_support_records()
+    aggregate = Counter()
+    candidate_depths: Counter[str] = Counter()
+    search_state_depths: Counter[str] = Counter()
+    empty_depths: Counter[str] = Counter()
+    per_activation_center: dict[int, Counter[str]] = defaultdict(Counter)
+    prefix_survivors: list[dict[str, object]] = []
+    supply_chain_survivors: list[dict[str, object]] = []
+
+    def record_stats(center: int, depth: int, stats: Mapping[str, object]) -> None:
+        aggregate["candidate_extension_count"] += 1
+        candidate_depths[str(depth)] += 1
+        aggregate["search_node_count"] += int(stats["search_node_count"])
+        aggregate["empty_domain_count"] += int(stats["empty_domain_count"])
+        aggregate["detected_solution_count"] += int(stats["detected_solution_count"])
+        aggregate[f"initial_status:{stats['initial_status']}"] += 1
+        aggregate[f"solution_search_status:{stats['solution_search_status']}"] += 1
+
+        center_counter = per_activation_center[center]
+        center_counter["candidate_extension_count"] += 1
+        center_counter["search_node_count"] += int(stats["search_node_count"])
+        center_counter["empty_domain_count"] += int(stats["empty_domain_count"])
+        center_counter["detected_solution_count"] += int(stats["detected_solution_count"])
+        center_counter[f"initial_status:{stats['initial_status']}"] += 1
+        center_counter[f"solution_search_status:{stats['solution_search_status']}"] += 1
+
+        for empty_depth, count in dict(stats["empty_domain_depth_histogram"]).items():
+            empty_depths[str(empty_depth)] += int(count)
+
+    def dfs(
+        connector_index: int,
+        connector_record: Mapping[str, object],
+        auxiliary_supports: Mapping[int, int],
+        closure: frozenset[int],
+        chain: Sequence[Mapping[str, object]],
+    ) -> None:
+        search_state_depths[str(len(chain))] += 1
+        for center in ACTIVATION_CENTERS:
+            if center in closure:
+                continue
+            for support_mask in _activation_support_masks(center, closure):
+                depth = len(chain) + 1
+                next_supports = dict(auxiliary_supports)
+                next_supports[center] = support_mask
+                stats = _search_auxiliary_support_catalogue(
+                    next_supports,
+                    incompatible_status=(
+                        "INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE"
+                    ),
+                )
+                record_stats(center, depth, stats)
+                if not int(stats["detected_solution_count"]):
+                    continue
+
+                step = {
+                    "center": center,
+                    "support": _bit_labels(support_mask),
+                    "support_mask": support_mask,
+                    "support_size": support_mask.bit_count(),
+                    "activation_trigger_pool": sorted(closure),
+                }
+                next_chain = [*chain, step]
+                record = {
+                    "connector_index": connector_index,
+                    "connector_support": connector_record["support"],
+                    "target_center_activation_triple": connector_record[
+                        "activation_triple"
+                    ],
+                    "target_center_forbidden_connector_endpoint": connector_record[
+                        "forbidden_connector_endpoint"
+                    ],
+                    "chain_length": len(next_chain),
+                    "chain_centers": _chain_centers(next_chain),
+                    "chain": _compact_chain(next_chain),
+                    "search_node_count": stats["search_node_count"],
+                    "empty_domain_count": stats["empty_domain_count"],
+                    "max_depth": stats["max_depth"],
+                    "first_solution_selected_rows": stats[
+                        "first_solution_selected_rows"
+                    ],
+                }
+                if center == SUPPLY_CENTER:
+                    supply_chain_survivors.append(record)
+                    per_activation_center[center]["supply_chain_survivor_count"] += 1
+                    continue
+
+                prefix_survivors.append(record)
+                per_activation_center[center]["prefix_survivor_count"] += 1
+                dfs(
+                    connector_index,
+                    connector_record,
+                    next_supports,
+                    frozenset({*closure, center}),
+                    next_chain,
+                )
+
+    for connector_index, connector_record in enumerate(connector_records):
+        connector_support = int(connector_record["support_mask"])
+        dfs(
+            connector_index,
+            connector_record,
+            {TARGET_ROW_CENTER: connector_support},
+            frozenset(TARGET_DELETION_SEED),
+            [],
+        )
+
+    prefix_depths = Counter(str(record["chain_length"]) for record in prefix_survivors)
+    return {
+        "aggregate": dict(sorted(aggregate.items())),
+        "candidate_extension_depth_histogram": dict(sorted(candidate_depths.items())),
+        "search_state_depth_histogram": dict(sorted(search_state_depths.items())),
+        "empty_domain_depth_histogram": dict(sorted(empty_depths.items())),
+        "per_activation_center": {
+            str(center): dict(sorted(counter.items()))
+            for center, counter in sorted(per_activation_center.items())
+        },
+        "prefix_survivor_depth_histogram": dict(sorted(prefix_depths.items())),
+        "prefix_survivors": prefix_survivors,
+        "supply_chain_survivors": supply_chain_survivors,
+    }
+
+
+def build_t12_81_3_chain_closure_csp_payload() -> dict[str, object]:
+    """Return the deterministic ordered chain-closure CSP packet."""
+
+    chain_scan = _scan_chains()
+    aggregate = chain_scan["aggregate"]
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("aggregate must be a mapping")
+    prefix_survivors = chain_scan["prefix_survivors"]
+    supply_survivors = chain_scan["supply_chain_survivors"]
+    if not isinstance(prefix_survivors, Sequence):
+        raise AssertionError("prefix_survivors must be a sequence")
+    if not isinstance(supply_survivors, Sequence):
+        raise AssertionError("supply_chain_survivors must be a sequence")
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "interpretation_warnings": [
+            "This CSP audits a sequential support-chain model, not a full arbitrary rich-class catalogue.",
+            "The target center 3 is held back; the eventual pre-3 supply target is center/label 6.",
+            "A next support is eligible only when it contains at least three currently closed labels.",
+            (
+                "The scan uses incidence, crossing, pair-cap, and same-center "
+                "disjointness filters only, not Euclidean realizability."
+            ),
+            "No n=9 finite-case status, bridge status, official status, or counterexample status changes.",
+        ],
+        "summary": {
+            "target_row_key": TARGET_ROW_KEY,
+            "source_record_ids": [81],
+            "cyclic_order": CYCLIC_ORDER,
+            "deletion_seed": TARGET_DELETION_SEED,
+            "connector_pair": CONNECTOR_PAIR,
+            "target_center": TARGET_ROW_CENTER,
+            "eventual_supply_label": SUPPLY_CENTER,
+            "activation_centers": ACTIVATION_CENTERS,
+            "connector_support_count": len(_connector_support_records()),
+            "candidate_extension_count": aggregate["candidate_extension_count"],
+            "candidate_extension_depth_histogram": chain_scan[
+                "candidate_extension_depth_histogram"
+            ],
+            "search_state_depth_histogram": chain_scan[
+                "search_state_depth_histogram"
+            ],
+            "search_node_count": aggregate["search_node_count"],
+            "empty_domain_count": aggregate["empty_domain_count"],
+            "initial_auxiliary_support_catalogue_incompatible_count": aggregate[
+                "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE"
+            ],
+            "initial_auxiliary_support_catalogue_searched_count": aggregate[
+                "initial_status:SEARCH_EXHAUSTED"
+            ],
+            "detected_solution_count": aggregate["detected_solution_count"],
+            "prefix_survivor_count": len(prefix_survivors),
+            "prefix_survivor_depth_histogram": chain_scan[
+                "prefix_survivor_depth_histogram"
+            ],
+            "supply_chain_survivor_count": len(supply_survivors),
+            "scan_status": SCAN_STATUS,
+            "remaining_gap": (
+                "This rules out only the audited sequential support-chain "
+                "model. It does not prove that genuine rich-class catalogues "
+                "must expose supports in this order, and it does not prove row "
+                "forcing, n=9, the bridge, or Erdos Problem #97."
+            ),
+        },
+        "chain_scan": {
+            "aggregate": chain_scan["aggregate"],
+            "candidate_extension_depth_histogram": chain_scan[
+                "candidate_extension_depth_histogram"
+            ],
+            "search_state_depth_histogram": chain_scan[
+                "search_state_depth_histogram"
+            ],
+            "empty_domain_depth_histogram": chain_scan[
+                "empty_domain_depth_histogram"
+            ],
+            "per_activation_center": chain_scan["per_activation_center"],
+            "prefix_survivor_depth_histogram": chain_scan[
+                "prefix_survivor_depth_histogram"
+            ],
+        },
+        "prefix_survivors": prefix_survivors,
+        "supply_chain_survivors": supply_survivors,
+        "source_first_supply_chains": {
+            "path": FIRST_SUPPLY_ARTIFACT.relative_to(REPO_ROOT).as_posix(),
+            "schema": FIRST_SUPPLY_SCHEMA,
+            "status": FIRST_SUPPLY_STATUS,
+            "scan_status": FIRST_SUPPLY_SCAN_STATUS,
+        },
+        "provenance": {
+            "generator": "scripts/check_bootstrap_t12_81_3_chain_closure_csp.py",
+            "command": (
+                "python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py "
+                "--write --assert-expected"
+            ),
+        },
+    }
+    assert_expected_payload(payload)
+    return payload
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    return _load_json(path)
+
+
+def assert_expected_payload(payload: Mapping[str, Any]) -> None:
+    expected_top = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+    }
+    for key, expected in expected_top.items():
+        if payload.get(key) != expected:
+            raise AssertionError(f"{key} mismatch: expected {expected!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be a mapping")
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [81],
+        "cyclic_order": CYCLIC_ORDER,
+        "deletion_seed": TARGET_DELETION_SEED,
+        "connector_pair": CONNECTOR_PAIR,
+        "target_center": TARGET_ROW_CENTER,
+        "eventual_supply_label": SUPPLY_CENTER,
+        "activation_centers": ACTIVATION_CENTERS,
+        "connector_support_count": 30,
+        "candidate_extension_count": 5916,
+        "candidate_extension_depth_histogram": {"1": 4650, "2": 912, "3": 354},
+        "search_state_depth_histogram": {"0": 30, "1": 3, "2": 1},
+        "search_node_count": 9214,
+        "empty_domain_count": 5498,
+        "initial_auxiliary_support_catalogue_incompatible_count": 5213,
+        "initial_auxiliary_support_catalogue_searched_count": 703,
+        "detected_solution_count": 4,
+        "prefix_survivor_count": 4,
+        "prefix_survivor_depth_histogram": {"1": 3, "2": 1},
+        "supply_chain_survivor_count": 0,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary {key} is {summary.get(key)!r}, expected {expected!r}"
+            )
+
+    chain_scan = payload.get("chain_scan")
+    if not isinstance(chain_scan, Mapping):
+        raise AssertionError("chain_scan must be a mapping")
+    aggregate = chain_scan.get("aggregate")
+    if not isinstance(aggregate, Mapping):
+        raise AssertionError("chain_scan aggregate must be a mapping")
+    expected_aggregate = {
+        "candidate_extension_count": 5916,
+        "search_node_count": 9214,
+        "empty_domain_count": 5498,
+        "detected_solution_count": 4,
+        "initial_status:INITIAL_AUXILIARY_SUPPORT_CATALOGUE_INCOMPATIBLE": 5213,
+        "initial_status:SEARCH_EXHAUSTED": 703,
+        "solution_search_status:EXHAUSTED_NO_SOLUTION": 699,
+        "solution_search_status:NOT_SEARCHED_INITIAL_PAIR_INCOMPATIBLE": 5213,
+        "solution_search_status:STOPPED_AFTER_FIRST_SOLUTION": 4,
+    }
+    for key, expected in expected_aggregate.items():
+        if aggregate.get(key) != expected:
+            raise AssertionError(
+                f"aggregate {key} is {aggregate.get(key)!r}, expected {expected!r}"
+            )
+
+    prefix_survivors = payload.get("prefix_survivors")
+    if not isinstance(prefix_survivors, Sequence) or len(prefix_survivors) != 4:
+        raise AssertionError("expected four prefix survivor records")
+    compact = [
+        {
+            "connector_support": record.get("connector_support"),
+            "chain": [
+                [step.get("center"), step.get("support")]
+                for step in record.get("chain", [])
+            ],
+        }
+        for record in prefix_survivors
+        if isinstance(record, Mapping)
+    ]
+    expected_compact = [
+        {
+            "connector_support": [0, 2, 4, 6],
+            "chain": [[8, [0, 1, 4, 7]]],
+        },
+        {
+            "connector_support": [0, 2, 4, 6],
+            "chain": [[8, [0, 1, 4, 7]], [2, [1, 3, 4, 8]]],
+        },
+        {
+            "connector_support": [1, 2, 4, 6],
+            "chain": [[8, [0, 1, 4, 7]]],
+        },
+        {
+            "connector_support": [1, 4, 6, 8],
+            "chain": [[8, [0, 1, 4, 5]]],
+        },
+    ]
+    if compact != expected_compact:
+        raise AssertionError(f"prefix survivor compact records drifted: {compact!r}")
+
+    if payload.get("supply_chain_survivors") != []:
+        raise AssertionError("supply chain survivors must be empty")
+
+    source = payload.get("source_first_supply_chains")
+    if not isinstance(source, Mapping):
+        raise AssertionError("source_first_supply_chains must be a mapping")
+    if source.get("schema") != FIRST_SUPPLY_SCHEMA:
+        raise AssertionError("source first-supply schema drifted")
+    if source.get("scan_status") != FIRST_SUPPLY_SCAN_STATUS:
+        raise AssertionError("source first-supply scan status drifted")
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise AssertionError("provenance must be a mapping")
+    if provenance.get("generator") != (
+        "scripts/check_bootstrap_t12_81_3_chain_closure_csp.py"
+    ):
+        raise AssertionError("provenance generator drifted")

--- a/tests/test_bootstrap_t12_81_3_chain_closure_csp.py
+++ b/tests/test_bootstrap_t12_81_3_chain_closure_csp.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from erdos97.bootstrap_t12_81_3_chain_closure_csp import (
+    DEFAULT_ARTIFACT,
+    SCAN_STATUS,
+    assert_expected_payload,
+    build_t12_81_3_chain_closure_csp_payload,
+)
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return build_t12_81_3_chain_closure_csp_payload()
+
+
+def test_bootstrap_t12_81_3_chain_closure_expected_payload(
+    payload: dict[str, object],
+) -> None:
+    assert_expected_payload(payload)
+    assert payload["status"] == "BOOTSTRAP_T12_81_3_CHAIN_CLOSURE_CSP_DIAGNOSTIC_ONLY"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    assert "sequential support-chain model" in claim_scope
+    assert "not a proof of n=9" in claim_scope
+    assert "not a counterexample" in claim_scope
+
+    summary = payload["summary"]
+    assert summary["scan_status"] == SCAN_STATUS
+    assert summary["prefix_survivor_count"] == 4
+    assert summary["supply_chain_survivor_count"] == 0
+
+
+def test_bootstrap_t12_81_3_chain_closure_survivor_shapes(
+    payload: dict[str, object],
+) -> None:
+    survivors = payload["prefix_survivors"]
+    assert [record["chain_centers"] for record in survivors] == [
+        [8],
+        [8, 2],
+        [8],
+        [8],
+    ]
+    assert payload["supply_chain_survivors"] == []
+
+
+def test_bootstrap_t12_81_3_chain_closure_artifact_matches_generator(
+    payload: dict[str, object],
+) -> None:
+    checked_in = json.loads(DEFAULT_ARTIFACT.read_text(encoding="utf-8"))
+    assert checked_in == payload
+
+
+def test_bootstrap_t12_81_3_chain_closure_expected_payload_rejects_drift(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["summary"]["supply_chain_survivor_count"] = 1
+
+    with pytest.raises(AssertionError, match="supply_chain_survivor_count"):
+        assert_expected_payload(bad)

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -232,6 +232,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -331,6 +331,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_81_3_post8_supply_chains.py "
         "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py "
+        "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_81_8_singleton_support_audit.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check "


### PR DESCRIPTION
## Summary

- add an ordered chain-closure CSP for the bootstrap/T12 `81:3` pre-`3` label-`6` escape
- store the generated certificate and provenance metadata for the `5916` candidate-extension scan
- wire the checker into `verify-bridge-frontier`, artifact audit metadata, navigation, and source-of-truth ledgers

## Scope

This is diagnostic proof-mining only. It closes the audited sequential support-chain model and does not claim support existence, row forcing, `n=9`, the bootstrap bridge, a general proof, or a counterexample.

## Validation

- `python scripts/check_bootstrap_t12_81_3_chain_closure_csp.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_81_3_chain_closure_csp.py tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1168 passed, 440 deselected`)

Local `make verify-bridge-frontier` could not be run because `make` is not installed in this Windows shell; the new checker and its Makefile/audit wiring were run directly.