### PR TITLE
Add summary JSON for n9 motif audits

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1118,11 +1118,11 @@ finite descent regions and extracted strict-cycle certificates. It records
 `1:13`, `2:1`, and `3:2`. This is diagnostic local-packet data only, not a
 proof of `n=9` or a bridge proof.
 The partial-pruning audit
-`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
 checks all 94,024 nonempty selected-row subsets of the stored 184 frontier
 assignments. It finds zero checker/replay status mismatches and zero stored
 extension violations for obstructed subsets. This is stored-frontier pruning
-diagnostics only.
+diagnostics only. Use `--json` when the full mismatch example block is needed.
 The frontier-assignment audit
 `scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
 checks the stored 184 frontier assignments directly. It records zero row-shape,
@@ -1146,16 +1146,18 @@ complete selected-row assignments match the stored frontier classification
 artifact row-for-row, with zero status mismatches. This is stored-frontier
 coverage bookkeeping only; use `--json` for the full audit records. The
 dihedral-orbit audit
-`scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json`
 independently replays the 18 dihedral relabelings for the stored motif-family
 representatives and cross-checks the 184 frontier-classification rows against
-those disjoint orbits. It is orbit bookkeeping only.
+those disjoint orbits. It is orbit bookkeeping only. Use `--json` when the
+full mismatch example block is needed.
 The motif-obstruction audit
-`scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json`
 treats the 16 stored motif representatives as input and checks their
 representative self-edge equality paths or strict-cycle edge chains after
 recomputing quotient classes and strict interval edges. It is
-stored-certificate bookkeeping only.
+stored-certificate bookkeeping only. Use `--json` when the full example error
+block is needed.
 The frontier comparison
 `scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
 checks the stored P18/C19 comparison artifact against the current local-core
@@ -1164,10 +1166,11 @@ the recorded P18 and C19 patterns, while preserving the P18 strict-cycle and
 C19 fixed-order pass guardrails. It is comparison diagnostics only, not a
 transfer theorem, counterexample, or proof of `n=9`.
 The local-core subset audit
-`scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
 checks that the compact local-core packet rows are exact subsets of the stored
 full motif representatives and already force the same obstruction status by
-direct quotient replay. It is compact-core bookkeeping only.
+direct quotient replay. It is compact-core bookkeeping only. Use `--json` when
+the full example error block is needed.
 The focused packet catalog audit
 `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
 checks that the 12 focused local-lemma packets, source template packet records,

--- a/STATE.md
+++ b/STATE.md
@@ -707,11 +707,12 @@ regions, with region/cycle length counts `1:13`, `2:1`, and `3:2`.
 It is a diagnostic reformulation only, not local-lemma completeness, a bridge
 proof, or an `n=9` proof.
 The partial-pruning audit
-`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
 checks all 94,024 nonempty selected-row subsets of the stored 184 frontier
 assignments for monotone obstruction persistence and checker/replay status
 agreement. It is stored-frontier diagnostics only and leaves frontier coverage,
-brancher soundness, strict-edge geometry, and quotient soundness separate.
+brancher soundness, strict-edge geometry, and quotient soundness separate. Use
+`--json` when the full mismatch example block is needed.
 The frontier-assignment audit
 `scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
 checks the stored 184 frontier assignments directly for row shape, center
@@ -737,17 +738,19 @@ complete selected-row assignments, in order, with the stored frontier
 motif-classification artifact. It is coverage bookkeeping against the current
 brancher, not filter soundness or a proof of `n=9`. Use `--json` instead for
 the full audit records and histograms. The dihedral-orbit audit
-`scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json`
 then treats the stored motif and frontier-classification artifacts as inputs,
 replays the dihedral relabeling action independently, and checks canonical
 representatives, orbit sizes, orbit disjointness, and assignment-to-orbit maps.
-It is orbit bookkeeping only, not frontier coverage or a proof of `n=9`.
+It is orbit bookkeeping only, not frontier coverage or a proof of `n=9`. Use
+`--json` when the full mismatch example block is needed.
 The motif-obstruction audit
-`scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json`
 treats the stored motif representatives as input and verifies their stored
 self-edge equality paths or strict-cycle edge chains by recomputing quotient
 classes and strict interval edges. It is stored-certificate bookkeeping only,
-not frontier coverage, brancher soundness, or a proof of `n=9`.
+not frontier coverage, brancher soundness, or a proof of `n=9`. Use `--json`
+when the full example error block is needed.
 The frontier comparison
 `scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
 checks the stored P18/C19 comparison artifact against the current local-core
