### PR TITLE
Preserve n9 audit JSON key collisions

### DIFF
--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -708,9 +708,12 @@ malformed keys are also string-normalized before JSON output so sorted
 machine-readable diagnostics remain available. The final JSON rendering path
 also applies the same serialization-only key normalization recursively to
 failure payload mappings, so malformed diagnostic fixtures cannot hide the
-original layer failure by crashing sorted JSON output. Text-mode failure
-summaries mirror the nested schema, exception type, and count so reviewers can
-identify the failure contract without switching to JSON.
+original layer failure by crashing sorted JSON output. If a normalized key
+would collide with an existing string key, JSON rendering appends a
+deterministic `<collision:N>` suffix instead of dropping either diagnostic
+entry. Text-mode failure summaries mirror the nested schema, exception type,
+and count so reviewers can identify the failure contract without switching to
+JSON.
 
 This is still only a review-pending audit-path diagnostic. It does not prove
 packet soundness, mini-replay soundness, local-lemma completeness, frontier

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3487,8 +3487,9 @@ def _json_safe_for_output(value: Any) -> Any:
 
 
 def _json_safe_contract_mapping(record: Mapping[Any, Any]) -> dict[str, Any]:
+    seen: set[str] = set()
     return {
-        _json_safe_mapping_key(key): _json_safe_for_output(value)
+        _unique_json_safe_mapping_key(key, seen): _json_safe_for_output(value)
         for key, value in record.items()
     }
 

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -3460,10 +3460,25 @@ def _json_safe_mapping_key(key: Any) -> str:
     return f"<{type(key).__name__}:{key!r}>"
 
 
+def _unique_json_safe_mapping_key(key: Any, seen: set[str]) -> str:
+    safe_key = _json_safe_mapping_key(key)
+    if safe_key not in seen:
+        seen.add(safe_key)
+        return safe_key
+    suffix = 2
+    while True:
+        collision_key = f"{safe_key}<collision:{suffix}>"
+        if collision_key not in seen:
+            seen.add(collision_key)
+            return collision_key
+        suffix += 1
+
+
 def _json_safe_for_output(value: Any) -> Any:
     if isinstance(value, Mapping):
+        seen: set[str] = set()
         return {
-            _json_safe_mapping_key(key): _json_safe_for_output(nested)
+            _unique_json_safe_mapping_key(key, seen): _json_safe_for_output(nested)
             for key, nested in value.items()
         }
     if isinstance(value, list):

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1923,6 +1923,57 @@ def test_local_lemma_audit_path_cli_json_normalizes_nested_failure_keys(
     assert parsed["validation_errors"][0]["<int:3>"] == "bad"
 
 
+def test_local_lemma_audit_path_cli_json_preserves_top_level_key_collisions(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["validation_status"] = "failed"
+    payload["validation_errors"] = ["manual failure"]
+    payload["<int:3>"] = "string key"
+    payload[3] = "integer key"
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    assert parsed["<int:3>"] == "string key"
+    assert parsed["<int:3><collision:2>"] == "integer key"
+
+
+def test_local_lemma_audit_path_cli_json_preserves_nested_key_collisions(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = local_lemma_audit_path_payload()
+    payload["validation_status"] = "failed"
+    payload["validation_errors"] = [
+        {"<int:3>": "string key", 3: "integer key"},
+    ]
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    failure_record = parsed["validation_errors"][0]
+    assert failure_record["<int:3>"] == "string key"
+    assert failure_record["<int:3><collision:2>"] == "integer key"
+
+
 def test_local_lemma_audit_path_cli_json() -> None:
     result = subprocess.run(
         [

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1876,6 +1876,34 @@ def test_local_lemma_audit_path_cli_json_crosschecks_mixed_failure_keys(
     )
 
 
+def test_local_lemma_audit_path_cli_json_crosschecks_failure_key_collisions(
+    monkeypatch,
+    capsys,
+) -> None:
+    payload = _assert_expected_failure_contract_tamper_payload()
+    payload["assert_expected_failure"]["<int:3>"] = "string key"
+    payload["assert_expected_failure"][3] = "integer key"
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_local_lemma_audit_path."
+        "local_lemma_audit_path_payload",
+        lambda: payload,
+    )
+
+    assert audit_path_main(["--check", "--json"]) == 1
+
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert captured.err == ""
+    assert parsed["validation_status"] == "failed"
+    failure_record = parsed["assert_expected_failure"]
+    assert failure_record["<int:3>"] == "string key"
+    assert failure_record["<int:3><collision:2>"] == "integer key"
+    assert any(
+        error == "assert_expected_failure unexpected keys: [3, '<int:3>']"
+        for error in parsed["validation_errors"]
+    )
+
+
 def test_local_lemma_audit_path_cli_json_normalizes_top_level_failure_keys(
     monkeypatch,
     capsys,


### PR DESCRIPTION
## What changed
- Added deterministic collision handling to the n=9 local-lemma audit-path JSON serializer.
- If a malformed non-string key normalizes to the same text as an existing string key, the later key receives a `<collision:N>` suffix rather than overwriting a diagnostic entry.
- Added CLI JSON regressions for top-level and nested key-collision fixtures.
- Updated the local-lemma audit-path docs to describe collision-preserving failure JSON output.

## Claim scope and evidence level
- Scope is diagnostic/checker robustness for the review-pending n=9 local-lemma audit path only.
- This does not prove packet soundness, local-lemma completeness, frontier coverage, n=9, or Erdos Problem #97.
- No general proof, counterexample, official/global status update, or promotion beyond the existing repo-local status is claimed.

## Commands run
- `python -m ruff check scripts\check_n9_vertex_circle_local_lemma_audit_path.py tests\test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts\check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the existing `n9_vertex_circle_local_lemma_audit_path` review-pending JSON output path.
- No generated artifact files were rewritten.

## Known limitations / next review steps
- This is a serialization-contract hardening pass only.
- Future review should still audit the local-lemma handoff layers and packet soundness independently before any n=9 status movement.