### PR TITLE
[codex] Expose n9 local-lemma audit summaries

### DIFF
--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2333,10 +2333,11 @@ closed-descent crosswalk against the same `16` relation skeletons and `184`
 orbit records. It records `33` input artifacts and checks the layer contracts,
 layer provenance, layer source artifacts, claim scope guards, layer
 output/input contracts, focused mini-replay record paths, handoff checks, the
-closed-descent companion summary, and manifest contracts. This is a
-cross-artifact audit path only. It does not prove packet soundness,
-mini-replay soundness, local-lemma completeness, frontier coverage, `n=9`, a
-counterexample, or any official/global status update. Check it with
+closed-descent companion summary, source-artifact contract rollup,
+input-manifest rollup, and manifest contracts. This is a cross-artifact audit
+path only. It does not prove packet soundness, mini-replay soundness,
+local-lemma completeness, frontier coverage, `n=9`, a counterexample, or any
+official/global status update. Check it with
 `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`;
 use `--json` instead when the full layer and manifest records are needed.
 

--- a/docs/n9-vertex-circle-exhaustive.md
+++ b/docs/n9-vertex-circle-exhaustive.md
@@ -119,8 +119,9 @@ The combined local-lemma audit-path command
 checks the focused packet/catalog, focused mini-replay, aggregate/simple
 replay, exhaustive/local-lemma, and relation-skeleton/local-lemma handoffs as
 one review-pending diagnostic chain. It is still bookkeeping only, not packet
-soundness or an `n=9` proof. Use `--json` instead when the full layer and
-manifest records are needed.
+soundness or an `n=9` proof. The compact summary includes source-artifact and
+input-manifest rollups; use `--json` instead when the full layer and manifest
+records are needed.
 
 The input-data audit command
 `scripts/check_n9_vertex_circle_input_audit.py` treats the checked-in

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -697,10 +697,12 @@ manifest-contract records are needed. If validation fails after a complete
 payload is available, the text mode prints those same compact summary lines
 before the detailed validation errors. With either JSON flag, failed runs
 return machine-readable diagnostics and exit nonzero when `--check` is
