### PR TITLE
Enforce exact strict-edge geometry claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_strict_edge_geometry.py
+++ b/scripts/check_n9_vertex_circle_strict_edge_geometry.py
@@ -179,7 +179,9 @@ def assert_expected_strict_edge_geometry(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove row coverage",
         "brancher coverage",

--- a/tests/test_n9_vertex_circle_strict_edge_geometry.py
+++ b/tests/test_n9_vertex_circle_strict_edge_geometry.py
@@ -5,8 +5,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from erdos97 import n9_vertex_circle_exhaustive as n9
 from scripts.check_n9_vertex_circle_strict_edge_geometry import (
+    CLAIM_SCOPE,
     EXPECTED_SELECTED_ROWS,
     EXPECTED_SPAN_HISTOGRAM,
     EXPECTED_STRICT_EDGES_PER_ROW,
@@ -44,6 +47,14 @@ def test_strict_edge_geometry_expected_counts_and_scope() -> None:
     assert "does not prove row coverage" in payload["claim_scope"]
     assert "selected-distance quotient soundness" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_strict_edge_geometry_rejects_appended_claim_scope_overclaim() -> None:
+    payload = strict_edge_geometry_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_strict_edge_geometry(payload)
 
 
 def test_strict_edge_geometry_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Tightened `scripts/check_n9_vertex_circle_strict_edge_geometry.py` so `assert_expected_strict_edge_geometry` requires the emitted `claim_scope` to match the canonical `CLAIM_SCOPE` exactly.
- Added a regression test that appends `This proves n=9.` to the otherwise-valid claim scope and expects a `claim_scope mismatch` failure.

## Claim scope and evidence level
- Scope remains a review-pending strict-edge geometry rule audit for the n=9 vertex-circle checker only.
- This does not prove row coverage, brancher coverage, selected-distance quotient soundness, n=9, a counterexample, or any official/global status update.
- Evidence level is guardrail/test hardening around an existing review-pending diagnostic.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_strict_edge_geometry.py tests/test_n9_vertex_circle_strict_edge_geometry.py`
- `python -m pytest tests/test_n9_vertex_circle_strict_edge_geometry.py -q`
- `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`

## Artifacts generated or checked
- Checked the strict-edge geometry JSON payload in-memory/CLI; no generated artifact file was changed.
- Rechecked the review-pending n=9 exhaustive artifact replay command for compatibility.

## Known limitations / next review steps
- This only prevents overclaims in this strict-edge geometry checker's expected-payload assertions.
- It does not independently audit quotient soundness, frontier coverage, or the other n=9 review-pending audit layers.
- Continue applying exact claim-scope equality guards to nearby n=9 audit checkers that still rely on substring checks.