### PR TITLE
Assert n9 local lemma layer summaries

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -415,6 +415,23 @@ HANDOFF_COMPARE_KEYS = (
     "strict_cycle_family_count",
     "strict_cycle_assignment_count",
 )
+EXPECTED_LAYER_SUMMARY_COUNTS = {
+    layer_id: {
+        "template_count": 12,
+        "template_ids": EXPECTED_TEMPLATE_IDS,
+        "family_count": 16,
+        "assignment_count": 184,
+        "self_edge_family_count": 13,
+        "self_edge_assignment_count": 158,
+        "strict_cycle_family_count": 3,
+        "strict_cycle_assignment_count": 26,
+    }
+    for layer_id in EXPECTED_LAYER_IDS
+}
+EXPECTED_LAYER_SUMMARY_COUNTS["relation_skeleton_local_lemma"] = {
+    **EXPECTED_LAYER_SUMMARY_COUNTS["relation_skeleton_local_lemma"],
+    "relation_skeleton_count": 16,
+}
 
 AssertFn = Callable[[Mapping[str, Any]], None]
 
@@ -642,6 +659,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_manifest_consistency(payload)
     _assert_expected_manifest_contract_summary(payload)
     _assert_expected_audit_contract_summary(payload)
+    _assert_expected_layer_summaries(payload)
 
     audit_path = payload.get("audit_path")
     if not isinstance(audit_path, Mapping):
@@ -1234,6 +1252,39 @@ def _assert_expected_audit_contract_summary(payload: Mapping[str, Any]) -> None:
                 f"audit_contract_summary[{key!r}] mismatch: "
                 f"{summary.get(key)!r} != {value!r}"
             )
+
+
+def _assert_expected_layer_summaries(payload: Mapping[str, Any]) -> None:
+    audit_path = payload.get("audit_path")
+    if not isinstance(audit_path, Mapping):
+        raise AssertionError("audit_path must be an object")
+    layer_summaries = audit_path.get("layers")
+    if not isinstance(layer_summaries, list):
+        raise AssertionError("audit_path.layers must be a list")
+    observed_ids = [
+        summary.get("layer_id")
+        for summary in layer_summaries
+        if isinstance(summary, Mapping)
+    ]
+    if observed_ids != EXPECTED_LAYER_IDS:
+        raise AssertionError(f"layer summary ids mismatch: {observed_ids!r}")
+    for summary in layer_summaries:
+        if not isinstance(summary, Mapping):
+            raise AssertionError("layer summary must be an object")
+        layer_id = str(summary.get("layer_id"))
+        expected = _expected_layer_summary(layer_id)
+        if summary != expected:
+            raise AssertionError(
+                f"{layer_id} layer summary mismatch: {summary!r} != {expected!r}"
+            )
+
+
+def _expected_layer_summary(layer_id: str) -> dict[str, Any]:
+    return {
+        "layer_id": layer_id,
+        **EXPECTED_LAYER_CONTRACTS[layer_id],
+        **EXPECTED_LAYER_SUMMARY_COUNTS[layer_id],
+    }
 
 
 def _append_layer_expected_errors(

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1148,6 +1148,18 @@ def test_local_lemma_audit_path_layer_summaries() -> None:
     assert by_layer["relation_skeleton_local_lemma"]["relation_skeleton_count"] == 16
 
 
+def test_local_lemma_audit_path_rejects_layer_summary_drift() -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["audit_path"]["layers"][0]["assignment_count"] = 183
+
+    try:
+        assert_expected_local_lemma_audit_path(payload)
+    except AssertionError as exc:
+        assert "focused_packet_catalog layer summary mismatch" in str(exc)
+    else:
+        raise AssertionError("expected layer summary mismatch")
+
+
 def test_local_lemma_audit_path_handoff_summaries() -> None:
     payload = local_lemma_audit_path_payload()
     handoffs = payload["audit_path"]["handoff_checks"]


### PR DESCRIPTION
## What changed
- Added exact expected per-layer summary contracts to `check_n9_vertex_circle_local_lemma_audit_path.py`.
- Wired `--assert-expected` to reject drift in `audit_path.layers`, including assignment/family counts and relation-skeleton counts.
- Added a regression test that tampers with a layer assignment count and expects the assertion path to fail.

## Claim scope and evidence level
- Scope is limited to the review-pending `n=9` vertex-circle local-lemma audit-path checker.
- This strengthens checker/audit consistency only; it does not claim a general proof, a counterexample, or a global status update.
- The existing repository status remains unchanged: official/global status open/falsifiable, `n <= 8` repo-local machine-checked, and `n=9` artifacts review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the local-lemma audit-path payload via `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This is a checker hardening increment, not an independent mathematical review of the n=9 local-lemma artifacts.
- Follow-up review should continue strengthening independent audit paths for the review-pending n=9 layer stack.