### PR TITLE
Add n9 partial-pruning claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1791,6 +1791,30 @@ prove row coverage, brancher coverage, strict-edge geometry, `n=9`, a
 counterexample, or any official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`.
 
+### n=9 vertex-circle partial-pruning audit
+
+Status: `REVIEW_PENDING_PARTIAL_PRUNING_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_partial_pruning.py` scans all
+nonempty selected-row subsets of the stored `184` pre-vertex-circle frontier
+assignments. It checks monotone obstruction persistence: every obstructed
+stored subset extends to a stored full assignment that remains obstructed. It
+also compares the repo-native checker status with the reusable quotient replay
+status on every subset.
+
+When run with `--check --assert-expected --json`, the audit checks `94,024`
+nonempty row subsets. It records `35,418` `ok` subsets, `24,890` self-edge
+subsets, and `33,716` strict-cycle subsets, with `58,606` obstructed subsets
+in total. The minimal obstruction size distribution is `182` assignments first
+obstructed by a 3-row subset and `2` assignments first obstructed by a 4-row
+subset. The stored-row-order prefix scan checks `1,656` prefixes and records
+zero extension violations and zero checker/replay status mismatches. This is
+stored-frontier pruning diagnostics only. It does not prove frontier coverage,
+brancher soundness, strict-edge geometry, selected-distance quotient
+soundness, `n=9`, a counterexample, or any official/global status update.
+Check it with
+`python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -390,6 +390,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_local_core_packet.json; data/certificates/n9_vertex_circle_frontier_motif_classification.json"
       verifier: "scripts/check_n9_vertex_circle_quotient_soundness.py"
       claim_scope: "quotient implementation agreement audit only; compares exhaustive checker, reusable quotient replay helper, and direct quotient/status replay on stored local-core rows, full frontier assignments, and transformed frontier cores, but does not prove row coverage, brancher coverage, strict-edge geometry, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_partial_pruning"
+      status: "stored-frontier partial-pruning monotonicity audit"
+      artifact: "data/certificates/n9_vertex_circle_frontier_motif_classification.json"
+      verifier: "scripts/check_n9_vertex_circle_partial_pruning.py"
+      claim_scope: "stored-frontier pruning diagnostic only; checks 94024 nonempty subsets of the 184 stored frontier assignments for monotone obstruction persistence and checker/replay status agreement, but does not prove frontier coverage, brancher soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the review-pending `n=9` partial-pruning audit.
- Registered the audit in `metadata/erdos97.yaml` as a stored-frontier pruning diagnostic.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_PARTIAL_PRUNING_AUDIT` / review-pending diagnostic evidence.
- The audit checks 94,024 nonempty subsets of the 184 stored frontier assignments for monotone obstruction persistence and checker/replay status agreement.
- This is stored-frontier pruning diagnostics only. It does not prove frontier coverage, brancher soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, claim a counterexample, or update official/global status.

## Commands run
- `python scripts\check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_partial_pruning.py -q -m slow`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- Independent review is still needed for frontier coverage, brancher soundness, strict-edge geometry, quotient soundness, and full certificate replay.
- This intentionally leaves `n=9` review-pending and does not change the repository source-of-truth strongest result.