### PR TITLE
Index closure activation negative controls

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -374,9 +374,15 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-chain-closure-csp.md` then checks `5916`
    sequential support-chain extensions from closure `[0,1,4]`; it leaves four
    non-supply prefixes and no surviving prefix whose next activated center is
-   `6`. The next useful PR must therefore either handle repeated/multiple
-   supports, introduce a genuine rich-class/minimality hypothesis that forces
-   or excludes such a support, or move to a different bridge target. The
+   `6`. The closure-activation negative controls in
+   `docs/closure-activation-negative-controls.md` add a guardrail for this
+   whole lane: deletion-closure exposure, full target-label visibility, and
+   full selected-row incidence checks still do not pin the fourth witness or
+   force the named selected/rich row without extra hypotheses. The next useful
+   PR must therefore either handle repeated/multiple supports, introduce a
+   genuine rich-class/minimality hypothesis that forces or excludes such a
+   support, preserve enough activation provenance to identify the row, or move
+   to a different bridge target. The
    source-`81` row-`8` singleton-support audit in
    `docs/bootstrap-t12-81-8-singleton-support-audit.md` is one such adjacent
    target: it finds no non-original row-`8` activation survivor in the fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -304,6 +304,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-81-3-chain-closure-csp.md`](bootstrap-t12-81-3-chain-closure-csp.md):
   ordered sequential support-chain closure CSP showing that no surviving
   prefix can activate center `6` under the same basic filters.
+- [`closure-activation-negative-controls.md`](closure-activation-negative-controls.md):
+  replayable wrong-fourth, full-row, and closure-visibility negative controls
+  for overstrong closure-activation bridge claims; provenance and guardrail
+  data only.
 - [`bootstrap-t12-81-8-singleton-support-audit.md`](bootstrap-t12-81-8-singleton-support-audit.md):
   source-`81` row-`8` singleton-support audit showing only the original row
   survives the fixed-neighborhood and one-row-drop activation-row scans.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -790,6 +790,16 @@ condition that the surviving multi-block family does not automatically satisfy:
   denominator for the same bounded continuation model: `3,918,164,268`
   support catalogues, `58` initially compatible catalogues, and zero
   selected-row survivors.
+- bootstrap/T12 focused `81:3` chain-closure and activation negative-control
+  evidence, as recorded in
+  `docs/bootstrap-t12-81-3-chain-closure-csp.md` and
+  `docs/closure-activation-negative-controls.md`. The ordered chain CSP leaves
+  four non-supply prefixes and no surviving prefix whose next activated center
+  is `6`; the negative controls show that closure exposure, full target-label
+  visibility, or full selected-row incidence checks do not by themselves pin
+  the named fourth witness. The remaining bridge target needs activation
+  provenance, repeated/multiple support analysis, or a genuine
+  rich-class/minimality hypothesis.
 - bootstrap/T12 focused `81:8` singleton-support evidence, as recorded in
   `docs/bootstrap-t12-81-8-singleton-support-audit.md`, showing that the fixed
   source-`81` neighborhood and one-row-drop relaxation have no non-original


### PR DESCRIPTION
## What changed
- Added `docs/closure-activation-negative-controls.md` to the documentation index.
- Updated the Codex backlog and review priorities so the `81:3` chain-closure lane points at the closure-activation negative controls.
- Clarified that deletion-closure exposure, full target-label visibility, and full selected-row incidence checks do not pin a named fourth witness without extra hypotheses.

## Claim scope and evidence level
- Documentation/navigation and planning guidance only.
- Preserves the repository status: no general proof, no counterexample, no `n=9` promotion, and no official/global status update.
- References existing checked negative-control artifacts as bridge guardrails only.

## Commands run
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- No new artifacts generated.
- Checked the artifact provenance manifest remains valid.

## Known limitations / next review steps
- This does not prove or refute any closure-activation bridge theorem.
- Next useful bridge work still needs activation provenance, repeated/multiple-support analysis, or a genuine rich-class/minimality hypothesis.