### PR TITLE
Add relation-skeleton crosswalk summary JSON

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2255,7 +2255,8 @@ source packet paths, equality-chain counts, strict-edge counts, and simple
 replay step counts. This is cross-artifact bookkeeping only. It does not prove
 relation-skeleton soundness, local-lemma completeness, frontier coverage,
 `n=9`, a counterexample, or any official/global status update. Check it with
-`python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`.
+`python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full family crosswalk records are needed.
 
 ### n=9 relation-skeleton/closed-descent crosswalk
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -46,9 +46,10 @@ Use this queue when no more specific issue is selected.
    connects the same local-lemma accounting back to the review-pending
    exhaustive count artifact and motif classification. The relation-skeleton
    crosswalk
-   `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
    connects the compact 16-skeleton proof-mining catalog to the same
-   aggregate/simple-replay family accounting.
+   aggregate/simple-replay family accounting. Use `--json` instead when the
+   full family crosswalk records are needed.
    The relation-skeleton/closed-descent crosswalk
    `python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
    compares the same 16 relation skeletons with the closed-descent packet,

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -630,8 +630,11 @@ proof-mining view: it joins the 16-entry relation-skeleton catalog to the same
 aggregate/simple-replay family accounting:
 
 ```bash
-python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead of `--summary-json` when the full family crosswalk
+records are needed.
 
 This verifies that the compact quotient-relation skeletons agree with the
 stored local-lemma layer on template ids, family ids, obstruction kind, and

--- a/docs/relation-skeleton-catalog.md
+++ b/docs/relation-skeleton-catalog.md
@@ -219,8 +219,11 @@ Cross-check the catalog against the aggregate local-lemma scan and the simple
 packet replay:
 
 ```bash
-python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead of `--summary-json` when the full family crosswalk
+records are needed.
 
 Cross-check the same catalog against the closed-descent reformulation of the
 stored local-core quotient obstructions:

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -93,7 +93,7 @@ python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check -
 python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
-python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -421,9 +421,10 @@ handoffs rather than re-extracting T01 or T10.
   to compare the review-pending exhaustive counts, motif classification, and
   local-lemma replay chain without rerunning the brancher;
 - use
-  `scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
+  `scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
   to compare the 16-entry relation-skeleton catalog with the same
-  aggregate/simple-replay local-lemma family accounting;
+  aggregate/simple-replay local-lemma family accounting; use `--json` when
+  the full family crosswalk records are needed;
 - use
   `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
   to compare those 16 relation skeletons with the closed-descent packet's

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -123,7 +123,7 @@ python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check -
 python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
-python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json

--- a/scripts/check_relation_skeleton_local_lemma_crosswalk.py
+++ b/scripts/check_relation_skeleton_local_lemma_crosswalk.py
@@ -41,6 +41,21 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "cyclic_order",
+    "source_artifacts",
+    "coverage_summary",
+    "local_replay_crosswalk_summary",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
 
 DEFAULT_RELATION_SKELETONS = (
     ROOT / "data" / "certificates" / "relation_skeleton_catalog.json"
@@ -452,6 +467,12 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -467,7 +488,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Assert the expected relation/local-lemma counts.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Emit compact reviewer-facing JSON summary.",
+    )
     args = parser.parse_args(argv)
 
     relation_skeletons_path = _resolve(args.relation_skeletons)
@@ -505,7 +532,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_relation_local_crosswalk(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("relation-skeleton/local-lemma crosswalk")

--- a/tests/test_relation_skeleton_local_lemma_crosswalk.py
+++ b/tests/test_relation_skeleton_local_lemma_crosswalk.py
@@ -17,6 +17,7 @@ from scripts.check_relation_skeleton_local_lemma_crosswalk import (
     assert_expected_relation_local_crosswalk,
     crosswalk_payload,
     load_artifact,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -172,3 +173,42 @@ def test_relation_local_crosswalk_cli_json() -> None:
     assert parsed["validation_status"] == "passed"
     assert parsed["coverage_summary"]["matched_assignment_count"] == 184
     assert parsed["coverage_summary"]["matched_family_count"] == 16
+
+
+def test_relation_local_crosswalk_summary_json_payload(
+    relation_skeletons: dict[str, object],
+    aggregate: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = crosswalk_payload(relation_skeletons, aggregate, simple_replay)
+    summary = summary_json_payload(payload)
+
+    assert "family_crosswalk" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["coverage_summary"]["matched_assignment_count"] == 184
+    assert summary["local_replay_crosswalk_summary"]["matched_assignment_count"] == 184
+    assert summary["validation_status"] == "passed"
+
+
+def test_relation_local_crosswalk_cli_summary_json(
+    relation_skeletons: dict[str, object],
+    aggregate: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = crosswalk_payload(relation_skeletons, aggregate, simple_replay)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_relation_skeleton_local_lemma_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_relation_skeleton_local_lemma_crosswalk.py` as a compact reviewer-facing view.
- Kept full `--json` output available for detailed family crosswalk records.
- Added helper and CLI tests for the summary output.
- Updated reviewer/backlog/claims/reproduction docs to point at the compact command where appropriate.

## Claim scope and evidence level
- Evidence level: `REVIEW_PENDING_PACKET_AUDIT` / `REVIEW_PENDING_DIAGNOSTIC` reviewer ergonomics.
- This is cross-artifact bookkeeping for existing `n=9` relation-skeleton/local-lemma audit layers only.
- It does not prove packet soundness, local-lemma completeness, brancher coverage, `n=9`, Erdos Problem #97, or a counterexample, and it does not update official/global status.

## Commands run
- `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_relation_skeleton_local_lemma_crosswalk.py -q`
- `python -m ruff check scripts/check_relation_skeleton_local_lemma_crosswalk.py tests/test_relation_skeleton_local_lemma_crosswalk.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`

## Artifacts generated or checked
- Checked existing relation-skeleton/local-lemma source artifacts only.
- No checked JSON certificates were regenerated or changed.

## Known limitations / next review steps
- `--summary-json` omits full `family_crosswalk` records by design; reviewers should use `--json` for detailed family-level inspection.
- This does not review the local-lemma packet soundness, strict-edge geometry, selected-distance quotient soundness, or exhaustive brancher coverage.