### PR TITLE
[codex] Add Lean witness and certificate lemmas

### DIFF
--- a/lean/Erdos97/Basic.lean
+++ b/lean/Erdos97/Basic.lean
@@ -44,6 +44,65 @@ def WitnessInSet {Point : Type u} (A : Point -> Prop) (p : Point)
             (And (Not (W.b = p))
               (And (Not (W.c = p)) (Not (W.d = p))))))))
 
+namespace WitnessInSet
+
+/-- Build a `WitnessInSet` proof from its eight component facts. -/
+theorem of_components {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point}
+    (ha : A W.a) (hb : A W.b) (hc : A W.c) (hd : A W.d)
+    (ha_ne : Not (W.a = p)) (hb_ne : Not (W.b = p))
+    (hc_ne : Not (W.c = p)) (hd_ne : Not (W.d = p)) :
+    WitnessInSet A p W := by
+  exact
+    And.intro ha
+      (And.intro hb
+        (And.intro hc
+          (And.intro hd
+            (And.intro ha_ne
+              (And.intro hb_ne (And.intro hc_ne hd_ne))))))
+
+/-- The first selected witness belongs to the ambient set. -/
+theorem a_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.a :=
+  h.left
+
+/-- The second selected witness belongs to the ambient set. -/
+theorem b_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.b :=
+  h.right.left
+
+/-- The third selected witness belongs to the ambient set. -/
+theorem c_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.c :=
+  h.right.right.left
+
+/-- The fourth selected witness belongs to the ambient set. -/
+theorem d_mem {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : A W.d :=
+  h.right.right.right.left
+
+/-- The first selected witness is not the center. -/
+theorem a_ne_center {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : Not (W.a = p) :=
+  h.right.right.right.right.left
+
+/-- The second selected witness is not the center. -/
+theorem b_ne_center {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : Not (W.b = p) :=
+  h.right.right.right.right.right.left
+
+/-- The third selected witness is not the center. -/
+theorem c_ne_center {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : Not (W.c = p) :=
+  h.right.right.right.right.right.right.left
+
+/-- The fourth selected witness is not the center. -/
+theorem d_ne_center {Point : Type u} {A : Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessInSet A p W) : Not (W.d = p) :=
+  h.right.right.right.right.right.right.right
+
+end WitnessInSet
+
 /--
 `SameDistanceFrom p q r` should later be instantiated as
 `dist p q = dist p r`, or as an equivalent squared-distance relation with the
@@ -54,6 +113,41 @@ def WitnessEquidistant {Point : Type u}
     (W : Witness4 Point) : Prop :=
   And (SameDistanceFrom p W.a W.b)
     (And (SameDistanceFrom p W.a W.c) (SameDistanceFrom p W.a W.d))
+
+namespace WitnessEquidistant
+
+/-- Build a `WitnessEquidistant` proof from its three component facts. -/
+theorem of_components {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point}
+    (hab : SameDistanceFrom p W.a W.b)
+    (hac : SameDistanceFrom p W.a W.c)
+    (had : SameDistanceFrom p W.a W.d) :
+    WitnessEquidistant SameDistanceFrom p W := by
+  exact And.intro hab (And.intro hac had)
+
+/-- The first and second selected witnesses are equidistant from the center. -/
+theorem ab {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessEquidistant SameDistanceFrom p W) :
+    SameDistanceFrom p W.a W.b :=
+  h.left
+
+/-- The first and third selected witnesses are equidistant from the center. -/
+theorem ac {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessEquidistant SameDistanceFrom p W) :
+    SameDistanceFrom p W.a W.c :=
+  h.right.left
+
+/-- The first and fourth selected witnesses are equidistant from the center. -/
+theorem ad {Point : Type u}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} {p : Point}
+    {W : Witness4 Point} (h : WitnessEquidistant SameDistanceFrom p W) :
+    SameDistanceFrom p W.a W.d :=
+  h.right.right
+
+end WitnessEquidistant
 
 /--
 An abstract point-set version of "every point has four other equidistant

--- a/lean/Erdos97/CertificateFormats.lean
+++ b/lean/Erdos97/CertificateFormats.lean
@@ -20,12 +20,33 @@ structure EqualityPath where
   reasons : List String
 deriving Repr
 
+namespace EqualityPath
+
+/-- If both endpoints of an equality path are a common class, the path is a loop. -/
+theorem endpoints_eq_of_common_class {path : EqualityPath} {q : QuotientClass}
+    (hstart : path.start = q) (hfinish : path.finish = q) :
+    path.start = path.finish := by
+  rw [hstart, hfinish]
+
+end EqualityPath
+
 /-- A certificate shape for a strict self-edge contradiction. -/
 structure SelfEdgeCertificate where
   className : QuotientClass
   equalityPath : EqualityPath
   strictReason : String
 deriving Repr
+
+namespace SelfEdgeCertificate
+
+/-- A self-edge certificate whose equality path returns to its class has equal endpoints. -/
+theorem equalityPath_endpoints_eq {c : SelfEdgeCertificate}
+    (hstart : c.equalityPath.start = c.className)
+    (hfinish : c.equalityPath.finish = c.className) :
+    c.equalityPath.start = c.equalityPath.finish := by
+  exact EqualityPath.endpoints_eq_of_common_class hstart hfinish
+
+end SelfEdgeCertificate
 
 /-- A directed strict edge between quotient classes. -/
 structure StrictEdge where
@@ -42,5 +63,54 @@ deriving Repr
 
 def StrictCycleCertificate.hasEdges (c : StrictCycleCertificate) : Prop :=
   Not (c.edges = [])
+
+namespace StrictCycleCertificate
+
+/-- The `hasEdges` predicate is exactly nonemptiness of the edge list. -/
+theorem edges_ne_nil (c : StrictCycleCertificate) (h : c.hasEdges) :
+    Not (c.edges = []) :=
+  h
+
+/-- A certificate whose edge list is known to be a cons list has edges. -/
+theorem hasEdges_of_edges_eq_cons {c : StrictCycleCertificate}
+    {e : StrictEdge} {rest : List StrictEdge} (h : c.edges = e :: rest) :
+    c.hasEdges := by
+  intro hempty
+  rw [h] at hempty
+  cases hempty
+
+/-- A cons edge list is a nonempty strict-cycle certificate. -/
+theorem hasEdges_cons (e : StrictEdge) (rest : List StrictEdge)
+    (cycleReason : String) :
+    ({ edges := e :: rest, cycleReason := cycleReason } : StrictCycleCertificate).hasEdges := by
+  exact hasEdges_of_edges_eq_cons rfl
+
+/-- An empty edge list does not satisfy `hasEdges`. -/
+theorem not_hasEdges_empty (cycleReason : String) :
+    Not (({ edges := [], cycleReason := cycleReason } : StrictCycleCertificate).hasEdges) := by
+  intro h
+  exact h rfl
+
+/-- `hasEdges` is equivalent to decomposing the edge list as a head and tail. -/
+theorem hasEdges_iff_exists_cons (c : StrictCycleCertificate) :
+    c.hasEdges <->
+      Exists fun e : StrictEdge => Exists fun rest : List StrictEdge => c.edges = e :: rest := by
+  constructor
+  · intro h
+    cases c with
+    | mk edges cycleReason =>
+      cases edges with
+      | nil =>
+        exact False.elim (h rfl)
+      | cons e rest =>
+        exact Exists.intro e (Exists.intro rest rfl)
+  · intro h
+    cases h with
+    | intro e hrest =>
+      cases hrest with
+      | intro rest heq =>
+        exact hasEdges_of_edges_eq_cons heq
+
+end StrictCycleCertificate
 
 end Erdos97

--- a/lean/Erdos97/SelectedWitness.lean
+++ b/lean/Erdos97/SelectedWitness.lean
@@ -22,6 +22,96 @@ structure SelectedWitnessSystem {Point : Type u} (A : Point -> Prop)
     forall (p : Point) (hp : A p),
       WitnessEquidistant SameDistanceFrom p (witness p hp)
 
+namespace SelectedWitnessSystem
+
+/-- A selected witness system implies the abstract point-set property. -/
+theorem has_property {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) :
+    HasFourEquidistantProperty A SameDistanceFrom := by
+  intro p hp
+  exact Exists.intro (S.witness p hp)
+    (And.intro (S.witness_in_set p hp) (S.witness_equidistant p hp))
+
+/-- The first selected witness for a row belongs to the ambient set. -/
+theorem witness_a_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    A (S.witness p hp).a :=
+  WitnessInSet.a_mem (S.witness_in_set p hp)
+
+/-- The second selected witness for a row belongs to the ambient set. -/
+theorem witness_b_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    A (S.witness p hp).b :=
+  WitnessInSet.b_mem (S.witness_in_set p hp)
+
+/-- The third selected witness for a row belongs to the ambient set. -/
+theorem witness_c_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    A (S.witness p hp).c :=
+  WitnessInSet.c_mem (S.witness_in_set p hp)
+
+/-- The fourth selected witness for a row belongs to the ambient set. -/
+theorem witness_d_mem {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    A (S.witness p hp).d :=
+  WitnessInSet.d_mem (S.witness_in_set p hp)
+
+/-- The first selected witness for a row is not the row center. -/
+theorem witness_a_ne_center {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    Not ((S.witness p hp).a = p) :=
+  WitnessInSet.a_ne_center (S.witness_in_set p hp)
+
+/-- The second selected witness for a row is not the row center. -/
+theorem witness_b_ne_center {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    Not ((S.witness p hp).b = p) :=
+  WitnessInSet.b_ne_center (S.witness_in_set p hp)
+
+/-- The third selected witness for a row is not the row center. -/
+theorem witness_c_ne_center {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    Not ((S.witness p hp).c = p) :=
+  WitnessInSet.c_ne_center (S.witness_in_set p hp)
+
+/-- The fourth selected witness for a row is not the row center. -/
+theorem witness_d_ne_center {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    Not ((S.witness p hp).d = p) :=
+  WitnessInSet.d_ne_center (S.witness_in_set p hp)
+
+/-- The first and second selected witnesses in a row are equidistant from the center. -/
+theorem witness_ab {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    SameDistanceFrom p (S.witness p hp).a (S.witness p hp).b :=
+  WitnessEquidistant.ab (S.witness_equidistant p hp)
+
+/-- The first and third selected witnesses in a row are equidistant from the center. -/
+theorem witness_ac {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    SameDistanceFrom p (S.witness p hp).a (S.witness p hp).c :=
+  WitnessEquidistant.ac (S.witness_equidistant p hp)
+
+/-- The first and fourth selected witnesses in a row are equidistant from the center. -/
+theorem witness_ad {Point : Type u} {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop}
+    (S : SelectedWitnessSystem A SameDistanceFrom) (p : Point) (hp : A p) :
+    SameDistanceFrom p (S.witness p hp).a (S.witness p hp).d :=
+  WitnessEquidistant.ad (S.witness_equidistant p hp)
+
+end SelectedWitnessSystem
+
 noncomputable section
 
 /-- Choice-based extraction of selected witnesses from the abstract property. -/
@@ -54,6 +144,19 @@ theorem has_property_gives_selected_witness_system {Point : Type u}
     (h : HasFourEquidistantProperty A SameDistanceFrom) :
     Exists fun _S : SelectedWitnessSystem A SameDistanceFrom => True := by
   exact Exists.intro (selectedWitnessSystemOfProperty h) True.intro
+
+/-- A selected-witness system is equivalent to the abstract property. -/
+theorem has_property_iff_exists_selected_witness_system {Point : Type u}
+    {A : Point -> Prop}
+    {SameDistanceFrom : Point -> Point -> Point -> Prop} :
+    HasFourEquidistantProperty A SameDistanceFrom <->
+      Exists fun _S : SelectedWitnessSystem A SameDistanceFrom => True := by
+  constructor
+  · intro h
+    exact has_property_gives_selected_witness_system h
+  · intro h
+    cases h with
+    | intro S _ => exact SelectedWitnessSystem.has_property S
 
 end
 


### PR DESCRIPTION
## Summary
- add projection and constructor lemmas for the abstract `WitnessInSet` and `WitnessEquidistant` predicates
- add selected-witness-system lemmas, including the reverse implication from a selected witness system back to `HasFourEquidistantProperty`
- add lightweight certificate-shape lemmas for equality-path endpoints and strict-cycle edge-list nonemptiness

## Scope
- Lean lemma work only
- no documentation, generated artifact, Python checker, or mathematical-status claim changes
- does not claim a proof or counterexample for Erdos Problem #97

## Validation
- Not run: local container does not have `lean`/`lake` installed.