### PR TITLE
Add relation closed-descent summary JSON alias

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1168,7 +1168,7 @@ adjacent drift localization, plus the relation-skeleton/closed-descent
 companion summary. These are review-pending handoff audits only, not packet
 soundness, local-lemma completeness, frontier coverage, or a proof of `n=9`.
 The relation-skeleton/closed-descent crosswalk
-`scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
+`scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`
 checks the same 16 families against the closed-descent packet, matching
 self-edge skeletons to one-class regions and strict-cycle skeletons to
 multi-class regions. It is packet bookkeeping only.

--- a/STATE.md
+++ b/STATE.md
@@ -763,7 +763,7 @@ adjacent drift localization, plus the relation-skeleton/closed-descent
 companion summary. These are review-pending handoff audits only, not packet
 soundness, local-lemma completeness, frontier coverage, or a proof of `n=9`.
 The relation-skeleton/closed-descent crosswalk
-`scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
+`scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`
 checks the same 16 families against the closed-descent packet, matching
 self-edge skeletons to one-class regions and strict-cycle skeletons to
 multi-class regions. It is packet bookkeeping only.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2280,14 +2280,17 @@ same `16` stored families through two reviewer-facing representations: the
 relation-skeleton selected-distance quotient records and the closed-descent
 finite-region packet.
 
-When run with `--check --assert-expected --json`, the crosswalk matches all
-`184` assignment/orbit records. The `13` strict self-edge skeletons map to
-one-class closed-descent regions, and the `3` strict directed-cycle skeletons
-map to multi-class regions with class/cycle-length counts `2:1` and `3:2`.
-This is cross-artifact packet bookkeeping only. It does not prove
+When run with `--check --assert-expected --summary-json`, the crosswalk
+matches all `184` assignment/orbit records. The `13` strict self-edge
+skeletons map to one-class closed-descent regions, and the `3` strict
+directed-cycle skeletons map to multi-class regions with class/cycle-length
+counts `2:1` and `3:2`. This is cross-artifact packet bookkeeping only. It
+does not prove
 local-lemma completeness, brancher coverage, `n=9`, a bridge proof, a
 counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`.
+`python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`.
+The legacy `--json` flag emits the same compact checker summary; the checked
+artifact contains the full family crosswalk records.
 
 ### n=9 vertex-circle local-lemma audit path
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -54,7 +54,7 @@ Use this queue when no more specific issue is selected.
    aggregate/simple-replay family accounting. Use `--json` instead when the
    full family crosswalk records are needed.
    The relation-skeleton/closed-descent crosswalk
-   `python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`
    compares the same 16 relation skeletons with the closed-descent packet,
    checking the one-class self-edge and multi-class strict-cycle region split.
    The local-lemma audit-path checker

--- a/docs/relation-skeleton-catalog.md
+++ b/docs/relation-skeleton-catalog.md
@@ -229,14 +229,17 @@ Cross-check the same catalog against the closed-descent reformulation of the
 stored local-core quotient obstructions:
 
 ```bash
