### PR TITLE
Assert n9 audit summary line contracts

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -444,6 +444,36 @@ EXPECTED_COVERAGE_SUMMARY = {
     "strict_cycle_assignment_count": 26,
     "relation_skeleton_count": 16,
 }
+EXPECTED_SUMMARY_LINES = [
+    f"schema: {SCHEMA}",
+    f"status: {STATUS}",
+    "validation: passed",
+    "layers: 5",
+    "layer contracts: passed",
+    "layer provenance: passed",
+    "layer source artifacts: passed",
+    "claim-scope guards: passed",
+    "layer output contracts: passed",
+    "layer input contracts: passed",
+    "focused minireplay record paths: passed",
+    f"handoffs: {len(EXPECTED_HANDOFF_EDGES)}",
+    "audit contract summary: passed",
+    f"input artifacts: {EXPECTED_INPUT_ARTIFACT_COUNT}",
+    "manifest roles: passed",
+    "manifest digests: passed",
+    "manifest headers: passed",
+    "manifest provenance: passed",
+    "manifest metadata: passed",
+    "manifest claims: passed",
+    "manifest consistency: passed",
+    "manifest contract summary: passed",
+    "templates: 12",
+    "families: 16",
+    "assignments: 184",
+    "relation skeletons: 16",
+    "self-edge: 13 families, 158 assignments",
+    "strict-cycle: 3 families, 26 assignments",
+]
 
 AssertFn = Callable[[Mapping[str, Any]], None]
 
@@ -716,6 +746,11 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
         raise AssertionError(
             f"coverage_summary mismatch: {dict(coverage)!r} "
             f"!= {EXPECTED_COVERAGE_SUMMARY!r}"
+        )
+    if summary_lines(payload) != EXPECTED_SUMMARY_LINES:
+        raise AssertionError(
+            f"summary_lines mismatch: {summary_lines(payload)!r} "
+            f"!= {EXPECTED_SUMMARY_LINES!r}"
         )
 
 
@@ -3514,6 +3549,7 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         f"templates: {coverage['template_count']}",
         f"families: {coverage['family_count']}",
         f"assignments: {coverage['assignment_count']}",
+        f"relation skeletons: {coverage['relation_skeleton_count']}",
         (
             "self-edge: "
             f"{coverage['self_edge_family_count']} families, "

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -24,6 +24,7 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_LAYER_PROVENANCE,
     EXPECTED_LAYER_SOURCE_ARTIFACTS,
     EXPECTED_MANIFEST_CONTRACT_IDS,
+    EXPECTED_SUMMARY_LINES,
     assert_expected_failure_contract_errors,
     assert_expected_local_lemma_audit_path,
     failure_lines,
@@ -1239,6 +1240,7 @@ def test_local_lemma_audit_path_summary_lines_include_contract_rollups() -> None
     payload = local_lemma_audit_path_payload()
     lines = summary_lines(payload)
 
+    assert lines == EXPECTED_SUMMARY_LINES
     expected_lines = [
         "validation: passed",
         "layer contracts: passed",
@@ -1257,6 +1259,7 @@ def test_local_lemma_audit_path_summary_lines_include_contract_rollups() -> None
         "manifest claims: passed",
         "manifest consistency: passed",
         "manifest contract summary: passed",
+        "relation skeletons: 16",
     ]
 
     for line in expected_lines:


### PR DESCRIPTION
## What changed
- Added an explicit `EXPECTED_SUMMARY_LINES` contract for the n=9 local-lemma audit-path text summary.
- Wired `assert_expected_local_lemma_audit_path` to reject summary-line drift on the passed audit payload.
- Added the relation-skeleton count to the text summary so the CLI surface reflects the checked JSON coverage summary.
- Updated the summary-line test to compare the full ordered line list.

## Claim scope and evidence level
- Scope is limited to reviewer-facing checker output for the review-pending `n=9` vertex-circle local-lemma audit path.
- This is audit-surface hardening only; it does not prove packet soundness, prove `n=9`, claim a counterexample, or update official/global status.
- Repository source-of-truth status remains unchanged: official/global status open/falsifiable, `n <= 8` repo-local machine-checked, and `n=9` artifacts review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending n=9 local-lemma audit-path payload with `--check --assert-expected --json`.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This does not independently review the local-lemma packets or the exhaustive n=9 checker.
- Follow-up work should continue hardening audit assumptions or move toward proof-facing local lemma extraction from focused packet data.