### PR TITLE
Add T03 local lemma claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1307,6 +1307,57 @@ the focused packet and its small input-data replay with
 and
 `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`.
 
+### Vertex-circle T03 multi-family self-edge local lemma candidates
+
+Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
+
+In a strictly convex nonagon with cyclic order `0,1,2,3,4,5,6,7,8`, each of
+the following two selected-row cores is locally impossible:
+
+```text
+T03/F05:
+center 1: {2,5,7,8}
+center 2: {1,3,4,8}
+center 3: {0,2,4,7}
+center 6: {1,3,5,7}
+
+T03/F15:
+center 0: {1,3,4,8}
+center 1: {0,2,4,5}
+center 2: {1,3,5,6}
+center 3: {2,4,6,7}
+```
+
+For `F05`, the selected-distance equalities force
+
+```text
+[3,7] = [2,3] = [1,2] = [1,7].
+```
+
+The row-`6` witness order `[7,1,3,5]` puts the outer chord `[3,7]` around the
+inner chord `[1,7]`, so vertex-circle monotonicity gives `[3,7] > [1,7]`.
+For `F15`, the selected-distance equalities force
+
+```text
+[1,4] = [1,2] = [2,3] = [3,4],
+```
+
+while the row-`0` witness order `[1,3,4,8]` gives `[1,4] > [3,4]`. Thus each
+T03 core creates a reflexive strict edge in the selected-distance quotient,
+and no strictly convex realization can satisfy that exact local core in the
+displayed cyclic order.
+
+The checked packet covers 20 frontier assignments across `F05` and `F15`, but
+that assignment count is packet-catalog evidence only. The packet label `T03`
+and family labels `F05` and `F15` are navigation only; the hypotheses are the
+displayed cyclic order and selected rows. This is not an `n=9` completeness
+proof, not a promotion of the review-pending exhaustive checker, and not a
+proof of Erdos Problem #97. Check the focused packet and its small input-data
+replay with
+`python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json`
+and
+`python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json`.
+
 ### Vertex-circle T10/F12 strict-cycle local lemma candidate
 
 Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.


### PR DESCRIPTION
## What changed

- Added a `docs/claims.md` ledger entry for the focused vertex-circle T03 multi-family self-edge local lemma candidates.
- Recorded the two displayed family cores, their selected-distance equality chains, the vertex-circle strict inequalities, and the focused packet/minireplay check commands.

## Claim scope and evidence level

- Status remains `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
- This is a local row-core obstruction statement for the displayed cyclic order and selected rows only.
- No general proof, no counterexample, no promotion of the review-pending `n=9` exhaustive checker, and no global/official status update are claimed.
- The checked packet covers 20 frontier assignments across `F05` and `F15`, but that count is packet-catalog evidence only.

## Commands run

Focused T03 checks:

```bash
python scripts\check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
python scripts\check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
python scripts\check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
python -m pytest tests\test_n9_vertex_circle_t03_self_edge_lemma_packet.py tests\test_n9_t03_self_edge_minireplay.py -q
```

Fast tier:

```bash
python scripts\check_text_clean.py
python scripts\check_status_consistency.py
python scripts\check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

## Artifacts generated or checked

Checked existing artifacts only; no generated artifact content was changed:

- `data/certificates/n9_vertex_circle_t03_self_edge_lemma_packet.json`
- `data/certificates/n9_t03_self_edge_minireplay.json`
- `data/certificates/n9_vertex_circle_local_lemmas.json`

## Known limitations / next review steps

- A reviewer still needs to restate and check the T03 local hypotheses directly, without relying on template labels as theorem names.
- This PR does not audit brancher coverage, selected-distance quotient soundness beyond the focused packet replay, strict-edge geometric soundness beyond the existing local lemma framework, or the full `n=9` exhaustive checker.