-python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json
 ```
 
-This crosswalk is an accounting audit. It checks that the 16 relation
-skeletons and the local-lemma replay chain agree family by family on template
-ids, family ids, obstruction kind, and assignment counts. It does not certify
-that the local-lemma packets are complete for `n=9`, and it does not review the
-exhaustive brancher.
+The legacy `--json` flag emits the same compact checker summary; the checked
+artifact contains the full family crosswalk records.
+
+The relation-skeleton/local-lemma crosswalk above is an accounting audit. It
+checks that the 16 relation skeletons and the local-lemma replay chain agree
+family by family on template ids, family ids, obstruction kind, and assignment
+counts. It does not certify that the local-lemma packets are complete for
+`n=9`, and it does not review the exhaustive brancher.
 
 The closed-descent crosswalk is another accounting audit. It checks that the 13
 strict self-edge skeletons map to one-class descent regions and that the 3

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -429,7 +429,7 @@ handoffs rather than re-extracting T01 or T10.
   aggregate/simple-replay local-lemma family accounting; use `--json` when
   the full family crosswalk records are needed;
 - use
-  `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json`
+  `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`
   to compare those 16 relation skeletons with the closed-descent packet's
   one-class self-edge and multi-class strict-cycle regions;
 - use

--- a/scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py
+++ b/scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py
@@ -479,7 +479,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
     parser.add_argument("--write", action="store_true", help="write generated crosswalk")
     parser.add_argument("--check", action="store_true", help="validate an existing crosswalk")
-    parser.add_argument("--json", action="store_true", help="print stable JSON summary")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--json",
+        action="store_true",
+        help="print stable JSON summary",
+    )
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print stable JSON summary",
+    )
     parser.add_argument("--assert-expected", action="store_true")
     return parser.parse_args(argv)
 
@@ -506,7 +516,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             assert_expected_relation_closed_descent_crosswalk(payload)
         write_json(payload, out)
         if not args.check:
-            if args.json:
+            if args.json or args.summary_json:
                 print(json.dumps(summary_payload(out, payload, []), indent=2, sort_keys=True))
             else:
                 print(f"wrote {display_path(out, ROOT)}")
@@ -525,7 +535,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         errors = [str(exc)]
 
     summary = summary_payload(artifact, payload, errors)
-    if args.json:
+    if args.json or args.summary_json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     elif errors:
         print(f"FAILED: {display_path(artifact, ROOT)}", file=sys.stderr)

--- a/tests/test_n9_relation_skeleton_closed_descent_crosswalk.py
+++ b/tests/test_n9_relation_skeleton_closed_descent_crosswalk.py
@@ -182,3 +182,100 @@ def test_relation_closed_descent_crosswalk_cli_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["family_count"] == 16
+
+
+@pytest.mark.exhaustive
+def test_relation_closed_descent_crosswalk_cli_summary_json() -> None:
+    json_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    summary_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert summary_result.returncode == 0
+    assert summary_result.stderr == ""
+    assert json.loads(summary_result.stdout) == json.loads(json_result.stdout)
+    assert "family_crosswalk" not in json.loads(summary_result.stdout)
+
+
+@pytest.mark.exhaustive
+def test_relation_closed_descent_crosswalk_cli_write_summary_json(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "closed_descent_crosswalk.json"
+    json_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py",
+            "--write",
+            "--out",
+            str(out),
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    summary_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py",
+            "--write",
+            "--out",
+            str(out),
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert json_result.returncode == 0
+    assert summary_result.returncode == 0
+    assert json_result.stderr == ""
+    assert summary_result.stderr == ""
+    assert json.loads(summary_result.stdout) == json.loads(json_result.stdout)
+    assert load_artifact(out)["family_count"] == 16
+
+
+def test_relation_closed_descent_crosswalk_cli_rejects_json_alias_collision() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py",
+            "--json",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 2
+    assert "not allowed with argument" in result.stderr


### PR DESCRIPTION
## Summary
- add --summary-json as an explicit compact-summary alias for the relation-skeleton/closed-descent crosswalk checker
- keep legacy --json behavior stable for Makefile, artifact-audit, and metadata check paths
- update reviewer-facing docs and ledgers to recommend --summary-json while preserving review-pending/non-proof language

## Validation
- .venv/bin/python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --json
- .venv/bin/python -m pytest -q tests/test_n9_relation_skeleton_closed_descent_crosswalk.py -m artifact
- .venv/bin/python -m ruff check scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py tests/test_n9_relation_skeleton_closed_descent_crosswalk.py
- .venv/bin/python scripts/check_text_clean.py
- .venv/bin/python scripts/check_status_consistency.py
- .venv/bin/python scripts/check_artifact_provenance.py
- git diff --check
- make PYTHON=.venv/bin/python verify-fast

## Notes
- Subagent review found the CLI behavior sound; doc review nits were fixed before merge readiness.
- This is review-pending packet bookkeeping only; it does not prove local-lemma completeness, brancher coverage, n=9, or Erdos Problem #97.