### PR TITLE
[codex] Guard n9 turn frontier summary fields

### DIFF
--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -42,7 +42,7 @@ CLAIM_SCOPE = (
     "not a proof of Erdos Problem #97, not a counterexample, not an "
     "independent review, and not a source-of-truth status update."
 )
-CYCLIC_ORDER = list(range(N))
+CYCLIC_ORDER = tuple(range(N))
 CONCLUSION = (
     "All 184 regenerated n=9 pair/crossing/count frontier assignments "
     "have stored integer dual certificates proving infeasibility of "
@@ -621,7 +621,7 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
         errors.append(f"unexpected trust: {payload.get('trust')!r}")
     if payload.get("claim_scope") != CLAIM_SCOPE:
         errors.append("claim_scope mismatch")
-    if payload.get("cyclic_order") != CYCLIC_ORDER:
+    if payload.get("cyclic_order") != list(CYCLIC_ORDER):
         errors.append("cyclic_order mismatch")
     if payload.get("conclusion") != CONCLUSION:
         errors.append("conclusion mismatch")

--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -42,6 +42,12 @@ CLAIM_SCOPE = (
     "not a proof of Erdos Problem #97, not a counterexample, not an "
     "independent review, and not a source-of-truth status update."
 )
+CYCLIC_ORDER = list(range(N))
+CONCLUSION = (
+    "All 184 regenerated n=9 pair/crossing/count frontier assignments "
+    "have stored integer dual certificates proving infeasibility of "
+    "the candidate weak turn inequalities."
+)
 REVIEW_REQUIREMENTS = [
     "Review the geometric turn lemma and indexing conventions.",
     "Review the regenerated n=9 source frontier and lack of hidden symmetry quotienting.",
@@ -518,7 +524,7 @@ def summary_payload() -> dict[str, object]:
         "claim_scope": CLAIM_SCOPE,
         "n": N,
         "row_size": ROW_SIZE,
-        "cyclic_order": list(range(N)),
+        "cyclic_order": list(CYCLIC_ORDER),
         "source_frontier": {
             "description": (
                 "Complete selected-witness assignments surviving pair/crossing/count "
@@ -584,11 +590,7 @@ def summary_payload() -> dict[str, object]:
         },
         "farkas_certificates": farkas_certificates,
         "benchmarks": [side_cap_benchmark_summary(normalized_frontier)],
-        "conclusion": (
-            "All 184 regenerated n=9 pair/crossing/count frontier assignments "
-            "have stored integer dual certificates proving infeasibility of "
-            "the candidate weak turn inequalities."
-        ),
+        "conclusion": CONCLUSION,
         "review_requirements": list(REVIEW_REQUIREMENTS),
         "provenance": dict(PROVENANCE),
     }
@@ -619,6 +621,10 @@ def validate_payload(payload: dict[str, object]) -> list[str]:
         errors.append(f"unexpected trust: {payload.get('trust')!r}")
     if payload.get("claim_scope") != CLAIM_SCOPE:
         errors.append("claim_scope mismatch")
+    if payload.get("cyclic_order") != CYCLIC_ORDER:
+        errors.append("cyclic_order mismatch")
+    if payload.get("conclusion") != CONCLUSION:
+        errors.append("conclusion mismatch")
     if payload.get("review_requirements") != REVIEW_REQUIREMENTS:
         errors.append("review_requirements mismatch")
     if payload.get("provenance") != PROVENANCE:

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from erdos97.n9_turn_inequality_frontier import (
     CLAIM_SCOPE,
+    CONCLUSION,
+    CYCLIC_ORDER,
     EXPECTED_TURN_INEQUALITY_COUNT,
     PROVENANCE,
     REVIEW_REQUIREMENTS,
@@ -101,6 +103,8 @@ def test_payload_validation_accepts_canonical_claim_scope_fields() -> None:
             "status": STATUS,
             "trust": TRUST,
             "claim_scope": CLAIM_SCOPE,
+            "cyclic_order": list(CYCLIC_ORDER),
+            "conclusion": CONCLUSION,
             "review_requirements": list(REVIEW_REQUIREMENTS),
             "provenance": dict(PROVENANCE),
             "n": 9,
@@ -111,6 +115,8 @@ def test_payload_validation_accepts_canonical_claim_scope_fields() -> None:
     assert not any(error.startswith("unexpected status:") for error in errors)
     assert not any(error.startswith("unexpected trust:") for error in errors)
     assert "claim_scope mismatch" not in errors
+    assert "cyclic_order mismatch" not in errors
+    assert "conclusion mismatch" not in errors
     assert "review_requirements mismatch" not in errors
     assert "provenance mismatch" not in errors
     assert "missing source_frontier object" in errors
@@ -123,6 +129,8 @@ def test_payload_validation_rejects_claim_scope_with_extra_overclaim() -> None:
             "status": STATUS,
             "trust": TRUST,
             "claim_scope": CLAIM_SCOPE + " This establishes a counterexample.",
+            "cyclic_order": list(CYCLIC_ORDER),
+            "conclusion": CONCLUSION,
             "review_requirements": list(REVIEW_REQUIREMENTS),
             "provenance": dict(PROVENANCE),
             "n": 9,
@@ -131,3 +139,23 @@ def test_payload_validation_rejects_claim_scope_with_extra_overclaim() -> None:
     )
 
     assert "claim_scope mismatch" in errors
+
+
+def test_payload_validation_rejects_conclusion_and_order_drift() -> None:
+    errors = validate_payload(
+        {
+            "schema": "erdos97.n9_turn_inequality_frontier.v1",
+            "status": STATUS,
+            "trust": TRUST,
+            "claim_scope": CLAIM_SCOPE,
+            "cyclic_order": list(reversed(CYCLIC_ORDER)),
+            "conclusion": CONCLUSION + " This proves n=9.",
+            "review_requirements": list(REVIEW_REQUIREMENTS),
+            "provenance": dict(PROVENANCE),
+            "n": 9,
+            "row_size": 4,
+        }
+    )
+
+    assert "cyclic_order mismatch" in errors
+    assert "conclusion mismatch" in errors

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -97,6 +97,8 @@ def test_payload_validation_guards_review_pending_claim_scope() -> None:
 
 
 def test_payload_validation_accepts_canonical_claim_scope_fields() -> None:
+    assert CYCLIC_ORDER == tuple(range(9))
+
     errors = validate_payload(
         {
             "schema": "erdos97.n9_turn_inequality_frontier.v1",


### PR DESCRIPTION
## What changed
- Centralized the n=9 turn frontier `cyclic_order` and `conclusion` strings as canonical constants.
- Extended payload validation to reject drift in those fields.
- Added regression coverage for reversed cyclic order and appended overclaiming conclusion text.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- Preserves the repository status: no general proof, no counterexample, no official/global status update.
- The n=9 turn frontier artifact remains review-pending and is not promoted by this change.

## Commands run
- `python -m ruff check src/erdos97/n9_turn_inequality_frontier.py tests/test_n9_turn_inequality_frontier.py`
- `python -m pytest tests/test_n9_turn_inequality_frontier.py -q`
- `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_turn_inequality_frontier.json` through `scripts/check_n9_turn_inequality_frontier.py`.
- No generated artifacts were updated.
- Local `make verify-fast` was not used because the local PowerShell environment does not provide `make`; the explicit fast-tier commands above were run instead.

## Known limitations / next review steps
- Does not independently review the geometric turn lemma, indexing conventions, source frontier, or certificate arithmetic.
- Does not strengthen the n=9 result beyond review-pending artifact consistency.