### PR TITLE
Add T11 mini-replay claims ledger check

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1665,8 +1665,10 @@ strictly convex realization can satisfy these exact local hypotheses. The
 packet label `T11/F07` is navigation only; the hypotheses are the displayed
 cyclic order and selected rows. This is not an `n=9` completeness proof, not a
 promotion of the review-pending exhaustive checker, and not a proof of Erdos
-Problem #97. Check the focused packet with
-`python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`.
+Problem #97. Check the focused packet and its small input-data replay with
+`python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`
+and
+`python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`.
 
 ### Vertex-circle T12/F16 strict-cycle local lemma candidate
 


### PR DESCRIPTION
## What changed
- Updated `docs/claims.md` so the review-pending `T11/F07` strict-cycle local lemma candidate points to both the focused packet checker and its small input-data mini-replay checker.
- Kept the entry scoped to the displayed cyclic order and selected rows only.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_LOCAL_LEMMA_CANDIDATE`.
- This is a documentation/evidence cross-reference only: not an `n=9` completeness proof, not a promotion of the review-pending exhaustive checker, not a counterexample, and not a proof of Erdos Problem #97.

## Commands run
- `python scripts\check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts\check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts\check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_t11_strict_cycle_lemma_packet.py tests\test_n9_t11_strict_cycle_minireplay.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_t11_strict_cycle_lemma_packet.json`.
- Checked `data/certificates/n9_t11_strict_cycle_minireplay.json`.
- Checked aggregate local-lemma coverage in `data/certificates/n9_vertex_circle_local_lemmas.json`.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- The mini-replay confirms only the exact local `T11/F07` packet inputs.
- Independent review is still needed before using this local lemma in any stronger finite-case or theorem-style claim.
- Continue analogous ledger hardening for the remaining strict-cycle mini-replay entries.