### PR TITLE
Add closed-descent companion to n9 audit path

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1098,9 +1098,9 @@ input-data replay artifacts. The local-lemma audit path
 `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
 runs the packet/catalog, focused mini-replay, aggregate/simple-replay,
 exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
-adjacent drift localization. These are review-pending handoff audits only, not
-packet soundness, local-lemma completeness, frontier coverage, or a proof of
-`n=9`.
+adjacent drift localization, plus the relation-skeleton/closed-descent
+companion summary. These are review-pending handoff audits only, not packet
+soundness, local-lemma completeness, frontier coverage, or a proof of `n=9`.
 The relation-skeleton/closed-descent crosswalk
 `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
 checks the same 16 families against the closed-descent packet, matching

--- a/STATE.md
+++ b/STATE.md
@@ -708,9 +708,9 @@ input-data replay artifacts. The local-lemma audit path
 `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
 runs the packet/catalog, focused mini-replay, aggregate/simple-replay,
 exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
-adjacent drift localization. These are review-pending handoff audits only, not
-packet soundness, local-lemma completeness, frontier coverage, or a proof of
-`n=9`.
+adjacent drift localization, plus the relation-skeleton/closed-descent
+companion summary. These are review-pending handoff audits only, not packet
+soundness, local-lemma completeness, frontier coverage, or a proof of `n=9`.
 The relation-skeleton/closed-descent crosswalk
 `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
 checks the same 16 families against the closed-descent packet, matching

--- a/data/certificates/n9_vertex_circle_closed_descent_packet.json
+++ b/data/certificates/n9_vertex_circle_closed_descent_packet.json
@@ -1166,7 +1166,7 @@
       "strict_edge_count": 54
     }
   ],
-  "claim_scope": "Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, not local-lemma completeness, and not a bridge proof or global status update.",
+  "claim_scope": "Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, not local-lemma completeness, not a bridge proof, and not a global status update.",
   "closed_descent_cycle_length_counts": {
     "1": 13,
     "2": 1,
@@ -1179,7 +1179,8 @@
     "A multi-class region corresponds to a replayed strict-cycle obstruction.",
     "The packet is a reviewer aid for bridge-facing local lemma work.",
     "No proof of the n=9 case is claimed.",
-    "No bridge proof or global status update is claimed."
+    "No bridge proof is claimed.",
+    "No global status update is claimed."
   ],
   "max_region_class_count": 3,
   "n": 9,

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2235,21 +2235,24 @@ Status: `REVIEW_PENDING_LOCAL_LEMMA_AUDIT_PATH`.
 The checker `scripts/check_n9_vertex_circle_local_lemma_audit_path.py` treats
 the focused packet/catalog audit, focused mini-replay crosswalk,
 aggregate/simple replay crosswalk, exhaustive/local-lemma crosswalk, and
-relation-skeleton/local-lemma crosswalk as one review-pending audit path. It
-checks adjacent handoffs so future count, schema, provenance, or manifest drift
-can be localized to the first disagreeing layer.
+relation-skeleton/local-lemma crosswalk as one review-pending audit path, with
+the relation-skeleton/closed-descent crosswalk as a companion representation
+check. It checks adjacent handoffs so future count, schema, provenance, or
+manifest drift can be localized to the first disagreeing layer.
 
 When run with `--check --assert-expected --json`, the audit path checks `5`
 layers, `4` adjacent handoffs, `12` template ids, `16` local families, and all
 `184` covered assignments. The shared coverage summary has `13` self-edge
 families covering `158` assignments, `3` strict-cycle families covering `26`
