### PR TITLE
Add focused packet catalog summary JSON

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2154,7 +2154,8 @@ and zero aggregate focused-crosscheck mismatches. This is JSON cross-artifact
 packet/catalog bookkeeping only. It does not prove packet soundness,
 local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any
 official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full packet records are needed.
 
 ### n=9 vertex-circle focused mini-replay crosswalk
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -26,10 +26,11 @@ Use this queue when no more specific issue is selected.
    focused T01/T02/T03/T04/T05/T06/T07/T08/T09 self-edge packets and the focused T10/T11/T12
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
    than an `n=9` proof. The focused packet catalog audit command
-   `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
    now checks that the focused packet coverage, source template records,
    source catalog records, and aggregate focused-note crosschecks agree before
-   packet soundness review. The focused mini-replay crosswalk
+   packet soundness review; use `--json` when the full packet records are
+   needed. The focused mini-replay crosswalk
    `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
    joins those same 12 focused packets to their packet-specific mini-replay
    artifacts without promoting the layer to packet soundness or local-lemma

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -88,7 +88,7 @@ the full representatives and already force the same obstruction.
 lemma-candidate crosswalk for proof mining. All of these are review-pending
 diagnostics only, not independent proofs and not status promotions.
 The focused packet catalog audit
-`scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
 checks that the 12 focused packet JSON files, the source template packets, the
 template catalog, and the aggregate local-lemma focused-note ledger agree on
 packet coverage. This is bookkeeping only, not packet soundness or an `n=9`

--- a/docs/n9-vertex-circle-template-lemma-catalog.md
+++ b/docs/n9-vertex-circle-template-lemma-catalog.md
@@ -60,13 +60,16 @@ packets, this catalog, and the aggregate local-lemma focused-note ledger:
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py \
   --check \
   --assert-expected \
-  --json
+  --summary-json
 
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py \
   --check \
   --assert-expected \
   --json
 ```
+
+Use `--json` instead of `--summary-json` for the focused packet/catalog audit
+when the full packet records are needed.
 
 That audit is JSON bookkeeping only. It verifies agreement among checked-in
 packet, source-template, catalog, aggregate scan, and mini-replay records; it

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -66,7 +66,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
-python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -400,10 +400,10 @@ handoffs rather than re-extracting T01 or T10.
   self-edge and T10/T11/T12 strict-cycle integrations, keeping it scoped as proof-mining
   coverage of stored packets rather than an independent `n=9` proof;
 - use
-  `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
   to cross-check the 12 focused packet JSON files against the source template
   packets, template catalog, and aggregate focused-note ledger before reviewing
-  packet soundness;
+  packet soundness; use `--json` when the full packet records are needed;
 - use
   `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
   to join the same 12 focused packets to their packet-specific mini-replay

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -96,7 +96,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_path_join.py --check --assert
 python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
-python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py
+++ b/scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py
@@ -62,6 +62,22 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "focused_packet_catalog_audit",
+    "source_artifacts",
+    "packet_artifacts",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+SUMMARY_AUDIT_OMIT_KEYS = {"packet_records"}
 
 EXPECTED_TEMPLATE_IDS = [f"T{index:02d}" for index in range(1, 13)]
 EXPECTED_STATUS_COUNTS = {"self_edge": 9, "strict_cycle": 3}
@@ -622,13 +638,33 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = summary.get("focused_packet_catalog_audit")
+    if isinstance(audit, Mapping):
+        summary["focused_packet_catalog_audit"] = {
+            key: value
+            for key, value in audit.items()
+            if key not in SUMMARY_AUDIT_OMIT_KEYS
+        }
+    return summary
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--template-catalog", type=Path, default=DEFAULT_TEMPLATE_CATALOG)
     parser.add_argument("--local-lemmas", type=Path, default=DEFAULT_LOCAL_LEMMAS)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON summary",
+    )
     return parser.parse_args(argv)
 
 
@@ -653,7 +689,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_focused_packet_catalog_audit(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 focused packet/catalog audit")

--- a/tests/test_n9_vertex_circle_focused_packet_catalog_audit.py
+++ b/tests/test_n9_vertex_circle_focused_packet_catalog_audit.py
@@ -16,6 +16,7 @@ from scripts.check_n9_vertex_circle_focused_packet_catalog_audit import (
     assert_expected_focused_packet_catalog_audit,
     focused_packet_catalog_audit_payload,
     load_json,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -178,3 +179,35 @@ def test_focused_packet_catalog_audit_cli_json() -> None:
     assert parsed["validation_status"] == "passed"
     assert parsed["focused_packet_catalog_audit"]["covered_assignment_count"] == 184
     assert parsed["focused_packet_catalog_audit"]["focused_crosscheck_count"] == 12
+
+
+def test_focused_packet_catalog_audit_summary_json_payload() -> None:
+    payload = focused_packet_catalog_audit_payload()
+    summary = summary_json_payload(payload)
+
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["validation_status"] == "passed"
+    assert summary["packet_artifacts"] == payload["packet_artifacts"]
+    assert summary["focused_packet_catalog_audit"]["covered_assignment_count"] == 184
+    assert summary["focused_packet_catalog_audit"]["focused_crosscheck_count"] == 12
+    assert "packet_records" not in summary["focused_packet_catalog_audit"]
+
+
+def test_focused_packet_catalog_audit_cli_summary_json() -> None:
+    payload = focused_packet_catalog_audit_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py`.
- The compact view preserves audit totals, source artifacts, packet artifact identities, claim scope, and validation state while omitting the full `packet_records` array.
- Added helper and CLI tests for the summary output.
- Updated reviewer/backlog/claims/reproduction docs to use the compact command where appropriate.

## Claim scope and evidence level
- Evidence level: `REVIEW_PENDING_FOCUSED_PACKET_CATALOG_AUDIT` / `REVIEW_PENDING_DIAGNOSTIC` reviewer ergonomics.
- This is JSON-only cross-artifact bookkeeping for existing `n=9` focused local-lemma packets.
- It does not prove packet soundness, local-lemma completeness, frontier coverage, `n=9`, Erdos Problem #97, or a counterexample, and it does not update official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_focused_packet_catalog_audit.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py tests/test_n9_vertex_circle_focused_packet_catalog_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`

## Artifacts generated or checked
- Checked existing focused packet/catalog/local-lemma source artifacts only.
- No checked JSON certificates were regenerated or changed.

## Known limitations / next review steps
- `--summary-json` omits full `packet_records` by design; reviewers should use `--json` for per-packet assignment/family records.
- This does not review packet soundness, mini-replay soundness, strict-edge geometry, selected-distance quotient soundness, or exhaustive brancher coverage.