### PR TITLE
Add n9 focused packet catalog claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2066,6 +2066,31 @@ selected-distance quotient soundness in general, `n=9`, a counterexample, or
 any official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`.
 
+### n=9 vertex-circle focused packet catalog audit
+
+Status: `REVIEW_PENDING_FOCUSED_PACKET_CATALOG_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py`
+treats the focused `T01` through `T12` local-lemma packet JSON files, the
+template lemma catalog, the source template packets, and the aggregate
+local-lemma scan as input data. It checks that packet coverage, source template
+records, source catalog records, and aggregate focused-note crosschecks agree
+before any packet-soundness or local-lemma-completeness review.
+
+When run with `--check --assert-expected --json`, the audit checks `12`
+focused packets and `12` catalog templates. Those packets cover `184`
+assignments across `16` families, with template status counts `9` self-edge
+and `3` strict-cycle and assignment status counts `158` self-edge and `26`
+strict-cycle. It reports zero duplicate assignment ids, zero duplicate family
+ids, zero missing packet templates, zero extra packet templates, zero packet
+coverage mismatches, zero source-catalog mismatches, zero source-template
+mismatches, zero source-template extra fields, zero unexpected missing fields,
+and zero aggregate focused-crosscheck mismatches. This is JSON cross-artifact
+packet/catalog bookkeeping only. It does not prove packet soundness,
+local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any
+official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -430,6 +430,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_local_core_packet.json and data/certificates/n9_vertex_circle_motif_families.json"
       verifier: "scripts/check_n9_vertex_circle_local_core_subset_audit.py"
       claim_scope: "cross-artifact compact-core bookkeeping only; checks that each compact local core is literally a subset of its stored full motif representative and already forces the same quotient self-edge or strict-cycle obstruction by direct replay, but does not prove local-lemma completeness, frontier coverage, brancher soundness, motif-orbit bookkeeping, strict-edge geometry in general, quotient soundness in general, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_focused_packet_catalog_audit"
+      status: "focused local-lemma packet/catalog cross-artifact audit"
+      artifact: "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json through data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json, plus template catalog/source packet inputs"
+      verifier: "scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py"
+      claim_scope: "JSON packet/catalog bookkeeping only; checks that the 12 focused packets, template catalog records, source template packet records, and aggregate focused-note crosschecks agree on the same 184 assignments and 16 families, but does not prove packet soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle focused packet catalog audit.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_FOCUSED_PACKET_CATALOG_AUDIT`.
- Evidence level: JSON cross-artifact packet/catalog bookkeeping.
- The audit checks that the 12 focused packets, template catalog records, source template packet records, and aggregate focused-note crosschecks agree on the same 184 assignments and 16 families.
- It does not prove packet soundness, local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_focused_packet_catalog_audit.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the focused `T01`..`T12` packet JSON files, template catalog, source template packets, and aggregate local-lemma scan through `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- This is packet/catalog bookkeeping only; packet soundness, local-lemma completeness, frontier coverage, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.