### PR TITLE
Add partial pruning summary JSON

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1118,11 +1118,12 @@ finite descent regions and extracted strict-cycle certificates. It records
 `1:13`, `2:1`, and `3:2`. This is diagnostic local-packet data only, not a
 proof of `n=9` or a bridge proof.
 The partial-pruning audit
-`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
 checks all 94,024 nonempty selected-row subsets of the stored 184 frontier
 assignments. It finds zero checker/replay status mismatches and zero stored
 extension violations for obstructed subsets. This is stored-frontier pruning
-diagnostics only.
+diagnostics only. Use `--json` instead when mismatch examples or other full
+diagnostic fields are needed.
 The frontier-assignment audit
 `scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
 checks the stored 184 frontier assignments directly. It records zero row-shape,

--- a/STATE.md
+++ b/STATE.md
@@ -707,11 +707,13 @@ regions, with region/cycle length counts `1:13`, `2:1`, and `3:2`.
 It is a diagnostic reformulation only, not local-lemma completeness, a bridge
 proof, or an `n=9` proof.
 The partial-pruning audit
-`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
 checks all 94,024 nonempty selected-row subsets of the stored 184 frontier
 assignments for monotone obstruction persistence and checker/replay status
 agreement. It is stored-frontier diagnostics only and leaves frontier coverage,
 brancher soundness, strict-edge geometry, and quotient soundness separate.
+Use `--json` instead when mismatch examples or other full diagnostic fields are
+needed.
 The frontier-assignment audit
 `scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
 checks the stored 184 frontier assignments directly for row shape, center

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1966,7 +1966,9 @@ stored-frontier pruning diagnostics only. It does not prove frontier coverage,
 brancher soundness, strict-edge geometry, selected-distance quotient
 soundness, `n=9`, a counterexample, or any official/global status update.
 Check it with
-`python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`;
+use `--json` instead when mismatch examples or other full diagnostic fields are
+needed.
 
 ### n=9 vertex-circle frontier-assignment audit
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -156,10 +156,11 @@ Use this queue when no more specific issue is selected.
    row-pair crossing, witness-pair capacity, and selected-indegree capacity;
    use `--json` when the full example error block is needed.
    The partial-pruning replay
-   `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
    checks all nonempty selected-row subsets of the stored 184 frontier
    assignments for monotone obstruction persistence and checker/replay status
-   agreement only.
+   agreement only; use `--json` when the full mismatch examples or diagnostic
+   fields are needed.
 3. Continue the minimal fragile-cover bridge after the stored block-6
    vertex-circle full-extension audit
    `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -316,7 +316,7 @@ needed.
 The partial-pruning audit command checks stored-frontier row subsets:
 
 ```bash
-python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
 ```
 
 It scans all 94,024 nonempty row subsets from the 184 stored frontier
@@ -324,7 +324,8 @@ assignments, checks that every obstructed subset extends only to a stored full
 assignment that remains obstructed, and compares checker status with the
 reusable quotient replay. This is stored-frontier pruning diagnostics only, not
 frontier coverage, brancher soundness, strict-edge geometry, quotient
-soundness, or a completed `n=9` review.
+soundness, or a completed `n=9` review. Use `--json` instead when mismatch
+examples or other full diagnostic fields are needed.
 
 ## Commands
 

--- a/docs/n9-vertex-circle-partial-pruning-audit.md
+++ b/docs/n9-vertex-circle-partial-pruning-audit.md
@@ -98,11 +98,13 @@ pre-vertex-circle assignments, and does not prove the full `n=9` finite case.
 ## Stored-frontier Replay
 
 The command
-`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
 turns the monotonicity note into a stored-frontier diagnostic. It scans every
 nonempty subset of selected rows from the 184 stored pre-vertex-circle frontier
 assignments in
 `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
+Use `--json` instead when mismatch examples or other full diagnostic fields are
+needed.
 
 The replay checks:
 
@@ -131,7 +133,7 @@ partial-pruning step on the stored frontier only.
 Run the stored-frontier partial-pruning audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
 ```
 
 Run the exhaustive checker and the targeted artifact test:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -320,14 +320,15 @@ per-view status and mismatch example blocks are needed.
 Current partial-pruning audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
 ```
 
 This command scans all nonempty selected-row subsets of the 184 stored
 pre-vertex-circle frontier assignments. It checks monotone obstruction
 persistence and checker/replay status agreement on those stored subsets only.
 It does not prove frontier coverage, brancher soundness, strict-edge geometry,
