### PR TITLE
Add summary JSON for n9 geometry audits

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1091,10 +1091,11 @@ also closes the vertex-circle-pruned search and reaches the same
 `184 = 158 + 26` pre-vertex-circle frontier classification as the dynamic
 minimum-remaining-options artifact. This checks branch-order agreement only.
 The strict-edge geometry audit
-`scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
 checks that every candidate selected row produces exactly the proper-interval
 strict inequalities used by the checker, with `5,670` total local strict
-edges across 630 candidate rows. This is local rule verification only.
+edges across 630 candidate rows. This is local rule verification only; use
+`--json` when the full mismatch example block is needed.
 The incidence-filter audit
 `scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
 checks the row-level two-overlap crossing table, witness-pair cap predicate,
@@ -1102,11 +1103,12 @@ and selected-indegree cap predicate. This is row-filter implementation
 agreement only. Use `--json` instead when the full histogram blocks are
 needed.
 The quotient-soundness audit
-`scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`
 checks that the stored local-core rows and 184 stored frontier assignments get
 the same selected-distance quotient status from the exhaustive checker, the
 reusable replay helper, and a small direct replay. This is implementation
-agreement only.
+agreement only; use `--json` when the full per-view status and mismatch
+example blocks are needed.
 The closed-descent packet
 `scripts/check_n9_vertex_circle_closed_descent_packet.py --check --assert-expected --json`
 turns the 16 stored compact local-core quotient obstructions into checked

--- a/STATE.md
+++ b/STATE.md
@@ -682,9 +682,10 @@ A fixed-center-order replay,
 checks agreement with the dynamic minimum-remaining-options brancher on the
 closed search and 184-frontier classification. It is also a review aid only.
 The strict-edge geometry audit
-`scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
 checks the local proper-interval inequality generator for all 630 candidate
-selected rows, while leaving quotient and coverage review separate.
+selected rows, while leaving quotient and coverage review separate. Use
+`--json` instead when the full mismatch example block is needed.
 The incidence-filter audit
 `scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
 checks the row-level two-overlap crossing table, witness-pair cap predicate,
@@ -692,10 +693,12 @@ and selected-indegree cap predicate, while leaving branch replay and
 vertex-circle pruning review separate. Use `--json` instead when the full
 histogram blocks are needed.
 The quotient-soundness audit
-`scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`
 checks selected-distance quotient status agreement on the stored local-core
 rows, stored full frontier assignments, and stored transformed frontier cores.
-It leaves branch coverage and strict-edge geometry review separate.
+It leaves branch coverage and strict-edge geometry review separate. Use
+`--json` instead when the full per-view status and mismatch example blocks are
+needed.
 The closed-descent packet
 `scripts/check_n9_vertex_circle_closed_descent_packet.py --check --assert-expected --json`
 replays the 16 compact local-core representatives as finite closed-descent

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1893,7 +1893,7 @@ review-pending `n=9` vertex-circle checker. It compares that direct
 enumeration with the checker strict-edge table and with the one-row quotient
 replay strict-edge counts.
 
-When run with `--check --assert-expected --json`, the audit checks `630`
+When run with `--check --assert-expected --summary-json`, the audit checks `630`
 candidate selected rows, finds `9` strict edges per row, and records `5,670`
 total strict edges. The interval-span histogram is `2->1: 2,520`, `3->1:
 1,890`, and `3->2: 1,260`, with zero strict-edge table mismatches and zero
@@ -1901,7 +1901,8 @@ one-row quotient replay strict-edge count mismatches. This audits only the
 local proper-interval strict-edge generator. It does not prove row coverage,
 brancher coverage, selected-distance quotient soundness, `n=9`, a
 counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full mismatch example block is needed.
 
 ### n=9 vertex-circle quotient-soundness audit
 
@@ -1914,7 +1915,7 @@ and a small direct local quotient/status replay. It runs on the stored compact
 local-core packet, the stored `184` pre-vertex-circle frontier assignments, and
 the transformed frontier cores from the motif-classification artifact.
 