@@ -756,11 +759,12 @@ the recorded P18 and C19 patterns, while preserving the P18 strict-cycle and
 C19 fixed-order pass guardrails. It is comparison diagnostics only, not a
 transfer theorem, counterexample, or proof of `n=9`.
 The local-core subset audit
-`scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
 checks that the compact local-core packet rows are exact subsets of the stored
 full motif representatives and already force the same obstruction status by
 direct quotient replay. It is compact-core bookkeeping only, not local-lemma
-completeness or a proof of `n=9`.
+completeness or a proof of `n=9`. Use `--json` when the full example error
+block is needed.
 The focused packet catalog audit
 `scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
 checks that the 12 focused local-lemma packets, source template packet records,

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1955,7 +1955,7 @@ stored subset extends to a stored full assignment that remains obstructed. It
 also compares the repo-native checker status with the reusable quotient replay
 status on every subset.
 
-When run with `--check --assert-expected --json`, the audit checks `94,024`
+When run with `--check --assert-expected --summary-json`, the audit checks `94,024`
 nonempty row subsets. It records `35,418` `ok` subsets, `24,890` self-edge
 subsets, and `33,716` strict-cycle subsets, with `58,606` obstructed subsets
 in total. The minimal obstruction size distribution is `182` assignments first
@@ -1966,7 +1966,8 @@ stored-frontier pruning diagnostics only. It does not prove frontier coverage,
 brancher soundness, strict-edge geometry, selected-distance quotient
 soundness, `n=9`, a counterexample, or any official/global status update.
 Check it with
-`python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`.
+Use `--json` when the full mismatch example block is needed.
 
 ### n=9 vertex-circle frontier-assignment audit
 
@@ -2085,7 +2086,7 @@ canonical representatives, stored orbit sizes, orbit disjointness, and the
 assignment-to-orbit maps in
 `data/certificates/n9_vertex_circle_frontier_motif_classification.json`.
 
-When run with `--check --assert-expected --json`, the audit checks `16` stored
+When run with `--check --assert-expected --summary-json`, the audit checks `16` stored
 motif families with family status counts `13` self-edge and `3` strict-cycle.
 The stored orbit sizes have histogram `2: 5`, `6: 2`, and `18: 9`; their
 disjoint orbit union contains `184` rows. The frontier classification contains
@@ -2099,7 +2100,8 @@ orbits. The orbit-union and classification-row SHA-256 digest is
 dihedral orbit bookkeeping only. It does not prove frontier coverage, filter
 soundness, strict-edge geometry, selected-distance quotient soundness, `n=9`, a
 counterexample, or any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json`.
+Use `--json` when the full mismatch example block is needed.
 
 ### n=9 vertex-circle motif-obstruction audit
 
@@ -2112,7 +2114,7 @@ quotient classes and vertex-circle strict interval inequalities with a small
 local implementation, then verifies each stored representative self-edge path
 or strict-cycle edge list.
 
-When run with `--check --assert-expected --json`, the audit reports computed
+When run with `--check --assert-expected --summary-json`, the audit reports computed
 and stored representative status counts `13` self-edge and `3` strict-cycle.
 The self-edge representatives contain `276` checked self-edge conflicts. The
 strict-edge tables contain `1,053` strict edges for self-edge representatives
@@ -2125,7 +2127,8 @@ brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping,
 strict-edge geometry in general, selected-distance quotient soundness in
 general, `n=9`, a counterexample, or any official/global status update. Check
 it with
-`python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json`.
+Use `--json` when the full example error block is needed.
 
 ### n=9 vertex-circle local-core subset audit
 
@@ -2139,7 +2142,7 @@ subset of the corresponding full motif representative and then replays the
 compact rows directly to confirm that they already force the recorded self-edge
 or strict-cycle obstruction status.
 
-When run with `--check --assert-expected --json`, the audit checks `16` local
+When run with `--check --assert-expected --summary-json`, the audit checks `16` local
 cores with computed and stored status counts `13` self-edge and `3`
 strict-cycle. The compact core sizes have histogram `3: 5`, `4: 6`, `5: 2`,
 and `6: 3`; the orbit-size sum is `184`. The self-edge cores have size
@@ -2152,7 +2155,8 @@ It does not prove local-lemma completeness, frontier coverage, brancher
 soundness, motif-orbit bookkeeping, strict-edge geometry in general,
 selected-distance quotient soundness in general, `n=9`, a counterexample, or
 any official/global status update. Check it with
-`python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`.
+`python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`.
+Use `--json` when the full example error block is needed.
 
 ### n=9 vertex-circle focused packet catalog audit
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -137,29 +137,32 @@ Use this queue when no more specific issue is selected.
    stored frontier classification artifact; use `--json` when the full
    mismatch example block is needed.
    The dihedral-orbit audit
-   `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json`
    independently checks the stored 16 motif representatives, their labelled
    dihedral orbits, and the assignment-to-orbit maps in the frontier
-   classification artifact.
+   classification artifact; use `--json` when the full mismatch example block
+   is needed.
    The motif-obstruction audit
-   `python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json`
    checks the stored representative self-edge paths and strict-cycle records
-   for those 16 motif families with a small local quotient replay.
+   for those 16 motif families with a small local quotient replay; use
+   `--json` when the full example error block is needed.
    The local-core subset audit
-   `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
    checks that the compact row-local certificates are exact subsets of their
    stored full motif representatives and already obstruct by direct quotient