-supplied; `--summary-json` keeps only the compact rollup fields, while `--json`
-returns the full payload. Regression coverage exercises both layer-side and
-manifest-side contract failures so those two failure classes stay separate in
-text and JSON summaries. When `--assert-expected` is also supplied, an
+supplied; `--summary-json` keeps only the compact rollup fields, including
+the layer source-artifact contract summary and input-manifest summary, while
+`--json` returns the full per-artifact and per-layer payload. Regression
+coverage exercises both layer-side and manifest-side contract failures so
+those two failure classes stay separate in text and JSON summaries. When
+`--assert-expected` is also supplied, an
 expected-shape failure is recorded in `validation_errors` instead of replacing
 the JSON diagnostic with a traceback. If payload construction itself fails, the
 fallback payload records `failure_stage: payload_construction` and the Python

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -273,8 +273,10 @@ Run:
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
 ```
 
-Use `--json` instead of `--summary-json` when the full layer and manifest
-records are needed for audit.
+The compact `--summary-json` output includes the adjacent handoff checks, a
+per-layer source-artifact contract summary, and an input-manifest summary. Use
+`--json` instead when the full layer and manifest records are needed for
+audit.
 
 Check:
 

--- a/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
+++ b/scripts/check_n9_vertex_circle_local_lemma_audit_path.py
@@ -465,6 +465,61 @@ EXPECTED_CLOSED_DESCENT_COMPANION_SUMMARY = {
     },
     "region_class_count_counts": {"1": 13, "2": 1, "3": 2},
 }
+EXPECTED_SOURCE_ARTIFACT_CONTRACT_SUMMARY = {
+    "status": "passed",
+    "layer_count": 5,
+    "passed_layer_count": 5,
+    "failed_layer_count": 0,
+    "failed_layers": [],
+    "expected_artifact_count": 13,
+    "observed_artifact_count": 13,
+    "missing_source_artifact_paths": [],
+    "unexpected_source_artifact_paths": [],
+    "duplicate_source_artifact_paths": [],
+    "mismatched_source_artifacts": [],
+    "malformed_source_artifact_count": 0,
+    "layer_statuses": [
+        {
+            "layer_id": "focused_packet_catalog",
+            "status": "passed",
+            "expected_artifact_count": 4,
+            "observed_artifact_count": 4,
+        },
+        {
+            "layer_id": "focused_minireplay",
+            "status": "passed",
+            "expected_artifact_count": 0,
+            "observed_artifact_count": 0,
+        },
+        {
+            "layer_id": "aggregate_simple_replay",
+            "status": "passed",
+            "expected_artifact_count": 2,
+            "observed_artifact_count": 2,
+        },
+        {
+            "layer_id": "exhaustive_local_lemma",
+            "status": "passed",
+            "expected_artifact_count": 4,
+            "observed_artifact_count": 4,
+        },
+        {
+            "layer_id": "relation_skeleton_local_lemma",
+            "status": "passed",
+            "expected_artifact_count": 3,
+            "observed_artifact_count": 3,
+        },
+    ],
+}
+EXPECTED_INPUT_MANIFEST_SUMMARY = {
+    "artifact_count": 33,
+    "listed_artifact_count": 33,
+    "digest_algorithm": "sha256",
+    "role_reference_count": 35,
+    "manifest_consistency_status": "passed",
+    "missing_from_manifest": [],
+    "unreferenced_manifest_paths": [],
+}
 EXPECTED_SUMMARY_LINES = [
     f"schema: {SCHEMA}",
     f"status: {STATUS}",
@@ -510,6 +565,8 @@ SUMMARY_JSON_KEYS = (
     "layer_summaries",
     "handoff_checks",
     "closed_descent_companion",
+    "source_artifact_contract_summary",
+    "input_manifest_summary",
     "manifest_contract_summary",
     "audit_contract_summary",
 )
@@ -616,6 +673,9 @@ def local_lemma_audit_path_payload(
         layers["relation_skeleton_closed_descent"],
         errors,
     )
+    source_artifact_contract_summary = _source_artifact_contract_summary(
+        layer_source_artifact_contracts
+    )
     input_manifest = (
         dict(input_manifest_payload)
         if input_manifest_payload is not None
@@ -644,6 +704,10 @@ def local_lemma_audit_path_payload(
         claim_payloads=manifest_claim_payloads,
     )
     manifest_consistency = _manifest_consistency(layers, input_manifest, errors)
+    input_manifest_summary = _input_manifest_summary(
+        input_manifest,
+        manifest_consistency,
+    )
     manifest_contract_summary = _manifest_contract_summary(
         {
             "manifest_role_contract": manifest_role_contract,
@@ -693,7 +757,9 @@ def local_lemma_audit_path_payload(
         },
         "closed_descent_companion": closed_descent_companion,
         "audit_contract_summary": audit_contract_summary,
+        "source_artifact_contract_summary": source_artifact_contract_summary,
         "input_manifest": input_manifest,
+        "input_manifest_summary": input_manifest_summary,
         "manifest_role_contract": manifest_role_contract,
         "manifest_digest_contract": manifest_digest_contract,
         "manifest_header_contract": manifest_header_contract,
@@ -750,7 +816,9 @@ def assert_expected_local_lemma_audit_path(payload: Mapping[str, Any]) -> None:
     _assert_expected_layer_input_contracts(payload)
     _assert_expected_focused_minireplay_record_path_contract(payload)
     _assert_expected_closed_descent_companion(payload)
+    _assert_expected_source_artifact_contract_summary(payload)
     _assert_expected_input_manifest(payload)
+    _assert_expected_input_manifest_summary(payload)
     _assert_expected_manifest_role_contract(payload)
     _assert_expected_manifest_digest_contract(payload)
     _assert_expected_manifest_header_contract(payload)
@@ -1060,6 +1128,19 @@ def _assert_expected_closed_descent_companion(payload: Mapping[str, Any]) -> Non
         )
 
 
+def _assert_expected_source_artifact_contract_summary(
+    payload: Mapping[str, Any],
+) -> None:
+    summary = payload.get("source_artifact_contract_summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("source_artifact_contract_summary must be an object")
+    if dict(summary) != EXPECTED_SOURCE_ARTIFACT_CONTRACT_SUMMARY:
+        raise AssertionError(
+            "source_artifact_contract_summary mismatch: "
+            f"{dict(summary)!r} != {EXPECTED_SOURCE_ARTIFACT_CONTRACT_SUMMARY!r}"
+        )
+
+
 def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
     manifest = payload.get("input_manifest")
     if not isinstance(manifest, Mapping):
@@ -1104,6 +1185,17 @@ def _assert_expected_input_manifest(payload: Mapping[str, Any]) -> None:
         size = artifact.get("size_bytes")
         if not isinstance(size, int) or size <= 0:
             raise AssertionError(f"bad size for {artifact.get('path')!r}")
+
+
+def _assert_expected_input_manifest_summary(payload: Mapping[str, Any]) -> None:
+    summary = payload.get("input_manifest_summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("input_manifest_summary must be an object")
+    if dict(summary) != EXPECTED_INPUT_MANIFEST_SUMMARY:
+        raise AssertionError(
+            "input_manifest_summary mismatch: "
+            f"{dict(summary)!r} != {EXPECTED_INPUT_MANIFEST_SUMMARY!r}"
+        )
 
 
 def _assert_expected_manifest_role_contract(payload: Mapping[str, Any]) -> None:
@@ -2172,6 +2264,143 @@ def _manifest_contract_summary(
         "failed_contract_count": len(failed_contracts),
         "failed_contracts": failed_contracts,
         "contract_statuses": contract_statuses,
+    }
+
+
+def _source_artifact_contract_summary(
+    contracts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    layer_statuses: list[dict[str, Any]] = []
+    failed_layers: list[str] = []
+    missing_paths: list[dict[str, str]] = []
+    unexpected_paths: list[dict[str, str]] = []
+    duplicate_paths: list[dict[str, str]] = []
+    mismatched_artifacts: list[dict[str, Any]] = []
+    expected_artifact_count = 0
+    observed_artifact_count = 0
+    malformed_artifact_count = 0
+
+    for layer_id in EXPECTED_LAYER_IDS:
+        contract = next(
+            (
+                item
+                for item in contracts
+                if isinstance(item, Mapping) and item.get("layer_id") == layer_id
+            ),
+            {},
+        )
+        status = contract.get("status") if isinstance(contract, Mapping) else "missing"
+        if not isinstance(status, str):
+            status = "failed"
+        expected_count = _optional_int(contract.get("expected_artifact_count")) or 0
+        observed_count = _optional_int(contract.get("observed_artifact_count")) or 0
+        malformed_count = _optional_int(
+            contract.get("malformed_source_artifact_count")
+        ) or 0
+        expected_artifact_count += expected_count
+        observed_artifact_count += observed_count
+        malformed_artifact_count += malformed_count
+        if status != "passed":
+            failed_layers.append(layer_id)
+        layer_statuses.append(
+            {
+                "layer_id": layer_id,
+                "status": status,
+                "expected_artifact_count": expected_count,
+                "observed_artifact_count": observed_count,
+            }
+        )
+        missing_paths.extend(
+            _layer_path_records(
+                layer_id,
+                contract.get("missing_source_artifact_paths"),
+            )
+        )
+        unexpected_paths.extend(
+            _layer_path_records(
+                layer_id,
+                contract.get("unexpected_source_artifact_paths"),
+            )
+        )
+        duplicate_paths.extend(
+            _layer_path_records(
+                layer_id,
+                contract.get("duplicate_source_artifact_paths"),
+            )
+        )
+        mismatched_artifacts.extend(
+            _layer_mismatch_records(
+                layer_id,
+                contract.get("mismatched_source_artifacts"),
+            )
+        )
+
+    return {
+        "status": "passed" if not failed_layers else "failed",
+        "layer_count": len(EXPECTED_LAYER_IDS),
+        "passed_layer_count": len(EXPECTED_LAYER_IDS) - len(failed_layers),
+        "failed_layer_count": len(failed_layers),
+        "failed_layers": failed_layers,
+        "expected_artifact_count": expected_artifact_count,
+        "observed_artifact_count": observed_artifact_count,
+        "missing_source_artifact_paths": missing_paths,
+        "unexpected_source_artifact_paths": unexpected_paths,
+        "duplicate_source_artifact_paths": duplicate_paths,
+        "mismatched_source_artifacts": mismatched_artifacts,
+        "malformed_source_artifact_count": malformed_artifact_count,
+        "layer_statuses": layer_statuses,
+    }
+
+
+def _layer_path_records(layer_id: str, paths: Any) -> list[dict[str, str]]:
+    if not isinstance(paths, list):
+        return []
+    return [
+        {"layer_id": layer_id, "path": str(path)}
+        for path in paths
+        if isinstance(path, str)
+    ]
+
+
+def _layer_mismatch_records(layer_id: str, mismatches: Any) -> list[dict[str, Any]]:
+    if not isinstance(mismatches, list):
+        return []
+    records: list[dict[str, Any]] = []
+    for mismatch in mismatches:
+        if not isinstance(mismatch, Mapping):
+            continue
+        records.append({"layer_id": layer_id, **dict(mismatch)})
+    return records
+
+
+def _input_manifest_summary(
+    input_manifest: Mapping[str, Any],
+    manifest_consistency: Mapping[str, Any],
+) -> dict[str, Any]:
+    artifacts = input_manifest.get("artifacts")
+    artifact_records = artifacts if isinstance(artifacts, list) else []
+    role_reference_count = 0
+    listed_artifact_count = 0
+    for artifact in artifact_records:
+        if not isinstance(artifact, Mapping):
+            continue
+        listed_artifact_count += 1
+        roles = artifact.get("roles")
+        if isinstance(roles, list):
+            role_reference_count += sum(1 for role in roles if isinstance(role, str))
+    status = manifest_consistency.get("status")
+    return {
+        "artifact_count": input_manifest.get("artifact_count"),
+        "listed_artifact_count": listed_artifact_count,
+        "digest_algorithm": input_manifest.get("digest_algorithm"),
+        "role_reference_count": role_reference_count,
+        "manifest_consistency_status": status if isinstance(status, str) else "failed",
+        "missing_from_manifest": _string_list(
+            manifest_consistency.get("missing_from_manifest")
+        ),
+        "unreferenced_manifest_paths": _string_list(
+            manifest_consistency.get("unreferenced_manifest_paths")
+        ),
     }
 
 

--- a/tests/test_n9_vertex_circle_local_lemma_audit_path.py
+++ b/tests/test_n9_vertex_circle_local_lemma_audit_path.py
@@ -1026,6 +1026,19 @@ def test_local_lemma_audit_path_rejects_source_artifact_drift() -> None:
             "observed": "renamed aggregate source",
         }
     ]
+    assert payload["source_artifact_contract_summary"]["status"] == "failed"
+    assert payload["source_artifact_contract_summary"]["failed_layers"] == [
+        "aggregate_simple_replay"
+    ]
+    assert payload["source_artifact_contract_summary"]["mismatched_source_artifacts"] == [
+        {
+            "layer_id": "aggregate_simple_replay",
+            "path": "data/certificates/n9_vertex_circle_local_lemmas.json",
+            "key": "role",
+            "expected": "aggregate local-lemma scan",
+            "observed": "renamed aggregate source",
+        }
+    ]
     assert any(
         "aggregate_simple_replay source_artifacts mismatch" in error
         for error in payload["validation_errors"]
@@ -2043,6 +2056,10 @@ def test_local_lemma_audit_path_summary_json_payload() -> None:
     assert parsed["coverage_summary"]["assignment_count"] == 184
     assert parsed["audit_contract_summary"]["status"] == "passed"
     assert parsed["manifest_contract_summary"]["status"] == "passed"
+    assert parsed["source_artifact_contract_summary"]["status"] == "passed"
+    assert parsed["source_artifact_contract_summary"]["expected_artifact_count"] == 13
+    assert parsed["input_manifest_summary"]["artifact_count"] == 33
+    assert parsed["input_manifest_summary"]["role_reference_count"] == 35
     assert "audit_path" not in parsed
     assert "input_manifest" not in parsed
 


### PR DESCRIPTION
## Summary

- add compact `source_artifact_contract_summary` and `input_manifest_summary` fields to the n=9 vertex-circle local-lemma audit-path payload and `--summary-json` output
- keep the full per-layer/per-artifact diagnostics behind `--json`, while making compact drift localization visible to reviewers
- update the local-lemma, exhaustive-checker, claims, and reviewer-guide notes to describe the new reviewer-facing summary fields
- add regression coverage that a source-artifact drift is localized to the affected layer in the compact summary

## Scope

This is cross-artifact audit-path bookkeeping only. It does not change certificate data, does not prove packet soundness, does not prove local-lemma completeness, does not prove frontier coverage, does not prove `n=9`, and does not change official/global status.

## Validation

- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_local_lemma_audit_path.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1292 passed, 502 deselected`)