### PR TITLE
Add C19 proof tooling audit preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ verify-kalmanson:
 	$(PYTHON) scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_survivor_kalmanson_two_unsat.json --summary-json
 	$(PYTHON) scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 	$(PYTHON) scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
+	$(PYTHON) scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
+	$(PYTHON) scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json
+	$(PYTHON) scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json
 	$(PYTHON) scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
 	$(PYTHON) scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -72,6 +72,8 @@ python scripts/check_kalmanson_certificate.py data/certificates/c13_sidon_order_
 python scripts/check_kalmanson_two_order_search.py --name C13_sidon_1_2_4_10 --n 13 --offsets 1,2,4,10 --assert-obstructed --assert-c13-expected --json
 python scripts/check_kalmanson_two_order_z3.py --certificate data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat
 python scripts/analyze_kalmanson_z3_clauses.py --assert-expected --check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json
+python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json
+python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/independent_n9_vertex_circle_recheck.py --json
 python scripts/n9_vertex_circle_minimal_cores.py --check --assert-expected --json

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -138,6 +138,20 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="c19_proof_tooling_preflight",
+        command=(
+            "python",
+            "scripts/probe_c19_proof_tooling.py",
+            "--check-c19-cnf-summary",
+            "--json",
+        ),
+        claim_scope=(
+            "Environment and CNF-summary preflight for future C19 "
+            "solver-independent proof replay; not proof evidence, not an "
+            "UNSAT proof, and not a proof of Erdos Problem #97."
+        ),
+    ),
+    AuditCommand(
         ident="c13_fixed_order_compact_kalmanson",
         command=(
             "python",

--- a/tests/test_makefile_verify_targets.py
+++ b/tests/test_makefile_verify_targets.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _target_commands(target: str) -> list[str]:
+    lines = (ROOT / "Makefile").read_text(encoding="utf-8").splitlines()
+    commands: list[str] = []
+    in_target = False
+    for line in lines:
+        if line.startswith(f"{target}:"):
+            in_target = True
+            continue
+        if in_target and line and not line.startswith("\t"):
+            break
+        if in_target and line.startswith("\t$(PYTHON) "):
+            commands.append("python " + line.removeprefix("\t$(PYTHON) "))
+    return commands
+
+
+def test_verify_kalmanson_runs_c19_proof_tooling_preflight() -> None:
+    commands = _target_commands("verify-kalmanson")
+
+    z3_replay = (
+        "python scripts/check_kalmanson_two_order_z3.py --certificate "
+        "data/certificates/c19_skew_all_orders_kalmanson_z3.json --assert-unsat"
+    )
+    z3_clause_diagnostic = (
+        "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json"
+    )
+    order_cnf_summary = (
+        "python scripts/export_c19_kalmanson_order_cnf.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_order_cnf_summary.json"
+    )
+    tooling_preflight = (
+        "python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json"
+    )
+
+    assert z3_replay in commands
+    assert z3_clause_diagnostic in commands
+    assert order_cnf_summary in commands
+    assert tooling_preflight in commands
+    assert commands.index(z3_replay) < commands.index(z3_clause_diagnostic)
+    assert commands.index(z3_clause_diagnostic) < commands.index(order_cnf_summary)
+    assert commands.index(order_cnf_summary) < commands.index(tooling_preflight)

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -103,6 +103,28 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/export_c19_kalmanson_order_cnf.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_order_cnf_summary.json"
+        in command_texts
+    )
+    assert (
+        "python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json"
+        in command_texts
+    )
+    assert ordered_command_texts.index(
+        "python scripts/analyze_kalmanson_z3_clauses.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_z3_clause_diagnostics.json"
+    ) < ordered_command_texts.index(
+        "python scripts/export_c19_kalmanson_order_cnf.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_order_cnf_summary.json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/export_c19_kalmanson_order_cnf.py --assert-expected "
+        "--check-artifact reports/c19_kalmanson_order_cnf_summary.json"
+    ) < ordered_command_texts.index(
+        "python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json"
+    )
+    assert (
         "python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json"
         in command_texts
     )


### PR DESCRIPTION
## What changed
- Added the C19 Z3-clause diagnostic, order-CNF summary check, and proof-tooling preflight to `make verify-kalmanson`.
- Registered the C19 proof-tooling preflight in `scripts/run_artifact_audit.py` so scheduled artifact audits capture CNF-summary/environment readiness.
- Added regression coverage for the audit runner command list and the `verify-kalmanson` Makefile order.
- Updated the reviewer guide manual command list with the C19 order-CNF and proof-tooling preflight commands.

## Claim scope and evidence level
This is reproducibility and audit plumbing only. It does not add a DRAT/LRAT proof, does not prove the C19 order-CNF UNSAT independently of Z3, does not prove Erdos Problem #97, and does not claim a counterexample.

## Commands run
- `python -m pytest tests/test_makefile_verify_targets.py tests/test_run_artifact_audit.py tests/test_c19_proof_tooling_probe.py tests/test_c19_kalmanson_order_cnf.py tests/test_kalmanson_z3_clause_diagnostics.py -q`
- `python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json`
- `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json --json`
- Raw `verify-kalmanson` fallback commands, because `make` is unavailable in this Windows shell
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
Checked existing C19 artifacts only:
- `reports/c19_kalmanson_z3_clause_diagnostics.json`
- `reports/c19_kalmanson_order_cnf_summary.json`
- `data/certificates/c19_skew_all_orders_kalmanson_z3.json`

No generated artifacts were rewritten.

## Known limitations / next review steps
The local proof-tooling probe still reports no supported SAT proof solver/checker pair on PATH (`kissat`/`cadical` and `drat-trim`/`lrat-check` absent). The C19 all-order result therefore remains a checked Z3 certificate plus deterministic CNF replay target, not a solver-independent UNSAT proof.