### PR TITLE
Enforce exact branch-option claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_branch_options.py
+++ b/scripts/check_n9_vertex_circle_branch_options.py
@@ -120,7 +120,9 @@ def assert_expected_branch_option_payload(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove dynamic-MRO branch coverage",
         "strict-edge geometry",

--- a/tests/test_n9_vertex_circle_branch_options.py
+++ b/tests/test_n9_vertex_circle_branch_options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from scripts.check_n9_vertex_circle_branch_options import (
+    CLAIM_SCOPE,
     EXPECTED_EMPTY_OPTION_CONTEXTS,
     EXPECTED_HELPER_OPTION_TOTAL,
     EXPECTED_NODES_VISITED,
@@ -14,9 +15,12 @@ from scripts.check_n9_vertex_circle_branch_options import (
 pytestmark = pytest.mark.slow
 
 
-def test_branch_option_payload_scope_and_counts() -> None:
-    payload = branch_option_payload()
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return branch_option_payload()
 
+
+def test_branch_option_payload_scope_and_counts(payload: dict[str, object]) -> None:
     assert_expected_branch_option_payload(payload)
     assert payload["validation_status"] == "passed"
     summary = payload["branch_option_audit"]
@@ -29,3 +33,13 @@ def test_branch_option_payload_scope_and_counts() -> None:
     assert summary["example_mismatches"] == []
     assert "does not prove dynamic-MRO branch coverage" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_branch_option_rejects_top_level_claim_scope_append(
+    payload: dict[str, object],
+) -> None:
+    tampered = dict(payload)
+    tampered["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_branch_option_payload(tampered)


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_branch_options.py` so the top-level `claim_scope` must exactly equal the canonical review-pending branch-option text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.
- Converted the slow branch-option test payload to a module fixture so the fixed-order state walk is computed once across the slow assertions.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The branch-option audit remains a review-pending fixed-center-order implementation audit for the valid-options helper and maintained count arrays.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_branch_options.py tests/test_n9_vertex_circle_branch_options.py`
- `python -m pytest tests/test_n9_vertex_circle_branch_options.py -q -m slow`
- `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle branch-option payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not prove dynamic-MRO branch coverage, strict-edge geometry, selected-distance quotient soundness, n=9, a counterexample, or official/global status movement.
- Full fast pytest deselects slow tests by policy; the slow branch-option test was run explicitly above.