### PR TITLE
Enforce exact n10 row0 combined closure claim scope

### DIFF
--- a/scripts/check_n10_turn_row0_combined_closure.py
+++ b/scripts/check_n10_turn_row0_combined_closure.py
@@ -402,7 +402,9 @@ def assert_expected_payload(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "not a proof of n=10",
         "not a complete n=10 search",

--- a/tests/test_n10_turn_row0_combined_closure.py
+++ b/tests/test_n10_turn_row0_combined_closure.py
@@ -4,12 +4,15 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 from check_n10_turn_row0_combined_closure import (  # noqa: E402
+    CLAIM_SCOPE,
     DEFAULT_OUT,
     assert_expected_payload,
     build_payload,
@@ -20,6 +23,14 @@ def test_n10_turn_row0_combined_closure_matches_expected() -> None:
     payload = build_payload()
 
     assert_expected_payload(payload)
+
+
+def test_n10_turn_row0_combined_closure_rejects_appended_claim_scope_overclaim() -> None:
+    payload = build_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves n=10."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected_payload(payload)
 
 
 def test_n10_turn_row0_combined_closure_artifact_is_current() -> None:


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_payload` in the n=10 row0 turn + vertex-circle combined-closure checker so `claim_scope` must match the exact checked constant.
- Added a regression test that appends an overclaiming sentence and verifies the checker rejects it.

## Claim scope and evidence level
- Scope remains a bounded row0-index-0 finite-bookkeeping crosswalk: stored weak-turn Farkas certificates close 156 assignments, and four weak-turn SAT escapes are matched to stored row0-local vertex-circle self-edge templates.
- This is not a proof of n=10, not a complete n=10 search, not a counterexample, and not a global status update.
- Evidence remains `FINITE_BOOKKEEPING_NOT_A_PROOF`.

## Commands run
- `python -m ruff check scripts/check_n10_turn_row0_combined_closure.py tests/test_n10_turn_row0_combined_closure.py`
- `python scripts/check_n10_turn_row0_combined_closure.py --check --assert-expected --json`
- `python -m pytest tests/test_n10_turn_row0_combined_closure.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n10_turn_row0_pilot.py --check --assert-expected --json`
- `python scripts/check_n10_turn_row0_escape_self_edges.py --check --assert-expected --json`
- `python -m pytest tests/test_n10_turn_row0_pilot.py tests/test_n10_turn_row0_escape_self_edges.py tests/test_n10_turn_row0_combined_closure.py -q`

## Artifacts generated or checked
- Checked `data/certificates/n10_turn_row0_pilot.json`.
- Checked `data/certificates/n10_turn_row0_escape_self_edges.json`.
- Checked `data/certificates/n10_turn_row0_combined_closure.json`.
- No generated artifact contents were changed.

## Known limitations / next review steps
- This only hardens the exact scope accepted by the checker; it does not strengthen the n=10 result beyond bounded finite bookkeeping.
- Future cycles should continue exact-scope hardening for the remaining Kalmanson/sparse-frontier diagnostic checkers.