### PR TITLE
Add local lemma audit summary JSON

### DIFF
--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -270,8 +270,11 @@ Primary references:
 Run:
 
 ```bash
-python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead of `--summary-json` when the full layer and manifest
+records are needed for audit.
 
 Check:
 

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -496,6 +496,28 @@ EXPECTED_SUMMARY_LINES = [
     "self-edge: 13 families, 158 assignments",
     "strict-cycle: 3 families, 26 assignments",
 ]
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "provenance",
+    "validation_status",
+    "validation_errors",
+    "coverage_summary",
+    "layer_summaries",
+    "handoff_checks",
+    "closed_descent_companion",
+    "manifest_contract_summary",
+    "audit_contract_summary",
+)
+OPTIONAL_SUMMARY_JSON_KEYS = (
+    "failure_stage",
+    "exception_type",
+    "assert_expected_failure",
+)
 
 AssertFn = Callable[[Mapping[str, Any]], None]
 
@@ -3851,11 +3873,43 @@ def _payload_with_assert_expected_failure(
     return updated
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    audit_path = payload.get("audit_path")
+    summary: dict[str, Any] = {}
+    for key in SUMMARY_JSON_KEYS:
+        if (
+            key == "layer_summaries"
+            and isinstance(audit_path, Mapping)
+            and "layers" in audit_path
+        ):
+            summary[key] = audit_path["layers"]
+        elif (
+            key == "handoff_checks"
+            and isinstance(audit_path, Mapping)
+            and "handoff_checks" in audit_path
+        ):
+            summary[key] = audit_path["handoff_checks"]
+        elif key in payload:
+            summary[key] = payload[key]
+    for key in OPTIONAL_SUMMARY_JSON_KEYS:
+        if key in payload:
+            summary[key] = payload[key]
+    return summary
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit path")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Emit compact reviewer-facing JSON summary.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -3872,7 +3926,15 @@ def main(argv: list[str] | None = None) -> int:
             payload = _payload_with_assert_expected_failure(payload, exc)
     payload = _payload_with_existing_assert_expected_failure_contract_check(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(
+            json.dumps(
+                _json_safe_for_output(summary_json_payload(payload)),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif args.json:
         print(json.dumps(_json_safe_for_output(payload), indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle local-lemma audit path")

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -26,11 +26,13 @@ from scripts.check_n9_vertex_circle_local_lemma_audit_path import (
     EXPECTED_LAYER_SOURCE_ARTIFACTS,
     EXPECTED_MANIFEST_CONTRACT_IDS,
     EXPECTED_SUMMARY_LINES,
+    SUMMARY_JSON_KEYS,
     assert_expected_failure_contract_errors,
     assert_expected_local_lemma_audit_path,
     failure_lines,
     local_lemma_audit_path_payload,
     main as audit_path_main,
+    summary_json_payload,
     summary_lines,
 )
 from scripts.check_n9_vertex_circle_focused_minireplay_crosswalk import (
@@ -2030,3 +2032,39 @@ def test_local_lemma_audit_path_cli_json() -> None:
     assert parsed["validation_status"] == "passed"
     assert parsed["coverage_summary"]["assignment_count"] == 184
     assert parsed["coverage_summary"]["relation_skeleton_count"] == 16
+
+
+def test_local_lemma_audit_path_summary_json_payload() -> None:
+    payload = local_lemma_audit_path_payload()
+    parsed = summary_json_payload(payload)
+
+    assert tuple(parsed) == SUMMARY_JSON_KEYS
+    assert parsed["validation_status"] == "passed"
+    assert parsed["coverage_summary"]["assignment_count"] == 184
+    assert parsed["audit_contract_summary"]["status"] == "passed"
+    assert parsed["manifest_contract_summary"]["status"] == "passed"
+    assert "audit_path" not in parsed
+    assert "input_manifest" not in parsed
+
+
+def test_local_lemma_audit_path_cli_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    parsed = json.loads(result.stdout)
+    assert result.stderr == ""
+    assert parsed["validation_status"] == "passed"
+    assert parsed["coverage_summary"]["assignment_count"] == 184
+    assert parsed["audit_contract_summary"]["status"] == "passed"
+    assert "audit_path" not in parsed


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_local_lemma_audit_path.py`.
- The compact view exposes schema/status/trust, claim scope, provenance, coverage summary, layer summaries, handoff checks, closed-descent companion, and manifest/audit contract summaries without dumping full layer and manifest records.
- Updated reviewer-guide target G to use the checked compact command, while keeping full `--json` available for deep audit.
- Added tests for the compact helper and CLI path.

## Claim scope and evidence level
- Reproducibility/reviewer ergonomics only for an existing review-pending local-lemma audit path.
- No artifact content changed.
- Does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, Erdos #97, or a counterexample.
- Does not update official/global status or the source-of-truth strongest local result.

## Commands run
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py::test_local_lemma_audit_path_summary_json_payload tests/test_n9_vertex_circle_local_lemma_audit_path.py::test_local_lemma_audit_path_cli_summary_json tests/test_reviewer_guide.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_audit_path.py tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the existing `n=9` local-lemma audit-path input stack via the new compact CLI path.
- No generated artifact files changed.

## Known limitations / next review steps
- `--summary-json` is only a compact view; reviewers still need full `--json` when inspecting complete layer payloads, input manifests, and per-artifact contracts.
- The underlying audit path remains review-pending bookkeeping only; packet soundness, mini-replay soundness, local-lemma completeness, strict-edge geometry, selected-distance quotient soundness, and brancher coverage remain separate review scopes.