### PR TITLE
Add incidence filter summary JSON

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1096,10 +1096,11 @@ checks that every candidate selected row produces exactly the proper-interval
 strict inequalities used by the checker, with `5,670` total local strict
 edges across 630 candidate rows. This is local rule verification only.
 The incidence-filter audit
-`scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
 checks the row-level two-overlap crossing table, witness-pair cap predicate,
 and selected-indegree cap predicate. This is row-filter implementation
-agreement only.
+agreement only. Use `--json` instead when the full histogram blocks are
+needed.
 The quotient-soundness audit
 `scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
 checks that the stored local-core rows and 184 stored frontier assignments get

--- a/STATE.md
+++ b/STATE.md
@@ -686,10 +686,11 @@ The strict-edge geometry audit
 checks the local proper-interval inequality generator for all 630 candidate
 selected rows, while leaving quotient and coverage review separate.
 The incidence-filter audit
-`scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
 checks the row-level two-overlap crossing table, witness-pair cap predicate,
 and selected-indegree cap predicate, while leaving branch replay and
-vertex-circle pruning review separate.
+vertex-circle pruning review separate. Use `--json` instead when the full
+histogram blocks are needed.
 The quotient-soundness audit
 `scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
 checks selected-distance quotient status agreement on the stored local-core

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -114,9 +114,10 @@ Use this queue when no more specific issue is selected.
    selected-distance quotienting, stored Kalmanson self-edges, and digest
    agreement without importing the Kalmanson generator module.
    The incidence-filter replay
-   `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
    checks the row-level two-overlap crossing, witness-pair cap, and
-   selected-indegree cap tables.
+   selected-indegree cap tables; use `--json` when the full histogram blocks
+   are needed.
    The branch-option audit
    `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
    checks fixed-order no-vertex-circle helper options and maintained count
@@ -491,10 +492,11 @@ Use this queue when no more specific issue is selected.
    frontier rows only; branch coverage and strict-edge geometry remain separate
    review scopes.
    The incidence-filter command,
-   `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`,
    covers only row-level two-overlap crossing, witness-pair capacity, and
    selected-indegree capacity; brancher replay and vertex-circle pruning remain
-   separate review scopes.
+   separate review scopes. Use `--json` when the full histogram blocks are
+   needed.
    The branch-option command,
    `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`,
    covers only fixed-order no-vertex-circle helper-option agreement and

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -112,7 +112,7 @@ For the vertex-circle route:
 ```bash
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -141,12 +141,13 @@ The incidence-filter audit command checks the row-level two-overlap crossing,
 witness-pair cap, and selected-indegree cap tables:
 
 ```bash
-python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 ```
 
 It recomputes the finite row-pair and row-mask predicates directly and compares
 them with the checker tables. It is a row-level filter audit only, not a
-brancher replay, strict-edge geometry audit, or quotient-soundness audit.
+brancher replay, strict-edge geometry audit, or quotient-soundness audit. Use
+`--json` instead when the full histogram blocks are needed.
 
 The branch-option audit command checks the branch helper against a direct
 implementation on fixed-order no-vertex-circle search states:

--- a/docs/n9-vertex-circle-selected-indegree-cap-audit.md
+++ b/docs/n9-vertex-circle-selected-indegree-cap-audit.md
@@ -110,11 +110,12 @@ The audit is now replayable together with the other row-level incidence
 filters:
 
 ```bash
-python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 ```
 
 The command recomputes the selected-indegree formula, local cap predicate,
 update roundtrip, and label frequency histogram from the stored checker tables.
+Use `--json` instead when the full histogram blocks are needed.
 The transcript below records the historical one-off counts now stabilized by
 that command.
 

--- a/docs/n9-vertex-circle-two-overlap-crossing-audit.md
+++ b/docs/n9-vertex-circle-two-overlap-crossing-audit.md
@@ -79,13 +79,14 @@ The audit is now replayable together with the other row-level incidence
 filters:
 
 ```bash
-python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 ```
 
 The command recomputes the two-overlap crossing table for every pair of
 centers and every pair of selected-row masks, then compares it with the
-checker compatibility table. The transcript below records the historical
-one-off counts now stabilized by that command.
+checker compatibility table. Use `--json` instead when the full histogram
+blocks are needed. The transcript below records the historical one-off counts
+now stabilized by that command.
 
 A one-off predicate audit compared the checker with the shared
 `incidence_filters.chords_cross_in_order` implementation on all nonagon chord

--- a/docs/n9-vertex-circle-witness-pair-cap-audit.md
+++ b/docs/n9-vertex-circle-witness-pair-cap-audit.md
@@ -86,11 +86,12 @@ The audit is now replayable together with the other row-level incidence
 filters:
 
 ```bash
-python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 ```
 
 The command recomputes the row-pair indices, local cap predicate, update
 roundtrip, and witness-pair frequency histogram from the stored checker tables.
+Use `--json` instead when the full histogram blocks are needed.
 The transcript below records the historical one-off counts now stabilized by
 that command.
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -153,13 +153,14 @@ needed.
 Current incidence-filter audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 ```
 
 This command recomputes the row-level two-overlap crossing table,
 witness-pair cap predicate, and selected-indegree cap predicate. It does not
 rerun the brancher, audit strict-edge geometry, review selected-distance
-quotient soundness, prove `n=9`, or complete review.
+quotient soundness, prove `n=9`, or complete review. Use `--json` instead
+when the full histogram blocks are needed.
 
 Current branch-option audit:
 

