### PR TITLE
Enforce exact sparse frontier template claim scope

### DIFF
--- a/scripts/analyze_kalmanson_sparse_frontier_templates.py
+++ b/scripts/analyze_kalmanson_sparse_frontier_templates.py
@@ -146,7 +146,9 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not search cyclic orders",
         "does not prove an all-order obstruction",

--- a/tests/test_kalmanson_sparse_frontier_templates.py
+++ b/tests/test_kalmanson_sparse_frontier_templates.py
@@ -9,6 +9,7 @@ import pytest
 
 from scripts.analyze_kalmanson_sparse_frontier_templates import (
     CHECKED_PILOT_TEMPLATE_SET,
+    CLAIM_SCOPE,
     assert_expected,
     diagnostic_payload,
 )
@@ -60,6 +61,14 @@ def test_kalmanson_sparse_frontier_template_claim_scope_is_guarded() -> None:
     assert "does not claim a counterexample" in claim_scope
     assert "availability" in payload["interpretation"]
     assert "does not obstruct C25 or C29" in payload["interpretation"]
+
+
+def test_kalmanson_sparse_frontier_template_rejects_appended_claim_scope_overclaim() -> None:
+    payload = diagnostic_payload(top=1)
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves Erdos Problem #97."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected(payload)
 
 
 def test_kalmanson_sparse_frontier_template_rejects_tampering() -> None:


### PR DESCRIPTION
## What changed
- Tightened the Kalmanson sparse-frontier template diagnostic so `claim_scope` must match the exact checked constant.
- Added a regression test that appends an overclaiming proof sentence and verifies the checker rejects it.

## Claim scope and evidence level
- Scope remains an exact coefficient-template availability diagnostic for the registered `C25_sidon_2_5_9_14` and `C29_sidon_1_3_7_15` sparse-frontier selected-witness patterns.
- This does not search cyclic orders, prove an all-order obstruction, prove Erdos Problem #97, claim a counterexample, or transfer the obstruction to arbitrary selected-witness systems.
- Evidence remains `EXACT_CERTIFICATE_DIAGNOSTIC` and does not update the official/global status.

## Commands run
- `python -m ruff check scripts/analyze_kalmanson_sparse_frontier_templates.py tests/test_kalmanson_sparse_frontier_templates.py`
- `python scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json`
- `python -m pytest tests/test_kalmanson_sparse_frontier_templates.py -q -m slow`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the sparse-frontier template diagnostic output from `scripts/analyze_kalmanson_sparse_frontier_templates.py`.
- Read `data/patterns/candidate_patterns.json` through the diagnostic.
- No generated artifact contents were changed.

## Known limitations / next review steps
- This hardens accepted claim scope only; it does not strengthen the sparse-frontier diagnostic beyond template availability.
- Remaining exact-scope hardening candidates include the inverse-pair template diagnostic and sparse-frontier Kalmanson escape checker.