### PR TITLE
Guard n9 turn frontier claim scope

### DIFF
--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -42,13 +42,6 @@ CLAIM_SCOPE = (
     "not a proof of Erdos Problem #97, not a counterexample, not an "
     "independent review, and not a source-of-truth status update."
 )
-CLAIM_SCOPE_REQUIRED_PHRASES = (
-    "Candidate n=9 selected-witness turn-inequality frontier replay",
-    "not a proof of Erdos Problem #97",
-    "not a counterexample",
-    "not an independent review",
-    "not a source-of-truth status update",
-)
 REVIEW_REQUIREMENTS = [
     "Review the geometric turn lemma and indexing conventions.",
     "Review the regenerated n=9 source frontier and lack of hidden symmetry quotienting.",
@@ -624,17 +617,8 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
         errors.append(f"unexpected status: {payload.get('status')!r}")
     if payload.get("trust") != TRUST:
         errors.append(f"unexpected trust: {payload.get('trust')!r}")
-    claim_scope = payload.get("claim_scope")
-    if not isinstance(claim_scope, str):
-        errors.append("missing claim_scope string")
-    else:
-        missing_phrases = [
-            phrase
-            for phrase in CLAIM_SCOPE_REQUIRED_PHRASES
-            if phrase not in claim_scope
-        ]
-        if missing_phrases:
-            errors.append(f"claim_scope missing guard phrases: {missing_phrases!r}")
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        errors.append("claim_scope mismatch")
     if payload.get("review_requirements") != REVIEW_REQUIREMENTS:
         errors.append("review_requirements mismatch")
     if payload.get("provenance") != PROVENANCE:

--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -35,6 +35,33 @@ EXPECTED_FARKAS_CERTIFICATE_SHA256 = (
 EXPECTED_FARKAS_LAMBDA_HISTOGRAM = {"1": 180, "2": 4}
 EXPECTED_FARKAS_TERM_COUNT_HISTOGRAM = {"5": 180, "9": 4}
 EXPECTED_FARKAS_DEFICIT_HISTOGRAM = {"1": 184}
+STATUS = "REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY"
+TRUST = "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING"
+CLAIM_SCOPE = (
+    "Candidate n=9 selected-witness turn-inequality frontier replay; "
+    "not a proof of Erdos Problem #97, not a counterexample, not an "
+    "independent review, and not a source-of-truth status update."
+)
+CLAIM_SCOPE_REQUIRED_PHRASES = (
+    "Candidate n=9 selected-witness turn-inequality frontier replay",
+    "not a proof of Erdos Problem #97",
+    "not a counterexample",
+    "not an independent review",
+    "not a source-of-truth status update",
+)
+REVIEW_REQUIREMENTS = [
+    "Review the geometric turn lemma and indexing conventions.",
+    "Review the regenerated n=9 source frontier and lack of hidden symmetry quotienting.",
+    "Review the stored integer dual certificates and their arithmetic verifier.",
+    "Keep this scoped as review-pending n=9 finite-case evidence only.",
+]
+PROVENANCE = {
+    "generator": "scripts/check_n9_turn_inequality_frontier.py",
+    "command": (
+        "python scripts/check_n9_turn_inequality_frontier.py "
+        "--assert-expected --write"
+    ),
+}
 
 SIDE_CAP_BENCHMARK_PATTERN: list[list[int]] = [
     [1, 2, 4, 6],
@@ -493,13 +520,9 @@ def summary_payload() -> dict[str, object]:
 
     return {
         "schema": "erdos97.n9_turn_inequality_frontier.v1",
-        "status": "REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY",
-        "trust": "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING",
-        "claim_scope": (
-            "Candidate n=9 selected-witness turn-inequality frontier replay; "
-            "not a proof of Erdos Problem #97, not a counterexample, not an "
-            "independent review, and not a source-of-truth status update."
-        ),
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
         "n": N,
         "row_size": ROW_SIZE,
         "cyclic_order": list(range(N)),
@@ -573,19 +596,8 @@ def summary_payload() -> dict[str, object]:
             "have stored integer dual certificates proving infeasibility of "
             "the candidate weak turn inequalities."
         ),
-        "review_requirements": [
-            "Review the geometric turn lemma and indexing conventions.",
-            "Review the regenerated n=9 source frontier and lack of hidden symmetry quotienting.",
-            "Review the stored integer dual certificates and their arithmetic verifier.",
-            "Keep this scoped as review-pending n=9 finite-case evidence only.",
-        ],
-        "provenance": {
-            "generator": "scripts/check_n9_turn_inequality_frontier.py",
-            "command": (
-                "python scripts/check_n9_turn_inequality_frontier.py "
-                "--assert-expected --write"
-            ),
-        },
+        "review_requirements": list(REVIEW_REQUIREMENTS),
+        "provenance": dict(PROVENANCE),
     }
 
 
@@ -608,6 +620,25 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
     errors: list[str] = []
     if payload.get("schema") != "erdos97.n9_turn_inequality_frontier.v1":
         errors.append("unexpected schema")
+    if payload.get("status") != STATUS:
+        errors.append(f"unexpected status: {payload.get('status')!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"unexpected trust: {payload.get('trust')!r}")
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str):
+        errors.append("missing claim_scope string")
+    else:
+        missing_phrases = [
+            phrase
+            for phrase in CLAIM_SCOPE_REQUIRED_PHRASES
+            if phrase not in claim_scope
+        ]
+        if missing_phrases:
+            errors.append(f"claim_scope missing guard phrases: {missing_phrases!r}")
+    if payload.get("review_requirements") != REVIEW_REQUIREMENTS:
+        errors.append("review_requirements mismatch")
+    if payload.get("provenance") != PROVENANCE:
+        errors.append("provenance mismatch")
     if payload.get("n") != N:
         errors.append(f"unexpected n: {payload.get('n')!r}")
     if payload.get("row_size") != ROW_SIZE:

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -89,10 +89,7 @@ def test_payload_validation_guards_review_pending_claim_scope() -> None:
 
     assert "unexpected status: 'MACHINE_CHECKED_TURN_FRONTIER'" in errors
     assert "unexpected trust: 'MACHINE_CHECKED_FINITE_CASE_ARTIFACT'" in errors
-    assert any(
-        error.startswith("claim_scope missing guard phrases:")
-        for error in errors
-    )
+    assert "claim_scope mismatch" in errors
     assert "review_requirements mismatch" in errors
     assert "provenance mismatch" in errors
 
@@ -113,7 +110,24 @@ def test_payload_validation_accepts_canonical_claim_scope_fields() -> None:
 
     assert not any(error.startswith("unexpected status:") for error in errors)
     assert not any(error.startswith("unexpected trust:") for error in errors)
-    assert not any(error.startswith("claim_scope missing") for error in errors)
+    assert "claim_scope mismatch" not in errors
     assert "review_requirements mismatch" not in errors
     assert "provenance mismatch" not in errors
     assert "missing source_frontier object" in errors
+
+
+def test_payload_validation_rejects_claim_scope_with_extra_overclaim() -> None:
+    errors = validate_payload(
+        {
+            "schema": "erdos97.n9_turn_inequality_frontier.v1",
+            "status": STATUS,
+            "trust": TRUST,
+            "claim_scope": CLAIM_SCOPE + " This establishes a counterexample.",
+            "review_requirements": list(REVIEW_REQUIREMENTS),
+            "provenance": dict(PROVENANCE),
+            "n": 9,
+            "row_size": 4,
+        }
+    )
+
+    assert "claim_scope mismatch" in errors

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from erdos97.n9_turn_inequality_frontier import (
+    CLAIM_SCOPE,
     EXPECTED_TURN_INEQUALITY_COUNT,
+    PROVENANCE,
+    REVIEW_REQUIREMENTS,
     SIDE_CAP_BENCHMARK_PATTERN,
+    STATUS,
+    TRUST,
     find_turn_farkas_certificate,
     side_sensitive_pair_cap_violations,
     turn_inequality_terms_for_pattern,
@@ -63,3 +68,52 @@ def test_payload_validation_rejects_malformed_check_payload() -> None:
 
     assert "missing source_frontier object" in errors
     assert "missing farkas_certificates list" in errors
+
+
+def test_payload_validation_guards_review_pending_claim_scope() -> None:
+    errors = validate_payload(
+        {
+            "schema": "erdos97.n9_turn_inequality_frontier.v1",
+            "status": "MACHINE_CHECKED_TURN_FRONTIER",
+            "trust": "MACHINE_CHECKED_FINITE_CASE_ARTIFACT",
+            "claim_scope": "Candidate n=9 proof.",
+            "review_requirements": [],
+            "provenance": {
+                "generator": "scripts/check_n9_turn_inequality_frontier.py",
+                "command": "python scripts/check_n9_turn_inequality_frontier.py",
+            },
+            "n": 9,
+            "row_size": 4,
+        }
+    )
+
+    assert "unexpected status: 'MACHINE_CHECKED_TURN_FRONTIER'" in errors
+    assert "unexpected trust: 'MACHINE_CHECKED_FINITE_CASE_ARTIFACT'" in errors
+    assert any(
+        error.startswith("claim_scope missing guard phrases:")
+        for error in errors
+    )
+    assert "review_requirements mismatch" in errors
+    assert "provenance mismatch" in errors
+
+
+def test_payload_validation_accepts_canonical_claim_scope_fields() -> None:
+    errors = validate_payload(
+        {
+            "schema": "erdos97.n9_turn_inequality_frontier.v1",
+            "status": STATUS,
+            "trust": TRUST,
+            "claim_scope": CLAIM_SCOPE,
+            "review_requirements": list(REVIEW_REQUIREMENTS),
+            "provenance": dict(PROVENANCE),
+            "n": 9,
+            "row_size": 4,
+        }
+    )
+
+    assert not any(error.startswith("unexpected status:") for error in errors)
+    assert not any(error.startswith("unexpected trust:") for error in errors)
+    assert not any(error.startswith("claim_scope missing") for error in errors)
+    assert "review_requirements mismatch" not in errors
+    assert "provenance mismatch" not in errors
+    assert "missing source_frontier object" in errors


### PR DESCRIPTION
## What changed
- Centralized the n=9 turn-inequality frontier artifact status, trust, claim-scope text, review requirements, and provenance as checker constants.
- Extended `validate_payload` to reject drift in those review-pending claim-boundary fields.
- Added regression tests for overclaiming metadata and for canonical review-pending metadata.

## Claim scope and evidence level
- Claim-discipline and checker hardening only.
- Evidence level remains `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING` for this n=9 turn-inequality frontier replay.
- No general proof, no counterexample, no n=9 proof, and no official/global status update are claimed.

## Commands run
- `python -m ruff check src/erdos97/n9_turn_inequality_frontier.py tests/test_n9_turn_inequality_frontier.py`
- `python -m pytest tests/test_n9_turn_inequality_frontier.py -q`
- `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

`make verify-fast` could not be run locally because `make` is not installed in this PowerShell environment, so the explicit fast-tier command list above was run instead.

## Artifacts generated or checked
- Checked `data/certificates/n9_turn_inequality_frontier.json` via `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`.
- No artifact files were regenerated or edited.

## Known limitations / next review steps
- This does not review the geometric turn lemma, indexing conventions, or source frontier completeness.
- It does not promote n=9 beyond review-pending finite-case evidence.
- Next useful review remains independent audit of the turn lemma/certificate arithmetic and exact-four frontier pipeline.