### PR TITLE
Add n9 frontier-assignment claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1815,6 +1815,31 @@ soundness, `n=9`, a counterexample, or any official/global status update.
 Check it with
 `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`.
 
+### n=9 vertex-circle frontier-assignment audit
+
+Status: `REVIEW_PENDING_FRONTIER_ASSIGNMENT_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_frontier_assignment_audit.py`
+directly audits the stored `184` pre-vertex-circle frontier assignments from
+`data/certificates/n9_vertex_circle_frontier_motif_classification.json`. It
+checks row shape, row-center coverage, pairwise row-intersection caps,
+two-overlap crossing, witness-pair capacity, and selected-indegree capacity on
+the stored assignments.
+
+When run with `--check --assert-expected --json`, the audit checks `184`
+assignments and `1,656` selected rows, with status counts `158` self-edge and
+`26` strict-cycle. The center-pair intersection and witness-pair frequency
+histograms are both `0: 72`, `1: 3,168`, and `2: 3,384`; all `3,384`
+two-overlap row pairs cross; every selected indegree is `4`; and the assignment
+witness-pair profiles are `148` assignments with profile `1:18|2:18` and `36`
+assignments with profile `0:2|1:14|2:20`. It records zero row-shape,
+center-coverage, intersection-cap, two-overlap-crossing, witness-pair-cap, and
+selected-indegree-cap errors. This is stored-frontier diagnostics only. It does
+not prove frontier coverage, brancher soundness, strict-edge geometry,
+selected-distance quotient soundness, `n=9`, a counterexample, or any
+official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -395,6 +395,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_frontier_motif_classification.json"
       verifier: "scripts/check_n9_vertex_circle_partial_pruning.py"
       claim_scope: "stored-frontier pruning diagnostic only; checks 94024 nonempty subsets of the 184 stored frontier assignments for monotone obstruction persistence and checker/replay status agreement, but does not prove frontier coverage, brancher soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_frontier_assignment_audit"
+      status: "stored n9 frontier assignment row/capacity audit"
+      artifact: "data/certificates/n9_vertex_circle_frontier_motif_classification.json"
+      verifier: "scripts/check_n9_vertex_circle_frontier_assignment_audit.py"
+      claim_scope: "stored-frontier assignment diagnostic only; checks the 184 stored frontier assignments for row shape, center coverage, row-pair crossing, witness-pair capacity, and selected-indegree capacity, but does not prove frontier coverage, brancher soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the review-pending `n=9` frontier-assignment audit.
- Registered the audit in `metadata/erdos97.yaml` as a stored-frontier row/capacity diagnostic.

## Claim scope and evidence level
- Status remains `REVIEW_PENDING_FRONTIER_ASSIGNMENT_AUDIT` / review-pending diagnostic evidence.
- The audit checks the 184 stored frontier assignments for row shape, center coverage, row-pair crossing, witness-pair capacity, and selected-indegree capacity.
- This is stored-frontier assignment diagnostics only. It does not prove frontier coverage, brancher soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, claim a counterexample, or update official/global status.

## Commands run
- `python scripts\check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_frontier_assignment_audit.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
- No artifacts were regenerated in this cycle.

## Known limitations / next review steps
- Independent review is still needed for frontier coverage, brancher soundness, strict-edge geometry, quotient soundness, and full certificate replay.
- This intentionally leaves `n=9` review-pending and does not change the repository source-of-truth strongest result.