### PR TITLE
Add 81:3 repeated support summary JSON

### DIFF
--- a/docs/bootstrap-t12-81-3-repeated-support-catalogue-audit.md
+++ b/docs/bootstrap-t12-81-3-repeated-support-catalogue-audit.md
@@ -34,8 +34,11 @@ witness-pair, crossing, and same-center disjointness filters as the earlier
 Run:
 
 ```bash
-python scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py --assert-expected --json
+python scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead of `--summary-json` when the full per-catalogue records
+are needed for audit.
 
 ## Result
 

--- a/scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py
+++ b/scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py
@@ -21,6 +21,17 @@ from erdos97.bootstrap_t12_81_3_repeated_support_catalogue_audit import (  # noq
 )
 
 
+SUMMARY_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "interpretation_warnings",
+    "source_chain_closure_csp",
+    "summary",
+)
+
+
 def write_artifact(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -59,7 +70,13 @@ def main() -> int:
         help="compare artifact to regenerated payload",
     )
     parser.add_argument("--write", action="store_true", help="write regenerated payload")
-    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON summary",
+    )
     parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
     args = parser.parse_args()
 
@@ -81,7 +98,9 @@ def main() -> int:
     if args.write:
         write_artifact(artifact, generated)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print_summary(payload)
@@ -90,6 +109,12 @@ def main() -> int:
         if args.assert_expected:
             print("OK: bootstrap/T12 81:3 repeated-support expectations verified")
     return 0
+
+
+def summary_json_payload(payload: dict[str, object]) -> dict[str, object]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_KEYS}
 
 
 if __name__ == "__main__":

--- a/tests/test_bootstrap_t12_81_3_repeated_support_catalogue_audit.py
+++ b/tests/test_bootstrap_t12_81_3_repeated_support_catalogue_audit.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
+from scripts.check_bootstrap_t12_81_3_repeated_support_catalogue_audit import (
+    SUMMARY_KEYS,
+    summary_json_payload,
+)
 from erdos97.bootstrap_t12_81_3_repeated_support_catalogue_audit import (
     DEFAULT_ARTIFACT,
     SCAN_STATUS,
     assert_expected_payload,
     build_t12_81_3_repeated_support_catalogue_audit_payload,
 )
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
@@ -88,3 +98,35 @@ def test_bootstrap_t12_81_3_repeated_support_rejects_drift(
 
     with pytest.raises(AssertionError, match="supply_extension_survivor_count"):
         assert_expected_payload(bad)
+
+
+def test_bootstrap_t12_81_3_repeated_support_summary_json_payload(
+    payload: dict[str, object],
+) -> None:
+    summary_payload = summary_json_payload(payload)
+
+    assert tuple(summary_payload) == SUMMARY_KEYS
+    assert summary_payload["summary"]["supply_extension_candidate_count"] == 464
+    assert "repeated_support_catalogue_scan" not in summary_payload
+    assert "supply_extension_scan" not in summary_payload
+
+
+def test_bootstrap_t12_81_3_repeated_support_cli_summary_json(
+    payload: dict[str, object],
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py`.
- The compact JSON view keeps schema/status/trust, claim scope, interpretation warnings, source artifact identity, and the pinned summary counts while omitting the large per-catalogue record sections.
- Updated the repeated-support audit note to recommend the checked compact command for reviewer triage and kept full `--json` available for detailed audit.
- Added tests for the compact payload helper and CLI flag.

## Claim scope and evidence level
- Reproducibility/reviewer ergonomics only for an existing review-pending diagnostic artifact.
- No artifact content changed.
- Does not prove support existence, row forcing, `n=9`, the bridge, Erdos #97, or a counterexample.
- Does not update official/global status or the source-of-truth strongest local result.

## Commands run
- `python scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_bootstrap_t12_81_3_repeated_support_catalogue_audit.py -q`
- `python -m ruff check scripts/check_bootstrap_t12_81_3_repeated_support_catalogue_audit.py tests/test_bootstrap_t12_81_3_repeated_support_catalogue_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/bootstrap_t12_81_3_repeated_support_catalogue_audit.json` via the new compact CLI path.
- No generated artifact files changed.

## Known limitations / next review steps
- `--summary-json` is only a compact view; reviewers still need full `--json` when inspecting per-catalogue records.
- The underlying repeated-support audit remains one bounded layer only; broader multiple-support catalogues and genuine rich-class forcing remain open.