### PR TITLE
Add n9 quotient-soundness claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1770,6 +1770,27 @@ brancher coverage, selected-distance quotient soundness, `n=9`, a
 counterexample, or any official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`.
 
+### n=9 vertex-circle quotient-soundness audit
+
+Status: `REVIEW_PENDING_QUOTIENT_SOUNDNESS_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_quotient_soundness.py` compares
+three selected-distance quotient/status views for stored `n=9` vertex-circle
+rows: the repo-native exhaustive checker, the reusable quotient replay helper,
+and a small direct local quotient/status replay. It runs on the stored compact
+local-core packet, the stored `184` pre-vertex-circle frontier assignments, and
+the transformed frontier cores from the motif-classification artifact.
+
+When run with `--check --assert-expected --json`, the audit checks `16`
+local-core row sets with `67` selected rows and status counts `13` self-edge /
+`3` strict-cycle; `184` full frontier row sets with `1,656` selected rows and
+status counts `158` self-edge / `26` strict-cycle; and `184` transformed
+frontier cores with `802` selected rows and the same `158` / `26` status split.
+This is selected-distance quotient implementation agreement only. It does not
+prove row coverage, brancher coverage, strict-edge geometry, `n=9`, a
+counterexample, or any official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -385,6 +385,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
       verifier: "scripts/check_n9_vertex_circle_strict_edge_geometry.py"
       claim_scope: "local strict-edge generator audit only; checks 630 candidate selected rows and 5670 direct proper-interval strict edges against the checker table and one-row quotient replay counts, but does not prove row coverage, brancher coverage, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_quotient_soundness"
+      status: "selected-distance quotient status agreement audit for stored n9 vertex-circle rows"
+      artifact: "data/certificates/n9_vertex_circle_local_core_packet.json; data/certificates/n9_vertex_circle_frontier_motif_classification.json"
+      verifier: "scripts/check_n9_vertex_circle_quotient_soundness.py"
+      claim_scope: "quotient implementation agreement audit only; compares exhaustive checker, reusable quotient replay helper, and direct quotient/status replay on stored local-core rows, full frontier assignments, and transformed frontier cores, but does not prove row coverage, brancher coverage, strict-edge geometry, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the review-pending `n=9` quotient-soundness audit.
- Registered the audit in `metadata/erdos97.yaml` as a selected-distance quotient implementation-agreement diagnostic.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_QUOTIENT_SOUNDNESS_AUDIT` / review-pending diagnostic evidence.
- The audit compares the exhaustive checker, reusable quotient replay helper, and direct quotient/status replay on stored local-core rows, full frontier assignments, and transformed frontier cores.
- This is quotient implementation agreement only. It does not prove row coverage, brancher coverage, strict-edge geometry, `n=9`, claim a counterexample, or update official/global status.

## Commands run
- `python scripts\check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_quotient_soundness.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_local_core_packet.json`.
- Checked `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- Independent review is still needed for row/frontier coverage, brancher soundness, strict-edge geometry, and full certificate replay.
- This intentionally leaves `n=9` review-pending and does not change the repository source-of-truth strongest result.