### PR TITLE
Enforce exact exhaustive local-lemma claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
@@ -157,7 +157,9 @@ def assert_expected_exhaustive_local_lemma_crosswalk(payload: Mapping[str, Any])
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for forbidden in ("proof of n=9", "counterexample", "global status update"):
         if f"not a {forbidden}" not in claim_scope and f"not an {forbidden}" not in claim_scope:
             raise AssertionError(f"claim_scope must explicitly reject {forbidden!r}")

--- a/tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
+++ b/tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from scripts.check_n9_vertex_circle_exhaustive_local_lemma_crosswalk import (
+    CLAIM_SCOPE,
     DEFAULT_CLASSIFICATION,
     DEFAULT_EXHAUSTIVE,
     DEFAULT_LOCAL_LEMMAS,
@@ -66,6 +67,24 @@ def test_exhaustive_local_lemma_crosswalk_counts_and_scope(
     assert "not a proof of n=9" in payload["claim_scope"]
     assert "not a counterexample" in payload["claim_scope"]
     assert "not a global status update" in payload["claim_scope"]
+
+
+def test_exhaustive_local_lemma_crosswalk_rejects_top_level_claim_scope_append(
+    exhaustive: dict[str, object],
+    classification: dict[str, object],
+    local_lemmas: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = exhaustive_local_lemma_crosswalk_payload(
+        exhaustive,
+        classification,
+        local_lemmas,
+        simple_replay,
+    )
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_exhaustive_local_lemma_crosswalk(payload)
 
 
 def test_exhaustive_local_lemma_family_crosswalk(


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py` so the top-level `claim_scope` must exactly equal the canonical review-pending text.
- Added a regression test that rejects an appended overclaim such as `This proves n=9.` instead of accepting the payload by phrase presence alone.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The exhaustive/local-lemma crosswalk remains a review-pending audit joining stored exhaustive counts, motif classification, aggregate local-lemma scan, and simple replay bookkeeping.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py`
- `python -m pytest tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py -q`
- `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the exhaustive/local-lemma crosswalk payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not review the exhaustive brancher, local-lemma soundness, packet completeness, strict-edge geometry, or selected-distance quotient soundness.
- Does not change the repository's open/falsifiable global status.