### PR TITLE
Add summary JSON for n9 branch audits

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1126,21 +1126,22 @@ checks the stored 184 frontier assignments directly. It records zero row-shape,
 center-coverage, crossing, witness-pair-cap, and selected-indegree-cap errors;
 this is stored-frontier diagnostics only.
 The branch-option audit
-`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
 checks 520,598 no-vertex-circle fixed-order option contexts and finds zero
 helper/direct option mismatches and zero maintained-count mismatches. This is
 branch-option implementation diagnostics only. The dynamic-MRO choice audit
-`scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json`
 checks the actual minimum-remaining-options center choice on both dynamic
 searches. It recomputes all unassigned-center option lists at every reached
 state, finds zero center-choice mismatches, zero helper/direct option
 mismatches, and zero maintained-count mismatches. This is branch-choice
 implementation diagnostics only. The frontier-coverage crosswalk
-`scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json`
 reruns the dynamic no-vertex-circle brancher and verifies that its 184
 complete selected-row assignments match the stored frontier classification
 artifact row-for-row, with zero status mismatches. This is stored-frontier
-coverage bookkeeping only. The dihedral-orbit audit
+coverage bookkeeping only; use `--json` for the full audit records. The
+dihedral-orbit audit
 `scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
 independently replays the 18 dihedral relabelings for the stored motif-family
 representatives and cross-checks the 184 frontier-classification rows against

--- a/STATE.md
+++ b/STATE.md
@@ -715,22 +715,23 @@ coverage, row-pair intersection/crossing, witness-pair capacity, and
 selected-indegree capacity. It is stored-frontier diagnostics only, not
 frontier coverage or brancher soundness.
 The branch-option audit
-`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
 walks the fixed-order no-vertex-circle search states and compares
 `valid_options_for_center` plus maintained count arrays against a direct
 implementation. It is a branch-option implementation audit only, not
 dynamic-MRO coverage or vertex-circle geometry review. The dynamic-MRO choice
 audit
-`scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json`
 replays the actual minimum-remaining-options center choice with and without
 vertex-circle pruning. It checks direct all-center option counts, first-minimum
 tie breaking, and maintained count arrays at every reached state; it is still
 branch-choice implementation diagnostics only. The frontier-coverage crosswalk
-`scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json`
 reruns the dynamic no-vertex-circle brancher and compares the generated 184
 complete selected-row assignments, in order, with the stored frontier
 motif-classification artifact. It is coverage bookkeeping against the current
-brancher, not filter soundness or a proof of `n=9`. The dihedral-orbit audit
+brancher, not filter soundness or a proof of `n=9`. Use `--json` instead for
+the full audit records and histograms. The dihedral-orbit audit
 `scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
 then treats the stored motif and frontier-classification artifacts as inputs,
 replays the dihedral relabeling action independently, and checks canonical

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2001,7 +2001,7 @@ row shape, row-pair crossing, witness-pair capacity, and selected-indegree
 capacity. It also compares the maintained selected-indegree and witness-pair
 count arrays with independently recomputed counts.
 
-When run with `--check --assert-expected --json`, the audit visits `520,782`
+When run with `--check --assert-expected --summary-json`, the audit visits `520,782`
 fixed-order no-vertex-circle nodes and reaches `184` full assignments with
 status counts `158` self-edge and `26` strict-cycle. It checks `520,598` option
 contexts, `520,712` helper options in total, and `297,936` empty-option
@@ -2011,7 +2011,8 @@ assignment identities against the stored frontier artifact. It does not prove
 dynamic-MRO branch coverage, strict-edge geometry, selected-distance quotient
 soundness, `n=9`, a counterexample, or any official/global status update. Check
 it with
-`python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full mismatch example block is needed.
 
 ### n=9 vertex-circle dynamic-MRO choice audit
 
@@ -2025,7 +2026,7 @@ with a direct row-shape, row-pair crossing, witness-pair capacity, and
 selected-indegree predicate, and checks that the brancher chooses the first
 center with the minimum remaining options.
 
-When run with `--check --assert-expected --json`, the vertex-circle-pruned
+When run with `--check --assert-expected --summary-json`, the vertex-circle-pruned
 audit visits `16,752` nodes and checks `16,752` choice contexts, `93,837`
 center-option contexts, and `751,918` helper options, with `22,282`
 child-prune attempts and status counts `11,271` partial self-edge and `11,011`
@@ -2038,7 +2039,8 @@ option mismatches, and zero count-array mismatches. This is dynamic
 branch-choice implementation diagnostics only. It does not prove the geometric
 filters, strict-edge geometry, selected-distance quotient soundness, `n=9`, a
 counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full depth and tie histograms are needed.
 
 ### n=9 vertex-circle frontier-coverage crosswalk
 
@@ -2050,7 +2052,7 @@ pruning and compares the generated complete selected-witness assignments,
 as ordered rows, against the stored frontier motif-classification artifact
 `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
 
