### PR TITLE
Add n9 branch-option claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1853,13 +1853,15 @@ capacity. It also compares the maintained selected-indegree and witness-pair
 count arrays with independently recomputed counts.
 
 When run with `--check --assert-expected --json`, the audit visits `520,782`
-fixed-order no-vertex-circle nodes and reaches the same `184` full assignments
-with status counts `158` self-edge and `26` strict-cycle. It checks `520,598`
-option contexts, `520,712` helper options in total, and `297,936` empty-option
+fixed-order no-vertex-circle nodes and reaches `184` full assignments with
+status counts `158` self-edge and `26` strict-cycle. It checks `520,598` option
+contexts, `520,712` helper options in total, and `297,936` empty-option
 contexts, with zero option mismatches and zero count-array mismatches. This is
-branch-option implementation diagnostics only. It does not prove dynamic-MRO
-branch coverage, strict-edge geometry, selected-distance quotient soundness,
-`n=9`, a counterexample, or any official/global status update. Check it with
+a count/status and branch-option implementation diagnostic; it does not compare
+assignment identities against the stored frontier artifact. It does not prove
+dynamic-MRO branch coverage, strict-edge geometry, selected-distance quotient
+soundness, `n=9`, a counterexample, or any official/global status update. Check
+it with
 `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`.
 
 ### n=9 turn-inequality frontier replay

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1840,6 +1840,28 @@ selected-distance quotient soundness, `n=9`, a counterexample, or any
 official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`.
 
+### n=9 vertex-circle branch-option audit
+
+Status: `REVIEW_PENDING_BRANCH_OPTION_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_branch_options.py` walks the
+fixed-center-order, no-vertex-circle replay states for the review-pending
+`n=9` vertex-circle checker. At every nonterminal reached state, it compares
+the helper `valid_options_for_center` output with a direct implementation of
+row shape, row-pair crossing, witness-pair capacity, and selected-indegree
+capacity. It also compares the maintained selected-indegree and witness-pair
+count arrays with independently recomputed counts.
+
+When run with `--check --assert-expected --json`, the audit visits `520,782`
+fixed-order no-vertex-circle nodes and reaches the same `184` full assignments
+with status counts `158` self-edge and `26` strict-cycle. It checks `520,598`
+option contexts, `520,712` helper options in total, and `297,936` empty-option
+contexts, with zero option mismatches and zero count-array mismatches. This is
+branch-option implementation diagnostics only. It does not prove dynamic-MRO
+branch coverage, strict-edge geometry, selected-distance quotient soundness,
+`n=9`, a counterexample, or any official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -400,6 +400,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_frontier_motif_classification.json"
       verifier: "scripts/check_n9_vertex_circle_frontier_assignment_audit.py"
       claim_scope: "stored-frontier assignment diagnostic only; checks the 184 stored frontier assignments for row shape, center coverage, row-pair crossing, witness-pair capacity, and selected-indegree capacity, but does not prove frontier coverage, brancher soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_branch_options"
+      status: "fixed-order no-vertex-circle branch-option implementation audit"
+      artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
+      verifier: "scripts/check_n9_vertex_circle_branch_options.py"
+      claim_scope: "branch-option implementation diagnostic only; walks fixed-order no-vertex-circle replay states and compares helper options plus maintained count arrays against direct recomputation, but does not prove dynamic-MRO branch coverage, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle branch-option audit.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_BRANCH_OPTION_AUDIT`.
- Evidence level: fixed-center-order, no-vertex-circle implementation diagnostic.
- The audit compares `valid_options_for_center` with a direct implementation of row shape, row-pair crossing, witness-pair capacity, selected-indegree capacity, and recomputed count arrays across replay states.
- It does not prove dynamic-MRO branch coverage, strict-edge geometry, selected-distance quotient soundness, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_branch_options.py -q -m slow`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_exhaustive.json` through `scripts/check_n9_vertex_circle_branch_options.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- Dynamic-MRO branch coverage, strict-edge geometry, selected-distance quotient soundness, and vertex-circle certificate review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.