-   replay.
+   replay; use `--json` when the full example error block is needed.
    The frontier-assignment audit
    `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`
    checks the stored 184 frontier assignments directly against row shape,
    row-pair crossing, witness-pair capacity, and selected-indegree capacity;
    use `--json` when the full example error block is needed.
    The partial-pruning replay
-   `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+   `python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
    checks all nonempty selected-row subsets of the stored 184 frontier
    assignments for monotone obstruction persistence and checker/replay status
-   agreement only.
+   agreement only; use `--json` when the full mismatch example block is
+   needed.
 3. Continue the minimal fragile-cover bridge after the stored block-6
    vertex-circle full-extension audit
    `data/certificates/block6_fragile_vertex_circle_extension_audit.json`.
@@ -526,16 +529,17 @@ Use this queue when no more specific issue is selected.
    soundness remain separate review scopes. Use `--json` when the full
    mismatch example block is needed.
    The dihedral-orbit audit command,
-   `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json`,
    covers only stored motif-family orbit bookkeeping and assignment-to-orbit
    agreement; frontier coverage, filter soundness, vertex-circle geometry, and
-   quotient soundness remain separate review scopes.
+   quotient soundness remain separate review scopes. Use `--json` when the
+   full mismatch example block is needed.
    The motif-obstruction audit command,
-   `python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json`,
    covers only stored representative obstruction records for the 16 motif
    families; frontier coverage, brancher soundness, incidence-filter
    soundness, dihedral orbit bookkeeping, and full n=9 review remain separate
-   scopes.
+   scopes. Use `--json` when the full example error block is needed.
    The frontier-comparison command,
    `python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`,
    covers only the stored P18/C19 comparison against current local-core and
@@ -543,10 +547,11 @@ Use this queue when no more specific issue is selected.
    and C19 fixed-order pass behavior remain guardrails, not a proof of `n=9`,
    counterexample, or transfer theorem.
    The local-core subset audit command,
-   `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`,
+   `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`,
    covers only the compact-core-to-full-representative subset relation and
    compact-core obstruction replay; local-lemma completeness, frontier
    coverage, brancher soundness, and full n=9 review remain separate scopes.
+   Use `--json` when the full example error block is needed.
    The frontier-assignment command,
    `python scripts/check_n9_vertex_circle_frontier_assignment_audit.py --check --assert-expected --summary-json`,
    covers only the stored 184 frontier rows under those base predicates;

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -224,7 +224,7 @@ soundness, or a completed `n=9` review.
 The dihedral-orbit audit command checks stored motif-family orbit bookkeeping:
 
 ```bash
-python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json
 ```
 
 It independently enumerates the 18 dihedral relabelings of the stored 16
@@ -232,13 +232,14 @@ motif representatives, checks canonical representatives and orbit sizes, and
 verifies that the stored frontier-classification rows match the disjoint orbit
 union with stable canonical label maps. This is orbit bookkeeping only, not
 frontier coverage, filter soundness, strict-edge geometry, quotient soundness,
-or a completed `n=9` review.
+or a completed `n=9` review. Use `--json` when the full mismatch example block
+is needed.
 
 The motif-obstruction audit command checks the stored representative
 certificates for those 16 motif families:
 
 ```bash
-python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json
 ```
 
 It recomputes the selected-distance quotient classes and vertex-circle
