### PR TITLE
Add turn frontier summary JSON

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1054,11 +1054,12 @@ recomputes the row-0 choices as the 70 lexicographic 4-subsets of labels
 no-overclaiming scope. It does not rerun the brancher or replay the
 vertex-circle certificates.
 The turn-inequality frontier replay
-`scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+`scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
 checks stored integer dual certificates for the candidate weak turn system on
 all 184 regenerated pair/crossing/count frontier assignments. It records all
 184 weak systems as arithmetically infeasible, but the geometric turn lemma and
 indexing conventions remain review-pending, so this does not promote `n=9`.
+Use `--json` instead when the full certificate rows are needed.
 The compact Kalmanson self-edge replay
 `scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json`
 checks a separate certificate in which each of those 184 terminal assignments

--- a/STATE.md
+++ b/STATE.md
@@ -641,12 +641,12 @@ The companion input-data audit
 checks the stored row0 witness coverage and summary arithmetic without
 rerunning the brancher. It is a review aid only, not an `n=9` proof.
 The turn-inequality frontier replay
-`scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+`scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
 checks stored integer dual certificates for the candidate weak turn system on
 all 184 regenerated pair/crossing/count frontier assignments. It is
 review-pending finite-case evidence only: the geometric turn lemma and
 indexing conventions remain the review bottleneck, and this does not promote
-`n=9`.
+`n=9`. Use `--json` instead when the full certificate rows are needed.
 The compact Kalmanson self-edge replay
 `scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json`
 checks a stored certificate with one strict Kalmanson self-edge for each of the

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2340,7 +2340,8 @@ the indexing conventions, the regenerated source frontier, and the certificate
 arithmetic verifier still require independent review before this layer could
 support a stronger claim. It is not an `n=9` proof, not a counterexample, not a
 global status update, and not a proof of Erdos Problem #97. Check it with
-`python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`.
+`python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`;
+use `--json` instead when the full certificate rows are needed.
 
 ### Low-angle ascent for middle witnesses
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -85,10 +85,11 @@ Use this queue when no more specific issue is selected.
    `python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
    remains a diagnostic companion, not a theorem.
    The turn-inequality frontier replay
-   `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+   `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
    checks stored integer dual certificates for all 184 regenerated
    pair/crossing/count frontier assignments under the candidate weak turn
    system; the geometric turn lemma and indexing remain review bottlenecks.
+   Use `--json` instead when the full certificate rows are needed.
    The input-data audit
    `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
    now separately checks the stored row0 witness coverage and summary

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -51,7 +51,7 @@ if its geometric turn lemma is accepted.
 | B0 | Start from the same 184 assignments produced by A6-A7. | `scripts/check_n9_turn_inequality_frontier.py` regenerates the source frontier and records the same frontier hash. | machine-checked review-pending |
 | B1 | If two selected witnesses at offsets `1 <= a < b <= 8` are equidistant from center `i`, then two exterior-turn sums are strictly greater than `pi/2`. | `docs/turn-inequality-lemma.md`. | proof-facing review-pending |
 | B2 | Replacing the strict inequalities by weak normalized inequalities `>= 1` is legitimate. | Strict geometry implies the weaker closed halfspace, if B1 is correct. | conditional on B1 |
-| B3 | For each of the 184 assignments, the weak turn system has an integer turn-packing/Farkas contradiction. | `data/certificates/n9_turn_inequality_frontier.json` checked by `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`. | machine-checked review-pending |
+| B3 | For each of the 184 assignments, the weak turn system has an integer turn-packing/Farkas contradiction. | `data/certificates/n9_turn_inequality_frontier.json` checked by `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`; use `--json` for full certificate rows. | machine-checked review-pending |
 | B4 | The certificate principle is elementary: if `m > 4*lambda` intervals are forced and each turn variable appears at most `lambda` times, then `sum t_i = 4` is contradicted. | `docs/turn-packing-bridge.md`. | proved, assuming stored intervals are forced |
 | B5 | Therefore no true bad nonagon exists, assuming A6-A7, B1, and B3 survive independent review. | Follows from the chain above. | review-pending conditional |
 
@@ -122,7 +122,7 @@ python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert
 For the turn-packing route:
 
 ```bash
-python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 ```
 
 For the algebraic cross-audit:

--- a/docs/n9-turn-inequality-frontier.md
+++ b/docs/n9-turn-inequality-frontier.md
@@ -28,11 +28,12 @@ The generator and checker are:
 
 ```bash
 python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
-python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 ```
 
 The check command is also registered in `scripts/run_artifact_audit.py` and
 listed in the raw audit command set in `README.md`.
+Use `--json` instead when the full stored certificate rows are needed.
 
 ## Candidate Turn Lemma
 
