### PR TITLE
Add base-apex audit summary JSON alias

### DIFF
--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -301,7 +301,7 @@ Primary references:
 Run:
 
 ```bash
-python scripts/check_n9_base_apex_audit_path.py --check --json
+python scripts/check_n9_base_apex_audit_path.py --check --summary-json
 ```
 
 Check:

--- a/scripts/check_n9_base_apex_audit_path.py
+++ b/scripts/check_n9_base_apex_audit_path.py
@@ -1073,7 +1073,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             help=f"Path to {key}.",
         )
     parser.add_argument("--check", action="store_true", help="fail if validation fails")
-    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print stable compact reviewer-facing JSON",
+    )
     return parser.parse_args(argv)
 
 
@@ -1089,7 +1095,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         errors = validate_audit_path(artifacts)
     summary = summary_payload(ROOT, paths, artifacts, errors)
 
-    if args.json:
+    if args.json or args.summary_json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     elif errors:
         print("FAILED: n=9 base-apex audit path", file=sys.stderr)

--- a/tests/test_n9_base_apex_audit_path.py
+++ b/tests/test_n9_base_apex_audit_path.py
@@ -157,3 +157,25 @@ def test_base_apex_audit_path_checker_cli_json() -> None:
     assert all(check["ok"] is True for check in payload["handoff_checks"])
     assert payload["base_apex"]["d3_common_dihedral_pair_class_count"] == 18088
     assert payload["selected_baseline_d3"]["assignment_count"] == 184
+
+
+def test_base_apex_audit_path_checker_cli_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_base_apex_audit_path.py",
+            "--check",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert [check["name"] for check in payload["handoff_checks"]] == EXPECTED_HANDOFF_NAMES
+    assert payload["claim_scope"] == EXPECTED_CLAIM_SCOPE

--- a/tests/test_reviewer_guide.py
+++ b/tests/test_reviewer_guide.py
@@ -19,7 +19,10 @@ def test_reviewer_guide_base_apex_target_points_to_audit_path() -> None:
 
     assert "docs/n9-base-apex-frontier.md" in section
     assert "scripts/check_n9_base_apex_audit_path.py" in section
-    assert "python scripts/check_n9_base_apex_audit_path.py --check --json" in section
+    assert (
+        "python scripts/check_n9_base_apex_audit_path.py --check --summary-json"
+        in section
+    )
     assert "low-excess ledger" in section
     assert "selected-baseline D=3 crosswalk" in section
 


### PR DESCRIPTION
## What changed
- Added `--summary-json` as a compact reviewer-facing alias for `scripts/check_n9_base_apex_audit_path.py`.
- Updated reviewer-guide target H to use the checked compact command.
- Added CLI/test coverage and updated the reviewer-guide guard test.

## Claim scope and evidence level
- Reproducibility/reviewer ergonomics only for an existing finite-bookkeeping audit path.
- No artifact content changed.
- Does not prove `n=9`, incidence completeness, geometric realizability, Erdos #97, or a counterexample.
- Does not update official/global status or the source-of-truth strongest local result.

## Commands run
- `python scripts/check_n9_base_apex_audit_path.py --check --summary-json`
- `python -m pytest tests/test_n9_base_apex_audit_path.py tests/test_reviewer_guide.py -q -m "artifact or not artifact"`
- `python -m ruff check scripts/check_n9_base_apex_audit_path.py tests/test_n9_base_apex_audit_path.py tests/test_reviewer_guide.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked the existing `n=9` base-apex audit-path input stack via the compact alias.
- No generated artifact files changed.

## Known limitations / next review steps
- `--summary-json` is an alias for the existing stable compact JSON payload, not a new artifact or proof layer.
- The base-apex audit remains finite bookkeeping; low-excess ledger arithmetic, D=3 handoffs, selected-baseline semantics, and the review-pending vertex-circle frontier connection remain review scopes.