### PR TITLE
Assert n9 audit coverage summary contract

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -432,6 +432,18 @@ EXPECTED_LAYER_SUMMARY_COUNTS["relation_skeleton_local_lemma"] = {
     **EXPECTED_LAYER_SUMMARY_COUNTS["relation_skeleton_local_lemma"],
     "relation_skeleton_count": 16,
 }
+EXPECTED_COVERAGE_SUMMARY = {
+    "layer_count": 5,
+    "template_count": 12,
+    "template_ids": EXPECTED_TEMPLATE_IDS,
+    "family_count": 16,
+    "assignment_count": 184,
+    "self_edge_family_count": 13,
+    "self_edge_assignment_count": 158,
+    "strict_cycle_family_count": 3,
+    "strict_cycle_assignment_count": 26,
+    "relation_skeleton_count": 16,
+}
 
 AssertFn = Callable[[Mapping[str, Any]], None]
 
@@ -700,25 +712,11 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     coverage = payload.get("coverage_summary")
     if not isinstance(coverage, Mapping):
         raise AssertionError("coverage_summary must be an object")
-    expected = {
-        "layer_count": 5,
-        "template_count": 12,
-        "family_count": 16,
-        "assignment_count": 184,
-        "self_edge_family_count": 13,
-        "self_edge_assignment_count": 158,
-        "strict_cycle_family_count": 3,
-        "strict_cycle_assignment_count": 26,
-        "relation_skeleton_count": 16,
-    }
-    for key, value in expected.items():
-        if coverage.get(key) != value:
-            raise AssertionError(
-                f"coverage_summary[{key!r}] mismatch: expected {value}, "
-                f"got {coverage.get(key)!r}"
-            )
-    if coverage.get("template_ids") != EXPECTED_TEMPLATE_IDS:
-        raise AssertionError(f"template ids mismatch: {coverage.get('template_ids')!r}")
+    if dict(coverage) != EXPECTED_COVERAGE_SUMMARY:
+        raise AssertionError(
+            f"coverage_summary mismatch: {dict(coverage)!r} "
+            f"!= {EXPECTED_COVERAGE_SUMMARY!r}"
+        )
 
 
 def _assert_expected_layer_contracts(payload: Mapping[str, Any]) -> None:

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -110,6 +110,18 @@ def test_local_lemma_audit_path_rejects_top_level_claim_scope_append() -> None:
         raise AssertionError("expected top-level claim_scope mismatch")
 
 
+def test_local_lemma_audit_path_rejects_coverage_summary_extra_key() -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["coverage_summary"]["unreviewed_layer_count"] = 5
+
+    try:
+        assert_expected_local_lemma_audit_path(payload)
+    except AssertionError as exc:
+        assert "coverage_summary mismatch" in str(exc)
+    else:
+        raise AssertionError("expected coverage_summary mismatch")
+
+
 def test_local_lemma_audit_path_input_manifest() -> None:
     payload = local_lemma_audit_path_payload()
     manifest = payload["input_manifest"]


### PR DESCRIPTION
## What changed
- Added a single `EXPECTED_COVERAGE_SUMMARY` contract for the n=9 local-lemma audit-path checker.
- Changed `assert_expected_local_lemma_audit_path` to compare the complete `coverage_summary` mapping instead of only selected fields.
- Added a regression test that injects an unsupported coverage-summary key and expects the assertion path to reject it.

## Claim scope and evidence level
- Scope is limited to checker/audit hardening for the review-pending `n=9` vertex-circle local-lemma audit path.
- This prevents soft expansion of the audit coverage surface; it does not prove packet soundness, prove `n=9`, claim a counterexample, or update global status.
- Repository source-of-truth status remains unchanged: official/global status open/falsifiable, `n <= 8` repo-local machine-checked, and `n=9` artifacts review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending n=9 local-lemma audit-path payload with `--check --assert-expected --json`.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This is an assertion-surface hardening increment, not an independent mathematical review of the local-lemma packets.
- Follow-up work should continue hardening remaining audit summaries or move toward proof-facing local lemma extraction from the focused packets.