-When run with `--check --assert-expected --json`, the crosswalk visits
+When run with `--check --assert-expected --summary-json`, the crosswalk visits
 `100,817` dynamic no-vertex-circle nodes. It generates `184` complete
 assignments, all unique, and compares them with `184` stored assignments, also
 all unique. It reports `sequence_matches = true`, `set_matches = true`, zero
@@ -2064,7 +2066,8 @@ a frontier coverage crosswalk against the current brancher only. It does not
 prove filter soundness, dynamic brancher soundness, strict-edge geometry,
 selected-distance quotient soundness, `n=9`, a counterexample, or any
 official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full mismatch example block is needed.
 
 ### n=9 vertex-circle dihedral-orbit audit
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -119,17 +119,20 @@ Use this queue when no more specific issue is selected.
    selected-indegree cap tables; use `--json` when the full histogram blocks
    are needed.
    The branch-option audit
-   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
    checks fixed-order no-vertex-circle helper options and maintained count
-   arrays against a direct predicate implementation.
+   arrays against a direct predicate implementation; use `--json` when the
+   full mismatch example block is needed.
    The dynamic-MRO choice audit
-   `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json`
    checks the actual minimum-remaining-options center choice against direct
-   all-center option counts and first-minimum tie breaking.
+   all-center option counts and first-minimum tie breaking; use `--json` when
+   the full depth and tie histograms are needed.
    The frontier-coverage crosswalk
-   `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json`
    compares regenerated dynamic no-vertex complete assignments with the
-   stored frontier classification artifact.
+   stored frontier classification artifact; use `--json` when the full
+   mismatch example block is needed.
    The dihedral-orbit audit
    `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
    independently checks the stored 16 motif representatives, their labelled
@@ -498,20 +501,23 @@ Use this queue when no more specific issue is selected.
    separate review scopes. Use `--json` when the full histogram blocks are
    needed.
    The branch-option command,
-   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`,
    covers only fixed-order no-vertex-circle helper-option agreement and
    maintained count arrays; dynamic-MRO coverage and vertex-circle pruning
-   remain separate review scopes.
+   remain separate review scopes. Use `--json` when the full mismatch example
+   block is needed.
    The dynamic-MRO choice command,
-   `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json`,
    covers only the actual dynamic center-choice implementation and all-center
    option-count agreement; filter soundness, vertex-circle geometry, and
-   quotient soundness remain separate review scopes.
+   quotient soundness remain separate review scopes. Use `--json` when the full
+   depth and tie histograms are needed.
    The frontier-coverage crosswalk command,
-   `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json`,
    covers only generated-vs-stored frontier row agreement for the current
    dynamic brancher; filter soundness, vertex-circle geometry, and quotient
-   soundness remain separate review scopes.
+   soundness remain separate review scopes. Use `--json` when the full
+   mismatch example block is needed.
    The dihedral-orbit audit command,
    `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`,
    covers only stored motif-family orbit bookkeeping and assignment-to-orbit

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -113,7 +113,7 @@ For the vertex-circle route:
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -153,7 +153,7 @@ The branch-option audit command checks the branch helper against a direct
 implementation on fixed-order no-vertex-circle search states:
 
 ```bash
-python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json
 ```
 
 It walks 520,598 nonterminal option contexts, compares
@@ -161,12 +161,13 @@ It walks 520,598 nonterminal option contexts, compares
 capacity, and selected-indegree predicates, and also compares maintained count
 arrays with direct recomputation. This is branch-option implementation
 diagnostics only, not dynamic-MRO branch coverage, strict-edge geometry,
