### PR TITLE
Enforce exact n10 singleton input claim scope

### DIFF
--- a/scripts/check_n10_singleton_input_audit.py
+++ b/scripts/check_n10_singleton_input_audit.py
@@ -130,7 +130,9 @@ def assert_expected_input_audit(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not rerun the search",
         "does not prove n=10",

--- a/tests/test_n10_singleton_input_audit.py
+++ b/tests/test_n10_singleton_input_audit.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.check_n10_singleton_input_audit import (
+    CLAIM_SCOPE,
     DEFAULT_ARTIFACT,
     EXPECTED_COUNTS,
     EXPECTED_ROW0_CHOICES,
@@ -77,6 +80,14 @@ def test_n10_singleton_input_audit_expected_counts_and_scope() -> None:
     assert "does not rerun the search" in payload["claim_scope"]
     assert "does not prove n=10" in payload["claim_scope"]
     assert "does not claim a counterexample" in payload["claim_scope"]
+
+
+def test_n10_singleton_input_audit_rejects_appended_claim_scope_overclaim() -> None:
+    payload = n10_singleton_input_audit_payload(_payload())
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=10."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_input_audit(payload)
 
 
 def test_n10_singleton_input_audit_rejects_missing_row() -> None:


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_input_audit` so the n=10 singleton input-audit payload must match the exact checked claim scope.
- Added a regression test that appends an overclaiming sentence to the claim scope and verifies the checker rejects it.

## Claim scope and evidence level
- Scope is limited to input-data audit validation for the draft review-pending n=10 singleton-slice artifact.
- This does not rerun the search, replay terminal conflicts, prove n=10, claim a counterexample, or update the official/global status.
- Evidence remains `REVIEW_PENDING_DIAGNOSTIC` for the audit and draft/review-pending for the n=10 artifacts.

## Commands run
- `python -m ruff check scripts/check_n10_singleton_input_audit.py tests/test_n10_singleton_input_audit.py`
- `python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json`
- `python -m pytest tests/test_n10_singleton_input_audit.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json`
- `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125`
- `python -m pytest tests/test_n10_vertex_circle_singletons.py -q -m "artifact"`

## Artifacts generated or checked
- Checked `data/certificates/n10_vertex_circle_singleton_slices.json` via the input-audit checker.
- Checked `data/certificates/2026-05-05/n10_secondary.json` via the secondary replay checker.
- No generated artifact contents were changed.

## Known limitations / next review steps
- This is a guardrail/documentation-scope hardening only; it does not strengthen the n=10 result beyond review-pending diagnostic status.
- Future work should continue exact-scope hardening for nearby n=10 and Kalmanson diagnostic checkers.