### PR TITLE
Assert n9 audit handoff key contracts

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -671,6 +671,9 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     handoffs = audit_path.get("handoff_checks")
     if not isinstance(handoffs, list):
         raise AssertionError("handoff_checks must be a list")
+    for handoff in handoffs:
+        if not isinstance(handoff, Mapping):
+            raise AssertionError("handoff check must be an object")
     expected_edges = [
         {"from_layer": left, "to_layer": right}
         for left, right in EXPECTED_HANDOFF_EDGES
@@ -685,6 +688,12 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     if observed_edges != expected_edges:
         raise AssertionError(f"handoff edge mismatch: {observed_edges!r}")
     for handoff in handoffs:
+        edge_label = f"{handoff.get('from_layer')}->{handoff.get('to_layer')}"
+        if handoff.get("compared_keys") != list(HANDOFF_COMPARE_KEYS):
+            raise AssertionError(
+                f"{edge_label} handoff compared_keys mismatch: "
+                f"{handoff.get('compared_keys')!r}"
+            )
         if handoff.get("status") != "passed" or handoff.get("mismatches") != []:
             raise AssertionError(f"handoff failed: {handoff!r}")
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1172,6 +1172,23 @@ def test_local_lemma_audit_path_handoff_summaries() -> None:
     assert all(handoff["mismatches"] == [] for handoff in handoffs)
 
 
+def test_local_lemma_audit_path_rejects_handoff_compared_key_drift() -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["audit_path"]["handoff_checks"][0]["compared_keys"].remove(
+        "assignment_count"
+    )
+
+    try:
+        assert_expected_local_lemma_audit_path(payload)
+    except AssertionError as exc:
+        assert (
+            "focused_packet_catalog->focused_minireplay "
+            "handoff compared_keys mismatch"
+        ) in str(exc)
+    else:
+        raise AssertionError("expected handoff compared_keys mismatch")
+
+
 def test_local_lemma_audit_path_rejects_local_replay_drift() -> None:
     aggregate = load_artifact(DEFAULT_AGGREGATE)
     simple_replay = load_artifact(DEFAULT_SIMPLE_REPLAY)


### PR DESCRIPTION
## What changed
- Tightened `assert_expected_local_lemma_audit_path` so every handoff check must be an object.
- Required each audit-path handoff to report the exact expected `HANDOFF_COMPARE_KEYS` list, not only a passing status with empty mismatches.
- Added a regression test that removes `assignment_count` from the first handoff comparison key list and expects `--assert-expected` validation to reject it.

## Claim scope and evidence level
- Scope is limited to checker hardening for the review-pending `n=9` vertex-circle local-lemma audit path.
- This improves drift detection between existing audit layers only; it does not claim a proof, counterexample, incidence completeness, geometric realizability, or global status movement.
- Repository source-of-truth status remains unchanged: official/global status open/falsifiable, `n <= 8` repo-local machine-checked, and `n=9` artifacts review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending n=9 local-lemma audit-path payload with `--check --assert-expected --json`.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This is not an independent mathematical review of the n=9 local-lemma packets or exhaustive checker.
- Follow-up work should keep replacing soft audit assumptions with explicit contracts or move toward proof-facing local lemma extraction.