### PR TITLE
Enforce exact dynamic MRO claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_dynamic_mro_choices.py
+++ b/scripts/check_n9_vertex_circle_dynamic_mro_choices.py
@@ -184,7 +184,9 @@ def assert_expected_dynamic_mro_choice_payload(payload: Mapping[str, Any]) -> No
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove the geometric filters",
         "strict-edge geometry",

--- a/tests/test_n9_vertex_circle_dynamic_mro_choices.py
+++ b/tests/test_n9_vertex_circle_dynamic_mro_choices.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from scripts.check_n9_vertex_circle_dynamic_mro_choices import (
+    CLAIM_SCOPE,
     EXPECTED_WITH_VERTEX,
     EXPECTED_WITHOUT_VERTEX,
     assert_expected_dynamic_mro_choice_payload,
@@ -12,9 +13,12 @@ from scripts.check_n9_vertex_circle_dynamic_mro_choices import (
 pytestmark = pytest.mark.slow
 
 
-def test_dynamic_mro_choice_payload_scope_and_counts() -> None:
-    payload = dynamic_mro_choice_payload()
+@pytest.fixture(scope="module")
+def payload() -> dict[str, object]:
+    return dynamic_mro_choice_payload()
 
+
+def test_dynamic_mro_choice_payload_scope_and_counts(payload: dict[str, object]) -> None:
     assert_expected_dynamic_mro_choice_payload(payload)
     assert payload["validation_status"] == "passed"
     audits = payload["dynamic_mro_audits"]
@@ -30,3 +34,13 @@ def test_dynamic_mro_choice_payload_scope_and_counts() -> None:
     assert without_vertex["example_mismatches"] == []
     assert "does not prove the geometric filters" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_dynamic_mro_rejects_top_level_claim_scope_append(
+    payload: dict[str, object],
+) -> None:
+    tampered = dict(payload)
+    tampered["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_dynamic_mro_choice_payload(tampered)


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_dynamic_mro_choices.py` so the top-level `claim_scope` must exactly equal the canonical review-pending dynamic-MRO text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.
- Converted the slow dynamic-MRO test payload to a module fixture so the expensive replay is computed once across the slow assertions.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The dynamic-MRO audit remains a review-pending branch-choice implementation audit for the current n=9 vertex-circle checker.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_dynamic_mro_choices.py tests/test_n9_vertex_circle_dynamic_mro_choices.py`
- `python -m pytest tests/test_n9_vertex_circle_dynamic_mro_choices.py -q -m slow`
- `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the n=9 vertex-circle dynamic-MRO payload with `--check --assert-expected --json`.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not prove geometric filters, strict-edge geometry, selected-distance quotient soundness, n=9, a counterexample, or official/global status movement.
- Full fast pytest deselects slow tests by policy; the slow dynamic-MRO test was run explicitly above.