### PR TITLE
Enforce exact inverse pair template claim scope

### DIFF
--- a/scripts/analyze_kalmanson_inverse_pair_templates.py
+++ b/scripts/analyze_kalmanson_inverse_pair_templates.py
@@ -299,7 +299,9 @@ def assert_expected(payload: Mapping[str, Any]) -> None:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
     if payload.get("provenance") != PROVENANCE:
         raise AssertionError(f"provenance mismatch: {payload.get('provenance')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "does not search new cyclic orders",
         "does not prove Erdos Problem #97",

--- a/tests/test_kalmanson_inverse_pair_templates.py
+++ b/tests/test_kalmanson_inverse_pair_templates.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from scripts.analyze_kalmanson_inverse_pair_templates import (
+    CLAIM_SCOPE,
     assert_expected,
     diagnostic_payload,
 )
@@ -81,6 +82,14 @@ def test_kalmanson_inverse_pair_template_rejects_tampering() -> None:
         assert "C19_skew inverse_vector_pair_count mismatch" in str(exc)
     else:  # pragma: no cover - defensive assertion shape
         raise AssertionError("tampered inverse-pair diagnostic unexpectedly passed")
+
+
+def test_kalmanson_inverse_pair_template_rejects_appended_claim_scope_overclaim() -> None:
+    payload = diagnostic_payload()
+    payload["claim_scope"] = f"{CLAIM_SCOPE} This proves Erdos Problem #97."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
+        assert_expected(payload)
 
 
 def test_kalmanson_inverse_pair_template_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Tightened the Kalmanson inverse-pair template diagnostic so `claim_scope` must match the exact checked constant.
- Added a regression test that appends an overclaiming proof sentence and verifies the checker rejects it.

## Claim scope and evidence level
- Scope remains a coefficient-template diagnostic for checked all-order C13 Sidon and C19 skew Kalmanson inverse-pair pilots.
- This classifies quotient-vector inverse pairs available to fixed abstract selected-witness patterns only.
- It does not search new cyclic orders, prove Erdos Problem #97, claim a counterexample, transfer the obstruction to other patterns, or update official/global status.
- Evidence remains `EXACT_CERTIFICATE_DIAGNOSTIC`.

## Commands run
- `python -m ruff check scripts/analyze_kalmanson_inverse_pair_templates.py tests/test_kalmanson_inverse_pair_templates.py`
- `python scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json`
- `python -m pytest tests/test_kalmanson_inverse_pair_templates.py -q -m slow`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/c13_sidon_all_orders_kalmanson_two_search.json` through the diagnostic.
- Checked `data/certificates/c19_skew_all_orders_kalmanson_z3.json` through the diagnostic.
- No generated artifact contents were changed.

## Known limitations / next review steps
- This hardens accepted claim scope only; it does not strengthen the inverse-pair diagnostic beyond coefficient-template classification.
- Remaining exact-scope hardening candidate: the sparse-frontier Kalmanson escape checker.