### PR TITLE
Enforce exact compact brancher claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_compact_brancher.py
+++ b/scripts/check_n9_vertex_circle_compact_brancher.py
@@ -492,7 +492,9 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not import the project n=9 brancher modules",
         "does not read the stored 184-assignment frontier artifact",

--- a/tests/test_n9_vertex_circle_compact_brancher.py
+++ b/tests/test_n9_vertex_circle_compact_brancher.py
@@ -26,3 +26,13 @@ def test_compact_n9_brancher_expected_payload():
     checker = load_checker()
     payload = checker.compact_brancher_payload()
     checker.assert_expected_payload(payload)
+
+
+@pytest.mark.artifact
+def test_compact_n9_brancher_rejects_top_level_claim_scope_append():
+    checker = load_checker()
+    payload = checker.compact_brancher_payload()
+    payload["claim_scope"] = checker.CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        checker.assert_expected_payload(payload)


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_compact_brancher.py` so the top-level `claim_scope` must exactly equal the canonical review-pending compact-brancher text.
- Added an artifact-marked regression test that rejects appended overclaim text such as `This proves n=9.`.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The compact brancher remains a review-pending independent regeneration/replay aid for the n=9 selected-witness frontier and vertex-circle quotient obstruction.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_compact_brancher.py tests/test_n9_vertex_circle_compact_brancher.py`
- `python -m pytest tests/test_n9_vertex_circle_compact_brancher.py -q -m artifact`
- `python scripts/check_n9_vertex_circle_compact_brancher.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`

## Artifacts generated or checked
- Checked the compact brancher artifact payload against the stored artifact with `--check --assert-expected --json`.
- Checked the n=9 vertex-circle exhaustive artifact command from the artifact tier.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not complete independent review of the exhaustive checker, promote n=9 to a theorem, prove Erdos Problem #97, produce a counterexample, or update official/global status.
- Independent review is still required before any n=9 artifact promotion.