### PR TITLE
Add n9 dihedral-orbit claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1986,6 +1986,33 @@ selected-distance quotient soundness, `n=9`, a counterexample, or any
 official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`.
 
+### n=9 vertex-circle dihedral-orbit audit
+
+Status: `REVIEW_PENDING_DIHEDRAL_ORBIT_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_dihedral_orbit_audit.py` treats the
+stored motif-family artifact and frontier classification artifact as inputs. It
+independently recomputes the `18` cyclic/reflection relabelings, verifies
+canonical representatives, stored orbit sizes, orbit disjointness, and the
+assignment-to-orbit maps in
+`data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
+
+When run with `--check --assert-expected --json`, the audit checks `16` stored
+motif families with family status counts `13` self-edge and `3` strict-cycle.
+The stored orbit sizes have histogram `2: 5`, `6: 2`, and `18: 9`; their
+disjoint orbit union contains `184` rows. The frontier classification contains
+`184` unique rows with status counts `158` self-edge and `26` strict-cycle.
+The audit reports zero canonical-representative mismatches, zero canonical
+label-map mismatches, zero orbit-size mismatches, zero orbit overlaps, zero
+assignment-id mismatches, zero family mismatches, zero status mismatches, zero
+rows missing from classification, and zero classification rows missing from the
+orbits. The orbit-union and classification-row SHA-256 digest is
+`dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55`. This is
+dihedral orbit bookkeeping only. It does not prove frontier coverage, filter
+soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, a
+counterexample, or any official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -415,6 +415,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_frontier_motif_classification.json"
       verifier: "scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py"
       claim_scope: "frontier coverage crosswalk against the current brancher only; reruns the dynamic no-vertex-circle brancher and compares the generated 184 ordered complete assignments and status labels against the stored frontier motif-classification artifact, but does not prove filter soundness, dynamic brancher soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_dihedral_orbit_audit"
+      status: "stored motif-family dihedral-orbit bookkeeping audit"
+      artifact: "data/certificates/n9_vertex_circle_motif_families.json and data/certificates/n9_vertex_circle_frontier_motif_classification.json"
+      verifier: "scripts/check_n9_vertex_circle_dihedral_orbit_audit.py"
+      claim_scope: "dihedral orbit bookkeeping only; independently recomputes the 18 relabelings and checks stored motif representatives, orbit sizes, disjointness, and assignment-to-orbit maps, but does not prove frontier coverage, filter soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle dihedral-orbit audit.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_DIHEDRAL_ORBIT_AUDIT`.
- Evidence level: stored motif-family dihedral-orbit bookkeeping audit.
- The audit independently recomputes the 18 cyclic/reflection relabelings and checks canonical representatives, orbit sizes, orbit disjointness, and assignment-to-orbit maps for the stored motif and frontier-classification artifacts.
- It does not prove frontier coverage, filter soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_dihedral_orbit_audit.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_motif_families.json` and `data/certificates/n9_vertex_circle_frontier_motif_classification.json` through `scripts/check_n9_vertex_circle_dihedral_orbit_audit.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- This is orbit bookkeeping only; frontier coverage, filter soundness, dynamic brancher soundness, strict-edge geometry, selected-distance quotient soundness, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.