### PR TITLE
Add artifact audit command list mode

### DIFF
--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -59,7 +59,7 @@ check, so this audit path is stricter than the default fast tier.
 If `make` is unavailable, treat `Makefile` and
 `scripts/run_artifact_audit.py` as the source of truth for the current raw
 command set. To print the registered artifact-audit command list without
-running the audit, use:
+running the audit, including the two `audit-artifacts` preflight checks, use:
 
 ```bash
 python scripts/run_artifact_audit.py --list-commands

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -58,7 +58,15 @@ check, so this audit path is stricter than the default fast tier.
 
 If `make` is unavailable, treat `Makefile` and
 `scripts/run_artifact_audit.py` as the source of truth for the current raw
-command set. The current raw commands are:
+command set. To print the registered artifact-audit command list without
+running the audit, use:
+
+```bash
+python scripts/run_artifact_audit.py --list-commands
+```
+
+The following hand-maintained command excerpt is retained for reviewer
+orientation:
 
 ```bash
 python scripts/check_status_consistency.py --max-official-status-age-days 90

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -27,6 +27,31 @@ class AuditCommand:
     claim_scope: str
 
 
+AUDIT_PREFLIGHT_COMMANDS: tuple[AuditCommand, ...] = (
+    AuditCommand(
+        ident="official_status_freshness",
+        command=(
+            "python",
+            "scripts/check_status_consistency.py",
+            "--max-official-status-age-days",
+            "90",
+        ),
+        claim_scope=(
+            "Dated official-status consistency preflight for scheduled/manual "
+            "artifact audits; does not update the official/global status."
+        ),
+    ),
+    AuditCommand(
+        ident="artifact_provenance_manifest",
+        command=("python", "scripts/check_artifact_provenance.py"),
+        claim_scope=(
+            "Generated-artifact provenance manifest preflight; validates "
+            "artifact metadata and does not prove Erdos Problem #97."
+        ),
+    ),
+)
+
+
 AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
     AuditCommand(
         ident="n8_artifact_alignment",
@@ -2988,7 +3013,23 @@ def build_summary(output_dir: Path, commands: Sequence[AuditCommand]) -> dict[st
     }
 
 
-def list_commands_payload(commands: Sequence[AuditCommand]) -> dict[str, Any]:
+def _command_list_rows(commands: Sequence[AuditCommand]) -> list[dict[str, str]]:
+    return [
+        {
+            "id": command.ident,
+            "command": command_text(command.command),
+            "claim_scope": command.claim_scope,
+        }
+        for command in commands
+    ]
+
+
+def list_commands_payload(
+    commands: Sequence[AuditCommand],
+    *,
+    preflight_commands: Sequence[AuditCommand] = AUDIT_PREFLIGHT_COMMANDS,
+) -> dict[str, Any]:
+    listed_commands = (*preflight_commands, *commands)
     return {
         "type": "erdos97_artifact_audit_command_list_v1",
         "claim_scope": (
@@ -2996,15 +3037,10 @@ def list_commands_payload(commands: Sequence[AuditCommand]) -> dict[str, Any]:
             "does not run checks, prove Erdos Problem #97, or change any "
             "repository claim."
         ),
-        "command_count": len(commands),
-        "commands": [
-            {
-                "id": command.ident,
-                "command": command_text(command.command),
-                "claim_scope": command.claim_scope,
-            }
-            for command in commands
-        ],
+        "preflight_command_count": len(preflight_commands),
+        "audit_command_count": len(commands),
+        "command_count": len(listed_commands),
+        "commands": _command_list_rows(listed_commands),
     }
 
 

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2988,8 +2988,33 @@ def build_summary(output_dir: Path, commands: Sequence[AuditCommand]) -> dict[st
     }
 
 
+def list_commands_payload(commands: Sequence[AuditCommand]) -> dict[str, Any]:
+    return {
+        "type": "erdos97_artifact_audit_command_list_v1",
+        "claim_scope": (
+            "Registered artifact audit command list only; printing this list "
+            "does not run checks, prove Erdos Problem #97, or change any "
+            "repository claim."
+        ),
+        "command_count": len(commands),
+        "commands": [
+            {
+                "id": command.ident,
+                "command": command_text(command.command),
+                "claim_scope": command.claim_scope,
+            }
+            for command in commands
+        ],
+    }
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list-commands",
+        action="store_true",
+        help="Print the registered audit command list as JSON without running it.",
+    )
     parser.add_argument(
         "--output-dir",
         type=Path,
@@ -3001,6 +3026,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.list_commands:
+        print(json.dumps(list_commands_payload(AUDIT_COMMANDS), indent=2, sort_keys=True))
+        return 0
+
     output_dir = args.output_dir
     if not output_dir.is_absolute():
         output_dir = REPO_ROOT / output_dir

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 
 import yaml
 
-from scripts.run_artifact_audit import AUDIT_COMMANDS, AuditCommand, command_text, run_audit_command, sha256_bytes
+from scripts.run_artifact_audit import (
+    AUDIT_COMMANDS,
+    AuditCommand,
+    command_text,
+    list_commands_payload,
+    run_audit_command,
+    sha256_bytes,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -44,6 +53,37 @@ def test_audit_commands_cover_generated_artifact_check_commands() -> None:
             missing.append(f"{artifact['id']}: {check_command}")
 
     assert missing == []
+
+
+def test_list_commands_payload_is_claim_neutral() -> None:
+    payload = list_commands_payload(AUDIT_COMMANDS)
+
+    assert payload["type"] == "erdos97_artifact_audit_command_list_v1"
+    assert payload["command_count"] == len(AUDIT_COMMANDS)
+    assert "does not run checks" in payload["claim_scope"]
+    assert "prove Erdos Problem #97" in payload["claim_scope"]
+    assert payload["commands"][0] == {
+        "id": AUDIT_COMMANDS[0].ident,
+        "command": command_text(AUDIT_COMMANDS[0].command),
+        "claim_scope": AUDIT_COMMANDS[0].claim_scope,
+    }
+
+
+def test_run_artifact_audit_cli_lists_commands_without_running() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/run_artifact_audit.py", "--list-commands"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["type"] == "erdos97_artifact_audit_command_list_v1"
+    assert payload["command_count"] == len(AUDIT_COMMANDS)
+    assert "stdout_path" not in payload["commands"][0]
 
 
 def test_audit_commands_include_registered_followup_checkers() -> None:

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -9,6 +9,7 @@ import yaml
 
 from scripts.run_artifact_audit import (
     AUDIT_COMMANDS,
+    AUDIT_PREFLIGHT_COMMANDS,
     AuditCommand,
     command_text,
     list_commands_payload,
@@ -59,10 +60,17 @@ def test_list_commands_payload_is_claim_neutral() -> None:
     payload = list_commands_payload(AUDIT_COMMANDS)
 
     assert payload["type"] == "erdos97_artifact_audit_command_list_v1"
-    assert payload["command_count"] == len(AUDIT_COMMANDS)
+    assert payload["preflight_command_count"] == len(AUDIT_PREFLIGHT_COMMANDS)
+    assert payload["audit_command_count"] == len(AUDIT_COMMANDS)
+    assert payload["command_count"] == len(AUDIT_PREFLIGHT_COMMANDS) + len(AUDIT_COMMANDS)
     assert "does not run checks" in payload["claim_scope"]
     assert "prove Erdos Problem #97" in payload["claim_scope"]
     assert payload["commands"][0] == {
+        "id": AUDIT_PREFLIGHT_COMMANDS[0].ident,
+        "command": command_text(AUDIT_PREFLIGHT_COMMANDS[0].command),
+        "claim_scope": AUDIT_PREFLIGHT_COMMANDS[0].claim_scope,
+    }
+    assert payload["commands"][len(AUDIT_PREFLIGHT_COMMANDS)] == {
         "id": AUDIT_COMMANDS[0].ident,
         "command": command_text(AUDIT_COMMANDS[0].command),
         "claim_scope": AUDIT_COMMANDS[0].claim_scope,
@@ -82,7 +90,11 @@ def test_run_artifact_audit_cli_lists_commands_without_running() -> None:
     assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["type"] == "erdos97_artifact_audit_command_list_v1"
-    assert payload["command_count"] == len(AUDIT_COMMANDS)
+    assert payload["command_count"] == len(AUDIT_PREFLIGHT_COMMANDS) + len(AUDIT_COMMANDS)
+    assert payload["commands"][0]["command"] == (
+        "python scripts/check_status_consistency.py --max-official-status-age-days 90"
+    )
+    assert payload["commands"][1]["command"] == "python scripts/check_artifact_provenance.py"
     assert "stdout_path" not in payload["commands"][0]
 
 


### PR DESCRIPTION
## What changed
- Added `python scripts/run_artifact_audit.py --list-commands`, which prints the registered audit command list as JSON without running checks.
- Added tests for the claim-neutral command-list payload and CLI path.
- Updated the reviewer guide to point reviewers at the live command-list mode and mark the embedded raw commands as an orientation excerpt.

## Claim scope and evidence level
This is reproducibility tooling and documentation only. Listing audit commands does not run any checker, does not change repository status, does not prove Erdos Problem #97, and does not claim a counterexample.

## Commands run
- `python -m pytest tests/test_run_artifact_audit.py -q`
- `python scripts/run_artifact_audit.py --list-commands`
- `python -m ruff check scripts/run_artifact_audit.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
No generated artifact contents were rewritten. The command-list mode reports the currently registered audit commands and claim scopes from `scripts/run_artifact_audit.py`.

## Known limitations / next review steps
The reviewer-guide raw command block remains a hand-maintained orientation excerpt. The new `--list-commands` JSON output is the complete live command source when `make` is unavailable.