### PR TITLE
Enforce exact motif obstruction claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_motif_obstruction_audit.py
+++ b/scripts/check_n9_vertex_circle_motif_obstruction_audit.py
@@ -148,7 +148,9 @@ def assert_expected_motif_obstruction_audit(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove frontier coverage",
         "brancher soundness",

--- a/tests/test_n9_vertex_circle_motif_obstruction_audit.py
+++ b/tests/test_n9_vertex_circle_motif_obstruction_audit.py
@@ -5,7 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n9_vertex_circle_motif_obstruction_audit import (
+    CLAIM_SCOPE,
     DEFAULT_MOTIF_FAMILIES,
     assert_expected_motif_obstruction_audit,
     motif_obstruction_audit_payload,
@@ -28,6 +31,14 @@ def test_motif_obstruction_audit_payload_counts_and_scope() -> None:
     assert summary["strict_cycle_edge_mismatches"] == 0
     assert "does not prove frontier coverage" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_motif_obstruction_audit_rejects_appended_claim_scope_overclaim() -> None:
+    payload = motif_obstruction_audit_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_motif_obstruction_audit(payload)
 
 
 def test_motif_obstruction_audit_rejects_bad_self_edge_conflict(


### PR DESCRIPTION
## What changed
- Tightened `scripts/check_n9_vertex_circle_motif_obstruction_audit.py` so `assert_expected_motif_obstruction_audit` requires the emitted `claim_scope` to match the canonical `CLAIM_SCOPE` exactly.
- Added a regression test that appends `This proves n=9.` to the otherwise-valid claim scope and expects a `claim_scope mismatch` failure.

## Claim scope and evidence level
- Scope remains a stored-certificate audit for the 16 review-pending n=9 vertex-circle motif representatives.
- This does not prove frontier coverage, brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, n=9, a counterexample, or any official/global status update.
- Evidence level is no-overclaiming assertion/test hardening for an existing review-pending diagnostic.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_motif_obstruction_audit.py tests/test_n9_vertex_circle_motif_obstruction_audit.py`
- `python -m pytest tests/test_n9_vertex_circle_motif_obstruction_audit.py -q`
- `python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`

## Artifacts generated or checked
- Checked the motif-obstruction audit JSON payload in-memory/CLI; no generated artifact file was changed.
- Rechecked the review-pending n=9 exhaustive artifact replay command for compatibility.

## Known limitations / next review steps
- This only prevents overclaims in the motif-obstruction audit expected-payload assertions.
- It does not independently audit frontier coverage, brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, or the full n=9 review-pending stack.
- Continue applying exact claim-scope equality guards to remaining nearby n=9 audit checkers that still rely on substring checks.