### PR TITLE
Add summary JSON for n9 frontier audits

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1086,10 +1086,11 @@ self-edge records, assignment uniqueness, and digest agreement without
 importing the Kalmanson generator module. It is still stored-certificate
 bookkeeping only, not brancher coverage or a proof of `n=9`.
 A fixed-center-order replay command,
-`scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
+`scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json`,
 also closes the vertex-circle-pruned search and reaches the same
 `184 = 158 + 26` pre-vertex-circle frontier classification as the dynamic
-minimum-remaining-options artifact. This checks branch-order agreement only.
+minimum-remaining-options artifact. This checks branch-order agreement only;
+use `--json` when the full fixed-order replay sections are needed.
 The strict-edge geometry audit
 `scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
 checks that every candidate selected row produces exactly the proper-interval
@@ -1123,10 +1124,11 @@ assignments. It finds zero checker/replay status mismatches and zero stored
 extension violations for obstructed subsets. This is stored-frontier pruning
 diagnostics only.
 The frontier-assignment audit
-`scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
 checks the stored 184 frontier assignments directly. It records zero row-shape,
 center-coverage, crossing, witness-pair-cap, and selected-indegree-cap errors;
-this is stored-frontier diagnostics only.
+this is stored-frontier diagnostics only. Use `--json` when the full example
+error block is needed.
 The branch-option audit
 `scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
 checks 520,598 no-vertex-circle fixed-order option contexts and finds zero

--- a/STATE.md
+++ b/STATE.md
@@ -678,9 +678,10 @@ proof or source-of-truth promotion. See
 `docs/n9-regular-tournament-kalmanson-audit.md` and
 `docs/n9-one-reciprocal-kalmanson-audit.md`.
 A fixed-center-order replay,
-`scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
+`scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json`,
 checks agreement with the dynamic minimum-remaining-options brancher on the
-closed search and 184-frontier classification. It is also a review aid only.
+closed search and 184-frontier classification. It is also a review aid only;
+use `--json` when the full fixed-order replay sections are needed.
 The strict-edge geometry audit
 `scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
 checks the local proper-interval inequality generator for all 630 candidate
@@ -712,11 +713,12 @@ assignments for monotone obstruction persistence and checker/replay status
 agreement. It is stored-frontier diagnostics only and leaves frontier coverage,
 brancher soundness, strict-edge geometry, and quotient soundness separate.
 The frontier-assignment audit
-`scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
 checks the stored 184 frontier assignments directly for row shape, center
 coverage, row-pair intersection/crossing, witness-pair capacity, and
 selected-indegree capacity. It is stored-frontier diagnostics only, not
-frontier coverage or brancher soundness.
+frontier coverage or brancher soundness. Use `--json` when the full example
+error block is needed.
 The branch-option audit
 `scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --summary-json`
 walks the fixed-order no-vertex-circle search states and compares

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1871,7 +1871,7 @@ It reuses the same necessary-filter helpers and vertex-circle status helper,
 so the scope is branch-order agreement, not independent filter or geometry
 soundness.
 
-When run with `--check --assert-expected --json`, the fixed-order replay
+When run with `--check --assert-expected --summary-json`, the fixed-order replay
 closes the main search with `37,544` visited nodes and `0` full assignments.
 Its no-vertex-circle cross-check visits `520,782` nodes and leaves the same
 `184` pre-vertex-circle full assignments with the same `158` self-edge and
@@ -1880,7 +1880,8 @@ only that the fixed center order and dynamic MRO order agree on these stored
 frontier counts and classifications. It does not prove the pruning filters,
 independently replay vertex-circle geometry, prove `n=9`, claim a
 counterexample, or update the official/global status. Check it with
-`python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json`.
+Use `--json` when the full fixed-order replay sections are needed.
 
 ### n=9 vertex-circle strict-edge geometry audit
 
@@ -1978,7 +1979,7 @@ checks row shape, row-center coverage, pairwise row-intersection caps,
 two-overlap crossing, witness-pair capacity, and selected-indegree capacity on
 the stored assignments.
 
-When run with `--check --assert-expected --json`, the audit checks `184`
+When run with `--check --assert-expected --summary-json`, the audit checks `184`
 assignments and `1,656` selected rows, with status counts `158` self-edge and
 `26` strict-cycle. The center-pair intersection and witness-pair frequency
 histograms are both `0: 72`, `1: 3,168`, and `2: 3,384`; all `3,384`
@@ -1990,7 +1991,8 @@ selected-indegree-cap errors. This is stored-frontier diagnostics only. It does
 not prove frontier coverage, brancher soundness, strict-edge geometry,
 selected-distance quotient soundness, `n=9`, a counterexample, or any
 official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`.
