### PR TITLE
Add summary JSON for n9 frontier comparison

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1159,12 +1159,13 @@ recomputing quotient classes and strict interval edges. It is
 stored-certificate bookkeeping only. Use `--json` when the full example error
 block is needed.
 The frontier comparison
-`scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
+`scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --summary-json`
 checks the stored P18/C19 comparison artifact against the current local-core
 and vertex-circle helpers. It records zero exact n=9 local-core embeddings into
 the recorded P18 and C19 patterns, while preserving the P18 strict-cycle and
 C19 fixed-order pass guardrails. It is comparison diagnostics only, not a
-transfer theorem, counterexample, or proof of `n=9`.
+transfer theorem, counterexample, or proof of `n=9`. Use `--json` when the
+full pattern records are needed.
 The local-core subset audit
 `scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
 checks that the compact local-core packet rows are exact subsets of the stored

--- a/STATE.md
+++ b/STATE.md
@@ -752,12 +752,13 @@ classes and strict interval edges. It is stored-certificate bookkeeping only,
 not frontier coverage, brancher soundness, or a proof of `n=9`. Use `--json`
 when the full example error block is needed.
 The frontier comparison
-`scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`
+`scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --summary-json`
 checks the stored P18/C19 comparison artifact against the current local-core
 and vertex-circle helpers. It records zero exact n=9 local-core embeddings into
 the recorded P18 and C19 patterns, while preserving the P18 strict-cycle and
 C19 fixed-order pass guardrails. It is comparison diagnostics only, not a
-transfer theorem, counterexample, or proof of `n=9`.
+transfer theorem, counterexample, or proof of `n=9`. Use `--json` when the
+full pattern records are needed.
 The local-core subset audit
 `scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`
 checks that the compact local-core packet rows are exact subsets of the stored

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -541,11 +541,12 @@ Use this queue when no more specific issue is selected.
    soundness, dihedral orbit bookkeeping, and full n=9 review remain separate
    scopes. Use `--json` when the full example error block is needed.
    The frontier-comparison command,
-   `python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json`,
+   `python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --summary-json`,
    covers only the stored P18/C19 comparison against current local-core and
    vertex-circle helpers; exact-core non-embedding, P18 strict-cycle behavior,
    and C19 fixed-order pass behavior remain guardrails, not a proof of `n=9`,
-   counterexample, or transfer theorem.
+   counterexample, or transfer theorem. Use `--json` when the full pattern
+   records are needed.
    The local-core subset audit command,
    `python scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --summary-json`,
    covers only the compact-core-to-full-representative subset relation and

--- a/docs/n9-vertex-circle-frontier-comparison.md
+++ b/docs/n9-vertex-circle-frontier-comparison.md
@@ -50,8 +50,10 @@ Check the stored comparison artifact:
 python scripts/compare_n9_vertex_circle_frontier.py \
   --check \
   --assert-expected \
-  --json
+  --summary-json
 ```
+
+Use `--json` when the full pattern records are needed.
 
 Regenerate the comparison artifact:
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -256,14 +256,15 @@ a proof of `n=9`. Use `--json` when the full example error block is needed.
 Current frontier comparison:
 
 ```bash
