### PR TITLE
Harden n9 audit failure JSON output

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -705,9 +705,12 @@ nested object contract for schema, exact keys, stage, nonempty text fields, and
 the pre-assertion validation-error count, with malformed in-memory key types
 reported as contract errors instead of crashing the key-set check. Those
 malformed keys are also string-normalized before JSON output so sorted
-machine-readable diagnostics remain available. Text-mode failure summaries
-mirror the nested schema, exception type, and count so reviewers can identify
-the failure contract without switching to JSON.
+machine-readable diagnostics remain available. The final JSON rendering path
+also applies the same serialization-only key normalization recursively to
+failure payload mappings, so malformed diagnostic fixtures cannot hide the
+original layer failure by crashing sorted JSON output. Text-mode failure
+summaries mirror the nested schema, exception type, and count so reviewers can
+identify the failure contract without switching to JSON.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3454,15 +3454,28 @@ def _sorted_contract_keys(keys: set[Any]) -> list[Any]:
     return sorted(keys, key=lambda key: (type(key).__name__, repr(key)))
 
 
+def _json_safe_mapping_key(key: Any) -> str:
+    if isinstance(key, str):
+        return key
+    return f"<{type(key).__name__}:{key!r}>"
+
+
+def _json_safe_for_output(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            _json_safe_mapping_key(key): _json_safe_for_output(nested)
+            for key, nested in value.items()
+        }
+    if isinstance(value, list):
+        return [_json_safe_for_output(item) for item in value]
+    return value
+
+
 def _json_safe_contract_mapping(record: Mapping[Any, Any]) -> dict[str, Any]:
-    safe: dict[str, Any] = {}
-    for key, value in record.items():
-        if isinstance(key, str):
-            safe_key = key
-        else:
-            safe_key = f"<{type(key).__name__}:{key!r}>"
-        safe[safe_key] = value
-    return safe
+    return {
+        _json_safe_mapping_key(key): _json_safe_for_output(value)
+        for key, value in record.items()
+    }
 
 
 def assert_expected_failure_contract_errors(
@@ -3736,7 +3749,7 @@ def main(argv: list[str] | None = None) -> int:
     payload = _payload_with_existing_assert_expected_failure_contract_check(payload)
 
     if args.json:
-        print(json.dumps(payload, indent=2, sort_keys=True))
+        print(json.dumps(_json_safe_for_output(payload), indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle local-lemma audit path")
         for line in summary_lines(payload):

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1876,6 +1876,53 @@ def test_local_lemma_audit_path_cli_json_crosschecks_mixed_failure_keys(
     )
 
 
+def test_local_lemma_audit_path_cli_json_normalizes_top_level_failure_keys(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["validation_status"] = "failed"
+    payload["validation_errors"] = ["manual failure"]
+    payload[3] = "bad"
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["validation_errors"] == ["manual failure"]
+    assert parsed["<int:3>"] == "bad"
+
+
+def test_local_lemma_audit_path_cli_json_normalizes_nested_failure_keys(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["validation_status"] = "failed"
+    payload["validation_errors"] = [{"error": "mixed", 3: "bad"}]
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["validation_errors"][0]["error"] == "mixed"
+    assert parsed["validation_errors"][0]["<int:3>"] == "bad"
+
+
 def test_local_lemma_audit_path_cli_json() -> None:
     result = subprocess.run(
         [


### PR DESCRIPTION
## What changed
- Added a serialization-only JSON output guard for the n=9 local-lemma audit-path checker so non-string mapping keys in malformed failure payloads are converted to stable strings before `json.dumps(..., sort_keys=True)`.
- Reused the same key normalization for nested `assert_expected_failure` records.
- Added CLI JSON regressions for malformed top-level and nested failure mappings.
- Updated the local-lemma audit-path docs to describe the failure JSON contract.

## Claim scope and evidence level
- Scope is diagnostic/checker robustness for the review-pending n=9 local-lemma audit path only.
- This does not prove packet soundness, local-lemma completeness, frontier coverage, n=9, or Erdos Problem #97.
- No general proof, counterexample, official/global status update, or promotion beyond the existing repo-local status is claimed.

## Commands run
- `python -m ruff check scripts\check_n9_vertex_circle_local_lemma_audit_path.py tests\test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts\check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the existing `n9_vertex_circle_local_lemma_audit_path` review-pending JSON output path.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This is a serialization and regression-test hardening pass only.
- Future review should still audit the local-lemma handoff layers and packet soundness independently before any n=9 status movement.