-assignments, and `16` relation skeletons. It records `32` input artifacts and
-checks the layer contracts, layer provenance, layer source artifacts, claim
-scope guards, layer output/input contracts, focused mini-replay record paths,
-handoff checks, and manifest contracts. This is a cross-artifact audit path
-only. It does not prove packet soundness, mini-replay soundness, local-lemma
-completeness, frontier coverage, `n=9`, a counterexample, or any
-official/global status update. Check it with
+assignments, and `16` relation skeletons. It also checks the companion
+closed-descent crosswalk against the same `16` relation skeletons and `184`
+orbit records. It records `33` input artifacts and checks the layer contracts,
+layer provenance, layer source artifacts, claim scope guards, layer
+output/input contracts, focused mini-replay record paths, handoff checks, the
+closed-descent companion summary, and manifest contracts. This is a
+cross-artifact audit path only. It does not prove packet soundness,
+mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, a
+counterexample, or any official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`.
 
 ### n=9 turn-inequality frontier replay

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -58,8 +58,9 @@ Use this queue when no more specific issue is selected.
    runs the focused packet/catalog, focused mini-replay,
    aggregate/simple-replay, exhaustive/local-lemma, and
    relation-skeleton/local-lemma handoffs as one review-pending audit path,
-   with explicit adjacent handoff checks that identify where any future
-   count/schema drift first appears.
+   with the relation-skeleton/closed-descent companion summary and explicit
+   adjacent handoff checks that identify where any future count/schema drift
+   first appears.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -421,7 +421,8 @@ Next steps:
   to run the focused packet/catalog, focused mini-replay,
   aggregate/simple-replay, exhaustive/local-lemma, and
   relation-skeleton/local-lemma handoffs as one review-pending audit path,
-  with adjacent handoff checks that localize future drift between layers;
+  with the relation-skeleton/closed-descent companion summary and adjacent
+  handoff checks that localize future drift between layers;
 - use the focused mini-replay commands
   `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -467,9 +467,9 @@ local_repo:
       claim_scope: "cross-artifact packet bookkeeping only; checks that the 16 relation-skeleton entries and the closed-descent packet agree family-by-family on self-edge versus strict-cycle status, assignment/orbit counts, and one-class versus multi-class descent regions, but does not prove local-lemma completeness, brancher coverage, n=9, a bridge proof, official/global status movement, or a counterexample"
     - pattern: "n9_vertex_circle_local_lemma_audit_path"
       status: "combined local-lemma cross-artifact audit path"
-      artifact: "focused packet/catalog, focused mini-replay, aggregate/simple replay, exhaustive/local-lemma, and relation-skeleton/local-lemma audit layers"
+      artifact: "focused packet/catalog, focused mini-replay, aggregate/simple replay, exhaustive/local-lemma, relation-skeleton/local-lemma audit layers, and relation-skeleton/closed-descent companion crosswalk"
       verifier: "scripts/check_n9_vertex_circle_local_lemma_audit_path.py"
-      claim_scope: "cross-artifact audit-path bookkeeping only; checks that 5 review-pending local-lemma layers and 4 adjacent handoffs agree on 12 template ids, 16 families, 184 assignments, the 158 self-edge / 26 strict-cycle split, 16 relation skeletons, 32 input artifacts, layer contracts, provenance, manifest contracts, and claim-scope guards, but does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
+      claim_scope: "cross-artifact audit-path bookkeeping only; checks that 5 review-pending local-lemma layers and 4 adjacent handoffs agree on 12 template ids, 16 families, 184 assignments, the 158 self-edge / 26 strict-cycle split, 16 relation skeletons, plus a relation-skeleton/closed-descent companion summary and 33 input artifacts, layer contracts, provenance, manifest contracts, and claim-scope guards, but does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -713,8 +713,8 @@ artifacts:
 
   - id: n9_vertex_circle_closed_descent_packet
     path: data/certificates/n9_vertex_circle_closed_descent_packet.json
-    sha256: 4662746873f3f3a53fc1f12ed1b9e1a4f3c5d13fde0fde1257d01523ee9fa1b9
-    size_bytes: 24048
+    sha256: 70aad90833c27f9ece43b8383fdbd7896eb4dc9681b8f801c0b944f676060a02
+    size_bytes: 24071
     kind: certificate_diagnostic_artifact
     generator: scripts/check_n9_vertex_circle_closed_descent_packet.py
     command: python scripts/check_n9_vertex_circle_closed_descent_packet.py --assert-expected --write
@@ -723,13 +723,13 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, not local-lemma completeness, and not a bridge proof or global status update.
+    claim_scope: Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, not local-lemma completeness, not a bridge proof, and not a global status update.
     json_top_level_type: object
     expected_json:
       schema: erdos97.n9_vertex_circle_closed_descent_packet.v1
       status: REVIEW_PENDING_DIAGNOSTIC_ONLY
       trust: REVIEW_PENDING_DIAGNOSTIC
