### PR TITLE
Enforce exact mixed-rich frontier claim scope

### DIFF
--- a/scripts/check_n9_mixed_rich_frontier_crosswalk.py
+++ b/scripts/check_n9_mixed_rich_frontier_crosswalk.py
@@ -375,7 +375,9 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not prove the exact-four vertex-circle exhaustive checker",
         "does not prove filter soundness",

--- a/tests/test_n9_mixed_rich_frontier_crosswalk.py
+++ b/tests/test_n9_mixed_rich_frontier_crosswalk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from scripts.check_n9_mixed_rich_frontier_crosswalk import (
+    CLAIM_SCOPE,
     EXPECTED_SUMMARY,
     assert_expected_payload,
     mixed_frontier_crosswalk_payload,
@@ -34,3 +35,11 @@ def test_n9_mixed_rich_frontier_crosswalk_payload() -> None:
         "claim_scope"
     ]
     assert "counterexample" in payload["claim_scope"]
+
+
+def test_n9_mixed_rich_frontier_crosswalk_rejects_appended_claim_scope_overclaim() -> None:
+    payload = mixed_frontier_crosswalk_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_payload(payload)


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_payload` in the mixed-rich/frontier crosswalk so `claim_scope` must exactly match the canonical `CLAIM_SCOPE` text.
- Added a regression test that rejects appended overclaim text such as `This proves n=9.`.

## Claim scope and evidence level
- Scope remains the review-pending mixed-rich support to exact-four frontier crosswalk only.
- No proof of the exact-four vertex-circle exhaustive checker, filter soundness, strict-edge geometry, selected-distance quotient soundness, n=9, Erdos Problem #97, a counterexample, or official/global status movement is claimed.
- Evidence level remains `REVIEW_PENDING_DIAGNOSTIC`.

## Commands run
- `python -m ruff check scripts/check_n9_mixed_rich_frontier_crosswalk.py tests/test_n9_mixed_rich_frontier_crosswalk.py`
- `python scripts/check_n9_mixed_rich_frontier_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_mixed_rich_frontier_crosswalk.py -q -m slow`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_n9_mixed_rich_support_reduction.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the existing mixed-rich/frontier crosswalk artifact against the regenerated payload.
- Rechecked the source mixed-rich support reduction artifact command.
- Rechecked the review-pending n=9 vertex-circle exhaustive command.
- No generated artifact files were changed.

## Known limitations / next review steps
- This is a claim-hygiene hardening change only.
- The crosswalk remains a support-to-frontier landing check and does not independently validate the exact-four vertex-circle pipeline.