@@ -246,20 +247,21 @@ strict interval inequalities with a small local implementation, then verifies
 each stored self-edge equality path or strict-cycle edge chain. This is
 stored-certificate bookkeeping only, not frontier coverage, brancher
 soundness, incidence-filter soundness, dihedral orbit bookkeeping, or a
-completed `n=9` review.
+completed `n=9` review. Use `--json` when the full example error block is
+needed.
 
 The local-core subset audit command checks the compact local cores against the
 full motif representatives:
 
 ```bash
-python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json
 ```
 
 It verifies that every compact local-core row is copied from the corresponding
 full motif representative and that the compact row set alone gives the stored
 self-edge or strict-cycle status under a direct quotient replay. This is
 cross-artifact bookkeeping only, not local-lemma completeness or a completed
-`n=9` review.
+`n=9` review. Use `--json` when the full example error block is needed.
 
 The frontier-assignment audit command checks the stored 184 frontier rows
 directly against the base incidence/order filters:
@@ -316,7 +318,7 @@ needed.
 The partial-pruning audit command checks stored-frontier row subsets:
 
 ```bash
-python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
 ```
 
 It scans all 94,024 nonempty row subsets from the 184 stored frontier
@@ -324,7 +326,8 @@ assignments, checks that every obstructed subset extends only to a stored full
 assignment that remains obstructed, and compares checker status with the
 reusable quotient replay. This is stored-frontier pruning diagnostics only, not
 frontier coverage, brancher soundness, strict-edge geometry, quotient
-soundness, or a completed `n=9` review.
+soundness, or a completed `n=9` review. Use `--json` when the full mismatch
+example block is needed.
 
 ## Commands
 

--- a/docs/n9-vertex-circle-motif-families.md
+++ b/docs/n9-vertex-circle-motif-families.md
@@ -41,21 +41,23 @@ review-pending diagnostic classification, not an independent proof and not a
 promotion of the n=9 finite-case status.
 
 The dihedral-orbit audit
-`scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json`
 then checks the orbit bookkeeping from the other direction: it treats the
 stored motif representatives and assignment-level classification as input,
 independently replays all 18 cyclic/reflection relabelings, verifies the
 canonical representatives and orbit sizes, and checks that the 184 stored
 classification rows are exactly the disjoint orbit union. This is still
-review-pending bookkeeping, not a proof of `n=9`.
+review-pending bookkeeping, not a proof of `n=9`. Use `--json` when the full
+mismatch example block is needed.
 
 The motif-obstruction audit
-`scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json`
 treats the 16 stored representatives as input and replays their representative
 obstruction records. It recomputes the selected-distance quotient classes and
 all vertex-circle strict interval edges, then checks the stored self-edge
 conflict plus equality path or the stored strict-cycle edge chain. This is a
-stored-certificate audit only, not frontier coverage or a proof of `n=9`.
+stored-certificate audit only, not frontier coverage or a proof of `n=9`. Use
+`--json` when the full example error block is needed.
 
 The self-edge equality-path join
 `data/certificates/n9_vertex_circle_self_edge_path_join.json` then restricts
@@ -98,12 +100,13 @@ most 6 selected rows. Its template diagnostic groups those 16 local cores into
 templates. These buckets are review aids for lemma mining; they are not an
 independent n=9 proof path.
 The local-core subset audit
-`scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
 treats the motif-family artifact and compact local-core packet as inputs. It
 checks that each compact core is a literal subset of its full motif
 representative and that the compact rows alone still force the recorded
 self-edge or strict-cycle obstruction. This is cross-artifact bookkeeping
-only, not a local-lemma completeness theorem.
+only, not a local-lemma completeness theorem. Use `--json` when the full
+example error block is needed.
 
 The derived catalog
 `data/certificates/n9_vertex_circle_template_lemma_catalog.json` puts those 12

--- a/docs/n9-vertex-circle-partial-pruning-audit.md
+++ b/docs/n9-vertex-circle-partial-pruning-audit.md
@@ -98,7 +98,7 @@ pre-vertex-circle assignments, and does not prove the full `n=9` finite case.
 ## Stored-frontier Replay
 
 The command
-`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json`
+`scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json`
 turns the monotonicity note into a stored-frontier diagnostic. It scans every
 nonempty subset of selected rows from the 184 stored pre-vertex-circle frontier
 assignments in
@@ -124,15 +124,18 @@ strict_cycle: 33716
 This does not prove frontier coverage, brancher soundness, strict-edge
 geometry, selected-distance quotient soundness, `n=9`, a counterexample, or
 any official/global status update. It is a reproducibility check for the
-partial-pruning step on the stored frontier only.
+partial-pruning step on the stored frontier only. Use `--json` when the full
+mismatch example block is needed.
 
 ## Commands
 
 Run the stored-frontier partial-pruning audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
 ```
