### PR TITLE
Add T09 local lemma claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1562,6 +1562,48 @@ packet and its small input-data replay with
 and
 `python scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --json`.
 
+### Vertex-circle T09/F03 selected-path self-edge local lemma candidate
+
+Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
+
+In a strictly convex nonagon with cyclic order `0,1,2,3,4,5,6,7,8`, suppose the
+following six selected rows are present:
+
+```text
+center 0: {1,2,3,8}
+center 1: {0,3,5,7}
+center 2: {1,3,4,6}
+center 3: {2,4,5,8}
+center 4: {0,3,6,8}
+center 8: {0,1,4,7}
+```
+
+The selected-distance equalities force
+
+```text
+[1,3] = [0,1] = [0,8] = [4,8] = [3,4] = [2,3] = [1,2].
+```
+
+Meanwhile row `0` has witness order `[1,2,3,8]` around vertex `0`, so the
+outer chord `[1,3]` strictly contains the inner chord `[1,2]`. The
+vertex-circle chord monotonicity lemma gives
+
+```text
+[1,3] > [1,2].
+```
+
+Thus the selected-distance quotient has a reflexive strict edge, and no
+strictly convex realization can satisfy these exact local hypotheses. The
+checked packet covers 18 frontier assignments in family `F03`, but that count
+is packet-catalog evidence only. The packet label `T09/F03` is navigation
+only; the hypotheses are the displayed cyclic order and selected rows. This is
+not an `n=9` completeness proof, not a promotion of the review-pending
+exhaustive checker, and not a proof of Erdos Problem #97. Check the focused
+packet and its small input-data replay with
+`python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json`
+and
+`python scripts/check_n9_t09_self_edge_minireplay.py --check --assert-expected --json`.
+
 ### Vertex-circle T10/F12 strict-cycle local lemma candidate
 
 Status: `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.


### PR DESCRIPTION
## What changed

- Added a `docs/claims.md` ledger entry for the focused vertex-circle T09/F03 selected-path self-edge local lemma candidate.
- Recorded the six displayed selected rows, the selected-distance equality chain, the row-0 vertex-circle strict inequality, and focused packet/minireplay check commands.

## Claim scope and evidence level

- Status remains `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
- This is a local row-core obstruction statement for the displayed cyclic order and selected rows only.
- No general proof, no counterexample, no promotion of the review-pending `n=9` exhaustive checker, and no global/official status update are claimed.
- The checked packet covers 18 F03 frontier assignments, but that count is packet-catalog evidence only.

## Commands run

Focused T09 checks:

```bash
python scripts\check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
python scripts\check_n9_t09_self_edge_minireplay.py --check --assert-expected --json
python scripts\check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
python -m pytest tests\test_n9_vertex_circle_t09_self_edge_lemma_packet.py tests\test_n9_t09_self_edge_minireplay.py -q
```

Fast tier:

```bash
python scripts\check_text_clean.py
python scripts\check_status_consistency.py
python scripts\check_artifact_provenance.py
git diff --check
python -m ruff check .
python -m pytest -q
```

## Artifacts generated or checked

Checked existing artifacts only; no generated artifact content was changed:

- `data/certificates/n9_vertex_circle_t09_self_edge_lemma_packet.json`
- `data/certificates/n9_t09_self_edge_minireplay.json`
- `data/certificates/n9_vertex_circle_local_lemmas.json`

## Known limitations / next review steps

- A reviewer still needs to restate and check the T09/F03 local hypotheses directly, without relying on the template label as a theorem name.
- This PR does not audit brancher coverage, selected-distance quotient soundness beyond the focused packet replay, strict-edge geometric soundness beyond the existing local lemma framework, or the full `n=9` exhaustive checker.