### PR TITLE
Report n9 assert failure messages

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3581,6 +3581,8 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
                 f"{assert_expected_failure.get('schema')}",
                 "assert_expected failure type: "
                 f"{assert_expected_failure.get('exception_type')}",
+                "assert_expected failure message: "
+                f"{assert_expected_failure.get('message')}",
                 "assert_expected failure validation errors: "
                 f"{assert_expected_failure.get('validation_error_count')}",
             ]

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1376,6 +1376,7 @@ def test_local_lemma_audit_path_assert_expected_failure_contract_errors() -> Non
 def test_local_lemma_audit_path_failure_lines_crosscheck_assert_expected_failure() -> None:
     lines = failure_lines(_assert_expected_failure_contract_tamper_payload())
 
+    assert "assert_expected failure message: validation errors: []" in lines
     assert (
         "- assert_expected_failure schema mismatch: "
         "'erdos97.invalid_assert_expected_failure.v1'"


### PR DESCRIPTION
## What changed
- Updated the n=9 local-lemma audit-path text failure summary to include the stored `assert_expected_failure.message` field.
- Added a regression check that the failure summary surfaces that exception message.

## Claim scope and evidence level
- Scope is limited to reviewer-facing failure output for the review-pending `n=9` vertex-circle local-lemma audit path.
- This is diagnostic/audit-surface hardening only; it does not prove packet soundness, prove `n=9`, claim a counterexample, or update official/global status.
- Repository source-of-truth status remains unchanged: official/global status open/falsifiable, `n <= 8` repo-local machine-checked, and `n=9` artifacts review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending n=9 local-lemma audit-path payload with `--check --assert-expected --json`.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This does not independently review local-lemma packet soundness or the exhaustive n=9 checker.
- Follow-up work should continue strengthening audit contracts or move toward proof-facing local lemma extraction.