### PR TITLE
Enforce exact frontier coverage claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py
@@ -112,7 +112,9 @@ def assert_expected_frontier_coverage_crosswalk(payload: Mapping[str, Any]) -> N
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove filter soundness",
         "dynamic brancher soundness",

--- a/tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py
+++ b/tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from scripts.check_n9_vertex_circle_frontier_coverage_crosswalk import (
+    CLAIM_SCOPE,
     EXPECTED_ASSIGNMENT_COUNT,
     EXPECTED_SEQUENCE_ROWS_SHA256,
     EXPECTED_SORTED_ROWS_SHA256,
@@ -13,9 +14,14 @@ from scripts.check_n9_vertex_circle_frontier_coverage_crosswalk import (
 pytestmark = pytest.mark.slow
 
 
-def test_frontier_coverage_crosswalk_payload_scope_and_counts() -> None:
-    payload = frontier_coverage_crosswalk_payload()
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return frontier_coverage_crosswalk_payload()
 
+
+def test_frontier_coverage_crosswalk_payload_scope_and_counts(
+    payload: dict[str, object],
+) -> None:
     assert_expected_frontier_coverage_crosswalk(payload)
     assert payload["validation_status"] == "passed"
     summary = payload["frontier_coverage_crosswalk"]
@@ -29,3 +35,13 @@ def test_frontier_coverage_crosswalk_payload_scope_and_counts() -> None:
     assert summary["example_mismatches"] == []
     assert "does not prove filter soundness" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_frontier_coverage_crosswalk_rejects_top_level_claim_scope_append(
+    payload: dict[str, object],
+) -> None:
+    tampered = dict(payload)
+    tampered["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_frontier_coverage_crosswalk(tampered)


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_frontier_coverage_crosswalk.py` so the top-level `claim_scope` must exactly equal the canonical review-pending frontier-coverage text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.
- Converted the slow frontier-coverage test payload to a module fixture so the brancher crosswalk is computed once across the two slow assertions.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The frontier-coverage crosswalk remains a review-pending diagnostic comparing regenerated no-vertex-circle frontier rows to the stored motif-classification artifact.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py`
- `python -m pytest tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py -q -m slow`
- `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the frontier-coverage crosswalk payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not prove filter soundness, dynamic brancher soundness, strict-edge geometry, selected-distance quotient soundness, n=9, or any global status movement.
- Full fast pytest deselects slow tests by policy; the slow frontier-coverage test was run explicitly above.