### PR TITLE
[codex] Add n12 rich-support determinant obstruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
 	$(PYTHON) scripts/check_rich_support_counting_bound.py --check --json
 	$(PYTHON) scripts/check_support_saturation_obstruction.py --check --json
+	$(PYTHON) scripts/check_n12_rich_support_determinant.py --check --json
 	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -66,6 +66,13 @@ selected-indegree-four support case by counting alone. See
 `docs/rich-support-counting-lemma.md`,
 `docs/support-saturation-obstruction.md`, and
 `docs/localized-rich-support-counting.md`.
+The all-five-rich `n=12` equality wall also has an independent determinant
+obstruction: saturation would force a `12 x 12` column Gram matrix with first
+row `[5,1,2,2,2,2,2,2,2,2,2,1]` and determinant
+`2,592,000 = 720^2 * 5`, which is not a square. This rechecks the same boundary
+already closed by support saturation; it is not a proof of the full `n=12`
+case. See `docs/n12-rich-support-determinant-obstruction.md` and
+`scripts/check_n12_rich_support_determinant.py`.
 
 ### Lemma: crossing-bisector and sharpened count
 

--- a/STATE.md
+++ b/STATE.md
@@ -260,8 +260,13 @@ support-pair cap gives a second route to the same sharpened nonagon conclusion:
 any hypothetical 4-bad nonagon is forced into the all-exact-four,
 selected-indegree-four support case by counting alone. This does not prove the
 review-pending exact-four frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97.
-See `docs/rich-support-counting-lemma.md`,
-`docs/support-saturation-obstruction.md`, and
+An independent determinant obstruction now rechecks the all-five-rich `n=12`
+equality wall: the saturated `12 x 12` support-incidence Gram matrix would have
+determinant `2,592,000 = 720^2 * 5`, not a square, contradicting
+`det(A^T A) = det(A)^2`. This is redundant with support saturation and does
+not prove the full dodecagon case. See `docs/rich-support-counting-lemma.md`,
+`docs/support-saturation-obstruction.md`,
+`docs/n12-rich-support-determinant-obstruction.md`, and
 `docs/localized-rich-support-counting.md`.
 
 The follow-up mixed rich-support reduction enumerates every four- or

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -136,6 +136,15 @@ do not prove the review-pending exact-four vertex-circle checker, `n=9`,
 `scripts/check_support_saturation_obstruction.py`, and
 `scripts/check_localized_rich_support_counting.py`.
 
+The all-five-rich `n=12` equality wall also has an independent determinant
+obstruction in `docs/n12-rich-support-determinant-obstruction.md`: saturated
+pair capacities force a `12 x 12` incidence Gram matrix with nonsquare
+determinant `2,592,000 = 720^2 * 5`, contradicting
+`det(A^T A) = det(A)^2`. This is a support-level cross-check of the equality
+wall already closed by support saturation. It does not prove the full `n=12`
+case, any mixed exact-four/size-five catalogue, or Erdos Problem #97. Check it
+with `scripts/check_n12_rich_support_determinant.py`.
+
 ### Altman diagonal-order sums
 
 For a strict convex `n`-gon in cyclic order, the sums `U_k` of chord lengths of

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,9 @@ put detailed reconciliation in the canonical synthesis.
   equality-wall obstruction strengthening all-centers rich-support thresholds
   to `n >= binom(k,2)+3` for `k >= 4`; not an `n=9`, `n=10`, `n=11`, or
   global proof.
+- [`n12-rich-support-determinant-obstruction.md`](n12-rich-support-determinant-obstruction.md):
+  independent determinant obstruction for the all-five-rich `n=12`
+  support-count equality wall; not a proof of the full `n=12` case.
 - [`localized-rich-support-counting.md`](localized-rich-support-counting.md):
   proof-facing per-label rich-support occurrence cap reducing hypothetical
   4-bad nonagons to all-exact-four support systems by counting alone.

