### PR TITLE
[codex] Enforce exact local lemma audit claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -609,7 +609,9 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove packet soundness",
         "does not prove mini-replay soundness",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -13,6 +13,7 @@ from scripts.check_artifact_provenance import (
 from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     ASSERT_EXPECTED_FAILURE_KEYS,
     ASSERT_EXPECTED_FAILURE_SCHEMA,
+    CLAIM_SCOPE,
     CLAIM_SCOPE_GUARDS,
     EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS,
     EXPECTED_HANDOFF_EDGES,
@@ -95,6 +96,18 @@ def test_local_lemma_audit_path_counts_and_scope() -> None:
     assert "does not prove n=9" in payload["claim_scope"]
     assert "not a counterexample" in payload["claim_scope"]
     assert "not a global status update" in payload["claim_scope"]
+
+
+def test_local_lemma_audit_path_rejects_top_level_claim_scope_append() -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    try:
+        assert_expected_local_lemma_audit_path(payload)
+    except AssertionError as exc:
+        assert "claim_scope mismatch" in str(exc)
+    else:
+        raise AssertionError("expected top-level claim_scope mismatch")
 
 
 def test_local_lemma_audit_path_input_manifest() -> None:


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_local_lemma_audit_path` so the top-level audit-path `claim_scope` must exactly match the canonical text.
- Added a regression that rejects an appended `This proves n=9.` overclaim on the audit-path payload.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The local-lemma audit path remains review-pending packet/audit bookkeeping.
- No proof of packet soundness, local-lemma completeness, frontier coverage, n=9, a counterexample, or global status movement is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending `n9_vertex_circle_local_lemma_audit_path` path through its checker.
- No generated artifacts were updated.
- Local `make verify-fast` was not used because the local PowerShell environment does not provide `make`; the explicit fast-tier commands above were run instead.

## Known limitations / next review steps
- Does not independently review packet soundness, local-lemma completeness, the exhaustive brancher, or vertex-circle geometry.
- Does not promote the n=9 artifact status.