### PR TITLE
Add local lemma replay summary JSON

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2209,7 +2209,8 @@ checker reports status `REVIEW_PENDING_PACKET_AUDIT`, trust
 cross-artifact packet/replay bookkeeping only. It does not prove simple-replay
 soundness, packet soundness, local-lemma completeness, frontier coverage,
 `n=9`, a counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full family crosswalk records are needed.
 
 ### n=9 vertex-circle exhaustive/local-lemma crosswalk
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -40,9 +40,10 @@ Use this queue when no more specific issue is selected.
    reviewer-facing input for the aggregate local-template coverage. The replay
    checks the packet JSON without sharing the main quotient-replay helper, but
    it is still a packet audit rather than an `n=9` proof. The crosswalk command
-   `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json`
    compares that simple replay with the aggregate local-lemma scan
-   family-by-family. The follow-up crosswalk
+   family-by-family; use `--json` when the full family crosswalk records are
+   needed. The follow-up crosswalk
    `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
    connects the same local-lemma accounting back to the review-pending
    exhaustive count artifact and motif classification. The relation-skeleton

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -598,8 +598,11 @@ families and 184 assignments, including the split into 13 self-edge families
 and 3 strict-cycle families:
 
 ```bash
-python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead of `--summary-json` when the full family crosswalk
+records are needed.
 
 This is reviewer-facing packet bookkeeping only. It says the quotient-helper
 aggregate scan and the simpler replay audit describe the same stored local

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -69,7 +69,7 @@ python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected 
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
-python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -414,9 +414,10 @@ handoffs rather than re-extracting T01 or T10.
   replay the aggregate local-template coverage from stored packet JSON without
   sharing the main quotient-replay helper;
 - use
-  `scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json`
   to compare the aggregate local-lemma scan and simple replay
-  family-by-family;
+  family-by-family; use `--json` when the full family crosswalk records are
+  needed;
 - use
   `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
   to compare the review-pending exhaustive counts, motif classification, and

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -99,7 +99,7 @@ python scripts/check_n9_vertex_circle_local_lemmas.py --check --assert-expected 
 python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
-python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py
@@ -45,6 +45,21 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "cyclic_order",
+    "source_artifacts",
+    "coverage_summary",
+    "focused_crosscheck_summary",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
 
 DEFAULT_AGGREGATE = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_local_lemmas.json"
@@ -466,6 +481,12 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--aggregate", type=Path, default=DEFAULT_AGGREGATE)
@@ -476,7 +497,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Assert the expected cross-artifact replay counts.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Emit compact reviewer-facing JSON summary.",
+    )
     args = parser.parse_args(argv)
 
     aggregate_path = _resolve(args.aggregate)
@@ -508,7 +535,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_replay_crosswalk(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle local-lemma replay crosswalk")

--- a/tests/test_n9_vertex_circle_local_lemma_replay_crosswalk.py
+++ b/tests/test_n9_vertex_circle_local_lemma_replay_crosswalk.py
@@ -14,6 +14,7 @@ from scripts.check_n9_vertex_circle_local_lemma_replay_crosswalk import (
     assert_expected_replay_crosswalk,
     crosswalk_payload,
     load_artifact,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -155,3 +156,40 @@ def test_replay_crosswalk_cli_json() -> None:
     assert parsed["validation_status"] == "passed"
     assert parsed["coverage_summary"]["matched_assignment_count"] == 184
     assert parsed["focused_crosscheck_summary"]["focused_family_count"] == 16
+
+
+def test_replay_crosswalk_summary_json_payload(
+    aggregate: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = crosswalk_payload(aggregate, simple_replay)
+    summary = summary_json_payload(payload)
+
+    assert "family_crosswalk" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["coverage_summary"]["matched_assignment_count"] == 184
+    assert summary["focused_crosscheck_summary"]["focused_family_count"] == 16
+    assert summary["validation_status"] == "passed"
+
+
+def test_replay_crosswalk_cli_summary_json(
+    aggregate: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = crosswalk_payload(aggregate, simple_replay)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py`.
- The compact view preserves source artifact identities, aggregate/simple coverage counts, focused crosscheck counts, claim scope, and validation state while omitting the full `family_crosswalk` records.
- Added helper and CLI tests for the summary output.
- Updated reviewer/backlog/claims/reproduction docs to use the compact command where appropriate.

## Claim scope and evidence level
- Evidence level: `REVIEW_PENDING_PACKET_AUDIT` / `REVIEW_PENDING_DIAGNOSTIC` reviewer ergonomics.
- This is cross-artifact bookkeeping for the existing aggregate local-lemma scan and simple packet replay.
- It does not prove simple-replay soundness, packet soundness, local-lemma completeness, frontier coverage, `n=9`, Erdos Problem #97, or a counterexample, and it does not update official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_replay_crosswalk.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py tests/test_n9_vertex_circle_local_lemma_replay_crosswalk.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`

## Artifacts generated or checked
- Checked existing aggregate local-lemma and simple replay artifacts only.
- No checked JSON certificates were regenerated or changed.

## Known limitations / next review steps
- `--summary-json` omits full `family_crosswalk` records by design; reviewers should use `--json` for family-level inspection.
- This does not review simple-replay soundness, packet soundness, strict-edge geometry, selected-distance quotient soundness, or exhaustive brancher coverage.