### PR TITLE
Document local lemma audit summary mode

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1161,11 +1161,12 @@ The focused mini-replay crosswalk
 `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
 joins those same 12 focused packets to their packet-specific minimal
 input-data replay artifacts. The local-lemma audit path
-`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
 runs the packet/catalog, focused mini-replay, aggregate/simple-replay,
 exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
 adjacent drift localization, plus the relation-skeleton/closed-descent
-companion summary. These are review-pending handoff audits only, not packet
+companion summary. Use `--json` instead when the full layer and manifest
+records are needed. These are review-pending handoff audits only, not packet
 soundness, local-lemma completeness, frontier coverage, or a proof of `n=9`.
 The relation-skeleton/closed-descent crosswalk
 `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`

--- a/STATE.md
+++ b/STATE.md
@@ -756,11 +756,12 @@ The focused mini-replay crosswalk
 `scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --json`
 joins those same 12 focused packets to their packet-specific minimal
 input-data replay artifacts. The local-lemma audit path
-`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
 runs the packet/catalog, focused mini-replay, aggregate/simple-replay,
 exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs with
 adjacent drift localization, plus the relation-skeleton/closed-descent
-companion summary. These are review-pending handoff audits only, not packet
+companion summary. Use `--json` instead when the full layer and manifest
+records are needed. These are review-pending handoff audits only, not packet
 soundness, local-lemma completeness, frontier coverage, or a proof of `n=9`.
 The relation-skeleton/closed-descent crosswalk
 `scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2317,7 +2317,8 @@ closed-descent companion summary, and manifest contracts. This is a
 cross-artifact audit path only. It does not prove packet soundness,
 mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, a
 counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`;
+use `--json` instead when the full layer and manifest records are needed.
 
 ### n=9 turn-inequality frontier replay
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -58,13 +58,14 @@ Use this queue when no more specific issue is selected.
    compares the same 16 relation skeletons with the closed-descent packet,
    checking the one-class self-edge and multi-class strict-cycle region split.
    The local-lemma audit-path checker
-   `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
    runs the focused packet/catalog, focused mini-replay,
    aggregate/simple-replay, exhaustive/local-lemma, and
    relation-skeleton/local-lemma handoffs as one review-pending audit path,
    with the relation-skeleton/closed-descent companion summary and explicit
    adjacent handoff checks that identify where any future count/schema drift
-   first appears.
+   first appears. Use `--json` instead when the full layer and manifest
+   records are needed.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -116,7 +116,7 @@ python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expe
 python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
-python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 ```
 
 For the turn-packing route:

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -115,11 +115,12 @@ families. Use `--json` instead when the full family crosswalk records are
 needed.
 
 The combined local-lemma audit-path command
-`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
 checks the focused packet/catalog, focused mini-replay, aggregate/simple
 replay, exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs as
 one review-pending diagnostic chain. It is still bookkeeping only, not packet
-soundness or an `n=9` proof.
+soundness or an `n=9` proof. Use `--json` instead when the full layer and
+manifest records are needed.
 
 The input-data audit command
 `scripts/check_n9_vertex_circle_input_audit.py` treats the checked-in

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -685,24 +685,27 @@ focused minireplay record-path contract, adjacent handoff checks, and manifest
 contracts into a single reviewer-facing pass/fail table:
 
 ```bash
-python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 ```
 
-Without `--json`, the same checker prints the compact text summary. That
-summary includes both `audit contract summary` and `manifest contract summary`
-lines so reviewers can quickly see whether a failure is layer-side or
-manifest-side before inspecting the full JSON payload. If validation fails
-after a complete payload is available, the text mode prints those same compact
-summary lines before the detailed validation errors. With `--json`, failed
-runs return the same machine-readable payload, including the rollup fields,
-and exit nonzero when `--check` is supplied. Regression coverage exercises both
-layer-side and manifest-side contract failures so those two failure classes stay
-separate in text and JSON summaries. When `--assert-expected` is also supplied,
-an expected-shape failure is recorded in `validation_errors` instead of
-replacing the JSON diagnostic with a traceback. If payload construction itself
-fails, the fallback payload records `failure_stage: payload_construction` and
-the Python exception type before returning nonzero under `--check`. Text-mode
-failure rendering also rejects malformed scalar `validation_errors` payloads
+Without either JSON flag, the same checker prints the compact text summary.
+That summary includes both `audit contract summary` and `manifest contract
+summary` lines so reviewers can quickly see whether a failure is layer-side or
+manifest-side before inspecting the full JSON payload. Use `--json` instead of
+`--summary-json` when the full layer, handoff, input-manifest, and
+manifest-contract records are needed. If validation fails after a complete
+payload is available, the text mode prints those same compact summary lines
+before the detailed validation errors. With either JSON flag, failed runs
+return machine-readable diagnostics and exit nonzero when `--check` is
+supplied; `--summary-json` keeps only the compact rollup fields, while `--json`
+returns the full payload. Regression coverage exercises both layer-side and
+manifest-side contract failures so those two failure classes stay separate in
+text and JSON summaries. When `--assert-expected` is also supplied, an
+expected-shape failure is recorded in `validation_errors` instead of replacing
+the JSON diagnostic with a traceback. If payload construction itself fails, the
+fallback payload records `failure_stage: payload_construction` and the Python
+exception type before returning nonzero under `--check`. Text-mode failure
+rendering also rejects malformed scalar `validation_errors` payloads
 as a single schema problem instead of treating the scalar as multiple errors.
 Malformed non-string entries in a `validation_errors` list are normalized to
 explicit typed diagnostics before assert-expected failure counting, so the

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -94,7 +94,7 @@ python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -433,12 +433,13 @@ handoffs rather than re-extracting T01 or T10.
   to compare those 16 relation skeletons with the closed-descent packet's
   one-class self-edge and multi-class strict-cycle regions;
 - use
-  `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
   to run the focused packet/catalog, focused mini-replay,
   aggregate/simple-replay, exhaustive/local-lemma, and
   relation-skeleton/local-lemma handoffs as one review-pending audit path,
   with the relation-skeleton/closed-descent companion summary and adjacent
-  handoff checks that localize future drift between layers;
+  handoff checks that localize future drift between layers; use `--json`
+  when the full layer and manifest records are needed;
 - use the focused mini-replay commands
   `scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
   `scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -124,7 +124,7 @@ python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected
 python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
 python scripts/check_relation_skeleton_catalog.py --check --assert-expected --json
 python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json


### PR DESCRIPTION
## Summary
- update reviewer-facing local-lemma audit-path commands to prefer `--summary-json`
- keep `--json` documented as the full layer/manifest record mode
- preserve the review-pending/non-proof language across STATE, RESULTS, and review docs

## Validation
- `.venv/bin/python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/test_n9_vertex_circle_local_lemma_audit_path.py`
- `make PYTHON=.venv/bin/python verify-fast`

## Review notes
- CLI-consistency subagent found no issues; remaining exact `--json` command is the full-artifact Makefile context.
- Claims-language subagent found no issues; STATE and RESULTS remain aligned and preserve the non-proof/non-counterexample scope.