--- a/docs/n12-rich-support-determinant-obstruction.md
+++ b/docs/n12-rich-support-determinant-obstruction.md
@@ -1,0 +1,115 @@
+# n=12 all-five-rich determinant obstruction
+
+Status: `LEMMA` / exact support-level obstruction. This note does not claim a
+general proof of Erdos Problem #97, does not prove the full `n=12` case, and
+does not claim a counterexample.
+
+The support-saturation obstruction in
+`docs/support-saturation-obstruction.md` already rules out the all-five-rich
+`n=12` equality wall. This note records an independent determinant obstruction
+for the same support-level boundary; it is useful as a separate algebraic
+certificate, not as a stronger global status claim.
+
+## Setup
+
+Let `V` be the vertex set of a strictly convex 12-gon in cyclic hull order. For
+each center `i`, suppose there is a same-radius support of size at least five.
+Choose one five-element subset
+
+```text
+R_i subset V \ {i}
+```
+
+from such a support at every center.
+
+The rich-support counting lemma gives
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 2).
+```
+
+For `n = 12` and `|R_i| = 5`, this is tight:
+
+```text
+12 * binom(5, 2) = 120 = 12 * (12 - 2).
+```
+
+Because the proof of the counting lemma is a pointwise capacity count over
+witness pairs, equality forces every capacity to be saturated:
+
+- every hull-edge witness pair occurs in exactly one chosen support;
+- every non-edge witness pair occurs in exactly two chosen supports.
+
+## Determinant obstruction
+
+Let `A` be the `12 x 12` incidence matrix with
+
+```text
+A[i,j] = 1  iff  j in R_i.
+```
+
+The diagonal of `A` is zero and every row has sum `5`. By the saturated pair
+count above, the off-diagonal entries of the column Gram matrix `A^T A` are
+forced:
+
+```text
+(A^T A)[a,b] = 1  if {a,b} is a hull edge,
+(A^T A)[a,b] = 2  otherwise.
+```
+
+The diagonal entries are also forced. Fix a column `a`. The total saturated
+capacity of witness pairs containing `a` is
+
+```text
+2 * 1 + 9 * 2 = 20.
+```
+
+Every occurrence of `a` in a chosen five-support contributes four such pairs,
+so column `a` occurs `20 / 4 = 5` times. Thus `A^T A = G`, where `G` has
+first row
+
+```text
+[5, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1].
+```
+
+An exact determinant calculation gives
+
+```text
+det(G) = 2,592,000 = 2^8 * 3^4 * 5^3 = 720^2 * 5.
+```
+
+This is not a perfect square. But if an integer incidence matrix `A` existed,
+then
+
+```text
+det(G) = det(A^T A) = det(A)^2,
+```
+
+which must be a perfect square integer. Contradiction.
+
+## Consequence
+
+There is no strictly convex 12-gon in which every vertex has five equidistant
+witnesses.
+
+Equivalently, any hypothetical 4-bad convex 12-gon must have at least one
+exact-four center. This independently closes the first size-five equality wall
+left by the edge-sensitive pair count alone: that count allowed the
+all-five-rich `n=12` case by equality, but the saturated incidence matrix has
+nonsquare determinant. The conclusion is redundant with the support-saturation
+obstruction, which rules out the same equality wall by geometric turn-cover
+bookkeeping.
+
+This is only a support-level obstruction. It does not handle mixed exact-four /
+size-five catalogues, prove `n=12`, prove `n=9`, `n=10`, or `n=11`, or prove
+Erdos Problem #97.
+
+## Verification command
+
+```bash
+python scripts/check_n12_rich_support_determinant.py --check --json
+```
+
+The checker uses exact integer arithmetic and verifies the equality budget,
+forced column sums, forced Gram first row, determinant factorization, and
+nonsquare determinant obstruction.

--- a/docs/rich-support-counting-lemma.md
+++ b/docs/rich-support-counting-lemma.md
@@ -71,6 +71,11 @@ polygon in which every vertex has five equidistant witnesses. The companion
 support-saturation obstruction rules out the equality wall and improves the
 proof-facing threshold to `n >= 13` for the all-five-rich case. See
 `docs/support-saturation-obstruction.md`.
+The `n=12` equality wall also has an independent support-incidence determinant
+obstruction: if the edge-sensitive pair capacities were saturated, the forced
+column Gram matrix of the `12 x 12` incidence matrix would have determinant
+`2,592,000 = 720^2 * 5`, not a square. See
+`docs/n12-rich-support-determinant-obstruction.md`.
 
 For a hypothetical 4-bad nonagon, choose a maximum rich support at every
 center, so `|R_i| = E(i) >= 4`. The same inequality gives

--- a/scripts/check_n12_rich_support_determinant.py
+++ b/scripts/check_n12_rich_support_determinant.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Check the n=12 tight all-five-rich determinant obstruction.
+
+This standalone checker verifies a small exact obstruction at the first
+size-five equality wall of the edge-sensitive rich-support count. The current
+support-saturation lemma already rules out this wall; this checker records an
+independent determinant obstruction for the same n=12 all-five-rich subcase.
+
+If a strict convex 12-gon had a same-radius support of size at least five at
+every center, choose five witnesses at each center.  The existing pair-sharing
+count is then tight:
+
+    12 * binom(5, 2) = 12 * (12 - 2).
+
+Tightness forces every hull-edge witness pair to occur in exactly one chosen
+support and every non-edge witness pair to occur in exactly two chosen supports.
+The 12 by 12 center/witness incidence matrix A would therefore satisfy
+A^T A = G, where G has diagonal 5, adjacent off-diagonal entries 1, and all
+other off-diagonal entries 2.  But det(G) = 2,592,000 = 720^2 * 5 is not a
+square, contradicting det(A^T A) = det(A)^2 for an integer matrix A.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from math import comb, isqrt
+from typing import Any
+
+SCHEMA = "erdos97.n12_rich_support_determinant.v1"
+STATUS = "PROVED_N12_ALL_FIVE_RICH_DETERMINANT_OBSTRUCTION"
+TRUST = "LEMMA"
+
+
+def cycle_adjacent(a: int, b: int, n: int) -> bool:
+    """Return whether vertices a and b are adjacent in cyclic order C_n."""
+
+    if not 0 <= a < n or not 0 <= b < n:
+        raise ValueError("vertices must lie in range(n)")
+    return (a - b) % n in {1, n - 1}
+
+
+def pair_capacity(a: int, b: int, n: int) -> int:
+    """Capacity of a witness pair in the rich-support counting lemma."""
+
+    if a == b:
+        raise ValueError("pair endpoints must be distinct")
+    return 1 if cycle_adjacent(a, b, n) else 2
+
+
+def tight_size_five_gram(n: int = 12) -> list[list[int]]:
+    """Return the forced column Gram matrix for the tight all-five n=12 case."""
+
+    if n != 12:
+        raise ValueError("this checker is intentionally scoped to n=12")
+    gram = [[0 for _ in range(n)] for _ in range(n)]
+    for a in range(n):
+        for b in range(n):
+            if a == b:
+                gram[a][b] = 5
+            else:
+                gram[a][b] = pair_capacity(a, b, n)
+    return gram
+
+
+def bareiss_det(matrix: list[list[int]]) -> int:
+    """Compute an exact integer determinant with the Bareiss algorithm."""
+
+    n = len(matrix)
+    if any(len(row) != n for row in matrix):
+        raise ValueError("matrix must be square")
+    a = [row[:] for row in matrix]
+    sign = 1
+    prev = 1
+    for k in range(n - 1):
+        pivot = a[k][k]
+        if pivot == 0:
+            swap = next((r for r in range(k + 1, n) if a[r][k] != 0), None)
+            if swap is None:
+                return 0
+            a[k], a[swap] = a[swap], a[k]
+            sign *= -1
+            pivot = a[k][k]
+        for i in range(k + 1, n):
+            for j in range(k + 1, n):
+                a[i][j] = (a[i][j] * pivot - a[i][k] * a[k][j]) // prev
+        prev = pivot
+        for i in range(k + 1, n):
+            a[i][k] = 0
+        for j in range(k + 1, n):
+            a[k][j] = 0
+    return sign * a[n - 1][n - 1]
+
+
+def factorint(value: int) -> dict[int, int]:
+    """Return the prime factorization of a positive integer."""
+
+    if value <= 0:
+        raise ValueError("value must be positive")
+    remaining = value
+    factors: dict[int, int] = {}
+    p = 2
+    while p * p <= remaining:
+        while remaining % p == 0:
+            factors[p] = factors.get(p, 0) + 1
+            remaining //= p
+        p += 1 if p == 2 else 2
+    if remaining > 1:
+        factors[remaining] = factors.get(remaining, 0) + 1
+    return factors
+
+
+def is_square(value: int) -> bool:
+    """Return whether value is a perfect square."""
+
+    if value < 0:
+        return False
+    root = isqrt(value)
+    return root * root == value
+
+
+def column_sum_for_tight_all_five(column: int, n: int = 12) -> int:
+    """Derive the forced column sum from saturated pair capacities."""
+
+    incident_pair_capacity = sum(
+        pair_capacity(column, other, n) for other in range(n) if other != column
+    )
+    support_size_minus_one = 4
+    if incident_pair_capacity % support_size_minus_one != 0:
+        raise AssertionError("unexpected nonintegral forced column sum")
+    return incident_pair_capacity // support_size_minus_one
+
+
+def build_summary() -> dict[str, Any]:
+    """Build a stable machine-readable summary of the obstruction."""
+
+    n = 12
+    support_size = 5
+    total_support_pair_count = n * comb(support_size, 2)
+    pair_capacity_budget = n + 2 * (comb(n, 2) - n)
+    gram = tight_size_five_gram(n)
+    determinant = bareiss_det(gram)
+    root = isqrt(determinant)
+    factors = factorint(determinant)
+    forced_column_sums = [column_sum_for_tight_all_five(column, n) for column in range(n)]
+    first_row = gram[0]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Exact support-level obstruction for the n=12 all-centers-size-at-least-five "
+            "rich-support subcase. This independently checks the same all-five-rich "
+            "dodecagon equality wall closed by support saturation; it does not prove "
+            "n=12, does not handle mixed exact-four/size-five catalogues, and does not "
+            "prove Erdos Problem #97."
+        ),
+        "n": n,
+        "support_size_chosen_at_each_center": support_size,
+        "total_support_pair_count": total_support_pair_count,
+        "edge_sensitive_pair_capacity_budget": pair_capacity_budget,
+        "counting_bound_is_tight": total_support_pair_count == pair_capacity_budget,
+        "forced_column_sums": forced_column_sums,
+        "forced_column_gram_first_row": first_row,
+        "forced_column_gram_description": {
+            "diagonal": 5,
+            "hull_edge_off_diagonal": 1,
+            "nonedge_off_diagonal": 2,
+        },
+        "determinant": determinant,
+        "determinant_factorization": {str(prime): exponent for prime, exponent in factors.items()},
+        "floor_square_root": root,
+        "is_square": is_square(determinant),
+        "contradiction": not is_square(determinant),
+        "consequence": (
+            "A hypothetical 4-bad convex 12-gon cannot have E(v) >= 5 at every vertex; "
+            "there must be at least one exact-four center. This consequence is redundant "
+            "with the support-saturation obstruction but follows here by determinant "
+            "parity alone."
+        ),
+    }
+
+
+def check_expected(summary: dict[str, Any]) -> None:
+    """Assert the exact arithmetic used by the proof note."""
+
+    expected = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "n": 12,
+        "support_size_chosen_at_each_center": 5,
+        "total_support_pair_count": 120,
+        "edge_sensitive_pair_capacity_budget": 120,
+        "counting_bound_is_tight": True,
+        "forced_column_sums": [5] * 12,
+        "forced_column_gram_first_row": [5, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1],
+        "determinant": 2_592_000,
+        "determinant_factorization": {"2": 8, "3": 4, "5": 3},
+        "floor_square_root": 1609,
+        "is_square": False,
+        "contradiction": True,
+    }
+    for key, want in expected.items():
+        got = summary[key]
+        if got != want:
+            raise AssertionError(f"{key}: got {got!r}, expected {want!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="assert expected exact arithmetic")
+    parser.add_argument("--json", action="store_true", help="emit JSON summary")
+    args = parser.parse_args()
+
+    summary = build_summary()
+    if args.check:
+        check_expected(summary)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"schema: {summary['schema']}")
+        print(f"counting-bound equality: {summary['total_support_pair_count']} = {summary['edge_sensitive_pair_capacity_budget']}")
+        print(f"determinant: {summary['determinant']}")
+        print(f"factorization: {summary['determinant_factorization']}")
+        print(f"perfect square: {summary['is_square']}")
+        print(summary["consequence"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1571,6 +1571,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n12_rich_support_determinant",
+        command=(
+            "python",
+            "scripts/check_n12_rich_support_determinant.py",
+            "--check",
+            "--json",
+        ),
+        claim_scope=(
+            "Proof-facing determinant obstruction for the n=12 all-five-rich "
+            "support-count equality wall; independently checks the same "
+            "boundary closed by support saturation, but is not a proof of "
+            "n=12, not a proof of Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="localized_rich_support_counting",
         command=(
             "python",

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -126,6 +126,7 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
         "python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json",
         "python scripts/check_rich_support_counting_bound.py --check --json",
         "python scripts/check_support_saturation_obstruction.py --check --json",
+        "python scripts/check_n12_rich_support_determinant.py --check --json",
         "python scripts/check_localized_rich_support_counting.py --check --json",
         (
             "python scripts/check_bootstrap_core_crosswalk.py "

--- a/tests/test_n12_rich_support_determinant.py
+++ b/tests/test_n12_rich_support_determinant.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_n12_rich_support_determinant import (  # noqa: E402
+    SCHEMA,
+    STATUS,
+    build_summary,
+    check_expected,
+    cycle_adjacent,
+    is_square,
+    pair_capacity,
+    tight_size_five_gram,
+)
+
+
+def test_n12_rich_support_determinant_expected_summary() -> None:
+    summary = build_summary()
+
+    check_expected(summary)
+    assert summary["schema"] == SCHEMA
+    assert summary["status"] == STATUS
+    assert summary["trust"] == "LEMMA"
+    assert summary["counting_bound_is_tight"] is True
+    assert summary["forced_column_sums"] == [5] * 12
+    assert summary["determinant"] == 2_592_000
+    assert summary["is_square"] is False
+    assert "does not prove n=12" in str(summary["claim_scope"])
+
+
+def test_n12_rich_support_determinant_gram_shape() -> None:
+    gram = tight_size_five_gram()
+
+    assert gram[0] == [5, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1]
+    assert all(row[index] == 5 for index, row in enumerate(gram))
+    assert pair_capacity(0, 1, 12) == 1
+    assert pair_capacity(0, 11, 12) == 1
+    assert pair_capacity(0, 2, 12) == 2
+    assert cycle_adjacent(0, 11, 12)
+    assert not is_square(2_592_000)
+
+
+def test_n12_rich_support_determinant_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n12_rich_support_determinant.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == SCHEMA
+    assert payload["status"] == STATUS
+    assert payload["determinant_factorization"] == {"2": 8, "3": 4, "5": 3}
+    assert payload["contradiction"] is True

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -261,6 +261,10 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_support_saturation_obstruction.py --check --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_n12_rich_support_determinant.py --check --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check "
         "--assert-expected --json"
@@ -275,6 +279,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_support_saturation_obstruction.py --check --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_n12_rich_support_determinant.py --check --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_n12_rich_support_determinant.py --check --json"
     ) < ordered_command_texts.index(
         "python scripts/check_localized_rich_support_counting.py --check --json"
     )


### PR DESCRIPTION
## Summary

- add an exact determinant checker and note for the `n=12` all-five-rich support-count equality wall
- frame the result as an independent algebraic cross-check of the boundary already closed by support saturation
- wire the checker into `verify-bridge-frontier`, artifact-audit command coverage, docs index, claims, state, and results

## Scope

This is a support-level lemma/cross-check only. It does not prove the full `n=12` case, does not handle mixed exact-four/size-five catalogues, does not prove Erdős Problem #97, and does not provide a counterexample.

## Validation

- `python scripts/check_n12_rich_support_determinant.py --check --json`
- `python -m ruff check scripts/check_n12_rich_support_determinant.py tests/test_n12_rich_support_determinant.py`
- `python -m pytest -q tests/test_n12_rich_support_determinant.py tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `python -m py_compile scripts/check_n12_rich_support_determinant.py tests/test_n12_rich_support_determinant.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1171 passed, 440 deselected`)