### PR TITLE
Add exhaustive local lemma summary JSON

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2235,8 +2235,10 @@ The nested aggregate/simple-replay summary also reports `16` aggregate
 families, `16` simple-replay families, and `184` matched assignments. This is
 cross-artifact accounting only. It does not review the exhaustive brancher,
 prove local-lemma completeness, prove frontier coverage, prove `n=9`, give a
-counterexample, or update the official/global status. Check it with
-`python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`.
+counterexample, or update the official/global status. Check the compact
+reviewer-facing view with
+`python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full family crosswalk records are needed.
 
 ### n=9 vertex-circle relation-skeleton/local-lemma crosswalk
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -44,9 +44,11 @@ Use this queue when no more specific issue is selected.
    compares that simple replay with the aggregate local-lemma scan
    family-by-family; use `--json` when the full family crosswalk records are
    needed. The follow-up crosswalk
-   `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`
    connects the same local-lemma accounting back to the review-pending
-   exhaustive count artifact and motif classification. The relation-skeleton
+   exhaustive count artifact and motif classification; use `--json` when the
+   full exhaustive/local family crosswalk records are needed. The
+   relation-skeleton
    crosswalk
    `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
    connects the compact 16-skeleton proof-mining catalog to the same

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -105,13 +105,14 @@ stored accounting chain from this exhaustive artifact to the motif
 classification and then to the aggregate/simple local-lemma replay artifacts:
 
 ```bash
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 ```
 
 This command does not rerun or independently review the exhaustive brancher.
 It verifies only that the checked-in artifacts agree on the same
 review-pending `184 = 158 + 26` frontier accounting and the same 16 motif
-families.
+families. Use `--json` instead when the full family crosswalk records are
+needed.
 
 The combined local-lemma audit-path command
 `scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --json`

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -625,11 +625,12 @@ from the review-pending exhaustive artifact through the motif classification
 before joining to the local-lemma replay artifacts:
 
 ```bash
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 ```
 
 That command is also an artifact-accounting audit only; it does not rerun the
-exhaustive brancher or complete independent review.
+exhaustive brancher or complete independent review. Use `--json` instead when
+the full family crosswalk records are needed.
 
 The relation-skeleton/local-lemma crosswalk checks the downstream
 proof-mining view: it joins the 16-entry relation-skeleton catalog to the same

--- a/docs/reproduction-log.md
+++ b/docs/reproduction-log.md
@@ -70,7 +70,7 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -419,9 +419,10 @@ handoffs rather than re-extracting T01 or T10.
   family-by-family; use `--json` when the full family crosswalk records are
   needed;
 - use
-  `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`
   to compare the review-pending exhaustive counts, motif classification, and
-  local-lemma replay chain without rerunning the brancher;
+  local-lemma replay chain without rerunning the brancher; use `--json` when
+  the full family crosswalk records are needed;
 - use
   `scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
   to compare the 16-entry relation-skeleton catalog with the same

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -100,7 +100,7 @@ python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --
 python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_simple_replay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_t01_self_edge_lemma_packet.py --check --assert-expected --json
 python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json

--- a/scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
@@ -43,6 +43,21 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "cyclic_order",
+    "source_artifacts",
+    "coverage_summary",
+    "local_replay_crosswalk_summary",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
 
 DEFAULT_EXHAUSTIVE = (
     ROOT / "data" / "certificates" / "n9_vertex_circle_exhaustive.json"
@@ -191,6 +206,12 @@ def assert_expected_exhaustive_local_lemma_crosswalk(payload: Mapping[str, Any])
     ]
     if family_ids != EXPECTED_FAMILY_IDS:
         raise AssertionError(f"family ids mismatch: {family_ids!r}")
+
+
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
 
 
 def _append_expected_errors(
@@ -393,7 +414,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Assert the expected exhaustive/local-lemma crosswalk counts.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="Emit JSON payload.")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="Emit compact reviewer-facing JSON without per-family records.",
+    )
     args = parser.parse_args(argv)
 
     exhaustive_path = _resolve(args.exhaustive)
@@ -437,7 +464,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_exhaustive_local_lemma_crosswalk(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 exhaustive/local-lemma crosswalk")

--- a/tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
+++ b/tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py
@@ -16,6 +16,7 @@ from scripts.check_n9_vertex_circle_exhaustive_local_lemma_crosswalk import (
     assert_expected_exhaustive_local_lemma_crosswalk,
     exhaustive_local_lemma_crosswalk_payload,
     load_artifact,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -175,6 +176,62 @@ def test_exhaustive_local_lemma_crosswalk_rejects_family_drift(
         "F01 assignment_count mismatch: classification 17 != local 18"
         in payload["validation_errors"]
     )
+
+
+def test_exhaustive_local_lemma_crosswalk_summary_json_payload(
+    exhaustive: dict[str, object],
+    classification: dict[str, object],
+    local_lemmas: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = exhaustive_local_lemma_crosswalk_payload(
+        exhaustive,
+        classification,
+        local_lemmas,
+        simple_replay,
+    )
+
+    summary = summary_json_payload(payload)
+
+    assert "family_crosswalk" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["coverage_summary"]["exhaustive_frontier_assignment_count"] == 184
+    assert summary["coverage_summary"]["strict_cycle_assignment_count"] == 26
+    assert (
+        summary["local_replay_crosswalk_summary"]["matched_assignment_count"]
+        == 184
+    )
+    assert summary["validation_status"] == "passed"
+
+
+def test_exhaustive_local_lemma_crosswalk_cli_summary_json(
+    exhaustive: dict[str, object],
+    classification: dict[str, object],
+    local_lemmas: dict[str, object],
+    simple_replay: dict[str, object],
+) -> None:
+    payload = exhaustive_local_lemma_crosswalk_payload(
+        exhaustive,
+        classification,
+        local_lemmas,
+        simple_replay,
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)
 
 
 def test_exhaustive_local_lemma_crosswalk_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py` as a compact reviewer-facing JSON view.
- Kept `--json` as the full payload path with per-family crosswalk records.
- Added tests for the helper and CLI output, and updated reviewer-facing docs to prefer the compact command.

## Claim scope and evidence level
- Scope remains review-pending cross-artifact accounting for the n=9 exhaustive/local-lemma handoff.
- This does not prove n=9, does not provide a counterexample, does not independently review the exhaustive checker, and does not update the official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py tests/test_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py`
- `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked compact and full JSON output for the exhaustive/local-lemma crosswalk.
- Checked the surrounding local-lemma audit-path handoff summary.
- No generated artifacts were changed.

## Known limitations / next review steps
- The summary JSON is a compact view over existing review-pending accounting only.
- The full family records remain available through `--json` for detailed review.
- Packet soundness, local-lemma completeness, and independent exhaustive-checker review remain open.