### PR TITLE
Guard against soft claim scope coercion

### DIFF
--- a/tests/test_claim_scope_guardrails.py
+++ b/tests/test_claim_scope_guardrails.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+SOFT_CLAIM_SCOPE_COERCION = re.compile(
+    r"claim_scope\s*=\s*str\(\s*payload\.get\(\s*['\"]claim_scope['\"]"
+)
+
+
+def test_scripts_do_not_accept_claim_scope_by_string_coercion() -> None:
+    offenders = []
+    for path in sorted(SCRIPTS.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if SOFT_CLAIM_SCOPE_COERCION.search(text):
+            offenders.append(path.relative_to(ROOT).as_posix())
+
+    assert offenders == [], (
+        "claim_scope validators must compare against the exact expected string; "
+        f"found soft string-coercion guards in {offenders}"
+    )


### PR DESCRIPTION
## What changed
- Added a regression test that scans `scripts/*.py` for the soft claim-scope anti-pattern `claim_scope = str(payload.get("claim_scope", ...))`.
- The test preserves the completed sweep that moved checkers to exact claim-scope comparisons.

## Claim scope and evidence level
- This is a test guardrail only.
- It makes no mathematical claim, does not prove Erdos Problem #97, does not claim a counterexample, and does not update official/global status.

## Commands run
- `python -m ruff check tests/test_claim_scope_guardrails.py`
- `python -m pytest tests/test_claim_scope_guardrails.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No generated artifacts were changed.
- Checked repository scripts for the soft claim-scope coercion anti-pattern through the new pytest guard.

## Known limitations / next review steps
- This guards one concrete anti-pattern; it does not prove every claim-scope validator is semantically ideal.
- Future research work should move back from guardrail hardening to the highest-priority certificate/audit tasks in the backlog.