-When run with `--check --assert-expected --json`, the audit checks `16`
+When run with `--check --assert-expected --summary-json`, the audit checks `16`
 local-core row sets with `67` selected rows and status counts `13` self-edge /
 `3` strict-cycle; `184` full frontier row sets with `1,656` selected rows and
 status counts `158` self-edge / `26` strict-cycle; and `184` transformed
@@ -1922,7 +1923,9 @@ frontier cores with `802` selected rows and the same `158` / `26` status split.
 This is selected-distance quotient implementation agreement only. It does not
 prove row coverage, brancher coverage, strict-edge geometry, `n=9`, a
 counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`.
+Use `--json` instead when the full per-view status and mismatch example blocks
+are needed.
 
 ### n=9 vertex-circle closed-descent packet
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -100,13 +100,15 @@ Use this queue when no more specific issue is selected.
    now reruns the same filters with fixed center order and checks agreement
    with the dynamic minimum-remaining-options artifact.
    The strict-edge geometry replay
-   `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
    independently checks the proper-interval strict-edge generator for all
-   candidate selected rows.
+   candidate selected rows; use `--json` when the full mismatch example block
+   is needed.
    The quotient-soundness replay
-   `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`
    checks selected-distance quotient status agreement on the stored local-core
-   and frontier rows.
+   and frontier rows; use `--json` when the full per-view status and mismatch
+   example blocks are needed.
    The Kalmanson self-edge independent replay
    `python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json`
    treats the stored `n9_kalmanson_selfedge` certificate as input data and
@@ -486,14 +488,16 @@ Use this queue when no more specific issue is selected.
    covers the branch-order checklist item only; the pruning lemmas and
    vertex-circle certificates still need separate review.
    The strict-edge geometry command,
-   `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`,
    covers the local vertex-circle strict-edge generator only; quotient
-   soundness and exhaustive coverage still need separate review.
+   soundness and exhaustive coverage still need separate review. Use `--json`
+   when the full mismatch example block is needed.
    The quotient-soundness command,
-   `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`,
    covers selected-distance quotient status agreement on stored local-core and
    frontier rows only; branch coverage and strict-edge geometry remain separate
-   review scopes.
+   review scopes. Use `--json` when the full per-view status and mismatch
+   example blocks are needed.
    The incidence-filter command,
    `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`,
    covers only row-level two-overlap crossing, witness-pair capacity, and

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -114,8 +114,8 @@ python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
-python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
-python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 ```
 

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -290,24 +290,27 @@ The strict-edge geometry audit command checks the local vertex-circle
 inequality generator:
 
 ```bash
-python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
 ```
 
 It independently enumerates proper interval containments for all 630 candidate
 selected rows and compares them with the checker strict-edge table. This is a
 local geometry-rule audit only, not selected-distance quotient or exhaustive
-coverage review.
+coverage review. Use `--json` instead when the full mismatch example block is
+needed.
 
 The quotient-soundness audit command checks selected-distance quotient status
 agreement on the stored local-core and frontier rows:
 
 ```bash
-python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
 ```
 
 It compares the exhaustive checker, the reusable quotient replay helper, and a
 small direct quotient/status replay. This is implementation agreement only, not
-branch coverage, strict-edge geometry, or a completed `n=9` review.
+branch coverage, strict-edge geometry, or a completed `n=9` review. Use
+`--json` instead when the full per-view status and mismatch example blocks are
+needed.
 
 The partial-pruning audit command checks stored-frontier row subsets:
 

--- a/docs/n9-vertex-circle-quotient-soundness-audit.md
+++ b/docs/n9-vertex-circle-quotient-soundness-audit.md
@@ -153,7 +153,7 @@ either obstruction is already a contradiction.
 The audit is now replayable:
 
 ```bash
-python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
 ```
 
 The script compares three status implementations on the stored local-core
@@ -162,6 +162,8 @@ checker, the reusable quotient replay helper, and a small direct
 quotient/status replay inside the audit command. It also checks the transformed
 core rows stored in the frontier-classification artifact. This is an
 implementation-agreement audit only, not branch coverage or geometry review.
+Use `--json` instead when the full per-view status and mismatch example blocks
+are needed.
 
 The closed-descent packet is also replayable:
 

--- a/docs/n9-vertex-circle-strict-edge-geometry-audit.md
+++ b/docs/n9-vertex-circle-strict-edge-geometry-audit.md
@@ -123,13 +123,14 @@ total strict edges 5670
 The same audit is now replayable:
 
 ```bash
