### PR TITLE
Test closure activation replay CLIs

### DIFF
--- a/tests/test_closure_activation_negative_controls.py
+++ b/tests/test_closure_activation_negative_controls.py
@@ -43,6 +43,27 @@ def test_wrong_fourth_negative_control_replays_expected_status() -> None:
     assert summary["target_row_absent"] == [0, 1, 4, 6]
 
 
+def test_wrong_fourth_negative_control_default_artifact_cli_check() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_closure_activation_wrong_fourth_negative_control.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["ok"] is True
+    assert summary["closure"] == [0, 1, 4, 7]
+    assert summary["target_row_absent"] == [0, 1, 4, 6]
+
+
 def test_wrong_fourth_negative_control_rejects_target_row_substitution() -> None:
     payload = wrong_fourth_negative_control_certificate()
     tampered = deepcopy(payload)
@@ -94,6 +115,27 @@ def test_full_row_anti_activation_control_replays_expected_status() -> None:
     }
     assert summary["checks"]["cover_ok"] is True
     assert summary["checks"]["adjacent_intersections_size_at_most_1"] is True
+
+
+def test_full_row_anti_activation_control_default_artifact_cli_check() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_anti_activation_negative_control.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["ok"] is True
+    assert summary["closure_result"] == [0, 1, 4, 7]
+    assert summary["anti_activation_row"]["target_row_active_at_center"] is False
 
 
 def test_full_row_anti_activation_control_rejects_target_fourth() -> None:


### PR DESCRIPTION
## What changed
- Added default-artifact CLI replay tests for the wrong-fourth closure-activation negative control.
- Added default-artifact CLI replay tests for the full-row bootstrap/T12 anti-activation negative control.
- This complements the existing aggregate and closure-visibility CLI replay coverage.

## Claim scope and evidence level
- Test/reproducibility hardening only.
- Preserves the existing status: no general proof, no counterexample, no finite-case promotion, and no official/global status update.
- The tested artifacts remain abstract negative controls, not Euclidean realization or obstruction claims.

## Commands run
- `python scripts/check_closure_activation_wrong_fourth_negative_control.py --check --assert-expected --json`
- `python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json`
- `python -m pytest tests/test_closure_activation_negative_controls.py -q`
- `python -m ruff check tests/test_closure_activation_negative_controls.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/closure_activation_wrong_fourth_negative_control.json` through its default CLI path.
- Checked `data/certificates/bootstrap_t12_anti_activation_negative_control.json` through its default CLI path.
- No artifacts generated.

## Known limitations / next review steps
- Does not add mathematical bridge strength.
- Keeps the closure-activation negative controls scoped as replayable guardrails against overstrong row-forcing shortcuts.