### PR TITLE
Enforce exact partial-pruning claim scope

### DIFF
--- a/scripts/check_n9_vertex_circle_partial_pruning.py
+++ b/scripts/check_n9_vertex_circle_partial_pruning.py
@@ -143,7 +143,9 @@ def assert_expected_partial_pruning(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove frontier coverage",
         "brancher soundness",

--- a/tests/test_n9_vertex_circle_partial_pruning.py
+++ b/tests/test_n9_vertex_circle_partial_pruning.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from scripts.check_n9_vertex_circle_partial_pruning import (
+    CLAIM_SCOPE,
     EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS,
     EXPECTED_PREFIX_STATUS_COUNTS,
     EXPECTED_SUBSET_STATUS_COUNTS,
@@ -35,6 +36,14 @@ def test_partial_pruning_payload_scope_and_counts() -> None:
     assert "stored frontier assignment subsets" in payload["claim_scope"]
     assert "does not prove frontier coverage" in payload["claim_scope"]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_partial_pruning_rejects_appended_claim_scope_overclaim() -> None:
+    payload = partial_pruning_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_partial_pruning(payload)
 
 
 def test_partial_pruning_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_partial_pruning` so the artifact `claim_scope` must exactly match the canonical `CLAIM_SCOPE` text.
- Added a regression test proving appended overclaim text such as `This proves n=9.` is rejected.

## Claim scope and evidence level
- Scope remains the review-pending n=9 vertex-circle partial-pruning diagnostic only.
- No general proof, counterexample, n=9 theorem promotion, frontier coverage proof, brancher soundness proof, or official/global status update is claimed.
- Evidence level remains `REVIEW_PENDING_DIAGNOSTIC`.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_partial_pruning.py tests/test_n9_vertex_circle_partial_pruning.py`
- `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_partial_pruning.py -q -m slow`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the partial-pruning replay payload emitted by `scripts/check_n9_vertex_circle_partial_pruning.py`.
- Checked the existing n=9 vertex-circle exhaustive artifact command as the relevant artifact-tier guard.
- No generated artifact files were changed.

## Known limitations / next review steps
- This is a claim-hygiene hardening change only.
- The n=9 artifact remains review-pending and does not establish a public theorem-style result without independent review.