### PR TITLE
Harden n9 assert failure count contract

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -693,6 +693,10 @@ fails, the fallback payload records `failure_stage: payload_construction` and
 the Python exception type before returning nonzero under `--check`. Text-mode
 failure rendering also rejects malformed scalar `validation_errors` payloads
 as a single schema problem instead of treating the scalar as multiple errors.
+Malformed non-string entries in a `validation_errors` list are normalized to
+explicit typed diagnostics before assert-expected failure counting, so the
+nested failure record and the reviewer-facing error list agree on what was
+actually malformed.
 JSON diagnostics for `--assert-expected` failures also include an
 `assert_expected_failure` object with its own schema tag, assertion stage,
 Python exception type, message, and underlying validation-error count so

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3435,6 +3435,21 @@ def _string_list(value: Any) -> list[str]:
     return [str(item) for item in value]
 
 
+def _normalized_validation_errors(errors: Any) -> list[str] | None:
+    if not isinstance(errors, list):
+        return None
+    normalized: list[str] = []
+    for index, error in enumerate(errors):
+        if isinstance(error, str):
+            normalized.append(error)
+        else:
+            normalized.append(
+                f"validation_errors[{index}] is not a string: "
+                f"{type(error).__name__}"
+            )
+    return normalized
+
+
 def assert_expected_failure_contract_errors(
     record: Any,
     *,
@@ -3482,13 +3497,14 @@ def assert_expected_failure_contract_errors(
 
 
 def _assert_expected_failure_validation_error_count(errors: Any) -> int | None:
-    if not isinstance(errors, list):
+    normalized = _normalized_validation_errors(errors)
+    if normalized is None:
         return None
     return sum(
         1
-        for error in errors
-        if not str(error).startswith("assert_expected failed:")
-        and not str(error).startswith("assert_expected_failure ")
+        for error in normalized
+        if not error.startswith("assert_expected failed:")
+        and not error.startswith("assert_expected_failure ")
     )
 
 
@@ -3637,9 +3653,8 @@ def _payload_with_existing_assert_expected_failure_contract_check(
 
     updated = dict(payload)
     raw_errors = updated.get("validation_errors", [])
-    if isinstance(raw_errors, list):
-        errors = [str(error) for error in raw_errors]
-    else:
+    errors = _normalized_validation_errors(raw_errors)
+    if errors is None:
         errors = [f"validation_errors is not a list: {type(raw_errors).__name__}"]
     for error in contract_errors:
         if error not in errors:
@@ -3654,11 +3669,10 @@ def _payload_with_assert_expected_failure(
     exc: Exception,
 ) -> dict[str, Any]:
     updated = dict(payload)
-    errors = payload.get("validation_errors", [])
-    if not isinstance(errors, list):
-        errors = [f"validation_errors is not a list: {type(errors).__name__}"]
-    else:
-        errors = [str(error) for error in errors]
+    raw_errors = payload.get("validation_errors", [])
+    errors = _normalized_validation_errors(raw_errors)
+    if errors is None:
+        errors = [f"validation_errors is not a list: {type(raw_errors).__name__}"]
     validation_error_count = len(errors)
     message = f"assert_expected failed: {exc}"
     if message not in errors:

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1572,6 +1572,34 @@ def test_local_lemma_audit_path_cli_json_scalar_validation_errors_shape(
     }
 
 
+def test_local_lemma_audit_path_cli_json_nonstring_validation_errors_shape(
+    monkeypatch,
+    capsys,
+) -> None:
+    malformed_payload = local_lemma_audit_path_payload()
+    malformed_payload["validation_status"] = "failed"
+    malformed_payload["validation_errors"] = [{"error": "not text"}]
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: malformed_payload,
+    )
+
+    assert audit_path_main(["--check", "--assert-expected", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["validation_errors"][0] == (
+        "validation_errors[0] is not a string: dict"
+    )
+    assert parsed["validation_errors"][1].startswith(
+        "assert_expected failed: validation errors:"
+    )
+    assert parsed["assert_expected_failure"]["validation_error_count"] == 1
+
+
 def test_local_lemma_audit_path_cli_json_assert_expected_failure_returns_payload(
     monkeypatch,
     capsys,
@@ -1780,6 +1808,36 @@ def test_local_lemma_audit_path_cli_json_crosschecks_assert_expected_failure(
     assert any(
         error.startswith(
             "assert_expected_failure validation_error_count mismatch: "
+        )
+        for error in parsed["validation_errors"]
+    )
+
+
+def test_local_lemma_audit_path_cli_json_crosschecks_nonstring_failure_count(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = _assert_expected_failure_contract_tamper_payload()
+    payload["validation_errors"] = [{"error": "not text"}]
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["validation_errors"][0] == (
+        "validation_errors[0] is not a string: dict"
+    )
+    assert any(
+        error == (
+            "assert_expected_failure validation_error_count mismatch: "
+            "expected 1, got 0"
         )
         for error in parsed["validation_errors"]
     )


### PR DESCRIPTION
## What changed
- Normalize malformed non-string `validation_errors` entries into explicit typed diagnostics before assert-expected failure recovery.
- Reuse that normalization when comparing the nested `assert_expected_failure.validation_error_count`, so the count matches the reviewer-facing diagnostic list.
- Add regression tests for non-string validation errors in assert-expected JSON recovery and existing failure-contract crosschecks.
- Document the normalized non-string validation-error behavior in the local-lemma audit note.

## Claim scope and evidence level
- Scope: n=9 vertex-circle local-lemma audit-path diagnostics only.
- Evidence level: review-pending checker/test hardening for failure reporting and contract accounting.
- This does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97; it is not a counterexample and not a global status update.

## Commands run
- `python -m ruff check scripts\check_n9_vertex_circle_local_lemma_audit_path.py tests\test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts\check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked: n=9 local-lemma audit path payload via `scripts/check_n9_vertex_circle_local_lemma_audit_path.py`.
- Generated: none.

## Known limitations / next review steps
- This only hardens malformed failure-reporting paths; it does not review local-lemma packet soundness or the exhaustive n=9 brancher.
- Next useful review remains auditing the exact-four vertex-circle frontier or replacing pieces of the review-pending pipeline with reusable local lemmas.