### PR TITLE
Harden n9 assert failure key contract

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -702,9 +702,10 @@ JSON diagnostics for `--assert-expected` failures also include an
 Python exception type, message, and underlying validation-error count so
 consumers do not have to parse the error string. The checker validates that
 nested object contract for schema, exact keys, stage, nonempty text fields, and
-the pre-assertion validation-error count. Text-mode failure summaries mirror
-the nested schema, exception type, and count so reviewers can identify the
-failure contract without switching to JSON.
+the pre-assertion validation-error count, with malformed in-memory key types
+reported as contract errors instead of crashing the key-set check. Text-mode
+failure summaries mirror the nested schema, exception type, and count so
+reviewers can identify the failure contract without switching to JSON.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -703,9 +703,11 @@ Python exception type, message, and underlying validation-error count so
 consumers do not have to parse the error string. The checker validates that
 nested object contract for schema, exact keys, stage, nonempty text fields, and
 the pre-assertion validation-error count, with malformed in-memory key types
-reported as contract errors instead of crashing the key-set check. Text-mode
-failure summaries mirror the nested schema, exception type, and count so
-reviewers can identify the failure contract without switching to JSON.
+reported as contract errors instead of crashing the key-set check. Those
+malformed keys are also string-normalized before JSON output so sorted
+machine-readable diagnostics remain available. Text-mode failure summaries
+mirror the nested schema, exception type, and count so reviewers can identify
+the failure contract without switching to JSON.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3450,6 +3450,10 @@ def _normalized_validation_errors(errors: Any) -> list[str] | None:
     return normalized
 
 
+def _sorted_contract_keys(keys: set[Any]) -> list[Any]:
+    return sorted(keys, key=lambda key: (type(key).__name__, repr(key)))
+
+
 def assert_expected_failure_contract_errors(
     record: Any,
     *,
@@ -3460,8 +3464,8 @@ def assert_expected_failure_contract_errors(
         return [f"assert_expected_failure must be an object: {type(record).__name__}"]
 
     observed_keys = set(record)
-    missing = sorted(ASSERT_EXPECTED_FAILURE_KEYS - observed_keys)
-    unexpected = sorted(observed_keys - ASSERT_EXPECTED_FAILURE_KEYS)
+    missing = _sorted_contract_keys(ASSERT_EXPECTED_FAILURE_KEYS - observed_keys)
+    unexpected = _sorted_contract_keys(observed_keys - ASSERT_EXPECTED_FAILURE_KEYS)
     if missing:
         errors.append(f"assert_expected_failure missing keys: {missing!r}")
     if unexpected:

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3454,6 +3454,17 @@ def _sorted_contract_keys(keys: set[Any]) -> list[Any]:
     return sorted(keys, key=lambda key: (type(key).__name__, repr(key)))
 
 
+def _json_safe_contract_mapping(record: Mapping[Any, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in record.items():
+        if isinstance(key, str):
+            safe_key = key
+        else:
+            safe_key = f"<{type(key).__name__}:{key!r}>"
+        safe[safe_key] = value
+    return safe
+
+
 def assert_expected_failure_contract_errors(
     record: Any,
     *,
@@ -3665,6 +3676,9 @@ def _payload_with_existing_assert_expected_failure_contract_check(
             errors.append(error)
     updated["validation_status"] = "failed"
     updated["validation_errors"] = errors
+    failure_record = updated.get("assert_expected_failure")
+    if isinstance(failure_record, Mapping):
+        updated["assert_expected_failure"] = _json_safe_contract_mapping(failure_record)
     return updated
 
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1386,6 +1386,14 @@ def test_local_lemma_audit_path_assert_expected_failure_contract_errors() -> Non
         in errors
     )
 
+    mixed_key_record = dict(valid_record)
+    mixed_key_record[3] = "bad"
+    mixed_key_record["extra"] = "surprise"
+    assert (
+        "assert_expected_failure unexpected keys: [3, 'extra']"
+        in assert_expected_failure_contract_errors(mixed_key_record)
+    )
+
 
 def test_local_lemma_audit_path_failure_lines_crosscheck_assert_expected_failure() -> None:
     lines = failure_lines(_assert_expected_failure_contract_tamper_payload())

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1851,6 +1851,31 @@ def test_local_lemma_audit_path_cli_json_crosschecks_nonstring_failure_count(
     )
 
 
+def test_local_lemma_audit_path_cli_json_crosschecks_mixed_failure_keys(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = _assert_expected_failure_contract_tamper_payload()
+    payload["assert_expected_failure"][3] = "bad"
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["assert_expected_failure"]["<int:3>"] == "bad"
+    assert any(
+        error == "assert_expected_failure unexpected keys: [3]"
+        for error in parsed["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_cli_json() -> None:
     result = subprocess.run(
         [


### PR DESCRIPTION
## What changed
- Sort nested `assert_expected_failure` key-set diagnostics by type/repr so mixed malformed in-memory key types report as contract errors instead of crashing the key check.
- Sanitize malformed non-string nested failure-contract keys into stable string keys before JSON output, preserving sorted machine-readable diagnostics.
- Add regressions covering mixed integer/string unexpected keys in both the direct contract checker and the CLI `--json` recovery path.
- Update the local-lemma audit note to document that malformed in-memory keys are reported and JSON-normalized rather than allowed to break failure-contract validation.

## Claim scope and evidence level
- Scope: n=9 vertex-circle local-lemma audit-path diagnostics only.
- Evidence level: review-pending checker/test hardening for failure contract validation.
- This does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, or Erdos Problem #97; it is not a counterexample and not a global status update.

## Commands run
- `python -m ruff check scripts\check_n9_vertex_circle_local_lemma_audit_path.py tests\test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts\check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked: n=9 local-lemma audit path payload via `scripts/check_n9_vertex_circle_local_lemma_audit_path.py`.
- Generated: none.

## Known limitations / next review steps
- This is a defensive diagnostics hardening only; it does not review packet soundness or the n=9 exhaustive brancher.
- Next useful review remains the exact-four vertex-circle frontier or compact reusable local lemmas replacing parts of the review-pending pipeline.