### PR TITLE
Add branch option summary JSON

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1126,10 +1126,11 @@ checks the stored 184 frontier assignments directly. It records zero row-shape,
 center-coverage, crossing, witness-pair-cap, and selected-indegree-cap errors;
 this is stored-frontier diagnostics only.
 The branch-option audit
-`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
 checks 520,598 no-vertex-circle fixed-order option contexts and finds zero
 helper/direct option mismatches and zero maintained-count mismatches. This is
-branch-option implementation diagnostics only. The dynamic-MRO choice audit
+branch-option implementation diagnostics only; use `--json` when mismatch
+examples are needed. The dynamic-MRO choice audit
 `scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
 checks the actual minimum-remaining-options center choice on both dynamic
 searches. It recomputes all unassigned-center option lists at every reached

--- a/STATE.md
+++ b/STATE.md
@@ -715,11 +715,12 @@ coverage, row-pair intersection/crossing, witness-pair capacity, and
 selected-indegree capacity. It is stored-frontier diagnostics only, not
 frontier coverage or brancher soundness.
 The branch-option audit
-`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
 walks the fixed-order no-vertex-circle search states and compares
 `valid_options_for_center` plus maintained count arrays against a direct
 implementation. It is a branch-option implementation audit only, not
-dynamic-MRO coverage or vertex-circle geometry review. The dynamic-MRO choice
+dynamic-MRO coverage or vertex-circle geometry review. Use `--json` instead
+when mismatch examples are needed. The dynamic-MRO choice
 audit
 `scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
 replays the actual minimum-remaining-options center choice with and without

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2011,7 +2011,8 @@ assignment identities against the stored frontier artifact. It does not prove
 dynamic-MRO branch coverage, strict-edge geometry, selected-distance quotient
 soundness, `n=9`, a counterexample, or any official/global status update. Check
 it with
-`python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`.
+Use `--json` instead when mismatch examples are needed.
 
 ### n=9 vertex-circle dynamic-MRO choice audit
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -119,9 +119,10 @@ Use this queue when no more specific issue is selected.
    selected-indegree cap tables; use `--json` when the full histogram blocks
    are needed.
    The branch-option audit
-   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
    checks fixed-order no-vertex-circle helper options and maintained count
-   arrays against a direct predicate implementation.
+   arrays against a direct predicate implementation; use `--json` when
+   mismatch examples are needed.
    The dynamic-MRO choice audit
    `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
    checks the actual minimum-remaining-options center choice against direct
@@ -498,10 +499,11 @@ Use this queue when no more specific issue is selected.
    separate review scopes. Use `--json` when the full histogram blocks are
    needed.
    The branch-option command,
-   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`,
    covers only fixed-order no-vertex-circle helper-option agreement and
    maintained count arrays; dynamic-MRO coverage and vertex-circle pruning
-   remain separate review scopes.
+   remain separate review scopes. Use `--json` when mismatch examples are
+   needed.
    The dynamic-MRO choice command,
    `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`,
    covers only the actual dynamic center-choice implementation and all-center

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -153,7 +153,7 @@ The branch-option audit command checks the branch helper against a direct
 implementation on fixed-order no-vertex-circle search states:
 
 ```bash
-python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json
 ```
 
 It walks 520,598 nonterminal option contexts, compares
@@ -161,7 +161,8 @@ It walks 520,598 nonterminal option contexts, compares
 capacity, and selected-indegree predicates, and also compares maintained count
 arrays with direct recomputation. This is branch-option implementation
 diagnostics only, not dynamic-MRO branch coverage, strict-edge geometry,