+Use `--json` when the full example error block is needed.
 
 ### n=9 vertex-circle branch-option audit
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -96,9 +96,10 @@ Use this queue when no more specific issue is selected.
    arithmetic for the exhaustive artifact without rerunning the brancher; use
    `--json` when the full expected-count block is needed.
    The branching replay
-   `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json`
    now reruns the same filters with fixed center order and checks agreement
-   with the dynamic minimum-remaining-options artifact.
+   with the dynamic minimum-remaining-options artifact; use `--json` when the
+   full fixed-order replay sections are needed.
    The strict-edge geometry replay
    `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
    independently checks the proper-interval strict-edge generator for all
@@ -150,9 +151,10 @@ Use this queue when no more specific issue is selected.
    stored full motif representatives and already obstruct by direct quotient
    replay.
    The frontier-assignment audit
-   `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
    checks the stored 184 frontier assignments directly against row shape,
-   row-pair crossing, witness-pair capacity, and selected-indegree capacity.
+   row-pair crossing, witness-pair capacity, and selected-indegree capacity;
+   use `--json` when the full example error block is needed.
    The partial-pruning replay
    `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
    checks all nonempty selected-row subsets of the stored 184 frontier
@@ -484,9 +486,10 @@ Use this queue when no more specific issue is selected.
    lemmas, and vertex-circle certificates still need review. Use `--json`
    when the full expected-count block is needed.
    The MRO branching replay command,
-   `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json`,
    covers the branch-order checklist item only; the pruning lemmas and
-   vertex-circle certificates still need separate review.
+   vertex-circle certificates still need separate review. Use `--json` when
+   the full fixed-order replay sections are needed.
    The strict-edge geometry command,
    `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`,
    covers the local vertex-circle strict-edge generator only; quotient
@@ -545,10 +548,11 @@ Use this queue when no more specific issue is selected.
    compact-core obstruction replay; local-lemma completeness, frontier
    coverage, brancher soundness, and full n=9 review remain separate scopes.
    The frontier-assignment command,
-   `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`,
    covers only the stored 184 frontier rows under those base predicates;
    brancher coverage, strict-edge geometry, quotient soundness, and pruning
-   remain separate review scopes.
+   remain separate review scopes. Use `--json` when the full example error
+   block is needed.
 
 ## Task CB-N9-T01 - Review Vertex-Circle Self-Edge Template
 

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -265,26 +265,27 @@ The frontier-assignment audit command checks the stored 184 frontier rows
 directly against the base incidence/order filters:
 
 ```bash
-python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json
 ```
 
 It verifies row shape, center coverage, pairwise row-intersection cap,
 two-overlap crossing, witness-pair capacity, and selected-indegree capacity on
 the stored frontier assignments. This is stored-frontier diagnostics only, not
 frontier coverage, brancher soundness, strict-edge geometry, quotient
-soundness, or a completed `n=9` review.
+soundness, or a completed `n=9` review. Use `--json` when the full example
+error block is needed.
 
 The MRO branching replay command checks a separate fixed center order against
 the stored dynamic minimum-remaining-options artifact:
 
 ```bash
-python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
 ```
 
 It closes the fixed-order vertex-circle-pruned search and reaches the same
 `184 = 158 + 26` no-vertex-circle frontier classification. It is a
 branch-order audit only, not a proof of the filters or a completed `n=9`
-review.
+review. Use `--json` when the full fixed-order replay sections are needed.
 
 The strict-edge geometry audit command checks the local vertex-circle
 inequality generator:

--- a/docs/n9-vertex-circle-mro-branching-audit.md
+++ b/docs/n9-vertex-circle-mro-branching-audit.md
@@ -95,7 +95,7 @@ A replayable fixed-order audit now checks the same control-flow issue without
 calling the dynamic minimum-remaining-options brancher:
 
 ```bash
