### PR TITLE
Add n9 relation skeleton claims ledger entry

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2186,6 +2186,28 @@ prove local-lemma completeness, prove frontier coverage, prove `n=9`, give a
 counterexample, or update the official/global status. Check it with
 `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`.
 
+### n=9 vertex-circle relation-skeleton/local-lemma crosswalk
+
+Status: `REVIEW_PENDING_PACKET_AUDIT`.
+
+The checker `scripts/check_relation_skeleton_local_lemma_crosswalk.py` treats
+`data/certificates/relation_skeleton_catalog.json`, the aggregate local-lemma
+scan, and the simple local-lemma replay audit as input data. It compares the
+compact relation-skeleton proof-mining catalog with the same local-lemma
+family accounting used by the aggregate/simple-replay crosswalk.
+
+When run with `--check --assert-expected --json`, the crosswalk checks `16`
+relation skeletons against `16` local families, matching all `184`
+assignments. The matched coverage has `13` self-edge families covering `158`
+assignments and `3` strict-cycle families covering `26` assignments. The
+family records compare skeleton ids, lemma ids, template ids, relation
+contradiction types, local obstruction groups, assignment counts, orbit sizes,
+source packet paths, equality-chain counts, strict-edge counts, and simple
+replay step counts. This is cross-artifact bookkeeping only. It does not prove
+relation-skeleton soundness, local-lemma completeness, frontier coverage,
+`n=9`, a counterexample, or any official/global status update. Check it with
+`python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -455,6 +455,11 @@ local_repo:
       artifact: "data/certificates/n9_vertex_circle_exhaustive.json, data/certificates/n9_vertex_circle_frontier_motif_classification.json, data/certificates/n9_vertex_circle_local_lemmas.json, and data/certificates/n9_vertex_circle_local_lemma_simple_replay.json"
       verifier: "scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py"
       claim_scope: "cross-artifact accounting only; checks that the review-pending exhaustive count artifact agrees with the motif classification/local-lemma layers on the aggregate 184-assignment total and 158 self-edge / 26 strict-cycle status split, while the motif classification and local-lemma/simple-replay layers agree family-by-family across 16 families; it does not review the exhaustive brancher, prove local-lemma completeness, prove frontier coverage, prove n=9, update official/global status, or give a counterexample"
+    - pattern: "relation_skeleton_local_lemma_crosswalk"
+      status: "relation-skeleton catalog and local-lemma cross-artifact audit"
+      artifact: "data/certificates/relation_skeleton_catalog.json, data/certificates/n9_vertex_circle_local_lemmas.json, and data/certificates/n9_vertex_circle_local_lemma_simple_replay.json"
+      verifier: "scripts/check_relation_skeleton_local_lemma_crosswalk.py"
+      claim_scope: "cross-artifact bookkeeping only; checks that 16 relation skeletons agree family-by-family with the aggregate local-lemma scan and simple replay on 184 assignments, relation contradiction types, obstruction groups, source packet paths, and compact relation counts, but does not prove relation-skeleton soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed
- Added a `docs/claims.md` ledger entry for the `n=9` vertex-circle relation-skeleton/local-lemma crosswalk.
- Added matching metadata in `metadata/erdos97.yaml` under `notable_frontier_diagnostics`.

## Claim scope and evidence level
- Status: `REVIEW_PENDING_PACKET_AUDIT`.
- Evidence level: cross-artifact bookkeeping only.
- The crosswalk checks that 16 relation skeletons agree family-by-family with the aggregate local-lemma scan and simple replay on 184 assignments, relation contradiction types, obstruction groups, source packet paths, and compact relation counts.
- It does not prove relation-skeleton soundness, local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any official/global status update.

## Commands run
- `python scripts\check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
- `python -m pytest tests\test_relation_skeleton_local_lemma_crosswalk.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/relation_skeleton_catalog.json`, `data/certificates/n9_vertex_circle_local_lemmas.json`, and `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` through the relation-skeleton/local-lemma crosswalk.
- No artifacts regenerated.

## Known limitations / next review steps
- This is relation-skeleton/local-lemma bookkeeping only; relation-skeleton soundness, local-lemma completeness, frontier coverage, and full `n=9` review remain separate scopes.
- The repository still makes no general proof claim and no counterexample claim; `n=9` remains review-pending.