-      claim_scope: Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, not local-lemma completeness, and not a bridge proof or global status update.
+      claim_scope: Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core motif representatives; not a proof of n=9, not a counterexample, not an independent review of the exhaustive checker, not local-lemma completeness, not a bridge proof, and not a global status update.
       n: 9
       row_size: 4
       family_count: 16

--- a/scripts/check_n9_vertex_circle_closed_descent_packet.py
+++ b/scripts/check_n9_vertex_circle_closed_descent_packet.py
@@ -36,7 +36,7 @@ CLAIM_SCOPE = (
     "Closed-descent reformulation of the 16 stored n=9 vertex-circle local-core "
     "motif representatives; not a proof of n=9, not a counterexample, not an "
     "independent review of the exhaustive checker, not local-lemma completeness, "
-    "and not a bridge proof or global status update."
+    "not a bridge proof, and not a global status update."
 )
 PROVENANCE = {
     "generator": "scripts/check_n9_vertex_circle_closed_descent_packet.py",
@@ -184,7 +184,8 @@ def closed_descent_packet_summary(
             "A multi-class region corresponds to a replayed strict-cycle obstruction.",
             "The packet is a reviewer aid for bridge-facing local lemma work.",
             "No proof of the n=9 case is claimed.",
-            "No bridge proof or global status update is claimed.",
+            "No bridge proof is claimed.",
+            "No global status update is claimed.",
         ],
         "source_artifacts": [
             {

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -43,6 +43,11 @@ from check_n9_vertex_circle_local_lemma_replay_crosswalk import (  # noqa: E402
     crosswalk_payload as local_replay_crosswalk_payload,
     load_artifact,
 )
+from check_n9_relation_skeleton_closed_descent_crosswalk import (  # noqa: E402
+    DEFAULT_CLOSED_DESCENT,
+    assert_expected_relation_closed_descent_crosswalk,
+    relation_closed_descent_crosswalk_payload,
+)
 from check_artifact_provenance import (  # noqa: E402
     DEFAULT_MANIFEST as DEFAULT_GENERATED_ARTIFACTS_MANIFEST,
     load_manifest as load_generated_artifact_manifest,
@@ -74,10 +79,11 @@ CLAIM_SCOPE = (
     "local-lemma packets. It joins focused packet/catalog bookkeeping, "
     "focused mini-replays, aggregate/simple replay accounting, the "
     "exhaustive/local-lemma count crosswalk, and the relation-skeleton "
-    "crosswalk. It does not prove packet soundness, does not prove "
-    "mini-replay soundness, does not prove local-lemma completeness, does "
-    "not prove frontier coverage, does not prove n=9, is not a "
-    "counterexample, and is not a global status update."
+    "crosswalk, with a relation-skeleton/closed-descent companion check. "
+    "It does not prove packet soundness, does not prove mini-replay "
+    "soundness, does not prove local-lemma completeness, does not prove "
+    "frontier coverage, does not prove n=9, is not a counterexample, and "
+    "is not a global status update."
 )
 PROVENANCE = {
     "generator": "scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
@@ -96,7 +102,7 @@ EXPECTED_LAYER_IDS = [
 ]
 EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
 EXPECTED_HANDOFF_EDGES = list(zip(EXPECTED_LAYER_IDS, EXPECTED_LAYER_IDS[1:]))
-EXPECTED_INPUT_ARTIFACT_COUNT = 32
+EXPECTED_INPUT_ARTIFACT_COUNT = 33
 EXPECTED_MANIFEST_CONTRACT_IDS = [
     "manifest_role_contract",
     "manifest_digest_contract",
@@ -115,6 +121,7 @@ EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS = [
     "layer_input_contracts",
     "focused_minireplay_record_path_contract",
     "handoff_checks",
+    "closed_descent_companion",
     "manifest_contracts",
 ]
 EXPECTED_LAYER_CONTRACTS = {
@@ -444,6 +451,20 @@ EXPECTED_COVERAGE_SUMMARY = {
     "strict_cycle_assignment_count": 26,
     "relation_skeleton_count": 16,
 }
+EXPECTED_CLOSED_DESCENT_COMPANION_SUMMARY = {
+    "status": "passed",
+    "schema": "erdos97.n9_relation_skeleton_closed_descent_crosswalk.v1",
+    "layer_status": "REVIEW_PENDING_PACKET_AUDIT",
+    "trust": "REVIEW_PENDING_DIAGNOSTIC",
+    "validation_status": "passed",
+    "family_count": 16,
+    "orbit_size_sum": 184,
+    "contradiction_type_counts": {
+        "strict_directed_cycle": 3,
+        "strict_self_edge": 13,
+    },
+    "region_class_count_counts": {"1": 13, "2": 1, "3": 2},
+}
 EXPECTED_SUMMARY_LINES = [
     f"schema: {SCHEMA}",
     f"status: {STATUS}",
@@ -457,6 +478,7 @@ EXPECTED_SUMMARY_LINES = [
     "layer input contracts: passed",
     "focused minireplay record paths: passed",
     f"handoffs: {len(EXPECTED_HANDOFF_EDGES)}",
+    "closed-descent companion: passed",
     "audit contract summary: passed",
     f"input artifacts: {EXPECTED_INPUT_ARTIFACT_COUNT}",
     "manifest roles: passed",
@@ -486,12 +508,14 @@ def default_layer_payloads() -> dict[str, Mapping[str, Any]]:
     exhaustive = load_artifact(DEFAULT_EXHAUSTIVE)
     classification = load_artifact(DEFAULT_CLASSIFICATION)
     relation_skeletons = load_artifact(DEFAULT_RELATION_SKELETONS)
+    closed_descent = load_artifact(DEFAULT_CLOSED_DESCENT)
     for name, payload in (
         ("aggregate", aggregate),
         ("simple replay", simple_replay),
         ("exhaustive", exhaustive),
         ("classification", classification),
         ("relation skeletons", relation_skeletons),
+        ("closed descent", closed_descent),
     ):
         if not isinstance(payload, Mapping):
             raise TypeError(f"{name} artifact top level must be an object")
@@ -514,6 +538,10 @@ def default_layer_payloads() -> dict[str, Mapping[str, Any]]:
             aggregate,
             simple_replay,
         ),
+        "relation_skeleton_closed_descent": relation_closed_descent_crosswalk_payload(
+            relation_skeletons,
+            closed_descent,
+        ),
     }
 
 
@@ -524,6 +552,7 @@ def local_lemma_audit_path_payload(
     aggregate_simple_replay_payload: Mapping[str, Any] | None = None,
     exhaustive_local_lemma_payload: Mapping[str, Any] | None = None,
     relation_skeleton_local_lemma_payload: Mapping[str, Any] | None = None,
+    relation_skeleton_closed_descent_payload: Mapping[str, Any] | None = None,
     input_manifest_payload: Mapping[str, Any] | None = None,
     manifest_header_payloads: Mapping[str, Any] | None = None,
     manifest_claim_payloads: Mapping[str, Any] | None = None,
@@ -538,6 +567,7 @@ def local_lemma_audit_path_payload(
         "aggregate_simple_replay": aggregate_simple_replay_payload,
         "exhaustive_local_lemma": exhaustive_local_lemma_payload,
         "relation_skeleton_local_lemma": relation_skeleton_local_lemma_payload,
+        "relation_skeleton_closed_descent": relation_skeleton_closed_descent_payload,
     }
     layers = default_layer_payloads()
     for layer_id, payload in provided.items():
@@ -560,6 +590,10 @@ def local_lemma_audit_path_payload(
     layer_summaries = [_layer_summary(layer_id, layers[layer_id], errors) for layer_id in EXPECTED_LAYER_IDS]
     handoff_checks = _handoff_checks(layer_summaries, errors)
     coverage = _coverage_summary(layer_summaries, errors)
+    closed_descent_companion = _closed_descent_companion_summary(
+        layers["relation_skeleton_closed_descent"],
+        errors,
+    )
     input_manifest = (
         dict(input_manifest_payload)
         if input_manifest_payload is not None
@@ -609,6 +643,7 @@ def local_lemma_audit_path_payload(
             "layer_input_contracts": layer_input_contracts,
             "focused_minireplay_record_path_contract": focused_record_path_contract,
             "handoff_checks": handoff_checks,
+            "closed_descent_companion": closed_descent_companion,
             "manifest_contracts": manifest_contract_summary,
         }
     )
@@ -634,6 +669,7 @@ def local_lemma_audit_path_payload(
             "handoff_checks": handoff_checks,
             "layers": layer_summaries,
         },
+        "closed_descent_companion": closed_descent_companion,
         "audit_contract_summary": audit_contract_summary,
         "input_manifest": input_manifest,
         "manifest_role_contract": manifest_role_contract,
@@ -691,6 +727,7 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_layer_output_contracts(payload)
     _assert_expected_layer_input_contracts(payload)
     _assert_expected_focused_minireplay_record_path_contract(payload)
+    _assert_expected_closed_descent_companion(payload)
     _assert_expected_input_manifest(payload)
     _assert_expected_manifest_role_contract(payload)
     _assert_expected_manifest_digest_contract(payload)
@@ -990,6 +1027,17 @@ def _assert_expected_focused_minireplay_record_path_contract(
         raise AssertionError("focused minireplay malformed records")
 
 
+def _assert_expected_closed_descent_companion(payload: Mapping[str, Any]) -> None:
+    summary = payload.get("closed_descent_companion")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("closed_descent_companion must be an object")
+    if dict(summary) != EXPECTED_CLOSED_DESCENT_COMPANION_SUMMARY:
+        raise AssertionError(
+            "closed_descent_companion mismatch: "
+            f"{dict(summary)!r} != {EXPECTED_CLOSED_DESCENT_COMPANION_SUMMARY!r}"
+        )
+
+
 def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
     manifest = payload.get("input_manifest")
     if not isinstance(manifest, Mapping):
@@ -1016,6 +1064,7 @@ def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
         "data/certificates/n9_vertex_circle_exhaustive.json",
         "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
         "data/certificates/relation_skeleton_catalog.json",
+        "data/certificates/n9_vertex_circle_closed_descent_packet.json",
         "data/certificates/n9_t12_strict_cycle_minireplay.json",
     }
     missing_paths = sorted(required_paths - set(paths))
@@ -1931,6 +1980,8 @@ def _input_manifest() -> dict[str, Any]:
     add(DEFAULT_EXHAUSTIVE, "exhaustive/local-lemma exhaustive count source")
     add(DEFAULT_CLASSIFICATION, "exhaustive/local-lemma motif classification source")
     add(DEFAULT_RELATION_SKELETONS, "relation-skeleton/local-lemma source")
+    add(DEFAULT_RELATION_SKELETONS, "relation-skeleton/closed-descent source")
+    add(DEFAULT_CLOSED_DESCENT, "relation-skeleton/closed-descent source")
     for kind, path in sorted(DEFAULT_TEMPLATE_PACKET_PATHS.items()):
         add(path, f"focused packet/catalog {kind.replace('_', '-')} template packet")
     for template_id, path in sorted(DEFAULT_PACKET_PATHS.items()):
@@ -2018,6 +2069,8 @@ def _expected_manifest_roles() -> dict[str, list[str]]:
     add(DEFAULT_EXHAUSTIVE, "exhaustive/local-lemma exhaustive count source")
     add(DEFAULT_CLASSIFICATION, "exhaustive/local-lemma motif classification source")
     add(DEFAULT_RELATION_SKELETONS, "relation-skeleton/local-lemma source")
+    add(DEFAULT_RELATION_SKELETONS, "relation-skeleton/closed-descent source")
+    add(DEFAULT_CLOSED_DESCENT, "relation-skeleton/closed-descent source")
     for kind, path in sorted(DEFAULT_TEMPLATE_PACKET_PATHS.items()):
         add(path, f"focused packet/catalog {kind.replace('_', '-')} template packet")
     for template_id, path in sorted(DEFAULT_PACKET_PATHS.items()):
@@ -2385,6 +2438,11 @@ def _expected_manifest_headers() -> dict[str, dict[str, Any]]:
         schema="erdos97.relation_skeleton_catalog.v1",
         status="REVIEW_PENDING_DIAGNOSTIC_ONLY",
     )
+    add(
+        DEFAULT_CLOSED_DESCENT,
+        schema="erdos97.n9_vertex_circle_closed_descent_packet.v1",
+        status="REVIEW_PENDING_DIAGNOSTIC_ONLY",
+    )
     for kind, path in sorted(DEFAULT_TEMPLATE_PACKET_PATHS.items()):
         add(
             path,
@@ -2591,6 +2649,10 @@ def _expected_manifest_provenance() -> dict[str, dict[str, Any]]:
         "check_n9_vertex_circle_frontier_motif_classification.py",
     )
     add_writer(DEFAULT_RELATION_SKELETONS, "check_relation_skeleton_catalog.py")
+    add_writer(
+        DEFAULT_CLOSED_DESCENT,
+        "check_n9_vertex_circle_closed_descent_packet.py",
+    )
     for kind, path in sorted(DEFAULT_TEMPLATE_PACKET_PATHS.items()):
         add_writer(path, f"check_n9_vertex_circle_{kind}_template_packet.py")
     for template_id, path in sorted(DEFAULT_PACKET_PATHS.items()):
@@ -2827,6 +2889,10 @@ def _expected_manifest_metadata() -> dict[str, dict[str, Any]]:
         "check_n9_vertex_circle_frontier_motif_classification.py",
     )
     add_writer(DEFAULT_RELATION_SKELETONS, "check_relation_skeleton_catalog.py")
+    add_writer(
+        DEFAULT_CLOSED_DESCENT,
+        "check_n9_vertex_circle_closed_descent_packet.py",
+    )
     for kind, path in sorted(DEFAULT_TEMPLATE_PACKET_PATHS.items()):
         add_writer(path, f"check_n9_vertex_circle_{kind}_template_packet.py")
     for template_id, path in sorted(DEFAULT_PACKET_PATHS.items()):
@@ -3322,6 +3388,47 @@ def _layer_summary(
     return {"layer_id": layer_id, "validation_status": "failed"}
 
 
+def _closed_descent_companion_summary(
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    error_count = len(errors)
+    try:
+        assert_expected_relation_closed_descent_crosswalk(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(f"relation_skeleton_closed_descent expected-check failed: {exc}")
+    status = (
+        "passed"
+        if len(errors) == error_count and payload.get("validation_status") == "passed"
+        else "failed"
+    )
+    return {
+        "status": status,
+        "schema": payload.get("schema"),
+        "layer_status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "validation_status": payload.get("validation_status"),
+        "family_count": int(payload.get("family_count", -1)),
+        "orbit_size_sum": int(payload.get("orbit_size_sum", -1)),
+        "contradiction_type_counts": dict(
+            _required_mapping(
+                payload,
+                "contradiction_type_counts",
+                "relation_skeleton_closed_descent",
+                errors,
+            )
+        ),
+        "region_class_count_counts": dict(
+            _required_mapping(
+                payload,
+                "region_class_count_counts",
+                "relation_skeleton_closed_descent",
+                errors,
+            )
+        ),
+    }
+
+
 def _coverage_summary(
     layer_summaries: list[Mapping[str, Any]],
     errors: list[str],
@@ -3595,6 +3702,7 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
         "focused minireplay record paths: "
         f"{payload['audit_path']['focused_minireplay_record_path_contract']['status']}",
         f"handoffs: {payload['audit_path']['handoff_count']}",
+        f"closed-descent companion: {payload['closed_descent_companion']['status']}",
         f"audit contract summary: {payload['audit_contract_summary']['status']}",
         f"input artifacts: {payload['input_manifest']['artifact_count']}",
         f"manifest roles: {payload['manifest_role_contract']['status']}",

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -16,6 +16,7 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     CLAIM_SCOPE,
     CLAIM_SCOPE_GUARDS,
     EXPECTED_AUDIT_CONTRACT_COMPONENT_IDS,
+    EXPECTED_CLOSED_DESCENT_COMPANION_SUMMARY,
     EXPECTED_HANDOFF_EDGES,
     EXPECTED_INPUT_ARTIFACT_COUNT,
     EXPECTED_LAYER_CONTRACTS,
@@ -77,6 +78,10 @@ def test_local_lemma_audit_path_counts_and_scope() -> None:
     assert payload["validation_status"] == "passed"
     assert payload["audit_path"]["layer_ids"] == EXPECTED_LAYER_IDS
     assert payload["audit_path"]["handoff_count"] == len(EXPECTED_HANDOFF_EDGES)
+    assert (
+        payload["closed_descent_companion"]
+        == EXPECTED_CLOSED_DESCENT_COMPANION_SUMMARY
+    )
     assert [item["status"] for item in payload["audit_path"]["handoff_checks"]] == [
         "passed"
         for _ in EXPECTED_HANDOFF_EDGES
@@ -137,6 +142,9 @@ def test_local_lemma_audit_path_input_manifest() -> None:
     assert all(artifact["size_bytes"] > 0 for artifact in artifacts)
     assert "data/certificates/n9_vertex_circle_local_lemmas.json" in by_path
     assert "data/certificates/n9_vertex_circle_exhaustive.json" in by_path
+    assert (
+        "data/certificates/n9_vertex_circle_closed_descent_packet.json" in by_path
+    )
     assert (
         "data/certificates/n9_t12_strict_cycle_minireplay.json" in by_path
     )
@@ -1250,6 +1258,7 @@ def test_local_lemma_audit_path_summary_lines_include_contract_rollups() -> None
         "layer output contracts: passed",
         "layer input contracts: passed",
         "focused minireplay record paths: passed",
+        "closed-descent companion: passed",
         "audit contract summary: passed",
         "manifest roles: passed",
         "manifest digests: passed",
@@ -1265,7 +1274,7 @@ def test_local_lemma_audit_path_summary_lines_include_contract_rollups() -> None
     for line in expected_lines:
         assert line in lines
     assert lines.index("audit contract summary: passed") < lines.index(
-        "input artifacts: 32"
+        f"input artifacts: {EXPECTED_INPUT_ARTIFACT_COUNT}"
     )
     assert lines.index("manifest contract summary: passed") > lines.index(
         "manifest consistency: passed"


### PR DESCRIPTION
## What changed
- Added the relation-skeleton/closed-descent crosswalk as a companion check in the n=9 local-lemma audit path, without changing the existing five-layer/four-handoff semantics.
- Included the closed-descent packet in the audit-path input manifest, header/provenance/metadata contracts, audit contract summary, summary lines, and tests.
- Regenerated the closed-descent diagnostic packet with explicit 
ot a global status update claim wording and refreshed generated-artifact provenance metadata.
- Updated claims/status/backlog/review-priority docs to describe the companion summary and 33 input artifacts.

## Claim scope and evidence level
Review-pending cross-artifact audit bookkeeping only. This does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, a counterexample, a bridge proof, or any official/global status update.

## Commands run
- python scripts/check_n9_vertex_circle_closed_descent_packet.py --assert-expected --write --check --json
- python scripts/check_n9_vertex_circle_closed_descent_packet.py --check --assert-expected --json
- python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json
- python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
- python -m pytest tests/test_n9_vertex_circle_closed_descent_packet.py tests/test_n9_vertex_circle_local_lemma_audit_path.py -q
- python scripts/check_text_clean.py
- python scripts/check_status_consistency.py
- python scripts/check_artifact_provenance.py
- git diff --check
- python -m ruff check .
- python -m pytest -q

Artifact-tier fallback because make is not installed in this Windows shell:
- python scripts/independent_check_n8_artifacts.py --check --json
- python scripts/enumerate_n8_incidence.py --summary
- python scripts/analyze_n8_exact_survivors.py --check --json
- python scripts/check_round2_certificates.py
- python scripts/check_kalmanson_certificate.py data/certificates/round2/c19_kalmanson_known_order_two_unsat.json --summary-json
- python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
- python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
- python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json
- python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json
- python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
- python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

## Artifacts generated or checked
- Regenerated data/certificates/n9_vertex_circle_closed_descent_packet.json from its generator.
- Checked the relation-skeleton/closed-descent crosswalk and the local-lemma audit-path companion summary.
- Refreshed metadata/generated_artifacts.yaml hash/size/scope for the regenerated diagnostic packet.

## Known limitations / next review steps
The companion check is representation/provenance bookkeeping only. It does not independently review the exhaustive checker, establish local-lemma completeness, or upgrade the repository/global status.