### PR TITLE
Enforce exact quotient soundness claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_quotient_soundness.py
+++ b/scripts/check_n9_vertex_circle_quotient_soundness.py
@@ -286,7 +286,9 @@ def assert_expected_quotient_soundness(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove row coverage",
         "brancher coverage",

--- a/tests/test_n9_vertex_circle_quotient_soundness.py
+++ b/tests/test_n9_vertex_circle_quotient_soundness.py
@@ -5,9 +5,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from erdos97 import n9_vertex_circle_exhaustive as n9
 from erdos97.vertex_circle_quotient_replay import parse_selected_rows
 from scripts.check_n9_vertex_circle_quotient_soundness import (
+    CLAIM_SCOPE,
     EXPECTED_FRONTIER_CORE,
     EXPECTED_FRONTIER_FULL,
     EXPECTED_LOCAL_CORE,
@@ -53,6 +56,14 @@ def test_quotient_soundness_expected_counts_and_scope() -> None:
     assert "strict-edge geometry" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
     assert "official/global status update" in payload["claim_scope"]
+
+
+def test_quotient_soundness_rejects_top_level_claim_scope_append() -> None:
+    payload = quotient_soundness_payload()
+    payload["claim_scope"] = CLAIM_SCOPE + " This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_quotient_soundness(payload)
 
 
 def test_quotient_soundness_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Hardened `check_n9_vertex_circle_quotient_soundness.py` so the top-level `claim_scope` must exactly equal the canonical review-pending quotient-soundness text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.

## Claim scope and evidence level
- Claim-discipline/checker hardening only.
- The quotient-soundness audit remains a review-pending implementation-agreement check across the repo-native checker, reusable replay helper, and direct quotient/status replay.
- No general proof, no counterexample, no official/global status update, and no promotion of n=9 artifacts is claimed.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_quotient_soundness.py tests/test_n9_vertex_circle_quotient_soundness.py`
- `python -m pytest tests/test_n9_vertex_circle_quotient_soundness.py -q`
- `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`

## Artifacts generated or checked
- Checked the quotient-soundness payload with `--check --assert-expected --json`.
- Checked the n=9 vertex-circle exhaustive artifact command from the artifact tier.
- No generated artifacts were changed.

## Known limitations / next review steps
- Does not prove row coverage, brancher coverage, strict-edge geometry, n=9, a counterexample, or official/global status movement.
- Independent review is still required before any n=9 artifact promotion.