### PR TITLE
Add n9 MRO branching claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1727,6 +1727,28 @@ official/global status, or promote the review-pending exhaustive checker.
 Check it with
 `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`.
 
+### n=9 vertex-circle fixed-order branching replay
+
+Status: `REVIEW_PENDING_BRANCHING_REPLAY`.
+
+The checker `scripts/check_n9_vertex_circle_mro_branching_replay.py` compares
+the stored dynamic minimum-remaining-options `n=9` vertex-circle artifact with
+a separate replay that fixes the center order as `0,1,...,8` after row `0`.
+It reuses the same necessary-filter helpers and vertex-circle status helper,
+so the scope is branch-order agreement, not independent filter or geometry
+soundness.
+
+When run with `--check --assert-expected --json`, the fixed-order replay
+closes the main search with `37,544` visited nodes and `0` full assignments.
+Its no-vertex-circle cross-check visits `520,782` nodes and leaves the same
+`184` pre-vertex-circle full assignments with the same `158` self-edge and
+`26` strict-cycle status counts as the stored dynamic-MRO artifact. This says
+only that the fixed center order and dynamic MRO order agree on these stored
+frontier counts and classifications. It does not prove the pruning filters,
+independently replay vertex-circle geometry, prove `n=9`, claim a
+counterexample, or update the official/global status. Check it with
+`python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -375,6 +375,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
       verifier: "scripts/check_n9_vertex_circle_input_audit.py"
       claim_scope: "stored-input consistency audit only; recomputes the 70 lexicographic row0 witness choices and checks stored witness lists, masks, and summary arithmetic, but does not rerun the brancher, replay vertex-circle certificates, prove n=9, update official/global status, or give a counterexample"
+    - pattern: "n9_vertex_circle_mro_branching_replay"
+      status: "fixed center-order replay against the dynamic MRO n9 vertex-circle artifact"
+      artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
+      verifier: "scripts/check_n9_vertex_circle_mro_branching_replay.py"
+      claim_scope: "branch-order agreement audit only; reruns the search with fixed center order 0..8 and compares full-assignment and vertex-circle status counts with the stored dynamic-MRO artifact, but does not prove filter soundness, independently replay vertex-circle geometry, prove n=9, update official/global status, or give a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the review-pending `n=9` fixed-center-order branching replay.
- Registered the replay in `metadata/erdos97.yaml` as a branch-order agreement diagnostic.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_BRANCHING_REPLAY` / review-pending diagnostic evidence.
- The replay checks a fixed center order `0,1,...,8` against the stored dynamic minimum-remaining-options artifact and compares full-assignment and vertex-circle status counts.
- It reuses the same necessary-filter helpers and vertex-circle status helper, so it does not prove filter soundness, independently replay vertex-circle geometry, prove `n=9`, claim a counterexample, or update official/global status.

## Commands run
- `python scripts\check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_mro_branching_replay.py -q -m "artifact and exhaustive"`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_exhaustive.json` through the fixed-order replay audit.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- Independent review is still needed for the pruning filters, strict-edge geometry, selected-distance quotient soundness, and vertex-circle certificates.
- This only checks branch-order agreement between fixed-order replay and the stored dynamic-MRO artifact; it intentionally leaves `n=9` review-pending.