### PR TITLE
Add witness predicate lemma accessors

### DIFF
--- a/lean/Erdos97/Basic.lean
+++ b/lean/Erdos97/Basic.lean
@@ -27,6 +27,42 @@ structure Witness4 (Point : Type u) where
   b_ne_d : Not (b = d)
   c_ne_d : Not (c = d)
 
+/-- The second witness is distinct from the first. -/
+theorem witness4_b_ne_a {Point : Type u} (W : Witness4 Point) :
+    Not (W.b = W.a) := by
+  intro h
+  exact W.a_ne_b h.symm
+
+/-- The third witness is distinct from the first. -/
+theorem witness4_c_ne_a {Point : Type u} (W : Witness4 Point) :
+    Not (W.c = W.a) := by
+  intro h
+  exact W.a_ne_c h.symm
+
+/-- The fourth witness is distinct from the first. -/
+theorem witness4_d_ne_a {Point : Type u} (W : Witness4 Point) :
+    Not (W.d = W.a) := by
+  intro h
+  exact W.a_ne_d h.symm
+
+/-- The third witness is distinct from the second. -/
+theorem witness4_c_ne_b {Point : Type u} (W : Witness4 Point) :
+    Not (W.c = W.b) := by
+  intro h
+  exact W.b_ne_c h.symm
+
+/-- The fourth witness is distinct from the second. -/
+theorem witness4_d_ne_b {Point : Type u} (W : Witness4 Point) :
+    Not (W.d = W.b) := by
+  intro h
+  exact W.b_ne_d h.symm
+
+/-- The fourth witness is distinct from the third. -/
+theorem witness4_d_ne_c {Point : Type u} (W : Witness4 Point) :
+    Not (W.d = W.c) := by
+  intro h
+  exact W.c_ne_d h.symm
+
 /--
 The chosen witnesses are members of `A` and are not the center.
 
@@ -44,6 +80,65 @@ def WitnessInSet {Point : Type u} (A : Point -> Prop) (p : Point)
             (And (Not (W.b = p))
               (And (Not (W.c = p)) (Not (W.d = p))))))))
 
+/-- Build a `WitnessInSet` fact from its named membership and center-avoidance components. -/
+theorem witnessInSet_mk {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point}
+    (ha : A W.a) (hb : A W.b) (hc : A W.c) (hd : A W.d)
+    (ha_ne_p : Not (W.a = p)) (hb_ne_p : Not (W.b = p))
+    (hc_ne_p : Not (W.c = p)) (hd_ne_p : Not (W.d = p)) :
+    WitnessInSet A p W := by
+  refine And.intro ha ?_
+  refine And.intro hb ?_
+  refine And.intro hc ?_
+  refine And.intro hd ?_
+  refine And.intro ha_ne_p ?_
+  refine And.intro hb_ne_p ?_
+  exact And.intro hc_ne_p hd_ne_p
+
+/-- The first witness lies in the ambient set. -/
+theorem witnessInSet_a_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.a :=
+  h.left
+
+/-- The second witness lies in the ambient set. -/
+theorem witnessInSet_b_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.b :=
+  h.right.left
+
+/-- The third witness lies in the ambient set. -/
+theorem witnessInSet_c_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.c :=
+  h.right.right.left
+
+/-- The fourth witness lies in the ambient set. -/
+theorem witnessInSet_d_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.d :=
+  h.right.right.right.left
+
+/-- The first witness is not the center. -/
+theorem witnessInSet_a_ne_center {Point : Type u} {A : Point -> Prop}
+    {p : Point} {W : Witness4 Point} (h : WitnessInSet A p W) :
+    Not (W.a = p) :=
+  h.right.right.right.right.left
+
+/-- The second witness is not the center. -/
+theorem witnessInSet_b_ne_center {Point : Type u} {A : Point -> Prop}
+    {p : Point} {W : Witness4 Point} (h : WitnessInSet A p W) :
+    Not (W.b = p) :=
+  h.right.right.right.right.right.left
+
+/-- The third witness is not the center. -/
+theorem witnessInSet_c_ne_center {Point : Type u} {A : Point -> Prop}
+    {p : Point} {W : Witness4 Point} (h : WitnessInSet A p W) :
+    Not (W.c = p) :=
+  h.right.right.right.right.right.right.left
+
+/-- The fourth witness is not the center. -/
+theorem witnessInSet_d_ne_center {Point : Type u} {A : Point -> Prop}
+    {p : Point} {W : Witness4 Point} (h : WitnessInSet A p W) :
+    Not (W.d = p) :=
+  h.right.right.right.right.right.right.right
+
 /--
 `SameDistanceFrom p q r` should later be instantiated as
 `dist p q = dist p r`, or as an equivalent squared-distance relation with the
