### PR TITLE
Add n9 frontier-coverage claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1960,6 +1960,32 @@ filters, strict-edge geometry, selected-distance quotient soundness, `n=9`, a
 counterexample, or any official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`.
 
+### n=9 vertex-circle frontier-coverage crosswalk
+
+Status: `REVIEW_PENDING_FRONTIER_COVERAGE_CROSSWALK`.
+
+The checker `scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py`
+reruns the dynamic minimum-remaining-options brancher without vertex-circle
+pruning and compares the generated complete selected-witness assignments,
+as ordered rows, against the stored frontier motif-classification artifact
+`data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
+
+When run with `--check --assert-expected --json`, the crosswalk visits
+`100,817` dynamic no-vertex-circle nodes. It generates `184` complete
+assignments, all unique, and compares them with `184` stored assignments, also
+all unique. It reports `sequence_matches = true`, `set_matches = true`, zero
+missing generated assignments, zero extra stored assignments, and zero status
+mismatches, with matching status counts `158` self-edge and `26` strict-cycle.
+The generated and stored ordered-row SHA-256 digest is
+`d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01`; the
+sorted-row digest is
+`dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55`. This is
+a frontier coverage crosswalk against the current brancher only. It does not
+prove filter soundness, dynamic brancher soundness, strict-edge geometry,
+selected-distance quotient soundness, `n=9`, a counterexample, or any
+official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -410,6 +410,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_exhaustive.json"
       verifier: "scripts/check_n9_vertex_circle_dynamic_mro_choices.py"
       claim_scope: "dynamic branch-choice diagnostic only; replays the minimum-remaining-options brancher with and without vertex-circle pruning and compares chosen centers, helper options, and maintained count arrays against direct recomputation, but does not prove geometric filters, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_frontier_coverage_crosswalk"
+      status: "dynamic no-vertex-circle generated-vs-stored frontier coverage crosswalk"
+      artifact: "data/certificates/n9_vertex_circle_frontier_motif_classification.json"
+      verifier: "scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py"
+      claim_scope: "frontier coverage crosswalk against the current brancher only; reruns the dynamic no-vertex-circle brancher and compares the generated 184 ordered complete assignments and status labels against the stored frontier motif-classification artifact, but does not prove filter soundness, dynamic brancher soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle frontier-coverage crosswalk.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_FRONTIER_COVERAGE_CROSSWALK`.
- Evidence level: generated-vs-stored frontier coverage crosswalk for the current dynamic no-vertex-circle brancher.
- The crosswalk regenerates the 184 complete selected-witness assignments and compares ordered rows plus status labels against `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
- It does not prove filter soundness, dynamic brancher soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_frontier_coverage_crosswalk.py -q -m slow`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_frontier_motif_classification.json` through `scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- This is a crosswalk against the current brancher only; filter soundness, dynamic brancher soundness, vertex-circle pruning, strict-edge geometry, selected-distance quotient soundness, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.