-quotient soundness, or a completed `n=9` review.
+quotient soundness, or a completed `n=9` review. Use `--json` instead when the
+full mismatch example block is needed.
 
 The dynamic-MRO choice audit command checks the actual dynamic branch choice:
 
 ```bash
-python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json
 ```
 
 It replays the vertex-circle-pruned search and the no-vertex-circle
@@ -175,13 +176,14 @@ predicate at every reached state, and checks first-minimum tie breaking. It
 records zero center-choice mismatches, zero helper/direct option mismatches,
 and zero maintained-count mismatches. This is dynamic branch-choice
 implementation diagnostics only, not filter soundness, strict-edge geometry,
-quotient soundness, or a completed `n=9` review.
+quotient soundness, or a completed `n=9` review. Use `--json` instead when the
+full depth and tie histograms are needed.
 
 The frontier-coverage crosswalk command compares regenerated dynamic frontier
 rows against the stored motif-classification artifact:
 
 ```bash
-python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
 ```
 
 It reruns the dynamic no-vertex-circle brancher, collects the 184 complete
@@ -189,7 +191,8 @@ selected-row assignments, and checks that the generated row sequence, row set,
 and vertex-circle status labels match the stored frontier classification. This
 is stored-frontier coverage bookkeeping against the current brancher, not
 filter soundness, strict-edge geometry, quotient soundness, or a completed
-`n=9` review.
+`n=9` review. Use `--json` instead when the full mismatch example block is
+needed.
 
 The compact independent brancher command gives a smaller second audit path:
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -165,37 +165,39 @@ when the full histogram blocks are needed.
 Current branch-option audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json
 ```
 
 This command walks the no-vertex-circle fixed-order search states and compares
 the helper `valid_options_for_center` predicate and maintained count arrays
 against a direct implementation. It does not prove dynamic-MRO branch coverage,
 strict-edge geometry, selected-distance quotient soundness, `n=9`, or complete
-review.
+review. Use `--json` instead when the full mismatch example block is needed.
 
 Current dynamic-MRO choice audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json
 ```
 
 This command replays the actual minimum-remaining-options branch choice with
 and without vertex-circle pruning. It recomputes all unassigned-center option
 lists directly at every reached state and checks first-minimum tie breaking.
 It does not prove filter soundness, strict-edge geometry, selected-distance
-quotient soundness, `n=9`, or complete review.
+quotient soundness, `n=9`, or complete review. Use `--json` instead when the
+full depth and tie histograms are needed.
 
 Current frontier-coverage crosswalk:
 
 ```bash
-python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
 ```
 
 This command reruns the dynamic no-vertex-circle brancher and compares the 184
 generated complete selected-row assignments with the stored frontier
 classification artifact. It does not prove filter soundness, strict-edge
-geometry, selected-distance quotient soundness, `n=9`, or complete review.
+geometry, selected-distance quotient soundness, `n=9`, or complete review. Use
+`--json` instead when the full mismatch example block is needed.
 
 Current Kalmanson self-edge replay:
 

--- a/scripts/check_n9_vertex_circle_branch_options.py
+++ b/scripts/check_n9_vertex_circle_branch_options.py
@@ -38,6 +38,32 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "pair_cap",
+    "max_selected_indegree",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+BRANCH_OPTION_SUMMARY_KEYS = (
+    "row_order_rule",
+    "vertex_circle_pruning",
+    "nodes_visited",
+    "full_assignments",
+    "status_counts",
+    "option_contexts",
+    "helper_option_total",
+    "empty_option_contexts",
+    "option_mismatches",
+    "count_array_mismatches",
+)
 
 N = 9
 ROW_SIZE = 4
