### PR TITLE
Add n9 input audit summary JSON

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1058,10 +1058,11 @@ then classifies all 184 as exact vertex-circle obstructions: 158 self-edges and
 26 strict cycles.
 
 The companion input-data audit
-`scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json`
 recomputes the row-0 choices as the 70 lexicographic 4-subsets of labels
 `1..8` and checks the stored witness lists, masks, summary counts, and
-no-overclaiming scope. It does not rerun the brancher or replay the
+no-overclaiming scope. Use `--json` instead when the full expected-count block
+is needed. It does not rerun the brancher or replay the
 vertex-circle certificates.
 The turn-inequality frontier replay
 `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`

--- a/STATE.md
+++ b/STATE.md
@@ -645,9 +645,10 @@ candidate repo-local finite-case extension only; it does not change the
 official/global falsifiable/open status, and it is not promoted beyond the
 current `n <= 8` source-of-truth result until independent review.
 The companion input-data audit
-`scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json`
 checks the stored row0 witness coverage and summary arithmetic without
-rerunning the brancher. It is a review aid only, not an `n=9` proof.
+rerunning the brancher. Use `--json` instead when the full expected-count
+block is needed. It is a review aid only, not an `n=9` proof.
 The turn-inequality frontier replay
 `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
 checks stored integer dual certificates for the candidate weak turn system on

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1857,7 +1857,8 @@ stored-input consistency evidence only. It does not rerun the brancher, replay
 vertex-circle certificates, prove `n=9`, claim a counterexample, update the
 official/global status, or promote the review-pending exhaustive checker.
 Check it with
-`python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full expected-count block is needed.
 
 ### n=9 vertex-circle fixed-order branching replay
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -91,9 +91,10 @@ Use this queue when no more specific issue is selected.
    system; the geometric turn lemma and indexing remain review bottlenecks.
    Use `--json` instead when the full certificate rows are needed.
    The input-data audit
-   `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json`
    now separately checks the stored row0 witness coverage and summary
-   arithmetic for the exhaustive artifact without rerunning the brancher.
+   arithmetic for the exhaustive artifact without rerunning the brancher; use
+   `--json` when the full expected-count block is needed.
    The branching replay
    `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`
    now reruns the same filters with fixed center order and checks agreement
@@ -472,9 +473,10 @@ Use this queue when no more specific issue is selected.
    Groebner-y2 certificates. The remaining `n=8` audit gap is now external
    review of these focused checkers and the underlying artifact assumptions.
    The first `n=9` input-data replay command,
-   `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json`,
    covers row0 choices and summary arithmetic only; the brancher, pruning
-   lemmas, and vertex-circle certificates still need review.
+   lemmas, and vertex-circle certificates still need review. Use `--json`
+   when the full expected-count block is needed.
    The MRO branching replay command,
    `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
    covers the branch-order checklist item only; the pruning lemmas and

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -111,7 +111,7 @@ For the vertex-circle route:
 
 ```bash
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
-python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -127,14 +127,15 @@ The input-data audit command
 exhaustive JSON as stored data:
 
 ```bash
-python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 ```
 
 It recomputes the row-0 choices directly as the 70 lexicographic 4-subsets of
 labels `1..8`, checks the stored witness lists and masks, and verifies the
 summary count arithmetic and no-overclaiming scope. It does not rerun the
 brancher, replay vertex-circle certificates, prove `n=9`, or complete the
-independent review.
+independent review. Use `--json` instead when the full expected-count block is
+needed.
 
 The incidence-filter audit command checks the row-level two-overlap crossing,
 witness-pair cap, and selected-indegree cap tables:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -139,7 +139,7 @@ Priority 5 review, but it does not by itself close the review or promote the
 Current input-data audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 ```
 
 This command recomputes the row-0 coverage directly as the 70 lexicographic
@@ -147,7 +147,8 @@ This command recomputes the row-0 coverage directly as the 70 lexicographic
 and verifies summary arithmetic from the checked-in JSON. It is a small audit
 of the "no hidden row0 quotient" checklist item only; it does not rerun the
 brancher, replay vertex-circle certificates, prove `n=9`, or complete
-independent review.
+independent review. Use `--json` instead when the full expected-count block is
+needed.
 
 Current incidence-filter audit:
 

--- a/scripts/check_n9_vertex_circle_input_audit.py
+++ b/scripts/check_n9_vertex_circle_input_audit.py
@@ -35,6 +35,19 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "source_artifact",
+    "review_independence",
+    "coverage_summary",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
 
 DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_exhaustive.json"
 N = 9
@@ -198,6 +211,12 @@ def assert_expected_input_audit(payload: Mapping[str, Any]) -> None:
             )
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+
+
 def _audit_top_level(
     artifact: Mapping[str, Any],
     expected_rows: Sequence[Mapping[str, Any]],
@@ -346,7 +365,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON summary",
+    )
     return parser.parse_args(argv)
 
 
@@ -375,7 +400,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_input_audit(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle input-data audit")

--- a/tests/test_n9_vertex_circle_input_audit.py
+++ b/tests/test_n9_vertex_circle_input_audit.py
@@ -18,6 +18,7 @@ from scripts.check_n9_vertex_circle_input_audit import (
     expected_row0_records,
     load_artifact,
     n9_vertex_circle_input_audit_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -127,6 +128,39 @@ def test_n9_vertex_circle_input_audit_rejects_scope_drift() -> None:
 
     assert payload["validation_status"] == "failed"
     assert any("source artifact scope/notes missing" in error for error in payload["validation_errors"])
+
+
+def test_n9_vertex_circle_input_audit_summary_json_payload() -> None:
+    payload = n9_vertex_circle_input_audit_payload(_payload())
+
+    summary = summary_json_payload(payload)
+
+    assert "expected_counts" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["review_independence"] == payload["review_independence"]
+    assert summary["coverage_summary"]["expected_row0_choices"] == EXPECTED_ROW0_CHOICES
+    assert summary["coverage_summary"]["cross_check_full_assignments"] == EXPECTED_CROSS_FULL
+    assert summary["validation_status"] == "passed"
+
+
+def test_n9_vertex_circle_input_audit_cli_summary_json() -> None:
+    payload = n9_vertex_circle_input_audit_payload(_payload())
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_input_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)
 
 
 def test_n9_vertex_circle_input_audit_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_input_audit.py` as a compact reviewer-facing view.
- Kept `--json` as the full payload path with the explicit expected-count block.
- Added helper/CLI tests and updated input-audit docs to prefer the compact command.

## Claim scope and evidence level
- Scope remains review-pending stored-input consistency for the n=9 vertex-circle exhaustive artifact.
- This does not rerun the brancher, does not replay vertex-circle certificates, does not prove n=9, does not claim a counterexample, and does not update the official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_input_audit.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_input_audit.py tests/test_n9_vertex_circle_input_audit.py`
- `python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked compact and full JSON output for the n=9 input-data audit.
- No generated artifacts were changed.

## Known limitations / next review steps
- The summary JSON is a compact view over stored-input bookkeeping only.
- The full expected-count block remains available through `--json`.
- Brancher soundness, pruning lemmas, vertex-circle certificate replay, and independent n=9 review remain open.