### PR TITLE
Enforce exact focused packet catalog claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py
+++ b/scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py
@@ -200,7 +200,9 @@ def assert_expected_focused_packet_catalog_audit(payload: Mapping[str, Any]) -> 
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove packet soundness",
         "local-lemma completeness",

--- a/tests/test_n9_vertex_circle_focused_packet_catalog_audit.py
+++ b/tests/test_n9_vertex_circle_focused_packet_catalog_audit.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_vertex_circle_focused_packet_catalog_audit import (
+    CLAIM_SCOPE,
     DEFAULT_LOCAL_LEMMAS,
     DEFAULT_PACKET_PATHS,
     DEFAULT_TEMPLATE_CATALOG,
@@ -42,6 +45,14 @@ def test_focused_packet_catalog_audit_counts_and_scope() -> None:
     assert summary["source_template_packet_count"] == 12
     assert summary["source_template_mismatch_count"] == 0
     assert summary["source_template_allowed_omitted_field_count"] == 14
+
+
+def test_focused_packet_catalog_audit_rejects_top_level_claim_scope_append() -> None:
+    payload = focused_packet_catalog_audit_payload()
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_focused_packet_catalog_audit(payload)
 
 
 def test_focused_packet_catalog_audit_rejects_packet_coverage_drift(


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_focused_packet_catalog_audit.py` so the top-level `claim_scope` must exactly match the canonical review-pending text.
- Added a regression test that rejects an appended overclaim such as `This proves n=9.` instead of accepting it by substring.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The focused packet/catalog audit remains review-pending JSON bookkeeping for the n=9 pipeline.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py tests/test_n9_vertex_circle_focused_packet_catalog_audit.py`
- `python -m pytest tests/test_n9_vertex_circle_focused_packet_catalog_audit.py -q`
- `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the focused packet/catalog audit payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not establish packet soundness, local-lemma completeness, frontier coverage, exhaustive brancher coverage, or geometry validity.
- Does not change the repository's open/falsifiable global status.