### PR TITLE
Mark T01 and T10 backlog tasks as extracted

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -494,9 +494,13 @@ Use this queue when no more specific issue is selected.
    brancher coverage, strict-edge geometry, quotient soundness, and pruning
    remain separate review scopes.
 
-## Task CB-N9-T01 - Extract Vertex-Circle Self-Edge Template
+## Task CB-N9-T01 - Review Vertex-Circle Self-Edge Template
 
 Issue: none yet.
+
+Status: extracted as a review-pending diagnostic/local lemma candidate. Do not
+start another extraction PR for this template; the next useful work is
+reviewing packet soundness and local-lemma assumptions.
 
 Read first:
 
@@ -514,16 +518,15 @@ python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 ```
 
-Expected artifacts:
+Current artifacts:
 
-- a proof-facing lemma note or update that states the exact incidence and
-  cyclic-order hypotheses for the T01/F09 self-edge template;
-- a minimal checker or checker update that verifies the compact template
-  packet independently of the full exhaustive search;
+- a proof-facing lemma note that states the exact incidence and cyclic-order
+  hypotheses for the T01/F09 self-edge template;
+- a compact packet verifier for the stored template data;
 - documentation that distinguishes the local template from any `n=9`
   completeness or global Erdos #97 claim.
 
-Acceptance criteria:
+Next review acceptance criteria:
 
 - The lemma candidate does not enumerate all `n=9` selected-witness systems.
 - The proof-facing text identifies the selected-distance quotienting and
@@ -541,9 +544,13 @@ Forbidden overclaiming text:
 - "the vertex-circle checker is independently reviewed"
 - "this proves Erdos #97"
 
-## Task CB-N9-T10 - Extract Vertex-Circle Strict-Cycle Template
+## Task CB-N9-T10 - Review Vertex-Circle Strict-Cycle Template
 
 Issue: none yet.
+
+Status: extracted as a review-pending diagnostic/local lemma candidate. Do not
+start another extraction PR for this template; the next useful work is
+reviewing packet soundness and local-lemma assumptions.
 
 Read first:
 
@@ -561,16 +568,16 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 ```
 
-Expected artifacts:
+Current artifacts:
 
-- a proof-facing lemma note or update that states the exact incidence and
-  cyclic-order hypotheses for the T10/F12 strict-cycle template;
+- a proof-facing lemma note that states the exact incidence and cyclic-order
+  hypotheses for the T10/F12 strict-cycle template;
 - a compact verifier that replays the quotient strict-cycle certificate from
   stored data;
 - documentation that keeps local-core strict-cycle counts separate from
   full-assignment obstruction-shape counts.
 
-Acceptance criteria:
+Next review acceptance criteria:
 
 - The lemma candidate states the directed quotient cycle and the exact local
   hypotheses that force it.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -329,6 +329,11 @@ be irreflexive and acyclic.
 
 Next steps:
 
+The focused T01--T12 packet notes and checkers are already extracted as
+review-pending diagnostic/local lemma candidates. New work in this priority
+should review packet soundness, local-lemma hypotheses, and aggregate
+handoffs rather than re-extracting T01 or T10.
+
 - classify the 13 self-edge dihedral incidence families into local lemmas;
 - review the 3 strict-cycle dihedral incidence families as directed
   quotient-cycle local templates, using the focused T10/T11/T12 notes;


### PR DESCRIPTION
## Summary

- mark CB-N9-T01 and CB-N9-T10 as already extracted review-pending local lemma candidates
- redirect future work in that lane toward packet soundness, local-lemma hypotheses, and aggregate handoff review
- keep the wording explicitly non-promoting: no `n=9`, global-status, or Erdos #97 claim changes

## Validation

- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `make PYTHON=.venv/bin/python verify-fast` (`1219 passed, 479 deselected`)