### PR TITLE
Add n9 input audit claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1707,6 +1707,26 @@ Problem #97. Check the focused packet and its small input-data replay with
 and
 `python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json`.
 
+### n=9 vertex-circle input-data audit
+
+Status: `REVIEW_PENDING_INPUT_DATA_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_input_audit.py` treats
+`data/certificates/n9_vertex_circle_exhaustive.json` as stored input data for
+the review-pending `n=9` vertex-circle package. It recomputes the row-`0`
+choices directly as the `70` lexicographic 4-subsets of labels `1..8`, checks
+the stored row-`0` witness lists and masks, and verifies the stored summary
+arithmetic for the main and no-vertex-circle cross-check runs.
+
+When run with `--check --assert-expected --json`, the audit reports matching
+row-`0` coverage for both runs, `0` main full assignments, `184`
+cross-check full assignments, and `184` cross-check status records. This is
+stored-input consistency evidence only. It does not rerun the brancher, replay
+vertex-circle certificates, prove `n=9`, claim a counterexample, update the
+official/global status, or promote the review-pending exhaustive checker.
+Check it with
+`python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -370,6 +370,11 @@ local_repo:
       artifact: "data/certificates/n9_mixed_rich_frontier_crosswalk.json"
       verifier: "scripts/check_n9_mixed_rich_frontier_crosswalk.py"
       claim_scope: "repo-local support-to-frontier bookkeeping only; checks that the 184 terminal mixed rich-support assignments equal the stored 184 pre-vertex-circle exact-four frontier assignments as a labelled row set, but does not prove the exact-four vertex-circle exhaustive checker, prove n=9, prove Erdos #97, or give a counterexample"
+    - pattern: "n9_vertex_circle_input_audit"
+      status: "stored row0 witness coverage and summary arithmetic audit"
+      artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
+      verifier: "scripts/check_n9_vertex_circle_input_audit.py"
+      claim_scope: "stored-input consistency audit only; recomputes the 70 lexicographic row0 witness choices and checks stored witness lists, masks, and summary arithmetic, but does not rerun the brancher, replay vertex-circle certificates, prove n=9, update official/global status, or give a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the review-pending `n=9` vertex-circle input-data audit.
- Registered the same audit in `metadata/erdos97.yaml` as a stored-input consistency diagnostic.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_INPUT_DATA_AUDIT` / stored-input consistency evidence.
- The audit checks row0 witness coverage, row0 masks, and stored summary arithmetic for `data/certificates/n9_vertex_circle_exhaustive.json`.
- This does not rerun the brancher, replay vertex-circle certificates, prove `n=9`, claim a counterexample, update official/global status, or promote the review-pending exhaustive checker.

## Commands run
- `python scripts\check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_exhaustive.json` as stored input data.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- Independent review is still needed for brancher coverage, incidence-filter soundness, strict-edge geometry, selected-distance quotient soundness, and the vertex-circle certificates.
- This is a discoverability/metadata hardening pass only; it intentionally leaves `n=9` review-pending.