+
+Use `--json` when the full mismatch example block is needed.
 
 Run the exhaustive checker and the targeted artifact test:
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -229,7 +229,7 @@ or complete independent review.
 Current dihedral-orbit audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json
 ```
 
 This command treats the stored motif-family artifact and frontier
@@ -237,12 +237,13 @@ classification as inputs. It independently replays the cyclic/reflection
 dihedral relabelings, checks canonical representatives and orbit sizes, and
 crosswalks the 184 stored classification rows back to the disjoint motif
 orbits. It is orbit bookkeeping only, not frontier coverage, filter soundness,
-or a proof of `n=9`.
+or a proof of `n=9`. Use `--json` when the full mismatch example block is
+needed.
 
 Current motif-obstruction audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json
 ```
 
 This command treats the stored 16 motif representatives as inputs, recomputes
@@ -250,7 +251,7 @@ selected-distance quotient classes and vertex-circle strict interval edges,
 and checks the stored representative self-edge equality paths or strict-cycle
 edge chains. It is stored-certificate bookkeeping only, not frontier coverage,
 brancher soundness, incidence-filter soundness, dihedral orbit bookkeeping, or
-a proof of `n=9`.
+a proof of `n=9`. Use `--json` when the full example error block is needed.
 
 Current frontier comparison:
 
@@ -320,14 +321,15 @@ per-view status and mismatch example blocks are needed.
 Current partial-pruning audit:
 
 ```bash
-python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
 ```
 
 This command scans all nonempty selected-row subsets of the 184 stored
 pre-vertex-circle frontier assignments. It checks monotone obstruction
 persistence and checker/replay status agreement on those stored subsets only.
 It does not prove frontier coverage, brancher soundness, strict-edge geometry,
-selected-distance quotient soundness, `n=9`, or complete review.
+selected-distance quotient soundness, `n=9`, or complete review. Use `--json`
+when the full mismatch example block is needed.
 
 ## Priority 6 - mine a reusable vertex-circle lemma
 
@@ -355,9 +357,10 @@ handoffs rather than re-extracting T01 or T10.
 - use `docs/n9-vertex-circle-local-cores.md` as the row-local certificate list
   to keep those lemmas small;
 - use
