### PR TITLE
Add two-repeated support summary JSON

### DIFF
--- a/docs/bootstrap-t12-81-3-two-repeated-support-catalogue-audit.md
+++ b/docs/bootstrap-t12-81-3-two-repeated-support-catalogue-audit.md
@@ -35,8 +35,11 @@ witness-pair, crossing, and same-center disjointness filters as the earlier
 Run:
 
 ```bash
-python scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py --assert-expected --json
+python scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py --check --assert-expected --summary-json
 ```
+
+Use `--json` instead when the full two-repeated-support catalogue record and
+failed supply-extension scan details are needed.
 
 ## Result
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -394,11 +394,14 @@ Use this queue when no more specific issue is selected.
    `docs/bootstrap-t12-81-3-two-repeated-support-catalogue-audit.md` then
    deduplicates the next catalogue layer: the only unique two-support
    catalogue is initially incompatible, and all `118` center-`6`
-   supply-extension attempts remain initially incompatible. The next useful PR
-   must therefore handle still broader multiple supports or richer catalogues,
-   introduce a genuine rich-class/minimality hypothesis that forces or excludes
-   such supports, preserve enough activation provenance to identify the row, or
-   move to a different bridge target. The
+   supply-extension attempts remain initially incompatible. The command
+   `python scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py --check --assert-expected --summary-json`
+   gives the compact reviewer-facing payload; use `--json` when the full
+   catalogue record and supply-extension scan details are needed. The next
+   useful PR must therefore handle still broader multiple supports or richer
+   catalogues, introduce a genuine rich-class/minimality hypothesis that forces
+   or excludes such supports, preserve enough activation provenance to identify
+   the row, or move to a different bridge target. The
    source-`81` row-`8` singleton-support audit in
    `docs/bootstrap-t12-81-8-singleton-support-audit.md` is one such adjacent
    target: it finds no non-original row-`8` activation survivor in the fixed

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -818,8 +818,11 @@ condition that the surviving multi-block family does not automatically satisfy:
   chain-closure survivors, each disjoint from the supports already present at
   its own center. The single deduplicated two-support catalogue is initially
   incompatible, and all `118` center-`6` supply-extension attempts remain
-  initially incompatible. Broader multiple-support catalogues and genuine
-  rich-class forcing remain open.
+  initially incompatible. Run
+  `scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py --check --assert-expected --summary-json`
+  for the compact reviewer payload, or `--json` for the full catalogue record
+  and supply-extension scan details. Broader multiple-support catalogues and
+  genuine rich-class forcing remain open.
 - bootstrap/T12 focused `81:8` singleton-support evidence, as recorded in
   `docs/bootstrap-t12-81-8-singleton-support-audit.md`, showing that the fixed
   source-`81` neighborhood and one-row-drop relaxation have no non-original

--- a/scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py
+++ b/scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py
@@ -20,6 +20,16 @@ from erdos97.bootstrap_t12_81_3_two_repeated_support_catalogue_audit import (  #
     load_artifact,
 )
 
+SUMMARY_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "interpretation_warnings",
+    "source_one_repeated_support_audit",
+    "summary",
+)
+
 
 def write_artifact(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -66,7 +76,13 @@ def main() -> int:
         help="compare artifact to regenerated payload",
     )
     parser.add_argument("--write", action="store_true", help="write regenerated payload")
-    parser.add_argument("--json", action="store_true", help="print JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON summary",
+    )
     parser.add_argument("--assert-expected", action="store_true", help="assert pinned values")
     args = parser.parse_args()
 
@@ -88,7 +104,9 @@ def main() -> int:
     if args.write:
         write_artifact(artifact, generated)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print_summary(payload)
@@ -97,6 +115,12 @@ def main() -> int:
         if args.assert_expected:
             print("OK: bootstrap/T12 81:3 two-repeated-support expectations verified")
     return 0
+
+
+def summary_json_payload(payload: dict[str, object]) -> dict[str, object]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_KEYS}
 
 
 if __name__ == "__main__":

--- a/tests/test_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py
+++ b/tests/test_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
+from scripts.check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit import (
+    SUMMARY_KEYS,
+    summary_json_payload,
+)
 from erdos97.bootstrap_t12_81_3_two_repeated_support_catalogue_audit import (
     DEFAULT_ARTIFACT,
     SCAN_STATUS,
     assert_expected_payload,
     build_t12_81_3_two_repeated_support_catalogue_audit_payload,
 )
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
@@ -82,3 +92,35 @@ def test_bootstrap_t12_81_3_two_repeated_support_rejects_drift(
 
     with pytest.raises(AssertionError, match="supply_extension_survivor_count"):
         assert_expected_payload(bad)
+
+
+def test_bootstrap_t12_81_3_two_repeated_support_summary_json_payload(
+    payload: dict[str, object],
+) -> None:
+    summary_payload = summary_json_payload(payload)
+
+    assert tuple(summary_payload) == SUMMARY_KEYS
+    assert summary_payload["summary"]["supply_extension_candidate_count"] == 118
+    assert "two_repeated_support_catalogue_scan" not in summary_payload
+    assert "supply_extension_scan" not in summary_payload
+
+
+def test_bootstrap_t12_81_3_two_repeated_support_cli_summary_json(
+    payload: dict[str, object],
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## Summary
- add `--summary-json` to the bootstrap/T12 `81:3` two-repeated-support audit checker
- keep full `--json` as the artifact/audit path while compact output omits scan-record blocks
- update reviewer-facing docs/backlog notes to prefer the compact command

## Validation
- `.venv/bin/python scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py --check --assert-expected --summary-json`
- `.venv/bin/python -m pytest tests/test_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py -q`
- `.venv/bin/python -m ruff check scripts/check_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py tests/test_bootstrap_t12_81_3_two_repeated_support_catalogue_audit.py`
- `make PYTHON=.venv/bin/python verify-fast`

## Review
- Raman: non-overclaiming/source-of-truth review found no issues
- Archimedes: CLI/API/test review found no issues