-python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
 ```
 
 The replay always chooses centers in the deterministic order `0,1,...,8`
@@ -105,6 +105,7 @@ assignments. With vertex-circle pruning disabled it visits `520,782` nodes and
 reaches the same `184` pre-vertex-circle frontier assignments, classified as
 `158` self-edges and `26` strict cycles. This checks branching agreement only;
 it does not prove the pruning lemmas or independently replay the geometry.
+Use `--json` when the full fixed-order replay sections are needed.
 
 ## Scope
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -267,19 +267,20 @@ provide a counterexample, or supply a transfer theorem.
 Current frontier-assignment audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json
 ```
 
 This command checks the stored 184 frontier assignments directly for row
 shape, center coverage, pairwise row-intersection caps, two-overlap crossing,
 witness-pair capacity, and selected-indegree capacity. It does not prove
 frontier coverage, brancher soundness, strict-edge geometry, selected-distance
-quotient soundness, `n=9`, or complete review.
+quotient soundness, `n=9`, or complete review. Use `--json` when the full
+example error block is needed.
 
 Current branching-order replay:
 
 ```bash
-python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
 ```
 
 This command reruns the search with a fixed center order `0,1,...,8` after row
@@ -287,7 +288,8 @@ This command reruns the search with a fixed center order `0,1,...,8` after row
 also closes the vertex-circle-pruned search and reaches the same `184`
 pre-vertex-circle frontier classification as the dynamic MRO artifact. It does
 not prove the filters, independently replay vertex-circle geometry, prove
-`n=9`, or complete review.
+`n=9`, or complete review. Use `--json` when the full fixed-order replay
+sections are needed.
 
 Current strict-edge geometry audit:
 

--- a/scripts/check_n9_vertex_circle_frontier_assignment_audit.py
+++ b/scripts/check_n9_vertex_circle_frontier_assignment_audit.py
@@ -39,6 +39,37 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "pair_cap",
+    "max_selected_indegree",
+    "source_artifact",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+FRONTIER_ASSIGNMENT_SUMMARY_KEYS = (
+    "assignment_count",
+    "row_count_total",
+    "status_counts",
+    "row_shape_errors",
+    "center_coverage_errors",
+    "intersection_cap_violations",
+    "two_overlap_crossing_violations",
+    "witness_pair_cap_violations",
+    "selected_indegree_cap_violations",
+    "center_pair_intersection_histogram",
+    "two_overlap_crossing_count",
+    "witness_pair_frequency_histogram",
+    "selected_indegree_value_histogram",
+    "assignment_witness_pair_profiles",
+)
 
 N = 9
 ROW_SIZE = 4
