### PR TITLE
Enforce exact sparse frontier escape claim scope

### DIFF
--- a/scripts/check_sparse_frontier_kalmanson_escapes.py
+++ b/scripts/check_sparse_frontier_kalmanson_escapes.py
@@ -309,7 +309,9 @@ def assert_expected(payload: Mapping[str, object]) -> None:
         raise AssertionError(f"status mismatch: {payload.get('status')!r}")
     if payload.get("trust") != TRUST:
         raise AssertionError(f"trust mismatch: {payload.get('trust')!r}")
-    claim_scope = str(payload.get("claim_scope", ""))
+    if payload.get("claim_scope") != CLAIM_SCOPE:
+        raise AssertionError(f"claim_scope mismatch: {payload.get('claim_scope')!r}")
+    claim_scope = CLAIM_SCOPE
     for required in (
         "not an all-order obstruction",
         "not a geometric realizability result",

--- a/tests/test_sparse_frontier_kalmanson_escapes.py
+++ b/tests/test_sparse_frontier_kalmanson_escapes.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scripts.check_sparse_frontier_kalmanson_escapes import (
+    CLAIM_SCOPE,
     SCHEMA,
     STATUS,
     assert_expected,
@@ -65,6 +66,16 @@ def test_sparse_frontier_kalmanson_escape_rejects_drift(
     bad["cases"][0]["inverse_pair_conflicts"] = 1
 
     with pytest.raises(AssertionError, match="inverse_pair_conflicts changed"):
+        assert_expected(bad)
+
+
+def test_sparse_frontier_kalmanson_escape_rejects_appended_claim_scope_overclaim(
+    payload: dict[str, object],
+) -> None:
+    bad = copy.deepcopy(payload)
+    bad["claim_scope"] = f"{CLAIM_SCOPE} This proves Erdos Problem #97."
+
+    with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected(bad)
 
 


### PR DESCRIPTION
## What changed
- Tightened the sparse-frontier Kalmanson escape audit so `claim_scope` must match the exact checked constant.
- Added a regression test that appends an overclaiming proof sentence and verifies the checker rejects it.

## Claim scope and evidence level
- Scope remains a fixed-order sparse-frontier probe audit for whether the direct two-inequality Kalmanson inverse-pair filter sees a contradiction after selected-distance quotienting.
- This is not an all-order obstruction, not a geometric realizability result, not a counterexample, not a proof of Erdos Problem #97, and not an official/global status update.
- Evidence remains `REVIEW_PENDING_DIAGNOSTIC`.

## Commands run
- `python -m ruff check scripts/check_sparse_frontier_kalmanson_escapes.py tests/test_sparse_frontier_kalmanson_escapes.py`
- `python scripts/check_sparse_frontier_kalmanson_escapes.py --check --assert-expected --json`
- `python -m pytest tests/test_sparse_frontier_kalmanson_escapes.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/sparse_frontier_kalmanson_escape_audit.json`.
- Read `data/certificates/c25_c29_sparse_frontier_probe.json` through the audit.
- No generated artifact contents were changed.

## Known limitations / next review steps
- This hardens accepted claim scope only; it does not strengthen the sparse-frontier escape audit beyond fixed-order review-pending diagnostics.
- The stored C25/C29 fixed orders still escape this lightweight inverse-pair route; stronger fixed-order certificates or additional geometric filters remain the next research path.