-  `scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json`
+  `scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
   to compare the compact row-local certificates against the full motif
-  representatives and verify that the compact rows alone still obstruct;
+  representatives and verify that the compact rows alone still obstruct; use
+  `--json` when the full example error block is needed;
 - use `data/certificates/n9_vertex_circle_self_edge_path_join.json` as the
   assignment-level replay aid for transformed self-edge equality paths;
 - use `data/certificates/n9_vertex_circle_self_edge_template_packet.json` to

--- a/scripts/check_n9_vertex_circle_dihedral_orbit_audit.py
+++ b/scripts/check_n9_vertex_circle_dihedral_orbit_audit.py
@@ -48,6 +48,42 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "dihedral_map_count",
+    "source_artifacts",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+DIHEDRAL_ORBIT_SUMMARY_KEYS = (
+    "family_count",
+    "classification_assignment_count",
+    "unique_classification_row_count",
+    "orbit_union_row_count",
+    "orbit_union_status_counts",
+    "classification_status_counts",
+    "family_status_counts",
+    "orbit_size_counts",
+    "canonical_rep_mismatches",
+    "orbit_size_mismatches",
+    "orbit_overlap_count",
+    "classification_missing_from_orbits",
+    "orbit_missing_from_classification",
+    "classification_duplicate_rows",
+    "classification_family_mismatches",
+    "classification_status_mismatches",
+    "canonical_label_map_mismatches",
+    "assignment_id_mismatches",
+    "orbit_union_rows_sha256",
+    "classification_rows_sha256",
+)
 
 EXPECTED_ASSIGNMENT_COUNT = 184
 EXPECTED_FAMILY_COUNT = 16
@@ -470,6 +506,18 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without mismatch examples."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = payload.get("dihedral_orbit_audit")
+    if isinstance(audit, Mapping):
+        summary["dihedral_orbit_audit_summary"] = {
+            key: audit[key] for key in DIHEDRAL_ORBIT_SUMMARY_KEYS if key in audit
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["dihedral_orbit_audit"]
     return [
@@ -498,7 +546,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without mismatch examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -523,7 +577,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_dihedral_orbit_audit(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle dihedral orbit audit")

--- a/scripts/check_n9_vertex_circle_local_core_subset_audit.py
+++ b/scripts/check_n9_vertex_circle_local_core_subset_audit.py
@@ -42,6 +42,34 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "source_artifacts",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+LOCAL_CORE_SUBSET_SUMMARY_KEYS = (
+    "family_count",
+    "orbit_size_sum",
+    "stored_status_counts",
+    "computed_status_counts",
+    "core_size_counts",
+    "status_core_size_counts",
+    "strict_cycle_length_counts",
+    "family_id_mismatches",
+    "orbit_size_mismatches",
+    "status_mismatches",
+    "core_size_mismatches",
+    "subset_mismatches",
+    "unobstructed_core_count",
+)
 
 EXPECTED_FAMILY_COUNT = 16
 EXPECTED_ORBIT_SIZE_SUM = 184
@@ -509,6 +537,18 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without example errors."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = payload.get("local_core_subset_audit")
+    if isinstance(audit, Mapping):
+        summary["local_core_subset_audit_summary"] = {
+            key: audit[key] for key in LOCAL_CORE_SUBSET_SUMMARY_KEYS if key in audit
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["local_core_subset_audit"]
     return [
@@ -532,7 +572,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--local-core-packet", type=Path, default=DEFAULT_LOCAL_CORE_PACKET)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without example errors",
+    )
     return parser.parse_args(argv)
 
 
@@ -557,7 +603,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_local_core_subset_audit(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle local-core subset audit")

--- a/scripts/check_n9_vertex_circle_motif_obstruction_audit.py
+++ b/scripts/check_n9_vertex_circle_motif_obstruction_audit.py
@@ -42,6 +42,32 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "source_artifact",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+MOTIF_OBSTRUCTION_SUMMARY_KEYS = (
+    "family_count",
+    "computed_status_counts",
+    "stored_status_counts",
+    "strict_edge_count_by_status",
+    "self_edge_count_by_status",
+    "strict_cycle_length_counts",
+    "stored_status_mismatches",
+    "self_edge_conflict_mismatches",
+    "equality_path_mismatches",
+    "strict_cycle_edge_mismatches",
+    "strict_cycle_chain_mismatches",
+)
 
 EXPECTED_FAMILY_COUNT = 16
 EXPECTED_STATUS_COUNTS = {"self_edge": 13, "strict_cycle": 3}
@@ -556,6 +582,18 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without example errors."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = payload.get("motif_obstruction_audit")
+    if isinstance(audit, Mapping):
+        summary["motif_obstruction_audit_summary"] = {
+            key: audit[key] for key in MOTIF_OBSTRUCTION_SUMMARY_KEYS if key in audit
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["motif_obstruction_audit"]
     return [
@@ -579,7 +617,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--motif-families", type=Path, default=DEFAULT_MOTIF_FAMILIES)
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without example errors",
+    )
     return parser.parse_args(argv)
 
 
@@ -603,7 +647,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_motif_obstruction_audit(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle motif obstruction audit")

--- a/scripts/check_n9_vertex_circle_partial_pruning.py
+++ b/scripts/check_n9_vertex_circle_partial_pruning.py
@@ -47,6 +47,31 @@ PROVENANCE = {
         "--check --assert-expected --json"
     ),
 }
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "row_size",
+    "source_artifact",
+    "validation_status",
+    "validation_errors",
+    "interpretation",
+    "provenance",
+)
+FRONTIER_SUBSET_SUMMARY_KEYS = (
+    "assignment_count",
+    "full_status_counts",
+    "subset_count",
+    "subset_status_counts",
+    "obstructed_subset_count",
+    "extension_violations",
+    "checker_replay_status_mismatches",
+    "min_obstruction_size_counts",
+    "stored_row_order_prefix_total",
+    "stored_row_order_prefix_status_counts",
+)
 
 EXPECTED_ASSIGNMENT_COUNT = 184
 EXPECTED_SUBSET_COUNT = 94_024
@@ -284,6 +309,18 @@ def _check_equal(errors: list[str], name: str, actual: Any, expected: Any) -> No
         errors.append(f"{name} mismatch: {actual!r} != {expected!r}")
 
 
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without mismatch examples."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    audit = payload.get("frontier_subset_audit")
+    if isinstance(audit, Mapping):
+        summary["frontier_subset_audit_summary"] = {
+            key: audit[key] for key in FRONTIER_SUBSET_SUMMARY_KEYS if key in audit
+        }
+    return summary
+
+
 def summary_lines(payload: Mapping[str, Any]) -> list[str]:
     summary = payload["frontier_subset_audit"]
     return [
@@ -307,7 +344,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--check", action="store_true", help="validate the audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="emit JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without mismatch examples",
+    )
     return parser.parse_args(argv)
 
 
@@ -323,7 +366,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.assert_expected:
         assert_expected_partial_pruning(payload)
 
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif payload.get("validation_status") == "passed":
         print("n=9 vertex-circle partial-pruning audit")

--- a/tests/test_n9_vertex_circle_dihedral_orbit_audit.py
+++ b/tests/test_n9_vertex_circle_dihedral_orbit_audit.py
@@ -16,6 +16,7 @@ from scripts.check_n9_vertex_circle_dihedral_orbit_audit import (
     EXPECTED_ROWS_SHA256,
     assert_expected_dihedral_orbit_audit,
     dihedral_orbit_audit_payload,
+    summary_json_payload,
 )
 
 
@@ -114,3 +115,40 @@ def test_dihedral_orbit_audit_cli_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["validation_status"] == "passed"
     assert payload["dihedral_orbit_audit"]["orbit_union_row_count"] == 184
+
+
+def test_dihedral_orbit_audit_summary_json_payload() -> None:
+    payload = dihedral_orbit_audit_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "dihedral_orbit_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit_summary = summary["dihedral_orbit_audit_summary"]
+    assert audit_summary["family_count"] == 16
+    assert audit_summary["orbit_union_row_count"] == 184
+    assert audit_summary["canonical_label_map_mismatches"] == 0
+    assert audit_summary["orbit_union_rows_sha256"] == EXPECTED_ROWS_SHA256
+    assert "example_mismatches" not in audit_summary
+    assert summary["validation_status"] == "passed"
+
+
+def test_dihedral_orbit_audit_cli_summary_json() -> None:
+    payload = dihedral_orbit_audit_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_dihedral_orbit_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected

--- a/tests/test_n9_vertex_circle_local_core_subset_audit.py
+++ b/tests/test_n9_vertex_circle_local_core_subset_audit.py
@@ -13,6 +13,7 @@ from scripts.check_n9_vertex_circle_local_core_subset_audit import (
     DEFAULT_MOTIF_FAMILIES,
     assert_expected_local_core_subset_audit,
     local_core_subset_audit_payload,
+    summary_json_payload,
 )
 
 
@@ -118,4 +119,44 @@ def test_local_core_subset_audit_cli_json() -> None:
     assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["validation_status"] == "passed"
+
+
+def test_local_core_subset_audit_summary_json_payload() -> None:
+    payload = local_core_subset_audit_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "local_core_subset_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit_summary = summary["local_core_subset_audit_summary"]
+    assert audit_summary["family_count"] == 16
+    assert audit_summary["computed_status_counts"] == {
+        "self_edge": 13,
+        "strict_cycle": 3,
+    }
+    assert audit_summary["subset_mismatches"] == 0
+    assert audit_summary["unobstructed_core_count"] == 0
+    assert "example_errors" not in audit_summary
+    assert summary["validation_status"] == "passed"
+
+
+def test_local_core_subset_audit_cli_summary_json() -> None:
+    payload = local_core_subset_audit_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_local_core_subset_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected
     assert payload["local_core_subset_audit"]["family_count"] == 16

--- a/tests/test_n9_vertex_circle_motif_obstruction_audit.py
+++ b/tests/test_n9_vertex_circle_motif_obstruction_audit.py
@@ -12,6 +12,7 @@ from scripts.check_n9_vertex_circle_motif_obstruction_audit import (
     DEFAULT_MOTIF_FAMILIES,
     assert_expected_motif_obstruction_audit,
     motif_obstruction_audit_payload,
+    summary_json_payload,
 )
 
 
@@ -112,3 +113,43 @@ def test_motif_obstruction_audit_cli_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["validation_status"] == "passed"
     assert payload["motif_obstruction_audit"]["family_count"] == 16
+
+
+def test_motif_obstruction_audit_summary_json_payload() -> None:
+    payload = motif_obstruction_audit_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "motif_obstruction_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit_summary = summary["motif_obstruction_audit_summary"]
+    assert audit_summary["family_count"] == 16
+    assert audit_summary["computed_status_counts"] == {
+        "self_edge": 13,
+        "strict_cycle": 3,
+    }
+    assert audit_summary["self_edge_conflict_mismatches"] == 0
+    assert audit_summary["strict_cycle_chain_mismatches"] == 0
+    assert "example_errors" not in audit_summary
+    assert summary["validation_status"] == "passed"
+
+
+def test_motif_obstruction_audit_cli_summary_json() -> None:
+    payload = motif_obstruction_audit_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_motif_obstruction_audit.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected

--- a/tests/test_n9_vertex_circle_partial_pruning.py
+++ b/tests/test_n9_vertex_circle_partial_pruning.py
@@ -14,6 +14,7 @@ from scripts.check_n9_vertex_circle_partial_pruning import (
     EXPECTED_SUBSET_STATUS_COUNTS,
     assert_expected_partial_pruning,
     partial_pruning_payload,
+    summary_json_payload,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -72,3 +73,43 @@ def test_partial_pruning_cli_json() -> None:
     assert summary["min_obstruction_size_counts"] == {"3": 182, "4": 2}
     assert summary["extension_violations"] == 0
     assert summary["checker_replay_status_mismatches"] == 0
+
+
+def test_partial_pruning_summary_json_payload() -> None:
+    payload = partial_pruning_payload()
+
+    summary = summary_json_payload(payload)
+
+    assert "frontier_subset_audit" not in summary
+    assert summary["schema"] == payload["schema"]
+    assert summary["claim_scope"] == payload["claim_scope"]
+    audit_summary = summary["frontier_subset_audit_summary"]
+    assert audit_summary["assignment_count"] == 184
+    assert audit_summary["subset_status_counts"] == EXPECTED_SUBSET_STATUS_COUNTS
+    assert audit_summary["min_obstruction_size_counts"] == (
+        EXPECTED_MIN_OBSTRUCTION_SIZE_COUNTS
+    )
+    assert audit_summary["extension_violations"] == 0
+    assert audit_summary["checker_replay_status_mismatches"] == 0
+    assert "example_mismatches" not in audit_summary
+    assert summary["validation_status"] == "passed"
+
+
+def test_partial_pruning_cli_summary_json() -> None:
+    payload = partial_pruning_payload()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_vertex_circle_partial_pruning.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected


### PR DESCRIPTION
## Summary
- add compact --summary-json output to the n9 dihedral-orbit, motif-obstruction, local-core subset, and partial-pruning audits
- keep full --json outputs available and mutually exclusive with summary mode
- update reviewer-facing docs to prefer compact commands while preserving diagnostic-only scope and full-json fallback notes

## Validation
- .venv/bin/python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --summary-json
- .venv/bin/python scripts/check_n9_vertex_circle_dihedral_orbit_audit.py --check --assert-expected --json
- .venv/bin/python scripts/check_n9_vertex_circle_motif_obstruction_audit.py --check --assert-expected --json
- .venv/bin/python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json
- .venv/bin/python scripts/check_n9_vertex_circle_partial_pruning.py --check --assert-expected --json
- direct --json --summary-json probes for all four CLIs exit with argparse code 2
- .venv/bin/python -m pytest tests/test_n9_vertex_circle_dihedral_orbit_audit.py tests/test_n9_vertex_circle_motif_obstruction_audit.py tests/test_n9_vertex_circle_local_core_subset_audit.py tests/test_n9_vertex_circle_partial_pruning.py -q
- .venv/bin/python -m pytest tests/test_n9_vertex_circle_partial_pruning.py -q -m slow
- .venv/bin/python -m ruff check scripts/check_n9_vertex_circle_dihedral_orbit_audit.py scripts/check_n9_vertex_circle_motif_obstruction_audit.py scripts/check_n9_vertex_circle_local_core_subset_audit.py scripts/check_n9_vertex_circle_partial_pruning.py tests/test_n9_vertex_circle_dihedral_orbit_audit.py tests/test_n9_vertex_circle_motif_obstruction_audit.py tests/test_n9_vertex_circle_local_core_subset_audit.py tests/test_n9_vertex_circle_partial_pruning.py
- .venv/bin/python scripts/check_text_clean.py
- .venv/bin/python scripts/check_status_consistency.py
- .venv/bin/python scripts/check_artifact_provenance.py
- git diff --check
- make verify-fast PYTHON=.venv/bin/python

## Review
- subagent script/test review: no issues found
- subagent docs/non-overclaiming review: no issues found