### PR TITLE
Report malformed n9 validation error entries

### DIFF
--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3603,7 +3603,13 @@ def failure_lines(payload: Mapping[str, Any]) -> list[str]:
     if not isinstance(errors, list):
         lines.append(f"- validation_errors is not a list: {type(errors).__name__}")
         return lines
-    for error in errors:
+    for index, error in enumerate(errors):
+        if not isinstance(error, str):
+            lines.append(
+                f"- validation_errors[{index}] is not a string: "
+                f"{type(error).__name__}"
+            )
+            continue
         lines.append(f"- {error}")
     return lines
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1333,6 +1333,20 @@ def test_local_lemma_audit_path_failure_lines_reject_scalar_errors() -> None:
     ]
 
 
+def test_local_lemma_audit_path_failure_lines_reject_nonstring_error_entries() -> None:
+    lines = failure_lines(
+        {
+            "validation_status": "failed",
+            "validation_errors": [{"error": "not text"}],
+        }
+    )
+
+    assert lines == [
+        "FAILED: local-lemma audit path",
+        "- validation_errors[0] is not a string: dict",
+    ]
+
+
 def test_local_lemma_audit_path_assert_expected_failure_contract_errors() -> None:
     valid_record = {
         "schema": ASSERT_EXPECTED_FAILURE_SCHEMA,


### PR DESCRIPTION
## What changed
- Hardened the n=9 local-lemma audit-path text failure summary for malformed `validation_errors` lists.
- Non-string entries now produce an explicit `validation_errors[index] is not a string` diagnostic instead of being printed as raw Python objects.
- Added a regression test for a dict entry inside `validation_errors`.

## Claim scope and evidence level
- Scope is limited to reviewer-facing failure output for the review-pending `n=9` vertex-circle local-lemma audit path.
- This is diagnostic/audit-surface hardening only; it does not prove packet soundness, prove `n=9`, claim a counterexample, or update official/global status.
- Repository source-of-truth status remains unchanged: official/global status open/falsifiable, `n <= 8` repo-local machine-checked, and `n=9` artifacts review-pending.

## Commands run
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the review-pending n=9 local-lemma audit-path payload with `--check --assert-expected --json`.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This does not independently review local-lemma packet soundness or the exhaustive n=9 checker.
- Follow-up work should continue strengthening audit contracts or move toward proof-facing local lemma extraction.