### PR TITLE
Enforce exact MRO branching replay claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_mro_branching_replay.py
+++ b/scripts/check_n9_vertex_circle_mro_branching_replay.py
@@ -197,7 +197,9 @@ def assert_expected_mro_branching_replay(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove the filters",
         "does not independently replay vertex-circle geometry",

--- a/tests/test_n9_vertex_circle_mro_branching_replay.py
+++ b/tests/test_n9_vertex_circle_mro_branching_replay.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scripts.check_n9_vertex_circle_mro_branching_replay import (
+    CLAIM_SCOPE,
     DEFAULT_ARTIFACT,
     EXPECTED_FIXED_CROSS_COUNTS,
     EXPECTED_FIXED_CROSS_FULL,
@@ -70,6 +71,16 @@ def test_mro_branching_replay_expected_counts_and_scope(
     assert comparison["cross_check_status_counts_match"] is True
     assert "does not prove n=9" in replay_payload["claim_scope"]
     assert "does not claim a counterexample" in replay_payload["claim_scope"]
+
+
+def test_mro_branching_replay_rejects_appended_claim_scope_overclaim(
+    replay_payload: dict[str, object],
+) -> None:
+    replay_payload = dict(replay_payload)
+    replay_payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_mro_branching_replay(replay_payload)
 
 
 def test_mro_branching_replay_rejects_dynamic_count_drift() -> None:


### PR DESCRIPTION
## What changed
- Tightened `scripts/check_n9_vertex_circle_mro_branching_replay.py` so `assert_expected_mro_branching_replay` requires the emitted `claim_scope` to match the canonical `CLAIM_SCOPE` exactly.
- Added a regression test that appends `This proves n=9.` to the otherwise-valid claim scope and expects a `claim_scope mismatch` failure.

## Claim scope and evidence level
- Scope remains a fixed-center-order replay audit for the review-pending n=9 vertex-circle exhaustive checker.
- This does not prove the filters, does not independently replay vertex-circle geometry, does not prove n=9, does not claim a counterexample, and does not update the official/global status.
- Evidence level is no-overclaiming assertion/test hardening for an existing review-pending diagnostic.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_mro_branching_replay.py tests/test_n9_vertex_circle_mro_branching_replay.py`
- `python -m pytest tests/test_n9_vertex_circle_mro_branching_replay.py -q -m "artifact and exhaustive"`
- `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`

## Artifacts generated or checked
- Checked the MRO branching replay JSON payload in-memory/CLI; no generated artifact file was changed.
- Rechecked the review-pending n=9 exhaustive artifact replay command for compatibility.

## Known limitations / next review steps
- This only prevents overclaims in the MRO branching replay expected-payload assertions.
- It does not independently audit filter soundness, vertex-circle geometry, quotient soundness, or the full n=9 review-pending stack.
- Continue applying exact claim-scope equality guards to remaining nearby n=9 audit checkers that still rely on substring checks.