### PR TITLE
Add focused mini-replay summary JSON

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2182,7 +2182,8 @@ mismatches. The self-edge compact path-length family histogram is `3: 9`,
 prove mini-replay soundness, packet soundness, local-lemma completeness,
 frontier coverage, `n=9`, a counterexample, or any official/global status
 update. Check it with
-`python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full mini-replay records are needed.
 
 ### n=9 vertex-circle aggregate/simple replay crosswalk
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -31,10 +31,10 @@ Use this queue when no more specific issue is selected.
    source catalog records, and aggregate focused-note crosschecks agree before
    packet soundness review; use `--json` when the full packet records are
    needed. The focused mini-replay crosswalk
-   `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json`
    joins those same 12 focused packets to their packet-specific mini-replay
    artifacts without promoting the layer to packet soundness or local-lemma
-   completeness.
+   completeness; use `--json` when the full mini-replay records are needed.
 2. Use the stored simple replay artifact
    `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` as a
    reviewer-facing input for the aggregate local-template coverage. The replay

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -94,7 +94,7 @@ template catalog, and the aggregate local-lemma focused-note ledger agree on
 packet coverage. This is bookkeeping only, not packet soundness or an `n=9`
 proof.
 The focused mini-replay crosswalk
-`scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json`
 then joins those focused packets to their 12 packet-specific mini-replay
 artifacts, checking identity, families, source schemas, obstruction flags, and
 compact local shape counts only.

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -611,8 +611,11 @@ mini-replays agree with their source focused packets on identity, source
 schema, family coverage, obstruction flags, and compact local shape counts:
 
 ```bash
-python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead of `--summary-json` when the full mini-replay records
+are needed.
 
 The related exhaustive/local-lemma crosswalk checks the upstream count chain
 from the review-pending exhaustive artifact through the motif classification

--- a/docs/n9-vertex-circle-template-lemma-catalog.md
+++ b/docs/n9-vertex-circle-template-lemma-catalog.md
@@ -65,11 +65,13 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py \
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py \
   --check \
   --assert-expected \
-  --json
+  --summary-json
 ```
 
 Use `--json` instead of `--summary-json` for the focused packet/catalog audit
 when the full packet records are needed.
+Use `--json` instead of `--summary-json` for the focused mini-replay
+crosswalk when the full mini-replay records are needed.
 
 That audit is JSON bookkeeping only. It verifies agreement among checked-in
 packet, source-template, catalog, aggregate scan, and mini-replay records; it

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -67,7 +67,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -405,10 +405,11 @@ handoffs rather than re-extracting T01 or T10.
   packets, template catalog, and aggregate focused-note ledger before reviewing
   packet soundness; use `--json` when the full packet records are needed;
 - use
-  `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json`
   to join the same 12 focused packets to their packet-specific mini-replay
   artifacts, checking identity, source schemas, families, obstruction flags,
-  and compact shape counts only;
+  and compact shape counts only; use `--json` when the full mini-replay
+  records are needed;
 - use `data/certificates/n9_vertex_circle_local_lemma_simple_replay.json` to
   replay the aggregate local-template coverage from stored packet JSON without
   sharing the main quotient-replay helper;

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -97,7 +97,7 @@ python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -77,6 +77,20 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "focused_minireplay_crosswalk",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+SUMMARY_CROSSWALK_OMIT_KEYS = {"records"}
 
 EXPECTED_STATUS_COUNTS = {"self_edge": 9, "strict_cycle": 3}
 EXPECTED_STATUS_ASSIGNMENT_COUNTS = {"self_edge": 158, "strict_cycle": 26}
@@ -507,11 +521,31 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    crosswalk = summary.get("focused_minireplay_crosswalk")
+    if isinstance(crosswalk, Mapping):
+        summary["focused_minireplay_crosswalk"] = {
+            key: value
+            for key, value in crosswalk.items()
+            if key not in SUMMARY_CROSSWALK_OMIT_KEYS
+        }
+    return summary
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the crosswalk")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON summary",
+    )
     return parser.parse_args(argv)
 
 
@@ -533,7 +567,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_focused_minireplay_crosswalk(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 focused mini-replay crosswalk")

--- a/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
+++ b/tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py
@@ -13,6 +13,7 @@ from scripts.check_n9_vertex_circle_focused_minireplay_crosswalk import (
     assert_expected_focused_minireplay_crosswalk,
     focused_minireplay_crosswalk_payload,
     load_json,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -128,3 +129,35 @@ def test_focused_minireplay_crosswalk_cli_json() -> None:
     summary = parsed["focused_minireplay_crosswalk"]
     assert summary["source_assignment_count"] == 184
     assert summary["obstruction_flagged_count"] == 12
+
+
+def test_focused_minireplay_crosswalk_summary_json_payload() -> None:
+    payload = focused_minireplay_crosswalk_payload()
+    summary = summary_json_payload(payload)
+
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["validation_status"] == "passed"
+    compact = summary["focused_minireplay_crosswalk"]
+    assert compact["source_assignment_count"] == 184
+    assert compact["obstruction_flagged_count"] == 12
+    assert "records" not in compact
+
+
+def test_focused_minireplay_crosswalk_cli_summary_json() -> None:
+    payload = focused_minireplay_crosswalk_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py`.
- The compact view preserves mini-replay totals, obstruction-flag counts, shape histograms, claim scope, and validation state while omitting the full `records` array.
- Added helper and CLI tests for the summary output.
- Updated reviewer/backlog/claims/reproduction docs to use the compact command where appropriate.

## Claim scope and evidence level
- Evidence level: `REVIEW_PENDING_FOCUSED_MINIREPLAY_CROSSWALK` / `REVIEW_PENDING_DIAGNOSTIC` reviewer ergonomics.
- This is JSON-only cross-artifact bookkeeping for existing `n=9` focused local-lemma packet mini-replays.
- It does not prove mini-replay soundness, packet soundness, local-lemma completeness, frontier coverage, `n=9`, Erdos Problem #97, or a counterexample, and it does not update official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py tests/test_n9_vertex_circle_focused_minireplay_crosswalk.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`

## Artifacts generated or checked
- Checked existing focused packet mini-replay artifacts only.
- No checked JSON certificates were regenerated or changed.

## Known limitations / next review steps
- `--summary-json` omits full mini-replay `records` by design; reviewers should use `--json` for per-template record inspection.
- This does not review mini-replay soundness, packet soundness, strict-edge geometry, selected-distance quotient soundness, or exhaustive brancher coverage.