### PR TITLE
Add n9 dynamic-MRO claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1933,6 +1933,33 @@ soundness, `n=9`, a counterexample, or any official/global status update. Check
 it with
 `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`.
 
+### n=9 vertex-circle dynamic-MRO choice audit
+
+Status: `REVIEW_PENDING_DYNAMIC_MRO_CHOICE_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_dynamic_mro_choices.py` replays the
+actual minimum-remaining-options brancher with and without vertex-circle
+pruning. At every reached state, it recomputes selected-indegree and
+witness-pair count arrays, recomputes every unassigned center's valid options
+with a direct row-shape, row-pair crossing, witness-pair capacity, and
+selected-indegree predicate, and checks that the brancher chooses the first
+center with the minimum remaining options.
+
+When run with `--check --assert-expected --json`, the vertex-circle-pruned
+audit visits `16,752` nodes and checks `16,752` choice contexts, `93,837`
+center-option contexts, and `751,918` helper options, with `22,282`
+child-prune attempts and status counts `11,271` partial self-edge and `11,011`
+partial strict-cycle. The no-vertex-circle audit visits `100,817` nodes,
+checks `100,633` choice contexts, `406,285` center-option contexts, and
+`1,596,469` helper options, and reaches `184` full assignments with status
+counts `158` self-edge and `26` strict-cycle. Both audits report zero
+chosen-center mismatches, zero chosen-option mismatches, zero helper/direct
+option mismatches, and zero count-array mismatches. This is dynamic
+branch-choice implementation diagnostics only. It does not prove the geometric
+filters, strict-edge geometry, selected-distance quotient soundness, `n=9`, a
+counterexample, or any official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -405,6 +405,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
       verifier: "scripts/check_n9_vertex_circle_branch_options.py"
       claim_scope: "branch-option implementation diagnostic only; walks fixed-order no-vertex-circle replay states and compares helper options plus maintained count arrays against direct recomputation, but does not prove dynamic-MRO branch coverage, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_dynamic_mro_choices"
+      status: "dynamic minimum-remaining-options branch-choice implementation audit"
+      artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
+      verifier: "scripts/check_n9_vertex_circle_dynamic_mro_choices.py"
+      claim_scope: "dynamic branch-choice diagnostic only; replays the minimum-remaining-options brancher with and without vertex-circle pruning and compares chosen centers, helper options, and maintained count arrays against direct recomputation, but does not prove geometric filters, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle dynamic-MRO choice audit.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_DYNAMIC_MRO_CHOICE_AUDIT`.
- Evidence level: dynamic branch-choice implementation diagnostic only.
- The audit replays the minimum-remaining-options brancher with and without vertex-circle pruning, recomputes count arrays, recomputes every unassigned center's direct option list, and checks first-minimum tie breaking.
- It does not prove geometric filters, strict-edge geometry, selected-distance quotient soundness, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_dynamic_mro_choices.py -q -m slow`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_exhaustive.json` through `scripts/check_n9_vertex_circle_dynamic_mro_choices.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- This is branch-choice implementation evidence only; frontier row identity, geometric filters, strict-edge geometry, selected-distance quotient soundness, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.