@@ -413,6 +444,18 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without example errors."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = payload.get("frontier_assignment_audit")
+    if isinstance(audit, Mapping):
+        summary["frontier_assignment_audit_summary"] = {
+            key: audit[key] for key in FRONTIER_ASSIGNMENT_SUMMARY_KEYS if key in audit
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["frontier_assignment_audit"]
     return [
@@ -436,7 +479,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without example errors",
+    )
     return parser.parse_args(argv)
 
 
@@ -452,7 +501,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_frontier_assignment_audit(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle frontier assignment audit")

--- a/scripts/check_n9_vertex_circle_mro_branching_replay.py
+++ b/scripts/check_n9_vertex_circle_mro_branching_replay.py
@@ -37,6 +37,28 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "source_artifact",
+    "review_independence",
+    "dynamic_mro_summary",
+    "comparison_summary",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+FIXED_ORDER_SUMMARY_KEYS = (
+    "row_order_rule",
+    "vertex_circle_pruning",
+    "row0_choices",
+    "nodes_visited",
+    "full_assignments",
+    "counts",
+)
 
 DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "n9_vertex_circle_exhaustive.json"
 EXPECTED_FIXED_MAIN_NODES = 37_544
@@ -330,6 +352,19 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> bo
     return True
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    for key in ("fixed_center_order_main", "fixed_center_order_cross_check"):
+        section = payload.get(key)
+        if isinstance(section, Mapping):
+            summary[f"{key}_summary"] = {
+                field: section[field] for field in FIXED_ORDER_SUMMARY_KEYS if field in section
+            }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     comparison = payload["comparison_summary"]
     return [
@@ -352,7 +387,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
     parser.add_argument("--check", action="store_true", help="validate the replay")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON summary",
+    )
     return parser.parse_args(argv)
 
 
@@ -378,7 +419,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_mro_branching_replay(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle MRO branching replay")

--- a/tests/test_n9_vertex_circle_frontier_assignment_audit.py
+++ b/tests/test_n9_vertex_circle_frontier_assignment_audit.py
@@ -15,6 +15,7 @@ from scripts.check_n9_vertex_circle_frontier_assignment_audit import (
     EXPECTED_WITNESS_PAIR_FREQUENCY_HISTOGRAM,
     assert_expected_frontier_assignment_audit,
     frontier_assignment_audit_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -87,3 +88,42 @@ def test_frontier_assignment_audit_cli_json() -> None:
     assert summary["two_overlap_crossing_violations"] == 0
     assert summary["witness_pair_cap_violations"] == 0
     assert summary["selected_indegree_cap_violations"] == 0
+
+
+def test_frontier_assignment_audit_summary_json_payload() -> None:
+    payload = frontier_assignment_audit_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "frontier_assignment_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit_summary = summary["frontier_assignment_audit_summary"]
+    assert audit_summary["assignment_count"] == 184
+    assert audit_summary["status_counts"] == {"self_edge": 158, "strict_cycle": 26}
+    assert audit_summary["witness_pair_frequency_histogram"] == (
+        EXPECTED_WITNESS_PAIR_FREQUENCY_HISTOGRAM
+    )
+    assert audit_summary["selected_indegree_cap_violations"] == 0
+    assert "example_errors" not in audit_summary
+    assert summary["validation_status"] == "passed"
+
+
+def test_frontier_assignment_audit_cli_summary_json() -> None:
+    payload = frontier_assignment_audit_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_frontier_assignment_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected

--- a/tests/test_n9_vertex_circle_mro_branching_replay.py
+++ b/tests/test_n9_vertex_circle_mro_branching_replay.py
@@ -21,6 +21,7 @@ from scripts.check_n9_vertex_circle_mro_branching_replay import (
     fixed_center_order_search,
     load_artifact,
     mro_branching_replay_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -114,3 +115,43 @@ def test_mro_branching_replay_cli_json() -> None:
     parsed = json.loads(result.stdout)
     assert parsed["validation_status"] == "passed"
     assert parsed["comparison_summary"]["cross_check_status_counts_match"] is True
+
+
+def test_mro_branching_replay_summary_json_payload(
+    replay_payload: dict[str, object],
+) -> None:
+    summary = summary_json_payload(replay_payload)
+
+    assert "fixed_center_order_main" not in summary
+    assert "fixed_center_order_cross_check" not in summary
+    assert summary["schema"] == replay_payload["schema"]
+    assert summary["claim_scope"] == replay_payload["claim_scope"]
+    assert summary["review_independence"] == replay_payload["review_independence"]
+    assert summary["comparison_summary"] == replay_payload["comparison_summary"]
+    fixed_main = summary["fixed_center_order_main_summary"]
+    fixed_cross = summary["fixed_center_order_cross_check_summary"]
+    assert fixed_main["nodes_visited"] == EXPECTED_FIXED_MAIN_NODES
+    assert fixed_cross["nodes_visited"] == EXPECTED_FIXED_CROSS_NODES
+    assert fixed_cross["counts"] == EXPECTED_FIXED_CROSS_COUNTS
+    assert summary["validation_status"] == "passed"
+
+
+def test_mro_branching_replay_cli_summary_json(
+    replay_payload: dict[str, object],
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_mro_branching_replay.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(replay_payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected


### PR DESCRIPTION
## Summary
- add compact --summary-json output to the n9 MRO branching replay and frontier-assignment audit
- keep full --json outputs available and mutually exclusive with summary mode
- update docs/tests to prefer compact reviewer-facing commands while preserving non-claim scope

## Validation
- .venv/bin/python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
- .venv/bin/python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --json
- .venv/bin/python -m pytest tests/test_n9_vertex_circle_mro_branching_replay.py tests/test_n9_vertex_circle_frontier_assignment_audit.py -q -m "artifact or exhaustive or not artifact"
- make verify-fast PYTHON=.venv/bin/python
- .venv/bin/python scripts/check_text_clean.py
- .venv/bin/python scripts/check_status_consistency.py
- .venv/bin/python scripts/check_artifact_provenance.py
- git diff --check