### PR TITLE
Add n9 motif-obstruction claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2013,6 +2013,32 @@ soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, a
 counterexample, or any official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`.
 
+### n=9 vertex-circle motif-obstruction audit
+
+Status: `REVIEW_PENDING_MOTIF_OBSTRUCTION_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_motif_obstruction_audit.py` treats
+`data/certificates/n9_vertex_circle_motif_families.json` as input data. For
+the `16` stored motif-family representatives, it recomputes selected-distance
+quotient classes and vertex-circle strict interval inequalities with a small
+local implementation, then verifies each stored representative self-edge path
+or strict-cycle edge list.
+
+When run with `--check --assert-expected --json`, the audit reports computed
+and stored representative status counts `13` self-edge and `3` strict-cycle.
+The self-edge representatives contain `276` checked self-edge conflicts. The
+strict-edge tables contain `1,053` strict edges for self-edge representatives
+and `243` strict edges for strict-cycle representatives; the stored strict
+cycles have length histogram `2: 1` and `3: 2`. It reports zero stored-status
+mismatches, zero self-edge conflict mismatches, zero equality-path mismatches,
+zero strict-cycle edge mismatches, and zero strict-cycle chain mismatches. This
+is stored-certificate bookkeeping only. It does not prove frontier coverage,
+brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping,
+strict-edge geometry in general, selected-distance quotient soundness in
+general, `n=9`, a counterexample, or any official/global status update. Check
+it with
+`python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -420,6 +420,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_motif_families.json and data/certificates/n9_vertex_circle_frontier_motif_classification.json"
       verifier: "scripts/check_n9_vertex_circle_dihedral_orbit_audit.py"
       claim_scope: "dihedral orbit bookkeeping only; independently recomputes the 18 relabelings and checks stored motif representatives, orbit sizes, disjointness, and assignment-to-orbit maps, but does not prove frontier coverage, filter soundness, strict-edge geometry, quotient soundness, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_motif_obstruction_audit"
+      status: "stored motif-family representative obstruction audit"
+      artifact: "data/certificates/n9_vertex_circle_motif_families.json"
+      verifier: "scripts/check_n9_vertex_circle_motif_obstruction_audit.py"
+      claim_scope: "stored-certificate bookkeeping only; recomputes selected-distance quotient classes and local vertex-circle strict interval inequalities for the 16 stored motif representatives and checks their stored self-edge paths or strict-cycle edges, but does not prove frontier coverage, brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, strict-edge geometry in general, quotient soundness in general, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle motif-obstruction audit.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_MOTIF_OBSTRUCTION_AUDIT`.
- Evidence level: stored-certificate bookkeeping for the 16 stored motif-family representatives.
- The audit recomputes selected-distance quotient classes and local vertex-circle strict interval inequalities, then verifies stored representative self-edge paths or strict-cycle edges.
- It does not prove frontier coverage, brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, strict-edge geometry in general, selected-distance quotient soundness in general, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_motif_obstruction_audit.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_motif_families.json` through `scripts/check_n9_vertex_circle_motif_obstruction_audit.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- This is stored-certificate bookkeeping only; frontier coverage, brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, strict-edge geometry, selected-distance quotient soundness, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.