@@ -107,6 +108,6 @@ Before this can support a theorem-style n=9 claim, reviewers should check:
 
 ```bash
 python scripts/check_n9_turn_inequality_frontier.py --assert-expected --json
-python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 python -m pytest tests/test_n9_turn_inequality_frontier.py -q
 ```

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -460,11 +460,11 @@ handoffs rather than re-extracting T01 or T10.
   `scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
   as a T10/F12 diagnostic companion only, not a theorem;
 - use
-  `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json`
+  `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
   to audit the stored integer dual certificates for the candidate weak
   turn-inequality system on all 184 regenerated n=9 frontier assignments,
   while keeping the geometric turn lemma and indexing conventions
-  review-pending;
+  review-pending; use `--json` when the full certificate rows are needed;
 - test whether the same motifs appear in the P18 obstruction and fail in the
   recorded `C19_skew` vertex-circle-only survivor, which is now retired as a
   fixed abstract pattern by the separate Z3 Kalmanson certificate;

--- a/docs/turn-packing-bridge.md
+++ b/docs/turn-packing-bridge.md
@@ -67,10 +67,11 @@ a contradiction.
 The replay command
 
 ```bash
-python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 ```
 
-checks the stored `n=9` frontier artifact. It regenerates the 184 complete
+checks the stored `n=9` frontier artifact. Use `--json` instead when the full
+certificate rows are needed. It regenerates the 184 complete
 selected-witness assignments surviving the pair/crossing/count filters before
 vertex-circle pruning and verifies one integer turn-packing certificate for
 each assignment. The replay is arithmetic after the stored interval choices:

--- a/scripts/check_n9_turn_inequality_frontier.py
+++ b/scripts/check_n9_turn_inequality_frontier.py
@@ -72,9 +72,56 @@ def _print_summary(payload: dict[str, object], elapsed: float | None = None) -> 
         print(f"elapsed_seconds: {elapsed:.6f}")
 
 
+def summary_json_payload(payload: dict[str, object]) -> dict[str, object]:
+    """Return a compact reviewer-facing JSON view without certificate rows."""
+
+    turn_system = payload.get("turn_system")
+    compact_turn_system: dict[str, object] = {}
+    if isinstance(turn_system, dict):
+        for key in (
+            "normalized_variables",
+            "sum_constraint",
+            "nonnegativity",
+            "weak_inequality_template",
+            "strict_geometry_note",
+            "inequality_count_histogram",
+        ):
+            if key in turn_system:
+                compact_turn_system[key] = turn_system[key]
+
+    compact: dict[str, object] = {}
+    for key in (
+        "schema",
+        "status",
+        "trust",
+        "claim_scope",
+        "n",
+        "row_size",
+        "cyclic_order",
+        "source_frontier",
+        "z3_replay",
+        "farkas_replay",
+        "benchmarks",
+        "conclusion",
+        "review_requirements",
+        "provenance",
+    ):
+        if key in payload:
+            compact[key] = payload[key]
+    if compact_turn_system:
+        compact["turn_system"] = compact_turn_system
+    return compact
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON without certificate rows",
+    )
     parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
     parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
     parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
@@ -103,7 +150,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.write:
         _write_json(out, payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         _print_summary(payload, elapsed)

--- a/tests/test_n9_turn_inequality_frontier.py
+++ b/tests/test_n9_turn_inequality_frontier.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+import subprocess
+import sys
+
 from erdos97.n9_turn_inequality_frontier import (
     CLAIM_SCOPE,
     CONCLUSION,
@@ -18,6 +23,8 @@ from erdos97.n9_turn_inequality_frontier import (
     verify_turn_farkas_certificate,
     vertex_circle_status_for_pattern,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_side_cap_benchmark_has_expected_turn_system() -> None:
@@ -161,3 +168,30 @@ def test_payload_validation_rejects_conclusion_and_order_drift() -> None:
 
     assert "cyclic_order mismatch" in errors
     assert "conclusion mismatch" in errors
+
+
+def test_turn_inequality_frontier_cli_summary_json_is_compact() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_turn_inequality_frontier.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["claim_scope"] == CLAIM_SCOPE
+    assert payload["source_frontier"]["assignment_count"] == 184
+    assert payload["turn_system"]["inequality_count_histogram"] == {"108": 184}
+    assert payload["z3_replay"]["status_counts"] == {"unsat": 184}
+    assert payload["farkas_replay"]["certificate_count"] == 184
+    assert payload["farkas_replay"]["lambda_histogram"] == {"1": 180, "2": 4}
+    assert "farkas_certificates" not in payload


### PR DESCRIPTION
## Summary
- add `--summary-json` to `check_n9_turn_inequality_frontier.py`
- keep `--json` as the full payload mode with all `farkas_certificates`
- update reviewer-facing docs to prefer the compact summary while preserving review-pending/non-proof scope

## Validation
- `.venv/bin/python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
- `.venv/bin/python -m pytest -q tests/test_n9_turn_inequality_frontier.py`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `make PYTHON=.venv/bin/python verify-fast`

## Review notes
- CLI/API subagent found no issues; `--summary-json` omits the 184 certificate rows and full `--json` still includes them.
- Claims-language subagent found no issues; status/trust/claim scope and review requirements stay in the compact payload and docs remain review-pending.