### PR TITLE
Document base-apex audit summary mode

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -768,9 +768,13 @@ python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json
 python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json
 python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
 python scripts/check_n9_base_apex_d3_artifact_join.py --check --json
-python scripts/check_n9_base_apex_audit_path.py --check --json
+python scripts/check_n9_base_apex_audit_path.py --check --summary-json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 ```
+
+Use `--json` instead on the base-apex audit-path checker for legacy
+artifact-audit machine-readable output; it currently emits the same compact
+payload as `--summary-json`.
 
 Expected artifacts:
 

--- a/docs/n9-base-apex-frontier.md
+++ b/docs/n9-base-apex-frontier.md
@@ -105,8 +105,12 @@ python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --j
 python scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py --assert-expected --out data/certificates/n9_base_apex_d3_incidence_capacity_packet.json
 python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
 python scripts/check_n9_base_apex_d3_artifact_join.py --check --json
-python scripts/check_n9_base_apex_audit_path.py --check --json
+python scripts/check_n9_base_apex_audit_path.py --check --summary-json
 ```
+
+Use `--json` instead on the audit-path checker for legacy artifact-audit
+machine-readable output; it currently emits the same compact payload as
+`--summary-json`.
 
 The focused generated report
 `data/certificates/n9_base_apex_low_excess_ledgers.json` records the


### PR DESCRIPTION
## Summary
- update the base-apex frontier doc and backlog to run the audit path with `--summary-json`
- keep `--json` described as the legacy artifact-audit machine-readable mode, matching the current checker behavior
- preserve the finite-bookkeeping / non-proof scope for the base-apex audit path

## Validation
- `.venv/bin/python scripts/check_n9_base_apex_audit_path.py --check --summary-json`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `.venv/bin/python -m pytest -q tests/test_reviewer_guide.py tests/test_n9_base_apex_audit_path.py`
- `make PYTHON=.venv/bin/python verify-fast`

## Review notes
- CLI-consistency subagent found one wording issue around `--json`; fixed by describing it as legacy artifact-audit machine-readable output rather than a fuller payload.
- Claims-language subagent found no non-overclaiming issues; the audit path remains finite bookkeeping only.