### PR TITLE
Add n9 focused minireplay claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2091,6 +2091,33 @@ local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any
 official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`.
 
+### n=9 vertex-circle focused mini-replay crosswalk
+
+Status: `REVIEW_PENDING_FOCUSED_MINIREPLAY_CROSSWALK`.
+
+The checker `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py`
+treats the focused `T01` through `T12` local-lemma packet JSON files and their
+packet-specific mini-replay JSON artifacts as input data. It joins those two
+layers before any review of mini-replay soundness, packet soundness, or
+local-lemma completeness by checking source identity, source schema records,
+family coverage, obstruction flags, assignment counts, and compact local shape
+counts.
+
+When run with `--check --assert-expected --json`, the crosswalk checks `12`
+focused packets and `12` mini-replay artifacts. Those source packets cover
+`184` assignments across `16` families, with template status counts `9`
+self-edge and `3` strict-cycle and assignment status counts `158` self-edge
+and `26` strict-cycle. It reports all `12` mini-replays as obstruction-flagged,
+with zero source-packet mismatches, zero source-schema mismatches, zero family
+mismatches, zero assignment-count mismatches, and zero obstruction-flag
+mismatches. The self-edge compact path-length family histogram is `3: 9`,
+`4: 2`, `5: 1`, and `6: 1`; the strict-cycle length family histogram is
+`2: 1` and `3: 2`. This is JSON-only cross-artifact bookkeeping. It does not
+prove mini-replay soundness, packet soundness, local-lemma completeness,
+frontier coverage, `n=9`, a counterexample, or any official/global status
+update. Check it with
+`python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -435,6 +435,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_t01_self_edge_lemma_packet.json through data/certificates/n9_vertex_circle_t12_strict_cycle_lemma_packet.json, plus template catalog/source packet inputs"
       verifier: "scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py"
       claim_scope: "JSON packet/catalog bookkeeping only; checks that the 12 focused packets, template catalog records, source template packet records, and aggregate focused-note crosschecks agree on the same 184 assignments and 16 families, but does not prove packet soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_focused_minireplay_crosswalk"
+      status: "focused packet/minireplay cross-artifact crosswalk audit"
+      artifact: "data/certificates/n9_t01_self_edge_minireplay.json through data/certificates/n9_t12_strict_cycle_minireplay.json, plus source focused packet JSON files"
+      verifier: "scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py"
+      claim_scope: "JSON-only packet/minireplay bookkeeping; checks that the 12 focused packets and their 12 packet-specific mini-replay artifacts agree on source identity, source schemas, families, assignment counts, obstruction flags, and compact local shape counts, but does not prove mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle focused mini-replay crosswalk.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_FOCUSED_MINIREPLAY_CROSSWALK`.
- Evidence level: JSON-only packet/minireplay cross-artifact bookkeeping.
- The crosswalk checks that the 12 focused packets and their 12 packet-specific mini-replay artifacts agree on source identity, source schemas, family coverage, assignment counts, obstruction flags, and compact local shape counts.
- It does not prove mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_focused_minireplay_crosswalk.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the focused `T01`..`T12` packet JSON files and their packet-specific mini-replay artifacts through `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py`.
- No artifacts regenerated.

## Known limitations / next review steps
- This is cross-artifact bookkeeping only; mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.