### PR TITLE
Add exhaustive local lemma summary JSON

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2243,7 +2243,8 @@ families, `16` simple-replay families, and `184` matched assignments. This is
 cross-artifact accounting only. It does not review the exhaustive brancher,
 prove local-lemma completeness, prove frontier coverage, prove `n=9`, give a
 counterexample, or update the official/global status. Check it with
-`python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full family crosswalk records are needed.
 
 ### n=9 vertex-circle relation-skeleton/local-lemma crosswalk
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -44,9 +44,10 @@ Use this queue when no more specific issue is selected.
    compares that simple replay with the aggregate local-lemma scan
    family-by-family; use `--json` when the full family crosswalk records are
    needed. The follow-up crosswalk
-   `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`
    connects the same local-lemma accounting back to the review-pending
-   exhaustive count artifact and motif classification. The relation-skeleton
+   exhaustive count artifact and motif classification; use `--json` when the
+   full family crosswalk records are needed. The relation-skeleton
    crosswalk
    `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
    connects the compact 16-skeleton proof-mining catalog to the same

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -105,13 +105,14 @@ stored accounting chain from this exhaustive artifact to the motif
 classification and then to the aggregate/simple local-lemma replay artifacts:
 
 ```bash
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 ```
 
 This command does not rerun or independently review the exhaustive brancher.
 It verifies only that the checked-in artifacts agree on the same
 review-pending `184 = 158 + 26` frontier accounting and the same 16 motif
-families.
+families. Use `--json` instead when the full family crosswalk records are
+needed.
 
 The combined local-lemma audit-path command
 `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -625,11 +625,13 @@ from the review-pending exhaustive artifact through the motif classification
 before joining to the local-lemma replay artifacts:
 
 ```bash
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 ```
 
 That command is also an artifact-accounting audit only; it does not rerun the
 exhaustive brancher or complete independent review.
+Use `--json` instead of `--summary-json` when the full family crosswalk
+records are needed.
 
 The relation-skeleton/local-lemma crosswalk checks the downstream
 proof-mining view: it joins the 16-entry relation-skeleton catalog to the same

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -70,7 +70,7 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -419,9 +419,10 @@ handoffs rather than re-extracting T01 or T10.
   family-by-family; use `--json` when the full family crosswalk records are
   needed;
 - use
-  `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`
   to compare the review-pending exhaustive counts, motif classification, and
-  local-lemma replay chain without rerunning the brancher;
+  local-lemma replay chain without rerunning the brancher; use `--json` when
+  the full family crosswalk records are needed;
 - use
   `scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
   to compare the 16-entry relation-skeleton catalog with the same

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -100,7 +100,7 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
@@ -43,6 +43,21 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "cyclic_order",
+    "source_artifacts",
+    "coverage_summary",
+    "local_replay_crosswalk_summary",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
 
 DEFAULT_EXHAUSTIVE = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_exhaustive.json"
@@ -381,6 +396,12 @@ def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--exhaustive", type=Path, default=DEFAULT_EXHAUSTIVE)
@@ -393,7 +414,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Assert the expected exhaustive/local-lemma crosswalk counts.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Emit compact reviewer-facing JSON summary.",
+    )
     args = parser.parse_args(argv)
 
     exhaustive_path = _resolve(args.exhaustive)
@@ -437,7 +464,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_exhaustive_local_lemma_crosswalk(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 exhaustive/local-lemma crosswalk")

--- a/tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
+++ b/tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
@@ -16,6 +16,7 @@ from scripts.check_n9_vertex_circle_exhaustive_local_lemma_crosswalk import (
     assert_expected_exhaustive_local_lemma_crosswalk,
     exhaustive_local_lemma_crosswalk_payload,
     load_artifact,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -196,3 +197,54 @@ def test_exhaustive_local_lemma_crosswalk_cli_json() -> None:
     assert parsed["validation_status"] == "passed"
     assert parsed["coverage_summary"]["exhaustive_frontier_assignment_count"] == 184
     assert parsed["coverage_summary"]["strict_cycle_assignment_count"] == 26
+
+
+def test_exhaustive_local_lemma_crosswalk_summary_json_payload(
+    exhaustive: dict[str, object],
+    classification: dict[str, object],
+    local_lemmas: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = exhaustive_local_lemma_crosswalk_payload(
+        exhaustive,
+        classification,
+        local_lemmas,
+        simple_replay,
+    )
+    summary = summary_json_payload(payload)
+
+    assert "family_crosswalk" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["coverage_summary"]["exhaustive_frontier_assignment_count"] == 184
+    assert summary["local_replay_crosswalk_summary"]["matched_assignment_count"] == 184
+    assert summary["validation_status"] == "passed"
+
+
+def test_exhaustive_local_lemma_crosswalk_cli_summary_json(
+    exhaustive: dict[str, object],
+    classification: dict[str, object],
+    local_lemmas: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = exhaustive_local_lemma_crosswalk_payload(
+        exhaustive,
+        classification,
+        local_lemmas,
+        simple_replay,
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## Summary
- add a compact --summary-json mode to the n=9 exhaustive/local-lemma crosswalk
- keep full --json output for the family_crosswalk and artifact/audit provenance paths
- update reviewer-facing docs to prefer the compact command while preserving review-pending/non-proof wording

## Validation
- .venv/bin/python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
- .venv/bin/python -m pytest -q tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
- .venv/bin/python -m ruff check scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
- .venv/bin/python scripts/check_text_clean.py
- .venv/bin/python scripts/check_status_consistency.py
- .venv/bin/python scripts/check_artifact_provenance.py
- git diff --check
- make PYTHON=.venv/bin/python verify-fast

## Notes
- Subagent review found no CLI/test or docs/non-overclaiming issues.
- This is review-pending handoff tooling only; it does not prove n=9, packet soundness, local-lemma completeness, or Erdos Problem #97.