### PR TITLE
Enforce exact local-core subset claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_local_core_subset_audit.py
+++ b/scripts/check_n9_vertex_circle_local_core_subset_audit.py
@@ -151,7 +151,9 @@ def assert_expected_local_core_subset_audit(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove frontier coverage",
         "brancher soundness",

--- a/tests/test_n9_vertex_circle_local_core_subset_audit.py
+++ b/tests/test_n9_vertex_circle_local_core_subset_audit.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_vertex_circle_local_core_subset_audit import (
+    CLAIM_SCOPE,
     DEFAULT_LOCAL_CORE_PACKET,
     DEFAULT_MOTIF_FAMILIES,
     assert_expected_local_core_subset_audit,
@@ -28,6 +31,14 @@ def test_local_core_subset_audit_counts_and_scope() -> None:
     assert summary["unobstructed_core_count"] == 0
     assert "does not prove frontier coverage" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_local_core_subset_audit_rejects_appended_claim_scope_overclaim() -> None:
+    payload = local_core_subset_audit_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_local_core_subset_audit(payload)
 
 
 def test_local_core_subset_audit_rejects_row_outside_full_family(


### PR DESCRIPTION
## What changed
- Tightened `scripts/check_n9_vertex_circle_local_core_subset_audit.py` so `assert_expected_local_core_subset_audit` requires the emitted `claim_scope` to match the canonical `CLAIM_SCOPE` exactly.
- Added a regression test that appends `This proves n=9.` to the otherwise-valid claim scope and expects a `claim_scope mismatch` failure.

## Claim scope and evidence level
- Scope remains a cross-artifact input audit for the review-pending n=9 vertex-circle motif representatives and compact local-core packet.
- This does not prove frontier coverage, brancher soundness, motif-orbit bookkeeping, n=9, a counterexample, or any official/global status update.
- Evidence level is no-overclaiming assertion/test hardening for an existing review-pending diagnostic.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_core_subset_audit.py tests/test_n9_vertex_circle_local_core_subset_audit.py`
- `python -m pytest tests/test_n9_vertex_circle_local_core_subset_audit.py -q`
- `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`

## Artifacts generated or checked
- Checked the local-core subset audit JSON payload in-memory/CLI; no generated artifact file was changed.
- Rechecked the review-pending n=9 exhaustive artifact replay command for compatibility.

## Known limitations / next review steps
- This only prevents overclaims in the local-core subset audit expected-payload assertions.
- It does not independently audit frontier coverage, brancher soundness, motif orbit bookkeeping, quotient soundness, or the full n=9 review-pending stack.
- Continue applying exact claim-scope equality guards to remaining nearby n=9 audit checkers that still rely on substring checks.