--- a/scripts/check_n9_vertex_circle_incidence_filters.py
+++ b/scripts/check_n9_vertex_circle_incidence_filters.py
@@ -36,6 +36,43 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "pair_cap",
+    "max_indegree",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+TWO_OVERLAP_SUMMARY_KEYS = (
+    "chord_cross_equivalence_mismatches",
+    "compatibility_errors",
+    "two_overlap_crossing_accepted",
+    "two_overlap_noncrossing_rejected",
+)
+WITNESS_PAIR_CAP_SUMMARY_KEYS = (
+    "unique_row_masks",
+    "row_pair_index_mismatches",
+    "rows_with_non_six_pair_indices",
+    "local_cap_profiles_tested",
+    "local_cap_predicate_mismatches",
+    "increment_decrement_roundtrip_errors",
+)
+SELECTED_INDEGREE_CAP_SUMMARY_KEYS = (
+    "max_indegree_formula",
+    "checker_max_indegree",
+    "unique_row_masks",
+    "row_mask_shape_errors",
+    "local_column_profiles_tested",
+    "local_column_predicate_mismatches",
+    "increment_decrement_roundtrip_errors",
+)
 
 EXPECTED_TWO_OVERLAP = {
     "chord_cross_equivalence_mismatches": 0,
@@ -267,6 +304,34 @@ def assert_expected_incidence_filters(payload: Mapping[str, Any]) -> None:
     _assert_section("selected_indegree_cap", payload, EXPECTED_SELECTED_INDEGREE)
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without histograms."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    section_specs = (
+        (
+            "two_overlap_crossing",
+            "two_overlap_crossing_summary",
+            TWO_OVERLAP_SUMMARY_KEYS,
+        ),
+        (
+            "witness_pair_cap",
+            "witness_pair_cap_summary",
+            WITNESS_PAIR_CAP_SUMMARY_KEYS,
+        ),
+        (
+            "selected_indegree_cap",
+            "selected_indegree_cap_summary",
+            SELECTED_INDEGREE_CAP_SUMMARY_KEYS,
+        ),
+    )
+    for section_key, summary_key, keys in section_specs:
+        section = payload.get(section_key)
+        if isinstance(section, Mapping):
+            summary[summary_key] = {key: section[key] for key in keys if key in section}
+    return summary
+
+
 def _direct_row_pair_indices(row_mask: int) -> list[int]:
     return [
         n9.PAIR_INDEX[n9.pair(a, b)]
@@ -333,7 +398,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without histogram blocks",
+    )
     return parser.parse_args(argv)
 
 
@@ -344,7 +415,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_incidence_filters(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle incidence filter audits")

--- a/tests/test_n9_vertex_circle_incidence_filters.py
+++ b/tests/test_n9_vertex_circle_incidence_filters.py
@@ -15,6 +15,7 @@ from scripts.check_n9_vertex_circle_incidence_filters import (
     assert_expected_incidence_filters,
     incidence_filter_payload,
     selected_indegree_cap_audit,
+    summary_json_payload,
     two_overlap_crossing_audit,
     witness_pair_cap_audit,
 )
@@ -45,6 +46,56 @@ def test_incidence_filter_rejects_top_level_claim_scope_append() -> None:
 
     with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected_incidence_filters(payload)
+
+
+def test_incidence_filter_summary_json_payload() -> None:
+    payload = incidence_filter_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "two_overlap_crossing" not in summary
+    assert "witness_pair_cap" not in summary
+    assert "selected_indegree_cap" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["two_overlap_crossing_summary"]["compatibility_errors"] == 0
+    assert (
+        "row_pair_candidate_overlap_histogram"
+        not in summary["two_overlap_crossing_summary"]
+    )
+    assert summary["witness_pair_cap_summary"]["unique_row_masks"] == 126
+    assert (
+        "witness_pair_frequency_histogram"
+        not in summary["witness_pair_cap_summary"]
+    )
+    assert (
+        summary["selected_indegree_cap_summary"]["local_column_predicate_mismatches"]
+        == 0
+    )
+    assert (
+        "label_frequency_histogram"
+        not in summary["selected_indegree_cap_summary"]
+    )
+    assert summary["validation_status"] == "passed"
+
+
+def test_incidence_filter_cli_summary_json() -> None:
+    payload = incidence_filter_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_incidence_filters.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)
 
 
 def test_incidence_filter_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_incidence_filters.py` as a compact reviewer-facing view without histogram blocks.
- Kept `--json` as the full payload path with two-overlap, witness-pair, and selected-indegree histograms.
- Added helper/CLI tests and updated incidence-filter review docs to prefer the compact command.

## Claim scope and evidence level
- Scope remains review-pending row-level incidence-filter implementation auditing for the n=9 vertex-circle checker.
- This does not replay the brancher, audit strict-edge geometry, review selected-distance quotient soundness, prove n=9, claim a counterexample, or update the official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_incidence_filters.py -q`
- `python -m ruff check scripts/check_n9_vertex_circle_incidence_filters.py tests/test_n9_vertex_circle_incidence_filters.py`
- `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked compact and full JSON output for the n=9 incidence-filter audit.
- No generated artifacts were changed.

## Known limitations / next review steps
- The summary JSON is a compact view over row-level predicate audits only.
- Full histogram blocks remain available through `--json`.
- Brancher replay, strict-edge geometry, quotient soundness, and independent n=9 review remain open.