### PR TITLE
Enforce exact input audit claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_input_audit.py
+++ b/scripts/check_n9_vertex_circle_input_audit.py
@@ -154,7 +154,9 @@ def assert_expected_input_audit(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not rerun the brancher",
         "does not replay vertex-circle certificates",

--- a/tests/test_n9_vertex_circle_input_audit.py
+++ b/tests/test_n9_vertex_circle_input_audit.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_vertex_circle_input_audit import (
+    CLAIM_SCOPE,
     DEFAULT_ARTIFACT,
     EXPECTED_CROSS_FULL,
     EXPECTED_MAIN_FULL,
@@ -73,6 +76,14 @@ def test_n9_vertex_circle_input_audit_expected_counts_and_scope() -> None:
     assert "does not rerun the brancher" in payload["claim_scope"]
     assert "does not prove n=9" in payload["claim_scope"]
     assert "does not claim a counterexample" in payload["claim_scope"]
+
+
+def test_n9_vertex_circle_input_audit_rejects_top_level_claim_scope_append() -> None:
+    payload = n9_vertex_circle_input_audit_payload(_payload())
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_input_audit(payload)
 
 
 def test_n9_vertex_circle_input_audit_rejects_row0_witness_drift() -> None:


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_input_audit.py` so the top-level `claim_scope` must exactly equal the canonical review-pending input-audit text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The input audit remains a review-pending stored-JSON audit of row0 coverage, witness lists, masks, and summary counts.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_input_audit.py tests/test_n9_vertex_circle_input_audit.py`
- `python -m pytest tests/test_n9_vertex_circle_input_audit.py -q`
- `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle input-audit payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not rerun the brancher, replay vertex-circle certificates, prove n=9, claim a counterexample, or update official/global status.
- Independent review is still needed before any n=9 artifact promotion.