### PR TITLE
[codex] Enforce exact focused minireplay claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -155,7 +155,9 @@ def assert_expected_focused_minireplay_crosswalk(payload: Mapping[str, Any]) -> 
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove mini-replay soundness",
         "packet soundness",

--- a/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_vertex_circle_focused_minireplay_crosswalk import (
+    CLAIM_SCOPE,
     DEFAULT_MINIREPLAY_PATHS,
     assert_expected_focused_minireplay_crosswalk,
     focused_minireplay_crosswalk_payload,
@@ -39,6 +42,14 @@ def test_focused_minireplay_crosswalk_counts_and_scope() -> None:
     assert summary["obstruction_flagged_count"] == 12
     assert summary["assignment_count_repeated_total"] == 184
     assert summary["assignment_count_source_only_total"] == 0
+
+
+def test_focused_minireplay_crosswalk_rejects_top_level_claim_scope_append() -> None:
+    payload = focused_minireplay_crosswalk_payload()
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_focused_minireplay_crosswalk(payload)
 
 
 def test_focused_minireplay_crosswalk_rejects_source_packet_drift(


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_focused_minireplay_crosswalk` so the top-level focused packet/minireplay `claim_scope` must exactly match the canonical text.
- Added a regression that rejects an appended `This proves n=9.` overclaim on the focused minireplay crosswalk payload.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The focused packet/minireplay crosswalk remains review-pending JSON bookkeeping.
- No proof of mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, n=9, a counterexample, or global status movement is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py`
- `python -m pytest tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py -q`
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending focused packet/minireplay crosswalk through its checker.
- No generated artifacts were updated.
- Local `make verify-fast` was not used because the local PowerShell environment does not provide `make`; the explicit fast-tier commands above were run instead.

## Known limitations / next review steps
- Does not independently review mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, the exhaustive brancher, or vertex-circle geometry.
- Does not promote the n=9 artifact status.