### PR TITLE
Enforce exact incidence filter claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_incidence_filters.py
+++ b/scripts/check_n9_vertex_circle_incidence_filters.py
@@ -247,7 +247,9 @@ def assert_expected_incidence_filters(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not replay the brancher",
         "strict-edge geometry",

--- a/tests/test_n9_vertex_circle_incidence_filters.py
+++ b/tests/test_n9_vertex_circle_incidence_filters.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_vertex_circle_incidence_filters import (
+    CLAIM_SCOPE,
     EXPECTED_SELECTED_INDEGREE,
     EXPECTED_TWO_OVERLAP,
     EXPECTED_WITNESS_PAIR_CAP,
@@ -34,6 +37,14 @@ def test_incidence_filter_payload_scope_and_validation() -> None:
     assert "strict-edge geometry" in payload["claim_scope"]
     assert "selected-distance quotient" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_incidence_filter_rejects_top_level_claim_scope_append() -> None:
+    payload = incidence_filter_payload()
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_incidence_filters(payload)
 
 
 def test_incidence_filter_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_incidence_filters.py` so the top-level `claim_scope` must exactly equal the canonical review-pending incidence-filter text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The incidence-filter audit remains a review-pending row-level audit of two-overlap crossing, witness-pair cap, and selected-indegree cap predicates.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_incidence_filters.py tests/test_n9_vertex_circle_incidence_filters.py`
- `python -m pytest tests/test_n9_vertex_circle_incidence_filters.py -q`
- `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle incidence-filter payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not replay the brancher, audit strict-edge geometry, audit selected-distance quotient soundness, prove n=9, claim a counterexample, or update official/global status.
- Independent review is still needed before any n=9 artifact promotion.