### PR TITLE
Add n9 base-apex reviewer target

### DIFF
--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -286,6 +286,36 @@ Check:
   bookkeeping, not as local-lemma completeness, brancher soundness, a proof of
   `n=9`, or an official/global status update.
 
+## Review target H - `n=9` base-apex audit path
+
+Primary references:
+
+- `docs/n9-base-apex-frontier.md`
+- `docs/n9-base-apex-d3-p19-degree-obstruction.md`
+- `docs/n9-base-apex-d3-p20-residue-obstruction.md`
+- `scripts/check_n9_base_apex_audit_path.py`
+
+Run:
+
+```bash
+python scripts/check_n9_base_apex_audit_path.py --check --json
+```
+
+Check:
+
+- that the low-excess ledger, escape budget, low-excess ladder, D=3 artifact
+  stack, selected-baseline D=3 crosswalk, and review-pending vertex-circle
+  frontier agree across the named handoff checks;
+- that the D=3 packet rows keep realizability and incidence states `UNKNOWN`,
+  and that selected-baseline landings are not treated as geometric
+  realizability counts;
+- that the P19 and P20 finite profile-capacity obstructions remain scoped to
+  their exact packet rows, not to all low-excess profiles or all `n=9`
+  selected-witness systems;
+- that the audit path is described only as finite bookkeeping over existing
+  artifacts, not as incidence completeness, geometric realizability,
+  a proof of `n=9`, a counterexample, or an official/global status update.
+
 ## Known weak points / independent review requests
 
 - Independent audit of `scripts/enumerate_n8_incidence.py`.
@@ -301,6 +331,9 @@ Check:
   soundness, mini-replay soundness, local-lemma completeness, strict-edge
   geometry, selected-distance quotient soundness, and brancher coverage before
   any `n=9` promotion.
+- Independent review of the `n=9` base-apex audit path should check the
+  low-excess ledger arithmetic, D=3 handoffs, selected-baseline crosswalk, and
+  vertex-circle frontier connection before using it as bridge evidence.
 - Independent reproduction of `certificates/n8_exact_analysis.json`.
 - A Lean, SMT, interval, or algebraic certificate checker would be high value.
 

--- a/tests/test_reviewer_guide.py
+++ b/tests/test_reviewer_guide.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "reviewer-guide.md"
+
+
+def _review_target_h() -> str:
+    text = GUIDE.read_text(encoding="utf-8")
+    return text.split("## Review target H - `n=9` base-apex audit path", 1)[
+        1
+    ].split("## Known weak points", 1)[0]
+
+
+def test_reviewer_guide_base_apex_target_points_to_audit_path() -> None:
+    section = _review_target_h()
+
+    assert "docs/n9-base-apex-frontier.md" in section
+    assert "scripts/check_n9_base_apex_audit_path.py" in section
+    assert "python scripts/check_n9_base_apex_audit_path.py --check --json" in section
+    assert "low-excess ledger" in section
+    assert "selected-baseline D=3 crosswalk" in section
+
+
+def test_reviewer_guide_base_apex_target_is_nonclaiming() -> None:
+    section = _review_target_h().lower()
+
+    for phrase in (
+        "finite bookkeeping",
+        "not as incidence completeness",
+        "geometric realizability",
+        "a proof of `n=9`",
+        "a counterexample",
+        "official/global status update",
+    ):
+        assert phrase in section


### PR DESCRIPTION
## What changed
- Added reviewer-guide target H for the `n=9` base-apex audit path.
- Pointed reviewers at the base-apex frontier docs, P19/P20 finite profile-capacity notes, and `scripts/check_n9_base_apex_audit_path.py`.
- Added `tests/test_reviewer_guide.py` to guard the reviewer target, command, and non-claiming language.

## Claim scope and evidence level
- Reviewer-facing documentation and guide-drift regression only.
- The base-apex audit path remains finite bookkeeping over existing artifacts.
- This does not prove `n=9`, establish incidence completeness, test geometric realizability, give a counterexample, or update official/global status.

## Commands run
- `python scripts/check_n9_base_apex_audit_path.py --check --json`
- `python -m pytest tests/test_reviewer_guide.py tests/test_n9_base_apex_audit_path.py -q`
- `python -m pytest tests/test_n9_base_apex_audit_path.py -q -m artifact`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked existing `n=9` base-apex audit-path artifacts via `scripts/check_n9_base_apex_audit_path.py`.
- No generated artifact files changed.

## Known limitations / next review steps
- Independent reviewers still need to audit low-excess ledger arithmetic, D=3 handoffs, selected-baseline crosswalk semantics, and the review-pending vertex-circle frontier connection before using this as bridge evidence.