-quotient soundness, or a completed `n=9` review.
+quotient soundness, or a completed `n=9` review. Use `--json` instead when
+mismatch examples are needed.
 
 The dynamic-MRO choice audit command checks the actual dynamic branch choice:
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -165,14 +165,14 @@ when the full histogram blocks are needed.
 Current branch-option audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json
 ```
 
 This command walks the no-vertex-circle fixed-order search states and compares
 the helper `valid_options_for_center` predicate and maintained count arrays
 against a direct implementation. It does not prove dynamic-MRO branch coverage,
 strict-edge geometry, selected-distance quotient soundness, `n=9`, or complete
-review.
+review. Use `--json` instead when mismatch examples are needed.
 
 Current dynamic-MRO choice audit:
 

--- a/scripts/check_n9_vertex_circle_branch_options.py
+++ b/scripts/check_n9_vertex_circle_branch_options.py
@@ -38,6 +38,32 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "pair_cap",
+    "max_selected_indegree",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+BRANCH_OPTION_SUMMARY_KEYS = (
+    "row_order_rule",
+    "vertex_circle_pruning",
+    "nodes_visited",
+    "full_assignments",
+    "status_counts",
+    "option_contexts",
+    "helper_option_total",
+    "empty_option_contexts",
+    "option_mismatches",
+    "count_array_mismatches",
+)
 
 N = 9
 ROW_SIZE = 4
@@ -153,6 +179,20 @@ def assert_expected_branch_option_payload(payload: Mapping[str, Any]) -> None:
     for key, value in expected.items():
         if summary.get(key) != value:
             raise AssertionError(f"{key} mismatch: {summary.get(key)!r} != {value!r}")
+
+
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without mismatch examples."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    branch_audit = payload.get("branch_option_audit")
+    if isinstance(branch_audit, Mapping):
+        summary["branch_option_audit_summary"] = {
+            key: branch_audit[key]
+            for key in BRANCH_OPTION_SUMMARY_KEYS
+            if key in branch_audit
+        }
+    return summary
 
 
 def _fixed_order_no_vertex_circle_replay() -> dict[str, Any]:
@@ -374,7 +414,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without mismatch examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -385,7 +431,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_branch_option_payload(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle branch-option audit")

--- a/tests/test_n9_vertex_circle_branch_options.py
+++ b/tests/test_n9_vertex_circle_branch_options.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from scripts.check_n9_vertex_circle_branch_options import (
@@ -10,9 +15,12 @@ from scripts.check_n9_vertex_circle_branch_options import (
     EXPECTED_OPTION_CONTEXTS,
     assert_expected_branch_option_payload,
     branch_option_payload,
+    summary_json_payload,
 )
 
 pytestmark = pytest.mark.slow
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
@@ -43,3 +51,36 @@ def test_branch_option_rejects_top_level_claim_scope_append(
 
     with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected_branch_option_payload(tampered)
+
+
+def test_branch_option_summary_json_payload(payload: dict[str, object]) -> None:
+    summary = summary_json_payload(payload)
+
+    assert "branch_option_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit = summary["branch_option_audit_summary"]
+    assert audit["nodes_visited"] == EXPECTED_NODES_VISITED
+    assert audit["option_contexts"] == EXPECTED_OPTION_CONTEXTS
+    assert audit["option_mismatches"] == 0
+    assert audit["count_array_mismatches"] == 0
+    assert "example_mismatches" not in audit
+    assert summary["validation_status"] == "passed"
+
+
+def test_branch_option_cli_summary_json(payload: dict[str, object]) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_branch_options.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_branch_options.py` as a compact reviewer-facing view without mismatch examples.
- Kept `--json` as the full payload path with `example_mismatches`.
- Added helper/CLI tests and updated branch-option review docs to prefer the compact command.

## Claim scope and evidence level
- Scope remains review-pending branch-option implementation auditing for the n=9 vertex-circle checker.
- This does not prove dynamic-MRO branch coverage, audit strict-edge geometry, review selected-distance quotient soundness, prove n=9, claim a counterexample, or update the official/global status.

## Commands run
- `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_branch_options.py -q -m slow`
- `python -m ruff check scripts/check_n9_vertex_circle_branch_options.py tests/test_n9_vertex_circle_branch_options.py`
- `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked compact and full JSON output for the n=9 branch-option audit.
- Checked the slow branch-option pytest module explicitly with `-m slow`.
- No generated artifacts were changed.

## Known limitations / next review steps
- The summary JSON is a compact view over fixed-order helper-option agreement only.
- Full mismatch examples remain available through `--json`.
- Dynamic-MRO coverage, vertex-circle pruning, strict-edge geometry, quotient soundness, and independent n=9 review remain open.