### PR TITLE
Add n9 strict-edge claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1749,6 +1749,27 @@ independently replay vertex-circle geometry, prove `n=9`, claim a
 counterexample, or update the official/global status. Check it with
 `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`.
 
+### n=9 vertex-circle strict-edge geometry audit
+
+Status: `REVIEW_PENDING_GEOMETRY_RULE_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_strict_edge_geometry.py`
+independently enumerates the proper-interval containments that create local
+vertex-circle strict edges for every candidate selected row in the
+review-pending `n=9` vertex-circle checker. It compares that direct
+enumeration with the checker strict-edge table and with the one-row quotient
+replay strict-edge counts.
+
+When run with `--check --assert-expected --json`, the audit checks `630`
+candidate selected rows, finds `9` strict edges per row, and records `5,670`
+total strict edges. The interval-span histogram is `2->1: 2,520`, `3->1:
+1,890`, and `3->2: 1,260`, with zero strict-edge table mismatches and zero
+one-row quotient replay strict-edge count mismatches. This audits only the
+local proper-interval strict-edge generator. It does not prove row coverage,
+brancher coverage, selected-distance quotient soundness, `n=9`, a
+counterexample, or any official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -380,6 +380,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
       verifier: "scripts/check_n9_vertex_circle_mro_branching_replay.py"
       claim_scope: "branch-order agreement audit only; reruns the search with fixed center order 0..8 and compares full-assignment and vertex-circle status counts with the stored dynamic-MRO artifact, but does not prove filter soundness, independently replay vertex-circle geometry, prove n=9, update official/global status, or give a counterexample"
+    - pattern: "n9_vertex_circle_strict_edge_geometry"
+      status: "proper-interval strict-edge generator audit for n9 vertex-circle rows"
+      artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
+      verifier: "scripts/check_n9_vertex_circle_strict_edge_geometry.py"
+      claim_scope: "local strict-edge generator audit only; checks 630 candidate selected rows and 5670 direct proper-interval strict edges against the checker table and one-row quotient replay counts, but does not prove row coverage, brancher coverage, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the review-pending `n=9` strict-edge geometry audit.
- Registered the strict-edge audit in `metadata/erdos97.yaml` as a local proper-interval generator diagnostic.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_GEOMETRY_RULE_AUDIT` / review-pending diagnostic evidence.
- The audit checks 630 candidate selected rows, 5,670 direct proper-interval strict edges, and one-row quotient replay strict-edge counts.
- This audits only the local strict-edge generator. It does not prove row coverage, brancher coverage, selected-distance quotient soundness, `n=9`, claim a counterexample, or update official/global status.

## Commands run
- `python scripts\check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_strict_edge_geometry.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_exhaustive.json` as the scoped source artifact for this audit.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- Independent review is still needed for row/frontier coverage, brancher soundness, quotient soundness, and full vertex-circle certificate replay.
- This is a geometry-rule audit only; it intentionally leaves `n=9` review-pending.