### PR TITLE
Enforce exact P20 residue obstruction claim scope

### DIFF
--- a/scripts/check_n9_base_apex_d3_p20_residue_obstruction.py
+++ b/scripts/check_n9_base_apex_d3_p20_residue_obstruction.py
@@ -272,7 +272,9 @@ def assert_expected_p20_residue_obstruction(payload: Mapping[str, Any]) -> None:
                 f"payload[{key!r}] mismatch: expected {expected!r}, got {payload.get(key)!r}"
             )
 
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "not a proof of n=9",
         "not a counterexample",

--- a/tests/test_n9_base_apex_d3_p20_residue_obstruction.py
+++ b/tests/test_n9_base_apex_d3_p20_residue_obstruction.py
@@ -1,4 +1,7 @@
+import pytest
+
 from scripts.check_n9_base_apex_d3_p20_residue_obstruction import (
+    CLAIM_SCOPE,
     DEFAULT_PACKET,
     assert_expected_p20_residue_obstruction,
     load_json,
@@ -10,3 +13,12 @@ def test_n9_base_apex_d3_p20_residue_obstruction_artifact():
     packet = load_json(DEFAULT_PACKET)
     payload = p20_residue_obstruction_payload(packet, packet_path=DEFAULT_PACKET)
     assert_expected_p20_residue_obstruction(payload)
+
+
+def test_n9_base_apex_d3_p20_residue_obstruction_rejects_claim_scope_overclaim():
+    packet = load_json(DEFAULT_PACKET)
+    payload = p20_residue_obstruction_payload(packet, packet_path=DEFAULT_PACKET)
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=9."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_p20_residue_obstruction(payload)


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_p20_residue_obstruction` so `claim_scope` must exactly match the canonical `CLAIM_SCOPE` text.
- Added a regression test proving appended overclaim text such as `This proves n=9.` is rejected.

## Claim scope and evidence level
- Scope remains the exact finite profile-capacity obstruction for only the P20 rows `R008..R015` of the n=9 base-apex D=3 incidence-capacity packet.
- This does not prove n=9, does not claim a counterexample, does not test geometric realizability, does not prove incidence completeness, and does not update global status.
- Evidence level remains `FINITE_BOOKKEEPING_NOT_A_PROOF`.

## Commands run
- `python -m ruff check scripts/check_n9_base_apex_d3_p20_residue_obstruction.py tests/test_n9_base_apex_d3_p20_residue_obstruction.py`
- `python scripts/check_n9_base_apex_d3_p20_residue_obstruction.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_base_apex_d3_p20_residue_obstruction.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json`
- `python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json`
- `python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the P20 residue obstruction payload.
- Checked the adjacent P19 incidence-capacity pilot and all-row D=3 incidence-capacity packet.
- Rechecked the review-pending n=9 vertex-circle exhaustive guard command.
- No generated artifact files were changed.

## Known limitations / next review steps
- This is claim-hygiene hardening for an existing finite P20 slice checker only.
- P21..P29 remain separate finite targets; this PR does not change their status.