### PR TITLE
Check closure visibility replay command

### DIFF
--- a/docs/closure-activation-negative-controls.md
+++ b/docs/closure-activation-negative-controls.md
@@ -28,7 +28,7 @@ python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check -
 Run the closure-visibility replay checker with:
 
 ```bash
-python scripts/check_closure_visibility_anti_activation_control.py --assert-expected --json
+python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json
 ```
 
 Regenerate the checked JSON artifacts with:

--- a/tests/test_closure_activation_negative_controls.py
+++ b/tests/test_closure_activation_negative_controls.py
@@ -217,6 +217,27 @@ def test_visibility_anti_activation_control_replays_expected_status() -> None:
     assert summary["target_center_activated_by_target_triple"] is False
 
 
+def test_visibility_anti_activation_control_default_artifact_cli_check() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_closure_visibility_anti_activation_control.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["ok"] is True
+    assert summary["final_closure"] == [0, 1, 3, 4, 7]
+    assert summary["target_row_present_at_center"] is False
+
+
 def test_visibility_anti_activation_control_rejects_target_triple_row() -> None:
     payload = visibility_anti_activation_control_certificate()
     tampered = deepcopy(payload)


### PR DESCRIPTION
## What changed
- Corrected the closure-visibility negative-control documentation command to use `--check` so it replays the stored JSON artifact.
- Added a focused regression test that runs `scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json` against the default artifact.

## Claim scope and evidence level
- Reproducibility/documentation hardening only.
- Preserves the existing status: no general proof, no counterexample, no `n=9`/`n=10` promotion, and no official/global status update.
- The closure-visibility artifact remains an abstract negative control only, not Euclidean evidence.

## Commands run
- `python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json`
- `python -m pytest tests/test_closure_activation_negative_controls.py -q`
- `python -m ruff check tests/test_closure_activation_negative_controls.py scripts/check_closure_visibility_anti_activation_control.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/closure_visibility_anti_activation_control.json` through its default CLI path.
- No artifacts generated.

## Known limitations / next review steps
- Does not strengthen the closure-activation bridge mathematically.
- Keeps the remaining bridge target at activation provenance, repeated/multiple-support analysis, or genuine rich-class/minimality hypotheses.