### PR TITLE
Add n9 local lemma replay claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2118,6 +2118,32 @@ frontier coverage, `n=9`, a counterexample, or any official/global status
 update. Check it with
 `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`.
 
+### n=9 vertex-circle aggregate/simple replay crosswalk
+
+Status: `REVIEW_PENDING_PACKET_AUDIT`.
+
+The checker `scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py`
+treats `data/certificates/n9_vertex_circle_local_lemmas.json` as the aggregate
+local-lemma scan and
+`data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` as a
+simple packet replay audit. The simple replay checks the stored packet JSON
+without sharing the main quotient-replay helper, and the crosswalk compares
+the aggregate scan and simple replay family-by-family.
+
+When run with `--check --assert-expected --json`, the crosswalk checks `16`
+aggregate families and `16` simple-replay families and matches all `184`
+covered assignments. The matched coverage has `13` self-edge families covering
+`158` assignments and `3` strict-cycle families covering `26` assignments.
+The focused-packet crosscheck summary records `12` focused templates, `16`
+focused families, and `184` focused assignments. The companion simple replay
+checker reports status `REVIEW_PENDING_PACKET_AUDIT`, trust
+`REVIEW_PENDING_DIAGNOSTIC`, `184` covered assignments, `16` covered families,
+`158` self-edge assignments, and `26` strict-cycle assignments. This is
+cross-artifact packet/replay bookkeeping only. It does not prove simple-replay
+soundness, packet soundness, local-lemma completeness, frontier coverage,
+`n=9`, a counterexample, or any official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -440,6 +440,11 @@ local_repo:
       artifact: "data/certificates/n9_t01_self_edge_minireplay.json through data/certificates/n9_t12_strict_cycle_minireplay.json, plus source focused packet JSON files"
       verifier: "scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py"
       claim_scope: "JSON-only packet/minireplay bookkeeping; checks that the 12 focused packets and their 12 packet-specific mini-replay artifacts agree on source identity, source schemas, families, assignment counts, obstruction flags, and compact local shape counts, but does not prove mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_local_lemma_replay_crosswalk"
+      status: "aggregate local-lemma simple-replay cross-artifact audit"
+      artifact: "data/certificates/n9_vertex_circle_local_lemmas.json and data/certificates/n9_vertex_circle_local_lemma_simple_replay.json"
+      verifier: "scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py"
+      claim_scope: "cross-artifact packet/replay bookkeeping only; checks that the aggregate local-lemma scan and simple packet replay agree family-by-family on 184 assignments across 16 families, but does not prove simple-replay soundness, packet soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle aggregate/simple replay crosswalk.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_PACKET_AUDIT`.
- Evidence level: cross-artifact packet/replay bookkeeping.
- The crosswalk checks that the aggregate local-lemma scan and simple packet replay agree family-by-family on 184 assignments across 16 families, with 13 self-edge families and 3 strict-cycle families.
- It does not prove simple-replay soundness, packet soundness, local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json`
- `python scripts\check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_local_lemma_simple_replay.py tests\test_n9_vertex_circle_local_lemma_replay_crosswalk.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_local_lemmas.json` and `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` through the replay crosswalk.
- Checked the stored simple replay artifact directly.
- No artifacts regenerated.

## Known limitations / next review steps
- This is aggregate/simple-replay bookkeeping only; simple-replay soundness, packet soundness, local-lemma completeness, frontier coverage, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.