@@ -54,6 +149,36 @@ def WitnessEquidistant {Point : Type u}
     (W : Witness4 Point) : Prop :=
   And (SameDistanceFrom p W.a W.b)
     (And (SameDistanceFrom p W.a W.c) (SameDistanceFrom p W.a W.d))
+
+/-- Build a `WitnessEquidistant` fact from its three named equal-distance components. -/
+theorem witnessEquidistant_mk {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point}
+    (hab : SameDistanceFrom p W.a W.b) (hac : SameDistanceFrom p W.a W.c)
+    (had : SameDistanceFrom p W.a W.d) :
+    WitnessEquidistant SameDistanceFrom p W := by
+  exact And.intro hab (And.intro hac had)
+
+/-- The first and second witnesses have the selected equal-distance relation. -/
+theorem witnessEquidistant_ab {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessEquidistant SameDistanceFrom p W) :
+    SameDistanceFrom p W.a W.b :=
+  h.left
+
+/-- The first and third witnesses have the selected equal-distance relation. -/
+theorem witnessEquidistant_ac {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessEquidistant SameDistanceFrom p W) :
+    SameDistanceFrom p W.a W.c :=
+  h.right.left
+
+/-- The first and fourth witnesses have the selected equal-distance relation. -/
+theorem witnessEquidistant_ad {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessEquidistant SameDistanceFrom p W) :
+    SameDistanceFrom p W.a W.d :=
+  h.right.right
 
 /--
 An abstract point-set version of "every point has four other equidistant
@@ -66,5 +191,15 @@ def HasFourEquidistantProperty {Point : Type u} (A : Point -> Prop)
     A p ->
       Exists fun W : Witness4 Point =>
         And (WitnessInSet A p W) (WitnessEquidistant SameDistanceFrom p W)
