### PR TITLE
[codex] Enforce exact relation skeleton claim scope

### DIFF
--- a/scripts/check_relation_skeleton_local_lemma_crosswalk.py
+++ b/scripts/check_relation_skeleton_local_lemma_crosswalk.py
@@ -153,9 +153,14 @@ def assert_expected_relation_local_crosswalk(payload: Mapping[str, Any]) -> None
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for forbidden in ("proof of n=9", "counterexample", "global status update"):
-        if f"not a {forbidden}" not in claim_scope and f"not an {forbidden}" not in claim_scope:
+        if (
+            f"not a {forbidden}" not in claim_scope
+            and f"not an {forbidden}" not in claim_scope
+        ):
             raise AssertionError(f"claim_scope must explicitly reject {forbidden!r}")
     if payload.get("validation_status") != "passed":
         raise AssertionError(f"validation errors: {payload.get('validation_errors')!r}")

--- a/tests/test_relation_skeleton_local_lemma_crosswalk.py
+++ b/tests/test_relation_skeleton_local_lemma_crosswalk.py
@@ -12,6 +12,7 @@ from scripts.check_n9_vertex_circle_local_lemma_replay_crosswalk import (
     DEFAULT_SIMPLE_REPLAY,
 )
 from scripts.check_relation_skeleton_local_lemma_crosswalk import (
+    CLAIM_SCOPE,
     DEFAULT_RELATION_SKELETONS,
     assert_expected_relation_local_crosswalk,
     crosswalk_payload,
@@ -60,6 +61,18 @@ def test_relation_local_crosswalk_expected_counts_and_scope(
     assert "not a proof of n=9" in payload["claim_scope"]
     assert "not a counterexample" in payload["claim_scope"]
     assert "not a global status update" in payload["claim_scope"]
+
+
+def test_relation_local_crosswalk_rejects_top_level_claim_scope_append(
+    relation_skeletons: dict[str, object],
+    aggregate: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = crosswalk_payload(relation_skeletons, aggregate, simple_replay)
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_relation_local_crosswalk(payload)
 
 
 def test_relation_local_crosswalk_family_records(


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_relation_local_crosswalk` so the top-level relation-skeleton/local-lemma `claim_scope` must exactly match the canonical text.
- Added a regression that rejects an appended `This proves n=9.` overclaim on the relation/local crosswalk payload.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The relation-skeleton/local-lemma crosswalk remains review-pending packet/audit bookkeeping.
- No proof of local-lemma completeness, exhaustive-checker soundness, n=9, a counterexample, or global status movement is claimed.

## Commands run
- `python -m ruff check scripts/check_relation_skeleton_local_lemma_crosswalk.py tests/test_relation_skeleton_local_lemma_crosswalk.py`
- `python -m pytest tests/test_relation_skeleton_local_lemma_crosswalk.py -q`
- `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending relation-skeleton/local-lemma crosswalk through its checker.
- No generated artifacts were updated.
- Local `make verify-fast` was not used because the local PowerShell environment does not provide `make`; the explicit fast-tier commands above were run instead.

## Known limitations / next review steps
- Does not independently review relation-skeleton soundness, local-lemma packet soundness, local-lemma completeness, the exhaustive brancher, or vertex-circle geometry.
- Does not promote the n=9 artifact status.