### PR TITLE
Document n9 local lemma audit path

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2208,6 +2208,30 @@ relation-skeleton soundness, local-lemma completeness, frontier coverage,
 `n=9`, a counterexample, or any official/global status update. Check it with
 `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`.
 
+### n=9 vertex-circle local-lemma audit path
+
+Status: `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH`.
+
+The checker `scripts/check_n9_vertex_circle_local_lemma_audit_path.py` treats
+the focused packet/catalog audit, focused mini-replay crosswalk,
+aggregate/simple replay crosswalk, exhaustive/local-lemma crosswalk, and
+relation-skeleton/local-lemma crosswalk as one review-pending audit path. It
+checks adjacent handoffs so future count, schema, provenance, or manifest drift
+can be localized to the first disagreeing layer.
+
+When run with `--check --assert-expected --json`, the audit path checks `5`
+layers, `4` adjacent handoffs, `12` template ids, `16` local families, and all
+`184` covered assignments. The shared coverage summary has `13` self-edge
+families covering `158` assignments, `3` strict-cycle families covering `26`
+assignments, and `16` relation skeletons. It records `32` input artifacts and
+checks the layer contracts, layer provenance, layer source artifacts, claim
+scope guards, layer output/input contracts, focused mini-replay record paths,
+handoff checks, and manifest contracts. This is a cross-artifact audit path
+only. It does not prove packet soundness, mini-replay soundness, local-lemma
+completeness, frontier coverage, `n=9`, a counterexample, or any
+official/global status update. Check it with
+`python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`.
+
 ### n=9 turn-inequality frontier replay
 
 Status: `REVIEW_PENDING_TURN_INEQUALITY_FRONTIER_REPLAY`.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -460,6 +460,11 @@ local_repo:
       artifact: "data/certificates/relation_skeleton_catalog.json, data/certificates/n9_vertex_circle_local_lemmas.json, and data/certificates/n9_vertex_circle_local_lemma_simple_replay.json"
       verifier: "scripts/check_relation_skeleton_local_lemma_crosswalk.py"
       claim_scope: "cross-artifact bookkeeping only; checks that 16 relation skeletons agree family-by-family with the aggregate local-lemma scan and simple replay on 184 assignments, relation contradiction types, obstruction groups, source packet paths, and compact relation counts, but does not prove relation-skeleton soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
+    - pattern: "n9_vertex_circle_local_lemma_audit_path"
+      status: "combined local-lemma cross-artifact audit path"
+      artifact: "focused packet/catalog, focused mini-replay, aggregate/simple replay, exhaustive/local-lemma, and relation-skeleton/local-lemma audit layers"
+      verifier: "scripts/check_n9_vertex_circle_local_lemma_audit_path.py"
+      claim_scope: "cross-artifact audit-path bookkeeping only; checks that 5 review-pending local-lemma layers and 4 adjacent handoffs agree on 12 template ids, 16 families, 184 assignments, the 158 self-edge / 26 strict-cycle split, 16 relation skeletons, 32 input artifacts, layer contracts, provenance, manifest contracts, and claim-scope guards, but does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"


### PR DESCRIPTION
## What changed

- Added a dedicated `docs/claims.md` entry for the `n=9` vertex-circle local-lemma audit path checker.
- Added matching `metadata/erdos97.yaml` diagnostic metadata for the same audit-path scope.

## Claim scope and evidence level

- Evidence level: `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH` / `REVIEW_PENDING_DIAGNOSTIC`.
- Scope is cross-artifact audit-path bookkeeping only: it records that 5 local-lemma layers and 4 adjacent handoffs agree on 12 template ids, 16 families, 184 assignments, the 158 self-edge / 26 strict-cycle split, 16 relation skeletons, 32 input artifacts, contracts, provenance, manifest checks, and claim-scope guards.
- This does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, a counterexample, or official/global status movement.

## Commands run

- `python scripts\check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked

- No generated artifacts were changed.
- Checked the audit path over the focused packet/catalog layer, focused mini-replay layer, aggregate/simple replay layer, exhaustive/local-lemma layer, relation-skeleton/local-lemma layer, and their 32 declared input artifacts.

## Known limitations / next review steps

- This is ledger and metadata documentation for an existing checker, not a new proof artifact.
- The underlying audit path remains review-pending and still needs independent review before it can support stronger `n=9` claims.