+
+/-- Unpack the abstract property at one center. -/
+theorem hasFourEquidistantProperty_exists_witness {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (h : HasFourEquidistantProperty A SameDistanceFrom) {p : Point}
+    (hp : A p) :
+    Exists fun W : Witness4 Point =>
+      And (WitnessInSet A p W) (WitnessEquidistant SameDistanceFrom p W) :=
+  h p hp
 
 end Erdos97

--- a/lean/Erdos97/SelectedWitness.lean
+++ b/lean/Erdos97/SelectedWitness.lean
@@ -22,6 +22,100 @@ structure SelectedWitnessSystem {Point : Type u} (A : Point -> Prop)
     forall (p : Point) (hp : A p),
       WitnessEquidistant SameDistanceFrom p (witness p hp)
 
+/-- A selected witness system recovers the abstract four-equidistant property. -/
+theorem selectedWitnessSystem_gives_property {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) :
+    HasFourEquidistantProperty A SameDistanceFrom := by
+  intro p hp
+  exact Exists.intro (S.witness p hp)
+    (And.intro (S.witness_in_set p hp) (S.witness_equidistant p hp))
+
+/-- The selected first witness lies in the ambient set. -/
+theorem selectedWitnessSystem_a_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    A (S.witness p hp).a :=
+  witnessInSet_a_mem (S.witness_in_set p hp)
+
+/-- The selected second witness lies in the ambient set. -/
+theorem selectedWitnessSystem_b_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    A (S.witness p hp).b :=
+  witnessInSet_b_mem (S.witness_in_set p hp)
+
+/-- The selected third witness lies in the ambient set. -/
+theorem selectedWitnessSystem_c_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    A (S.witness p hp).c :=
+  witnessInSet_c_mem (S.witness_in_set p hp)
+
+/-- The selected fourth witness lies in the ambient set. -/
+theorem selectedWitnessSystem_d_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    A (S.witness p hp).d :=
+  witnessInSet_d_mem (S.witness_in_set p hp)
+
+/-- The selected first witness is not the center. -/
+theorem selectedWitnessSystem_a_ne_center {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    Not ((S.witness p hp).a = p) :=
+  witnessInSet_a_ne_center (S.witness_in_set p hp)
+
+/-- The selected second witness is not the center. -/
+theorem selectedWitnessSystem_b_ne_center {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    Not ((S.witness p hp).b = p) :=
+  witnessInSet_b_ne_center (S.witness_in_set p hp)
+
+/-- The selected third witness is not the center. -/
+theorem selectedWitnessSystem_c_ne_center {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    Not ((S.witness p hp).c = p) :=
+  witnessInSet_c_ne_center (S.witness_in_set p hp)
+
+/-- The selected fourth witness is not the center. -/
+theorem selectedWitnessSystem_d_ne_center {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    Not ((S.witness p hp).d = p) :=
+  witnessInSet_d_ne_center (S.witness_in_set p hp)
+
+/-- The selected first and second witnesses satisfy the distance relation. -/
+theorem selectedWitnessSystem_ab_equidistant {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    SameDistanceFrom p (S.witness p hp).a (S.witness p hp).b :=
+  witnessEquidistant_ab (S.witness_equidistant p hp)
+
+/-- The selected first and third witnesses satisfy the distance relation. -/
+theorem selectedWitnessSystem_ac_equidistant {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    SameDistanceFrom p (S.witness p hp).a (S.witness p hp).c :=
+  witnessEquidistant_ac (S.witness_equidistant p hp)
+
+/-- The selected first and fourth witnesses satisfy the distance relation. -/
+theorem selectedWitnessSystem_ad_equidistant {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) {p : Point} (hp : A p) :
+    SameDistanceFrom p (S.witness p hp).a (S.witness p hp).d :=
+  witnessEquidistant_ad (S.witness_equidistant p hp)
+
 noncomputable section
 
 /-- Choice-based extraction of selected witnesses from the abstract property. -/
@@ -40,6 +134,20 @@ def selectedWitnessSystemOfProperty {Point : Type u} {A : Point -> Prop}
   · intro p hp
     exact (Classical.choose_spec (h p hp)).right
 
+/-- The abstract property is equivalent to the existence of a selected witness system. -/
+theorem has_property_iff_exists_selected_witness_system {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} :
+    HasFourEquidistantProperty A SameDistanceFrom ↔
+      Exists fun _S : SelectedWitnessSystem A SameDistanceFrom => True := by
+  constructor
+  · intro h
+    exact Exists.intro (selectedWitnessSystemOfProperty h) True.intro
+  · intro h
+    cases h with
+    | intro S _ =>
+        exact selectedWitnessSystem_gives_property S
+
 /--
 Bridge-shaped statement: the abstract four-equidistant property gives a
 selected-witness system.
@@ -53,7 +161,7 @@ theorem has_property_gives_selected_witness_system {Point : Type u}
     {SameDistanceFrom : Point -> Point -> Point -> Prop}
     (h : HasFourEquidistantProperty A SameDistanceFrom) :
     Exists fun _S : SelectedWitnessSystem A SameDistanceFrom => True := by
-  exact Exists.intro (selectedWitnessSystemOfProperty h) True.intro
+  exact (has_property_iff_exists_selected_witness_system.mp h)
 
 end
 


### PR DESCRIPTION
## What changed
- Added small Lean lemma accessors for the `Witness4`, `WitnessInSet`, and `WitnessEquidistant` abstract witness predicates.
- Added selected-witness-system lemmas that recover membership, center-avoidance, distance components, and the abstract property from a selected witness system.
- Added an iff bridge between `HasFourEquidistantProperty` and existence of a `SelectedWitnessSystem`.

## Scope
- Lemma-only Lean pilot work.
- No changes to Python checkers, certificate artifacts, claims ledgers, metadata, or global Erdos97 status.
- Does not prove `n=9`, selected-distance quotient soundness, vertex-circle geometry, or any official/global result.

## Validation
- Performed local text/syntax-shape checks only.
- I could not run `lake build` in this environment because Lean/Lake is not installed, and GitHub reported no workflow runs for the new branch commits at PR creation time.