-python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
 ```
 
 The script independently enumerates every proper interval containment for all
 `9 * binom(8,4) = 630` candidate selected rows, compares the resulting strict
 edge table with `src/erdos97/n9_vertex_circle_exhaustive.py`, and checks that
 the quotient replay implementation records the same one-row strict-edge count.
+Use `--json` instead when the full mismatch example block is needed.
 It preserves the same scope boundary as this note: local strict-edge geometry
 only, not quotient soundness or exhaustive coverage.
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -292,26 +292,28 @@ not prove the filters, independently replay vertex-circle geometry, prove
 Current strict-edge geometry audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
 ```
 
 This command independently enumerates all proper interval containments for the
 630 candidate selected rows and compares them with the checker strict-edge
 table. It addresses the vertex-circle strict-edge generator only; it does not
 review selected-distance quotient soundness, branch coverage, the crossing
-filters, prove `n=9`, or complete review.
+filters, prove `n=9`, or complete review. Use `--json` instead when the full
+mismatch example block is needed.
 
 Current quotient-soundness audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
 ```
 
 This command checks stored local-core rows, stored full frontier assignments,
 and stored transformed frontier cores against three quotient/status views: the
 exhaustive checker, the reusable quotient replay helper, and a small direct
 quotient/status replay. It does not audit branch coverage, strict-edge
-geometry, prove `n=9`, or complete review.
+geometry, prove `n=9`, or complete review. Use `--json` instead when the full
+per-view status and mismatch example blocks are needed.
 
 Current partial-pruning audit:
 

--- a/scripts/check_n9_vertex_circle_quotient_soundness.py
+++ b/scripts/check_n9_vertex_circle_quotient_soundness.py
@@ -52,6 +52,33 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "source_artifacts",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+QUOTIENT_SECTION_SUMMARY_KEYS = (
+    "label",
+    "row_set_count",
+    "selected_row_total",
+    "spoke_pairs_checked",
+    "status_counts",
+    "strict_edge_count_histogram",
+    "replay_self_edge_conflict_records",
+    "replay_cycle_edge_records",
+    "direct_self_edge_records",
+    "direct_strict_cycle_row_sets",
+    "row_equality_component_violations",
+    "status_mismatches",
+)
 
 EXPECTED_LOCAL_CORE = {
     "row_set_count": 16,
@@ -486,6 +513,25 @@ def _has_directed_cycle(edges: Sequence[tuple[Pair, Pair]]) -> bool:
     return any(color.get(node, 0) == 0 and visit(node) for node in sorted(graph))
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without mismatch examples."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    for section_key in (
+        "local_core_packet",
+        "frontier_full_assignments",
+        "frontier_core_assignments",
+    ):
+        section = payload.get(section_key)
+        if isinstance(section, Mapping):
+            summary[f"{section_key}_summary"] = {
+                key: section[key]
+                for key in QUOTIENT_SECTION_SUMMARY_KEYS
+                if key in section
+            }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     return [
         f"schema: {payload['schema']}",
@@ -510,7 +556,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without mismatch examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -534,7 +586,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_quotient_soundness(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle quotient soundness audit")

--- a/scripts/check_n9_vertex_circle_strict_edge_geometry.py
+++ b/scripts/check_n9_vertex_circle_strict_edge_geometry.py
@@ -40,6 +40,24 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "selected_rows_checked",
+    "strict_edge_mismatches",
+    "quotient_replay_strict_edge_mismatches",
+    "strict_edges_per_row",
+    "interval_span_histogram",
+    "total_strict_edges",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
 
 EXPECTED_SELECTED_ROWS = 630
 EXPECTED_STRICT_EDGES_PER_ROW = {9: 630}
@@ -245,6 +263,12 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> bo
     return True
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without mismatch examples."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     return [
         f"schema: {payload['schema']}",
@@ -260,7 +284,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without mismatch examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -271,7 +301,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_strict_edge_geometry(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle strict-edge geometry audit")

--- a/tests/test_n9_vertex_circle_quotient_soundness.py
+++ b/tests/test_n9_vertex_circle_quotient_soundness.py
@@ -17,6 +17,7 @@ from scripts.check_n9_vertex_circle_quotient_soundness import (
     assert_expected_quotient_soundness,
     direct_quotient_result,
     quotient_soundness_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -90,3 +91,45 @@ def test_quotient_soundness_cli_json() -> None:
     assert parsed["frontier_full_assignments"]["strict_edge_count_histogram"] == {
         "81": 184
     }
+
+
+def test_quotient_soundness_summary_json_payload() -> None:
+    payload = quotient_soundness_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "local_core_packet" not in summary
+    assert "frontier_full_assignments" not in summary
+    assert "frontier_core_assignments" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    local_core = summary["local_core_packet_summary"]
+    frontier_full = summary["frontier_full_assignments_summary"]
+    frontier_core = summary["frontier_core_assignments_summary"]
+    assert local_core["row_set_count"] == EXPECTED_LOCAL_CORE["row_set_count"]
+    assert frontier_full["selected_row_total"] == EXPECTED_FRONTIER_FULL["selected_row_total"]
+    assert frontier_core["spoke_pairs_checked"] == EXPECTED_FRONTIER_CORE["spoke_pairs_checked"]
+    assert frontier_full["status_mismatches"] == 0
+    assert "recorded_status_counts" not in frontier_full
+    assert "example_mismatches" not in frontier_core
+    assert summary["validation_status"] == "passed"
+
+
+def test_quotient_soundness_cli_summary_json() -> None:
+    payload = quotient_soundness_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_quotient_soundness.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected

--- a/tests/test_n9_vertex_circle_strict_edge_geometry.py
+++ b/tests/test_n9_vertex_circle_strict_edge_geometry.py
@@ -17,6 +17,7 @@ from scripts.check_n9_vertex_circle_strict_edge_geometry import (
     assert_expected_strict_edge_geometry,
     direct_strict_edges,
     strict_edge_geometry_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -76,3 +77,38 @@ def test_strict_edge_geometry_cli_json() -> None:
     assert parsed["validation_status"] == "passed"
     assert parsed["selected_rows_checked"] == 630
     assert parsed["strict_edges_per_row"] == {"9": 630}
+
+
+def test_strict_edge_geometry_summary_json_payload() -> None:
+    payload = strict_edge_geometry_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "example_mismatches" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    assert summary["selected_rows_checked"] == EXPECTED_SELECTED_ROWS
+    assert summary["strict_edges_per_row"] == EXPECTED_STRICT_EDGES_PER_ROW
+    assert summary["interval_span_histogram"] == EXPECTED_SPAN_HISTOGRAM
+    assert summary["strict_edge_mismatches"] == 0
+    assert summary["validation_status"] == "passed"
+
+
+def test_strict_edge_geometry_cli_summary_json() -> None:
+    payload = strict_edge_geometry_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_strict_edge_geometry.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected


### PR DESCRIPTION
## Summary
- add compact `--summary-json` modes for the n=9 strict-edge geometry and quotient-soundness audit scripts
- keep full `--json` payloads available for mismatch examples and per-view status records
- update reviewer-facing docs to prefer compact output while leaving Makefile/audit capture on full JSON

## Verification
- `.venv/bin/python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_n9_vertex_circle_strict_edge_geometry.py --json --summary-json` (argparse rejection expected)
- `.venv/bin/python scripts/check_n9_vertex_circle_quotient_soundness.py --json --summary-json` (argparse rejection expected)
- `.venv/bin/python -m pytest tests/test_n9_vertex_circle_strict_edge_geometry.py tests/test_n9_vertex_circle_quotient_soundness.py -q`
- `.venv/bin/python -m ruff check scripts/check_n9_vertex_circle_strict_edge_geometry.py scripts/check_n9_vertex_circle_quotient_soundness.py tests/test_n9_vertex_circle_strict_edge_geometry.py tests/test_n9_vertex_circle_quotient_soundness.py`
- `make verify-fast PYTHON=.venv/bin/python`