### PR TITLE
Document n9 mini-replay audit path summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ direct quotient replay.
 A focused packet catalog audit checks that the 12 proof-facing focused
 local-lemma packets agree with the source template packets, template catalog,
 and aggregate focused-note crosschecks; this is packet/catalog bookkeeping only.
+A focused mini-replay crosswalk joins those 12 packets to their packet-specific
+minimal input-data replay artifacts. A local-lemma audit-path checker chains
+the packet/catalog, focused mini-replay, aggregate/simple-replay,
+exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
+adjacent drift localization. These remain review-pending audit bookkeeping
+only, not packet soundness, local-lemma completeness, frontier coverage, or an
+`n=9` proof.
 See [`docs/n9-vertex-circle-exhaustive.md`](docs/n9-vertex-circle-exhaustive.md).
 
 An incoming `n=10` singleton-slice continuation is now recorded as a

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1023,6 +1023,16 @@ template catalog records, and aggregate focused-note crosschecks agree on the
 same `184` assignments and 16 families. It is packet/catalog bookkeeping only,
 not packet soundness, local-lemma completeness, frontier coverage, or a proof
 of `n=9`.
+The focused mini-replay crosswalk
+`scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+joins those same 12 focused packets to their packet-specific minimal
+input-data replay artifacts. The local-lemma audit path
+`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+runs the packet/catalog, focused mini-replay, aggregate/simple-replay,
+exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
+adjacent drift localization. These are review-pending handoff audits only, not
+packet soundness, local-lemma completeness, frontier coverage, or a proof of
+`n=9`.
 
 This is a candidate extension of the repo-local finite-case pipeline to `n=9`,
 but it is not yet the source-of-truth strongest result. The raw incoming bundle

--- a/STATE.md
+++ b/STATE.md
@@ -695,6 +695,16 @@ template catalog records, and aggregate focused-note crosschecks agree on the
 same `184` assignments and 16 families. It is packet/catalog bookkeeping only,
 not packet soundness, local-lemma completeness, frontier coverage, or a proof
 of `n=9`.
+The focused mini-replay crosswalk
+`scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+joins those same 12 focused packets to their packet-specific minimal
+input-data replay artifacts. The local-lemma audit path
+`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+runs the packet/catalog, focused mini-replay, aggregate/simple-replay,
+exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
+adjacent drift localization. These are review-pending handoff audits only, not
+packet soundness, local-lemma completeness, frontier coverage, or a proof of
+`n=9`.
 
 A 2026-05-05 multi-agent attack adds an independent Gröbner-basis verification
 at n=8 (all 15 incidence-completeness survivors unrealizable by algebra alone)


### PR DESCRIPTION
## What changed
- Added aligned README, STATE, and RESULTS notes for the focused mini-replay crosswalk and local-lemma audit-path checker.
- Kept the language scoped to review-pending handoff/audit bookkeeping.

## Claim scope and evidence level
- No source-of-truth promotion: `n=9` remains review-pending, not the strongest local result.
- This documents cross-artifact handoff checks only: not packet soundness, not local-lemma completeness, not frontier coverage, not an `n=9` proof, not a counterexample, and not a global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python scripts\check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python scripts\check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
- `python scripts\check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_focused_packet_catalog_audit.json` via its checker output.
- Checked the focused mini-replay crosswalk payload.
- Checked the aggregate/simple-replay local-lemma crosswalk payload.
- Checked the local-lemma audit-path payload and its handoff/claim-scope guard components.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- These notes do not independently review packet soundness or the exhaustive `n=9` checker.
- Future review should continue at the packet-soundness and local-lemma-completeness layers before any theorem-style claim is considered.