-selected-distance quotient soundness, `n=9`, or complete review.
+selected-distance quotient soundness, `n=9`, or complete review. Use `--json`
+instead when mismatch examples or other full diagnostic fields are needed.
 
 ## Priority 6 - mine a reusable vertex-circle lemma
 

--- a/scripts/check_n9_vertex_circle_partial_pruning.py
+++ b/scripts/check_n9_vertex_circle_partial_pruning.py
@@ -47,6 +47,31 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "source_artifact",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+FRONTIER_SUBSET_SUMMARY_KEYS = (
+    "assignment_count",
+    "full_status_counts",
+    "subset_count",
+    "subset_status_counts",
+    "obstructed_subset_count",
+    "extension_violations",
+    "checker_replay_status_mismatches",
+    "min_obstruction_size_counts",
+    "stored_row_order_prefix_total",
+    "stored_row_order_prefix_status_counts",
+)
 
 EXPECTED_ASSIGNMENT_COUNT = 184
 EXPECTED_SUBSET_COUNT = 94_024
@@ -178,6 +203,20 @@ def assert_expected_partial_pruning(payload: Mapping[str, Any]) -> None:
             raise AssertionError(f"{key} mismatch: {summary.get(key)!r} != {value!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without mismatch examples."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    subset_audit = payload.get("frontier_subset_audit")
+    if isinstance(subset_audit, Mapping):
+        summary["frontier_subset_audit_summary"] = {
+            key: subset_audit[key]
+            for key in FRONTIER_SUBSET_SUMMARY_KEYS
+            if key in subset_audit
+        }
+    return summary
+
+
 def _audit_frontier_subsets(frontier: Mapping[str, Any]) -> dict[str, Any]:
     assignments = frontier.get("assignments")
     if not isinstance(assignments, list):
@@ -307,7 +346,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without mismatch examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -323,7 +368,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_partial_pruning(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle partial-pruning audit")

--- a/tests/test_n9_vertex_circle_partial_pruning.py
+++ b/tests/test_n9_vertex_circle_partial_pruning.py
@@ -14,6 +14,7 @@ from scripts.check_n9_vertex_circle_partial_pruning import (
     EXPECTED_SUBSET_STATUS_COUNTS,
     assert_expected_partial_pruning,
     partial_pruning_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -44,6 +45,45 @@ def test_partial_pruning_rejects_appended_claim_scope_overclaim() -> None:
 
     with pytest.raises(AssertionError, match="claim_scope mismatch"):
         assert_expected_partial_pruning(payload)
+
+
+def test_partial_pruning_summary_json_payload() -> None:
+    payload = partial_pruning_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "frontier_subset_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit = summary["frontier_subset_audit_summary"]
+    assert audit["assignment_count"] == 184
+    assert audit["subset_count"] == 94_024
+    assert audit["subset_status_counts"] == EXPECTED_SUBSET_STATUS_COUNTS
+    assert audit["min_obstruction_size_counts"] == EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS
+    assert audit["extension_violations"] == 0
+    assert audit["checker_replay_status_mismatches"] == 0
+    assert "example_mismatches" not in audit
+    assert summary["validation_status"] == "passed"
+
+
+def test_partial_pruning_cli_summary_json() -> None:
+    payload = partial_pruning_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_partial_pruning.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload)))
+    assert json.loads(result.stdout) == expected
 
 
 def test_partial_pruning_cli_json() -> None:


### PR DESCRIPTION
## What changed
- Added `--summary-json` to `scripts/check_n9_vertex_circle_partial_pruning.py` as a compact reviewer-facing view that omits mismatch example blocks.
- Added unit and CLI coverage for the compact output path.
- Updated reviewer-facing docs to prefer `--summary-json` while keeping `--json` for full diagnostics.

## Claim scope and evidence level
- Scope remains `REVIEW_PENDING_PARTIAL_PRUNING_AUDIT` for stored-frontier subset replay only.
- No general proof, no counterexample, no `n=9` proof, and no official/global status update is claimed.
- Evidence is reproducible checker/test output against the existing stored frontier artifact.

## Commands run
- `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
- `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_partial_pruning.py -q -m slow`
- `python -m ruff check scripts/check_n9_vertex_circle_partial_pruning.py tests/test_n9_vertex_circle_partial_pruning.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

## Artifacts generated or checked
- Checked `data/certificates/n9_vertex_circle_frontier_motif_classification.json` through the partial-pruning audit.
- No generated artifact files were changed.

## Known limitations / next review steps
- This is a presentation and reproducibility improvement only.
- It does not prove frontier coverage, brancher soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, a counterexample, or any official/global status update.
- Reviewers should still use `--json` when full mismatch examples or diagnostic fields are needed.