-python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json
+python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --summary-json
 ```
 
 This command checks the stored P18/C19 comparison artifact against the current
 local-core and vertex-circle helpers. It records zero exact n=9 local-core
 embeddings into the recorded P18 and C19 patterns, preserves the P18
 strict-cycle and C19 fixed-order pass guardrails, and does not prove `n=9`,
-provide a counterexample, or supply a transfer theorem.
+provide a counterexample, or supply a transfer theorem. Use `--json` when the
+full pattern records are needed.
 
 Current frontier-assignment audit:
 

--- a/scripts/compare_n9_vertex_circle_frontier.py
+++ b/scripts/compare_n9_vertex_circle_frontier.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Any, Mapping
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -21,6 +22,32 @@ from erdos97.path_display import display_path  # noqa: E402
 
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_vertex_circle_frontier_comparison.json"
 DEFAULT_ARTIFACT = DEFAULT_OUT
+SUMMARY_JSON_KEYS = (
+    "type",
+    "trust",
+    "scope",
+    "notes",
+    "n9_local_core_artifact",
+    "interpretation",
+)
+EXACT_CORE_EMBEDDING_SUMMARY_KEYS = (
+    "pattern",
+    "order",
+    "exact_core_embedding_hits",
+    "checked_core_count",
+    "cyclic_order_preserving_maps_tested",
+)
+PATTERN_VERTEX_CIRCLE_SUMMARY_KEYS = (
+    "pattern",
+    "order",
+    "obstructed",
+    "status",
+    "core_size",
+    "vertex_support_size",
+    "cycle_length",
+    "span_signature",
+    "matching_n9_strict_cycle_span_bucket_count",
+)
 
 
 def load_json(path: Path) -> object:
@@ -43,9 +70,43 @@ def artifact_check_errors(payload: object, artifact: Path) -> list[str]:
     return []
 
 
+def _summarize_records(
+    records: object,
+    keys: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    if not isinstance(records, list):
+        return []
+    return [
+        {key: record[key] for key in keys if key in record}
+        for record in records
+        if isinstance(record, Mapping)
+    ]
+
+
+def summary_json_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without detailed records."""
+
+    summary = {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+    summary["exact_core_embedding_summary"] = _summarize_records(
+        payload.get("exact_core_embedding_results"),
+        EXACT_CORE_EMBEDDING_SUMMARY_KEYS,
+    )
+    summary["pattern_vertex_circle_summary"] = _summarize_records(
+        payload.get("pattern_vertex_circle_results"),
+        PATTERN_VERTEX_CIRCLE_SUMMARY_KEYS,
+    )
+    return summary
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON without detailed records",
+    )
     parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
     parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
     parser.add_argument(
@@ -75,7 +136,9 @@ def main() -> int:
         out.parent.mkdir(parents=True, exist_ok=True)
         with out.open("w", encoding="utf-8", newline="\n") as handle:
             handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print("n=9 vertex-circle frontier comparison")

--- a/tests/test_n9_vertex_circle_frontier_comparison.py
+++ b/tests/test_n9_vertex_circle_frontier_comparison.py
@@ -9,9 +9,11 @@ import pytest
 
 from erdos97.n9_vertex_circle_frontier_comparison import (
     assert_expected_frontier_comparison,
+    frontier_comparison_summary,
 )
 from scripts.compare_n9_vertex_circle_frontier import (
     artifact_check_errors,
+    summary_json_payload,
 )
 
 
@@ -35,6 +37,31 @@ def test_n9_vertex_circle_frontier_comparison_artifact_counts() -> None:
     assert pattern_results["P18_parity_balanced"]["status"] == "strict_cycle"
     assert pattern_results["P18_parity_balanced"]["core_size"] == 6
     assert pattern_results["C19_skew"]["status"] == "passes_vertex_circle_filter"
+
+
+def test_n9_vertex_circle_frontier_comparison_summary_json_payload() -> None:
+    payload = frontier_comparison_summary()
+
+    summary = summary_json_payload(payload)
+
+    assert "exact_core_embedding_results" not in summary
+    assert "pattern_vertex_circle_results" not in summary
+    assert summary["type"] == payload["type"]
+    assert summary["scope"] == payload["scope"]
+    embedding_summary = {
+        record["pattern"]: record for record in summary["exact_core_embedding_summary"]
+    }
+    assert embedding_summary["P18_parity_balanced"]["exact_core_embedding_hits"] == 0
+    assert embedding_summary["C19_skew"]["exact_core_embedding_hits"] == 0
+    assert "hits" not in embedding_summary["P18_parity_balanced"]
+    pattern_summary = {
+        record["pattern"]: record for record in summary["pattern_vertex_circle_summary"]
+    }
+    assert pattern_summary["P18_parity_balanced"]["status"] == "strict_cycle"
+    assert pattern_summary["P18_parity_balanced"]["core_size"] == 6
+    assert pattern_summary["C19_skew"]["status"] == "passes_vertex_circle_filter"
+    assert "cycle_steps" not in pattern_summary["P18_parity_balanced"]
+    assert "core_rows" not in pattern_summary["P18_parity_balanced"]
 
 
 def test_n9_vertex_circle_frontier_comparison_check_rejects_mismatch(
@@ -73,3 +100,25 @@ def test_n9_vertex_circle_frontier_comparison_script_check_is_current() -> None:
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert_expected_frontier_comparison(payload)
+
+
+@pytest.mark.artifact
+@pytest.mark.exhaustive
+def test_n9_vertex_circle_frontier_comparison_cli_summary_json() -> None:
+    payload = frontier_comparison_summary()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/compare_n9_vertex_circle_frontier.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = json.loads(json.dumps(summary_json_payload(payload), sort_keys=True))
+    assert json.loads(result.stdout) == expected


### PR DESCRIPTION
## Summary
- add compact --summary-json output to compare_n9_vertex_circle_frontier.py
- keep full --json and artifact audit/write paths unchanged
- update reviewer-facing docs to prefer compact output while preserving diagnostic-only scope and full-json fallback notes

## Validation
- .venv/bin/python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --summary-json
- .venv/bin/python scripts/compare_n9_vertex_circle_frontier.py --check --assert-expected --json
- .venv/bin/python scripts/compare_n9_vertex_circle_frontier.py --json --summary-json exits with argparse code 2
- .venv/bin/python -m pytest tests/test_n9_vertex_circle_frontier_comparison.py -q
- .venv/bin/python -m pytest tests/test_n9_vertex_circle_frontier_comparison.py -q -m "artifact or exhaustive"
- .venv/bin/python -m ruff check scripts/compare_n9_vertex_circle_frontier.py tests/test_n9_vertex_circle_frontier_comparison.py
- .venv/bin/python scripts/check_text_clean.py
- .venv/bin/python scripts/check_status_consistency.py
- .venv/bin/python scripts/check_artifact_provenance.py
- git diff --check
- make verify-fast PYTHON=.venv/bin/python

## Review
- subagent review: no issues found