### PR TITLE
Cross-check n9 audit expected-failure records

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3386,6 +3386,32 @@ def assert_expected_failure_contract_errors(
     return errors
 
 
+def _assert_expected_failure_validation_error_count(errors: Any) -> int | None:
+    if not isinstance(errors, list):
+        return None
+    return sum(
+        1
+        for error in errors
+        if not str(error).startswith("assert_expected failed:")
+        and not str(error).startswith("assert_expected_failure ")
+    )
+
+
+def _assert_expected_failure_payload_contract_errors(
+    payload: Mapping[str, Any],
+) -> list[str]:
+    if "assert_expected_failure" not in payload:
+        return []
+    return assert_expected_failure_contract_errors(
+        payload.get("assert_expected_failure"),
+        expected_validation_error_count=(
+            _assert_expected_failure_validation_error_count(
+                payload.get("validation_errors", [])
+            )
+        ),
+    )
+
+
 def _summary_status(items: Any) -> str:
     if not isinstance(items, list):
         return "failed"
@@ -3463,6 +3489,13 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
                 f"{assert_expected_failure.get('validation_error_count')}",
             ]
         )
+        errors = payload.get("validation_errors", [])
+        existing_errors = (
+            {str(error) for error in errors} if isinstance(errors, list) else set()
+        )
+        for error in _assert_expected_failure_payload_contract_errors(payload):
+            if error not in existing_errors:
+                lines.append(f"- {error}")
     elif assert_expected_failure is not None:
         lines.append(
             "assert_expected_failure is not an object: "
@@ -3489,6 +3522,27 @@ def _payload_with_generation_failure(exc: Exception) -> dict[str, Any]:
         "exception_type": type(exc).__name__,
         "provenance": dict(PROVENANCE),
     }
+
+
+def _payload_with_existing_assert_expected_failure_contract_check(
+    payload: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    contract_errors = _assert_expected_failure_payload_contract_errors(payload)
+    if not contract_errors:
+        return payload
+
+    updated = dict(payload)
+    raw_errors = updated.get("validation_errors", [])
+    if isinstance(raw_errors, list):
+        errors = [str(error) for error in raw_errors]
+    else:
+        errors = [f"validation_errors is not a list: {type(raw_errors).__name__}"]
+    for error in contract_errors:
+        if error not in errors:
+            errors.append(error)
+    updated["validation_status"] = "failed"
+    updated["validation_errors"] = errors
+    return updated
 
 
 def _payload_with_assert_expected_failure(
@@ -3543,6 +3597,7 @@ def main(argv: list[str] | None = None) -> int:
         except (AssertionError, KeyError, TypeError, ValueError) as exc:
             assert_expected_failed = True
             payload = _payload_with_assert_expected_failure(payload, exc)
+    payload = _payload_with_existing_assert_expected_failure_contract_check(payload)
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -56,6 +56,18 @@ def _layer_contract_trust_tamper_payload() -> dict[str, Any]:
     )
 
 
+def _assert_expected_failure_contract_tamper_payload() -> dict[str, Any]:
+    payload = _layer_contract_trust_tamper_payload()
+    payload["assert_expected_failure"] = {
+        "schema": "erdos97.invalid_assert_expected_failure.v1",
+        "stage": "payload_construction",
+        "exception_type": "AssertionError",
+        "message": "validation errors: []",
+        "validation_error_count": 0,
+    }
+    return payload
+
+
 def test_local_lemma_audit_path_counts_and_scope() -> None:
     payload = local_lemma_audit_path_payload()
 
@@ -1304,6 +1316,25 @@ def test_local_lemma_audit_path_assert_expected_failure_contract_errors() -> Non
     )
 
 
+def test_local_lemma_audit_path_failure_lines_crosscheck_assert_expected_failure() -> None:
+    lines = failure_lines(_assert_expected_failure_contract_tamper_payload())
+
+    assert (
+        "- assert_expected_failure schema mismatch: "
+        "'erdos97.invalid_assert_expected_failure.v1'"
+    ) in lines
+    assert (
+        "- assert_expected_failure stage mismatch: 'payload_construction'"
+        in lines
+    )
+    assert any(
+        line.startswith(
+            "- assert_expected_failure validation_error_count mismatch: "
+        )
+        for line in lines
+    )
+
+
 def test_local_lemma_audit_path_cli_failure_summary_includes_contract_rollups(
     monkeypatch,
     capsys,
@@ -1643,6 +1674,41 @@ def test_local_lemma_audit_path_cli_json_layer_failure_marks_layer_side(
     ]
     assert any(
         "aggregate_simple_replay contract mismatch on trust" in error
+        for error in parsed["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_cli_json_crosschecks_assert_expected_failure(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        _assert_expected_failure_contract_tamper_payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert any(
+        error == (
+            "assert_expected_failure schema mismatch: "
+            "'erdos97.invalid_assert_expected_failure.v1'"
+        )
+        for error in parsed["validation_errors"]
+    )
+    assert any(
+        error == "assert_expected_failure stage mismatch: 'payload_construction'"
+        for error in parsed["validation_errors"]
+    )
+    assert any(
+        error.startswith(
+            "assert_expected_failure validation_error_count mismatch: "
+        )
         for error in parsed["validation_errors"]
     )
 


### PR DESCRIPTION
## What changed
- Added a payload-level cross-check for any existing nested `assert_expected_failure` record in `scripts/check_n9_vertex_circle_local_lemma_audit_path.py`.
- Text failure output now surfaces malformed nested expected-failure records instead of only printing their fields.
- JSON CLI output now appends nested expected-failure schema/stage/count contract errors to `validation_errors` and keeps `validation_status` failed.
- Added regressions for direct failure-line output and JSON CLI output with a malformed nested record.

## Claim scope and evidence level
- Diagnostic/reproducibility hardening only.
- Evidence level remains `REVIEW_PENDING_DIAGNOSTIC` for the n=9 local-lemma audit path.
- No general proof, no counterexample, no n=9 proof, and no official/global status update are claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

`make verify-fast` could not be run in this PowerShell environment because `make` is not installed, so the explicit fast-tier command list above was run instead.

## Artifacts generated or checked
- Checked the n=9 vertex-circle local-lemma audit-path payload with `--check --assert-expected --json`.
- No generated artifacts were updated.

## Known limitations / next review steps
- This only hardens diagnostics around malformed expected-failure records.
- It does not audit strict-edge geometry, local-lemma packet soundness, frontier completeness, or selected-distance quotient soundness.
- n=9 artifacts remain review-pending.