### PR TITLE
Tighten n9 turn inequality claim scope

### DIFF
--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -104,7 +104,7 @@ local_repo:
       artifact: "data/certificates/n9_turn_inequality_frontier.json"
       verifier: "scripts/check_n9_turn_inequality_frontier.py"
       source_provenance: "candidate weak turn-inequality frontier replay"
-      claim_scope: "candidate weak turn-inequality replay for the 184 regenerated n=9 pair/crossing/count frontier assignments only; does not alter official/global status or the source-of-truth strongest local result"
+      claim_scope: "candidate n=9 selected-witness turn-inequality frontier replay for the 184 regenerated pair/crossing/count frontier assignments only; not a proof of Erdos Problem #97, not a counterexample, not an independent review, and not a source-of-truth status update"
       review_note: "Promote only after independent review validates the geometric turn lemma, indexing conventions, regenerated source frontier, and stored integer dual arithmetic verifier."
     - name: "n9_groebner_real_root_decoders"
       status: "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING"


### PR DESCRIPTION
## What changed

- Tightened the `n9_turn_inequality_frontier` metadata claim scope to mirror the checked artifact's explicit non-overclaiming boundary.
- Preserved the artifact, verifier, review-pending status, and review note.

## Claim scope and evidence level

- Evidence level remains `MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING`.
- Scope remains the candidate `n=9` selected-witness turn-inequality frontier replay for the 184 regenerated pair/crossing/count frontier assignments only.
- The metadata now explicitly says this is not a proof of Erdos Problem #97, not a counterexample, not an independent review, and not a source-of-truth status update.

## Commands run

- `python scripts\check_n9_turn_inequality_frontier.py --check --assert-expected --json`
- `python -m pytest tests\test_n9_turn_inequality_frontier.py -q`
- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked

- No generated artifacts were changed.
- Checked `data/certificates/n9_turn_inequality_frontier.json` with its verifier.

## Known limitations / next review steps

- This is metadata claim-scope alignment only.
- The turn-inequality frontier replay still requires independent review of the geometric turn lemma, indexing conventions, regenerated frontier, and stored integer dual arithmetic verifier before any stronger claim.