@@ -357,6 +383,18 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = payload.get("branch_option_audit")
+    if isinstance(audit, Mapping):
+        summary["branch_option_audit_summary"] = {
+            key: audit[key] for key in BRANCH_OPTION_SUMMARY_KEYS if key in audit
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["branch_option_audit"]
     return [
@@ -374,7 +412,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON summary",
+    )
     return parser.parse_args(argv)
 
 
@@ -385,7 +429,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_branch_option_payload(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle branch-option audit")

--- a/scripts/check_n9_vertex_circle_dynamic_mro_choices.py
+++ b/scripts/check_n9_vertex_circle_dynamic_mro_choices.py
@@ -40,6 +40,37 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "pair_cap",
+    "max_selected_indegree",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+DYNAMIC_MRO_SUMMARY_KEYS = (
+    "row_order_rule",
+    "vertex_circle_pruning",
+    "row0_choices",
+    "nodes_visited",
+    "full_assignments",
+    "counts",
+    "choice_contexts",
+    "center_option_contexts",
+    "helper_option_total",
+    "empty_choice_contexts",
+    "child_prune_attempts",
+    "chosen_center_mismatches",
+    "chosen_option_mismatches",
+    "helper_direct_option_mismatches",
+    "count_array_mismatches",
+)
 
 N = 9
 ROW_SIZE = 4
@@ -512,6 +543,23 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without histograms."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audits = payload.get("dynamic_mro_audits")
+    if isinstance(audits, Mapping):
+        summary["dynamic_mro_audit_summaries"] = {
+            audit_key: {
+                key: audit[key]
+                for key in DYNAMIC_MRO_SUMMARY_KEYS
+                if isinstance(audit, Mapping) and key in audit
+            }
+            for audit_key, audit in audits.items()
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     audits = payload["dynamic_mro_audits"]
     with_vertex = audits["with_vertex_circle_pruning"]
@@ -533,7 +581,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without histograms",
+    )
     return parser.parse_args(argv)
 
 
@@ -544,7 +598,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_dynamic_mro_choice_payload(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle dynamic MRO choice audit")

--- a/scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py
+++ b/scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py
@@ -46,6 +46,39 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "source_artifact",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+FRONTIER_COVERAGE_SUMMARY_KEYS = (
+    "row_order_rule",
+    "vertex_circle_pruning",
+    "nodes_visited",
+    "generated_assignment_count",
+    "stored_assignment_count",
+    "generated_unique_assignment_count",
+    "stored_unique_assignment_count",
+    "generated_status_counts",
+    "stored_status_counts",
+    "sequence_matches",
+    "set_matches",
+    "status_mismatches",
+    "missing_from_stored_count",
+    "extra_in_stored_count",
+    "generated_sorted_rows_sha256",
+    "stored_sorted_rows_sha256",
+    "generated_sequence_rows_sha256",
+    "stored_sequence_rows_sha256",
+)
 
 EXPECTED_NODES_VISITED = 100_817
 EXPECTED_ASSIGNMENT_COUNT = 184
@@ -365,6 +398,20 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    crosswalk = payload.get("frontier_coverage_crosswalk")
+    if isinstance(crosswalk, Mapping):
+        summary["frontier_coverage_crosswalk_summary"] = {
+            key: crosswalk[key]
+            for key in FRONTIER_COVERAGE_SUMMARY_KEYS
+            if key in crosswalk
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["frontier_coverage_crosswalk"]
     return [
@@ -388,7 +435,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--frontier-classification", type=Path, default=DEFAULT_FRONTIER_CLASSIFICATION)
     parser.add_argument("--check", action="store_true", help="validate the crosswalk")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON summary",
+    )
     return parser.parse_args(argv)
 
 
@@ -412,7 +465,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_frontier_coverage_crosswalk(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle frontier coverage crosswalk")

--- a/tests/test_n9_vertex_circle_branch_options.py
+++ b/tests/test_n9_vertex_circle_branch_options.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from scripts.check_n9_vertex_circle_branch_options import (
@@ -10,9 +15,11 @@ from scripts.check_n9_vertex_circle_branch_options import (
     EXPECTED_OPTION_CONTEXTS,
     assert_expected_branch_option_payload,
     branch_option_payload,
+    summary_json_payload,
 )
 
 pytestmark = pytest.mark.slow
+ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
@@ -43,3 +50,35 @@ def test_branch_option_rejects_top_level_claim_scope_append(
 
     with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected_branch_option_payload(tampered)
+
+
+def test_branch_option_summary_json_payload(payload: dict[str, object]) -> None:
+    summary = summary_json_payload(payload)
+
+    assert "branch_option_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit_summary = summary["branch_option_audit_summary"]
+    assert audit_summary["nodes_visited"] == EXPECTED_NODES_VISITED
+    assert audit_summary["option_contexts"] == EXPECTED_OPTION_CONTEXTS
+    assert audit_summary["option_mismatches"] == 0
+    assert audit_summary["count_array_mismatches"] == 0
+    assert "example_mismatches" not in audit_summary
+
+
+def test_branch_option_cli_summary_json(payload: dict[str, object]) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_branch_options.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)

--- a/tests/test_n9_vertex_circle_dynamic_mro_choices.py
+++ b/tests/test_n9_vertex_circle_dynamic_mro_choices.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from scripts.check_n9_vertex_circle_dynamic_mro_choices import (
@@ -8,9 +13,11 @@ from scripts.check_n9_vertex_circle_dynamic_mro_choices import (
     EXPECTED_WITHOUT_VERTEX,
     assert_expected_dynamic_mro_choice_payload,
     dynamic_mro_choice_payload,
+    summary_json_payload,
 )
 
 pytestmark = pytest.mark.slow
+ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
@@ -44,3 +51,39 @@ def test_dynamic_mro_rejects_top_level_claim_scope_append(
 
     with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected_dynamic_mro_choice_payload(tampered)
+
+
+def test_dynamic_mro_summary_json_payload(payload: dict[str, object]) -> None:
+    summary = summary_json_payload(payload)
+
+    assert "dynamic_mro_audits" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audits = summary["dynamic_mro_audit_summaries"]
+    with_vertex = audits["with_vertex_circle_pruning"]
+    without_vertex = audits["without_vertex_circle_pruning"]
+    assert with_vertex["nodes_visited"] == EXPECTED_WITH_VERTEX["nodes_visited"]
+    assert without_vertex["nodes_visited"] == EXPECTED_WITHOUT_VERTEX["nodes_visited"]
+    assert with_vertex["helper_direct_option_mismatches"] == 0
+    assert without_vertex["helper_direct_option_mismatches"] == 0
+    assert "assigned_depth_histogram" not in with_vertex
+    assert "minimum_option_count_histogram" not in without_vertex
+    assert "example_mismatches" not in with_vertex
+
+
+def test_dynamic_mro_cli_summary_json(payload: dict[str, object]) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_dynamic_mro_choices.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)

--- a/tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py
+++ b/tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from scripts.check_n9_vertex_circle_frontier_coverage_crosswalk import (
@@ -9,9 +14,11 @@ from scripts.check_n9_vertex_circle_frontier_coverage_crosswalk import (
     EXPECTED_SORTED_ROWS_SHA256,
     assert_expected_frontier_coverage_crosswalk,
     frontier_coverage_crosswalk_payload,
+    summary_json_payload,
 )
 
 pytestmark = pytest.mark.slow
+ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture(scope="module")
@@ -45,3 +52,40 @@ def test_frontier_coverage_crosswalk_rejects_top_level_claim_scope_append(
 
     with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected_frontier_coverage_crosswalk(tampered)
+
+
+def test_frontier_coverage_crosswalk_summary_json_payload(
+    payload: dict[str, object],
+) -> None:
+    summary = summary_json_payload(payload)
+
+    assert "frontier_coverage_crosswalk" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    crosswalk = summary["frontier_coverage_crosswalk_summary"]
+    assert crosswalk["generated_assignment_count"] == EXPECTED_ASSIGNMENT_COUNT
+    assert crosswalk["stored_assignment_count"] == EXPECTED_ASSIGNMENT_COUNT
+    assert crosswalk["sequence_matches"] is True
+    assert crosswalk["generated_sorted_rows_sha256"] == EXPECTED_SORTED_ROWS_SHA256
+    assert crosswalk["generated_sequence_rows_sha256"] == EXPECTED_SEQUENCE_ROWS_SHA256
+    assert "example_mismatches" not in crosswalk
+
+
+def test_frontier_coverage_crosswalk_cli_summary_json(
+    payload: dict[str, object],
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == summary_json_payload(payload)


### PR DESCRIPTION
## Summary
- add compact `--summary-json` modes for the n=9 branch-option, dynamic-MRO, and frontier-coverage audit scripts
- keep full `--json` payloads available for complete audit records and histograms
- update reviewer-facing docs and tests for the compact output paths

## Verification
- `.venv/bin/python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json`
- `.venv/bin/python -m pytest tests/test_n9_vertex_circle_branch_options.py tests/test_n9_vertex_circle_dynamic_mro_choices.py tests/test_n9_vertex_circle_frontier_coverage_crosswalk.py -q -m slow`
- `make verify-fast PYTHON=.venv/bin/python`

Note: plain `make verify-fast` fails in this checkout because `python` is not on PATH; the same target passes with `PYTHON=.venv/bin/python`.