### PR TITLE
[codex] Triage GPT-5.5 zip packets

### DIFF
--- a/docs/gpt55-pro-zip1-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip1-triage-2026-06-04.md
@@ -1,0 +1,89 @@
+# GPT-5.5 Pro Zip 1 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the first GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+The prompt asked for progress on Erdos #97 and explicitly requested either a
+proof or a counterexample. The returned packet did neither. Instead, it
+packaged a compact selected-witness vertex-circle replay for the existing
+review-pending `n=9` and draft `n=10` finite-case artifacts.
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\1.zip
+sha256: 692054c2d7e8a35d12ba284b121c176c720733715ad88976915ef746eafc4515
+```
+
+The extracted packet manifest verified byte-for-byte.
+
+## Contents
+
+The zip contains:
+
+- `src/fast_vertex_circle_search.cpp`: standalone C++ selected-witness search;
+- `src/generic_vertex_circle_search.py`: compact Python reference search;
+- `data/n9_replay_fast_cpp.json` and
+  `data/n9_replay_fast_cpp_unpruned.json`: `n=9` count replays;
+- `data/n10_chunks/*.json`: 26 chunks covering row0 choices `[0,126)`;
+- `data/n10_aggregate_replay.json`: aggregate `n=10` replay summary;
+- short README/provenance notes.
+
+## Checks Run
+
+The packet's static aggregate checker passed:
+
+```text
+row0 coverage: [0,126), exact
+chunk count: 26
+nodes visited: 4,142,738
+full assignments: 0
+partial self-edge prunes: 4,467,592
+partial strict-cycle prunes: 5,318,250
+```
+
+Those chunk totals exactly match the checked-in
+`data/certificates/n10_vertex_circle_singleton_slices.json` artifact when its
+126 singleton rows are regrouped into the packet's five-row chunks. The
+comparison found zero chunk mismatches.
+
+The Python files compile with `py_compile`. This triage did not rerun the C++
+verifier: no `g++`, `clang++`, or `cl` compiler was available on the Windows
+path, and WSL access was denied in the current sandbox. The full C++ rerun is
+therefore not locally reproduced here.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact.
+
+Reasons:
+
+- The numeric content is already present in the repository as the draft
+  `n=10` singleton-slice artifact.
+- The Python reference is a compact duplicate of the repo-native generic
+  vertex search rather than a new certificate format.
+- The C++ verifier is useful provenance, but it is not yet a maintained
+  repo-native checker and was not locally rerun during this triage.
+- The packet does not provide exact coordinates, an exact algebraic
+  certificate, an interval certificate, an SMT certificate, or a formal proof.
+
+This zip is useful as corroborating provenance for the existing draft `n=10`
+audit trail, not as a source-of-truth update.
+
+## Follow-Up
+
+If this line of work is continued, the useful next artifact is a maintained
+repo-native all-slice replay or a compact terminal-conflict certificate for
+the `n=10` singleton slices. That should remain scoped as
+`MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING` unless independent review
+promotes it.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip10-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip10-triage-2026-06-04.md
@@ -1,0 +1,122 @@
+# GPT-5.5 Pro Zip 10 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the tenth GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\10.zip
+sha256: b4082078083befa824a7974764cf607edc9fdaeeb2f691255146399b94c98e48
+```
+
+The extracted `manifest.sha256` verified byte-for-byte with zero SHA-256
+mismatches.
+
+## Contents
+
+The packet contains:
+
+- `src/localized_vertex_search.cpp`: standalone C++17 selected-witness /
+  vertex-circle replay with an optional localized edge-sensitive selected
+  indegree cap;
+- `src/localized_vertex_search`: compiled executable from the source packet;
+- `src/run_slices_range.py` and `src/run_n10_localized_slices.py`: helpers to
+  rerun `n=10` row0 slices;
+- `src/check_results.py`: expected-count validator for the saved outputs;
+- `results/n9_coarse_no_vc.json`: saved `n=9` no-vertex-circle frontier replay;
+- `results/n9_coarse_full.json`: saved `n=9` vertex-circle-pruned replay;
+- `results/n10_localized_slices.jsonl`: one saved JSON object per `n=10` row0
+  slice;
+- `results/n10_localized_summary.json`: aggregate `n=10` summary;
+- `docs/proof_note.md`, `README.md`, and `manifest.sha256`.
+
+## Checks Run
+
+The packet's Python files compile with `py_compile`.
+
+The packet's own validator passed:
+
+```text
+OK: packet outputs match expected n=9/n=10 finite-case counts
+```
+
+The saved `n=9` outputs match the known review-pending counts:
+
+```text
+n=9 without vertex-circle pruning:
+  nodes visited:       100,817
+  full assignments:    184
+  terminal split:      158 self-edge, 26 strict-cycle
+
+n=9 with vertex-circle pruning:
+  nodes visited:       16,752
+  full assignments:    0
+  partial split:       11,271 self-edge, 11,011 strict-cycle
+```
+
+The saved `n=10` output covers all row0 slices with the localized cap
+`floor((2n-4)/3)=5`:
+
+```text
+row0 slices covered:        126
+aborted slices:             0
+total nodes visited:        4,142,738
+full assignments:           0
+partial self-edge prunes:   4,467,592
+partial strict-cycle prunes: 5,318,250
+rows_sha256:                1e466efafff385d9e83cc111993114d809dc5ea2a8c3adb0d5b3378eb6b4bab1
+```
+
+Static comparison against
+`data/certificates/n10_vertex_circle_singleton_slices.json` found exact
+row-level agreement:
+
+```text
+zip rows:        126
+repo rows:       126
+row mismatches:  0
+```
+
+The C++ source was not locally rebuilt or rerun in this pass: no `g++`,
+`clang++`, or `cl` compiler was available on the Windows path. The bundled
+compiled executable was not imported or treated as a maintained artifact.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- The `n=9` and `n=10` numeric content duplicates checked-in review-pending
+  artifacts and previous June 4 GPT-5.5 Pro replay packets.
+- The localized edge-sensitive cap is useful audit context, but the relevant
+  counting idea is already represented in repo-native localized-counting
+  documentation and checks.
+- The packet includes a compiled binary, which should not be committed as a
+  research source-of-truth artifact.
+- The C++ source has not been locally rebuilt in this environment.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful corroborating provenance for the review-pending `n=9`
+and draft `n=10` vertex-circle audit trails. It is not a source-of-truth status
+update.
+
+## Follow-Up
+
+If a maintained C++ replay is added later, this localized-cap implementation is
+a reasonable comparison target against the prior June 4 C++ replay packets. A
+repo-native version should be source-only, compile in CI or a documented local
+toolchain, emit generated JSON, and compare generated `n=9`/`n=10` summaries
+against the checked-in artifacts.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip2-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip2-triage-2026-06-04.md
@@ -1,0 +1,103 @@
+# GPT-5.5 Pro Zip 2 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the second GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\2.zip
+sha256: fa5f47466ea8ea6f560d1c9423cee93dd062efaf56d370a2cc001cad6234ae1e
+```
+
+The extracted `MANIFEST.json` verified byte-for-byte.
+
+## Contents
+
+The packet contains:
+
+- `src/independent_vertex_search.cpp`: standalone C++17 selected-witness
+  searcher for the `n=9` and `n=10` vertex-circle pipeline;
+- `scripts/run_n10_full_rerun.py`: C++ compile-and-run wrapper that emits all
+  126 row0 singleton slices;
+- `scripts/independent_n9_core_certificate.py`: Python support checker that
+  regenerates the `n=9` frontier and records minimal obstructed row cores;
+- `results/independent_n10_full_rerun_with_slices.json`: per-slice `n=10`
+  rerun packet;
+- `results/independent_n9_vertex_circle_core_certificate.json`: full `n=9`
+  support packet;
+- `bin/independent_vertex_search_linux_x86_64`: prebuilt Linux binary, not
+  imported or executed during this triage.
+
+## Checks Run
+
+Static `n=10` per-slice comparison against the checked-in
+`data/certificates/n10_vertex_circle_singleton_slices.json` artifact found
+zero mismatches:
+
+```text
+slice count:                 126
+matched expected repo counts: true
+nodes visited:               4,142,738
+full assignments:            0
+partial self-edge prunes:    4,467,592
+partial strict-cycle prunes: 5,318,250
+```
+
+The Python support checker reran successfully with
+`--summary-json --assert-expected` and reproduced the expected `n=9` summary:
+
+```text
+frontier assignments: 184
+frontier status split: 158 self-edge, 26 strict-cycle
+minimal core sizes: 182 of size 3, 2 of size 4
+minimal core status split: 48 self-edge, 136 strict-cycle
+sha256_without_digest: 9145de3c170efab41d8c1ac4d3fc8943f4713872be10bf05405332e733b0ef8b
+```
+
+The packet's Python files compile with `py_compile`.
+
+The C++ verifier was not locally rerun in this pass: no `g++`, `clang++`, or
+`cl` compiler was available on the Windows path, WSL access was denied in the
+current sandbox, and the included binary targets Linux rather than the current
+Windows shell.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact.
+
+Reasons:
+
+- The `n=10` numeric content is already present in the repository's draft
+  singleton-slice artifact, and the packet's per-slice JSON matches it exactly.
+- The `n=9` Python support packet is useful corroboration, but its counts and
+  minimal-core direction overlap existing review-pending `n=9` vertex-circle
+  audit artifacts.
+- The most useful new item is the standalone C++ source, but it still needs a
+  maintained repo-native wrapper, local compilation in the review environment,
+  and normal generated-artifact provenance before it should enter the checked
+  artifact path.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is stronger corroborating provenance for the existing draft
+`n=10` audit trail than the first zip, but it is still not a source-of-truth
+status update.
+
+## Follow-Up
+
+The worthwhile follow-up is to convert the C++ searcher into a maintained
+artifact-tier verifier, then add a checker that compiles it where available and
+compares all 126 generated row0 slices to the checked-in singleton artifact.
+That should remain scoped as review-pending finite-case audit support unless
+independent review promotes the `n=10` package.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip3-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip3-triage-2026-06-04.md
@@ -1,0 +1,122 @@
+# GPT-5.5 Pro Zip 3 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the third GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\3.zip
+sha256: 2c23d6801737c1be131e50dde7faa4c455186d66c88e2d4a49c6e22d52a45e99
+```
+
+The extracted `MANIFEST.json` listed `138` files and verified byte-for-byte
+with zero SHA-256 mismatches.
+
+## Contents
+
+The packet contains:
+
+- `src/independent_vertex_replay.cpp`: standalone C++17 selected-witness
+  replay engine for the vertex-circle finite-case pipeline;
+- `scripts/run_n10_cpp_singletons.py`: runner that invokes the C++ binary on
+  all `126` `n=10` row0 singleton slices and aggregates the results;
+- `scripts/validate_reports.py`: report validator for the saved `n=9`,
+  `n=10`, and bounded `n=11` outputs;
+- `reports/n10_cpp_replay_aggregated.json` plus
+  `reports/n10_rows/row_000.json` through `row_125.json`: per-row `n=10`
+  audit trail;
+- `reports/n9_cpp_replay_summary.json` and
+  `reports/n9_cpp_no_vc_crosscheck.json`: independent `n=9` replay summaries;
+- `reports/n11_row0_limit1m.json`: node-limited `n=11` row0 scout;
+- `reports/proof_note_n10_selected_witness.md`, `reports/REPORT.md`, and
+  `reports/verification_transcript.txt`: prose summary and command transcript;
+- `bin/independent_vertex_replay_linux_x86_64`: prebuilt Linux binary, not
+  imported or executed during this triage.
+
+## Checks Run
+
+The packet's own report validator passed:
+
+```text
+validated reports: n9 replay, n9 no-VC cross-check, n10 singleton aggregate, n11 scout
+```
+
+The packet's Python files compile with `py_compile`.
+
+The static `n=10` aggregate and row-level comparison against the checked-in
+`data/certificates/n10_vertex_circle_singleton_slices.json` artifact found
+zero mismatches:
+
+```text
+row count:                    126
+aggregate mismatches:         0
+row mismatches:               0
+nodes visited:                4,142,738
+full assignments:             0
+partial self-edge prunes:     4,467,592
+partial strict-cycle prunes:  5,318,250
+matches repo expected totals: true
+```
+
+The static `n=9` summary comparison against
+`data/certificates/n9_vertex_circle_exhaustive.json` also found zero
+mismatches:
+
+```text
+vertex-circle replay nodes:       16,752
+vertex-circle replay full:        0
+partial self-edge prunes:         11,271
+partial strict-cycle prunes:      11,011
+no-vertex-circle replay nodes:    100,817
+no-vertex-circle full frontier:   184
+no-vertex-circle status split:    158 self-edge, 26 strict-cycle
+```
+
+The bounded `n=11` scout is diagnostic only. It covers row0 slice `[0, 1)`,
+hits the `1,000,000` node limit, reports `aborted: true`, and proves nothing
+about `n=11`.
+
+The C++ verifier was not locally rerun in this pass: no `g++`, `clang++`, or
+`cl` compiler was available on the Windows path, and the included binary
+targets Linux rather than the current Windows shell.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact.
+
+Reasons:
+
+- The checkable `n=10` row packet exactly duplicates the repository's existing
+  review-pending singleton-slice artifact.
+- The `n=9` summaries exactly duplicate the repository's existing
+  review-pending exhaustive vertex-circle artifact.
+- The `n=11` scout is intentionally incomplete and should not be used as
+  evidence.
+- The standalone C++ source is the interesting part, but it still needs a
+  maintained repo-native wrapper, local compilation in the review environment,
+  and generated-artifact provenance before it should enter the checked artifact
+  path.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful corroborating provenance for the existing review-pending
+`n=9` and draft `n=10` audit trails, but it is not a source-of-truth status
+update.
+
+## Follow-Up
+
+The worthwhile follow-up is to convert the independent C++ replay engine into
+a maintained artifact-tier verifier, then add a checker that compiles it where
+available and compares its generated `n=9` and `n=10` summaries to the
+checked-in JSON artifacts.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip4-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip4-triage-2026-06-04.md
@@ -1,0 +1,109 @@
+# GPT-5.5 Pro Zip 4 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the fourth GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\4.zip
+sha256: 54f97577facd40573f18c95186e4bcf13139ae587ebaa7cbbe07df0202d4a465
+```
+
+The extracted `MANIFEST.sha256` listed `6` files and verified byte-for-byte
+with zero SHA-256 mismatches.
+
+## Contents
+
+The packet contains:
+
+- `scripts/independent_n9_vertex_circle_replay.py`: self-contained Python
+  replay of the `n=9` selected-witness vertex-circle finite-case pipeline;
+- `data/certificates/independent_n9_vertex_circle_replay.json`: saved replay
+  output with the `184` classified frontier assignments;
+- `docs/independent-n9-vertex-circle-replay.md`: proof-facing note for the
+  replay;
+- `PATCH_NOTES.md`, `README.md`, `run.log`, and `MANIFEST.sha256`.
+
+The useful wrinkle is that the replay deliberately does not enforce the
+selected-indegree cap while branching. It uses row-pair crossing and
+witness-pair capacity filters before replaying the vertex-circle quotient
+obstruction.
+
+## Checks Run
+
+The packet's Python file compiles with `py_compile`.
+
+The replay was rerun from scratch with:
+
+```text
+python .codex-work\zip4-review\erdos97_progress_2026_06_03\scripts\independent_n9_vertex_circle_replay.py --assert-expected --write .codex-work\zip4-review\rerun_independent_n9_vertex_circle_replay.json
+```
+
+The rerun reproduced the expected summary:
+
+```text
+row0 choices:                                70
+search nodes without vertex-circle pruning: 100,817
+frontier assignments before vertex-circle:  184
+vertex-circle status split:                 158 self-edge, 26 strict-cycle
+selected-indegree cap enforced:             false
+all frontier indegrees:                     (4,4,4,4,4,4,4,4,4)
+frontier sha256:                            d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01
+```
+
+The regenerated JSON and the archived JSON differ byte-for-byte because of
+line-ending or formatting details, but their parsed JSON objects match.
+
+The summary agrees with the checked-in
+`data/certificates/n9_vertex_circle_exhaustive.json` no-vertex-circle
+cross-check:
+
+```text
+repo no-vertex-circle nodes:          100,817
+repo no-vertex-circle full frontier:  184
+repo no-vertex-circle status split:   158 self-edge, 26 strict-cycle
+```
+
+The frontier digest also matches the digest already recorded by existing
+frontier crosswalk artifacts.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- The count and digest content corroborates existing review-pending `n=9`
+  vertex-circle artifacts rather than changing the source-of-truth status.
+- The cap-free brancher is a useful independent audit shape, but it overlaps
+  existing frontier coverage, stored-frontier assignment, and mixed-rich
+  frontier crosswalk diagnostics.
+- The raw proof note contains theorem-facing phrasing that should be rewritten
+  into the repository's normal trust-taxonomy language before import.
+- A maintained import should use a repo-native `check_...` script name,
+  compact summary output by default, generated-artifact provenance metadata,
+  and an explicit crosswalk against the stored frontier artifact.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful provenance for the fact that the selected-indegree cap is
+not needed to reach the stored `n=9` pre-vertex-circle frontier, but it is not a
+source-of-truth status update.
+
+## Follow-Up
+
+The worthwhile follow-up is to turn the cap-free replay into a maintained
+artifact-tier checker. The checker should regenerate the `184` frontier without
+selected-indegree pruning, compare the ordered rows and status labels to the
+stored frontier artifact, and record a compact generated JSON summary.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip5-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip5-triage-2026-06-04.md
@@ -1,0 +1,123 @@
+# GPT-5.5 Pro Zip 5 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the fifth GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\5.zip
+sha256: f7675de416869b86c3195071334516a62315aab7eb78cc57352ad2f891615c2a
+```
+
+The extracted `checksums.sha256` listed `136` paths. The `135` payload-file
+checksums matched after clean extraction. The only mismatch was the
+`checksums.sha256` self-entry itself:
+
+```text
+expected: 954668307daa83186ebf3b1c5206de716705f04eb08ef503b203f15908449e12
+actual:   f4797cfdc7639a409e36057827ceeb650a4e099ed05740be678c6ef314e555b9
+```
+
+Treat the checksum file as useful for payload integrity, but not as a
+self-authenticating artifact.
+
+## Contents
+
+The packet contains:
+
+- `src/generic_vertex_search_cpp.cpp`: standalone C++17 selected-witness
+  replay checker;
+- `src/generic_vertex_search_standalone.py`: slower standalone Python port;
+- `scripts/run_n10_cpp_replay.sh`: compile-and-rerun wrapper for all
+  `n=10` row0 singleton slices;
+- `scripts/aggregate_n10_cpp.py`: aggregate checker for the saved slices;
+- `scripts/verify_expected_n10_cpp.py`: quick expected-count verifier;
+- `data/n10_cpp_slices/slice_000.json` through `slice_125.json`: per-slice
+  replay records;
+- `data/n10_cpp_aggregate.json`: aggregate result and slice hashes;
+- `docs/n10_cpp_replay_proof_note.md`, `REPORT.md`, `MANIFEST.json`, and
+  `checksums.sha256`.
+
+## Checks Run
+
+The packet's Python files compile with `py_compile`.
+
+The packet's quick aggregate verifier passed:
+
+```text
+OK: n=10 C++ replay aggregate matches expected repo counts.
+```
+
+Rerunning the packet's aggregate script over the saved slices reproduced the
+expected summary:
+
+```text
+completed slices:            126
+nodes visited:               4,142,738
+full assignments:            0
+partial self-edge prunes:    4,467,592
+partial strict-cycle prunes: 5,318,250
+matches expected counts:     true
+```
+
+The static aggregate and row-level comparison against the checked-in
+`data/certificates/n10_vertex_circle_singleton_slices.json` artifact found
+zero mismatches:
+
+```text
+aggregate mismatches: 0
+row mismatches:       0
+slice count:          126
+```
+
+The standalone Python port was run for slice `[0, 1)` and matched the archived
+slice and repo artifact:
+
+```text
+nodes visited:               9,759
+full assignments:            0
+partial self-edge prunes:    5,256
+partial strict-cycle prunes: 6,031
+```
+
+The C++ verifier was not locally rebuilt or rerun in this pass: no `g++`,
+`clang++`, or `cl` compiler was available on the Windows path.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- The checkable `n=10` row packet exactly duplicates the repository's existing
+  review-pending singleton-slice artifact.
+- The packet overlaps the earlier June 4 GPT-5.5 Pro C++ replay zips, which
+  already recorded the same `n=10` aggregate as corroborating provenance.
+- The C++ source may be useful as a future maintained optional verifier, but
+  it should enter through a repo-native wrapper, local build verification, and
+  generated-artifact provenance metadata.
+- The checksum file has a self-hash mismatch, even though the payload hashes
+  verified.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful corroborating provenance for the existing draft `n=10`
+audit trail, but it is not a source-of-truth status update.
+
+## Follow-Up
+
+The worthwhile follow-up is still to convert one of the independent C++ replay
+implementations into a maintained artifact-tier verifier that compiles where a
+C++17 compiler is available and compares generated `n=10` slices to the
+checked-in singleton artifact.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip6-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip6-triage-2026-06-04.md
@@ -1,0 +1,117 @@
+# GPT-5.5 Pro Zip 6 Triage, 2026-06-04
+
+Status: provenance and follow-up candidate only; not mathematical evidence.
+
+This note triages the sixth GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\6.zip
+sha256: 63872100c8adb8e2ed4ca8402dc6eba0a8e2c0613c4cfc1a6dab79b7a4799209
+```
+
+The packet does not include a payload checksum manifest, so this note records
+only the archive-level SHA-256 plus local consistency checks.
+
+## Contents
+
+The packet contains:
+
+- `src/enhanced_search.cpp`: standalone C++17 selected-witness brancher;
+- `scripts/run_enhanced_checks.sh`: compile-and-run script for the enhanced
+  checks;
+- `scripts/summarize_json_objects.py`: JSON-object stream aggregator;
+- `results/n5_n9_enhanced_summary.json`: saved enhanced runs for `n=5..9`;
+- `results/n10_enhanced_chunks.jsonl`: raw chunk outputs for the `n=10` run;
+- `results/n10_enhanced_summary.json`: aggregate enhanced `n=10` run;
+- `results/n11_probe_summary.json`: diagnostic `n=11` probe;
+- `CLAIM.json`, `README.md`, `docs/proof_note.md`, and
+  `docs/limitations.md`.
+
+The reported new ingredient is a Kalmanson one-cancellation strict-edge filter:
+after quotienting selected-distance equalities, strict Kalmanson quadrilateral
+inequalities that share one quotient class on both sides are converted into a
+single strict directed edge between the remaining distance classes. The branch
+is pruned on strict self-edges or directed strict cycles, together with the
+existing vertex-circle quotient pruning.
+
+## Checks Run
+
+The packet's Python summarizer compiles with `py_compile`.
+
+Rerunning the summarizer over `results/n10_enhanced_chunks.jsonl` reproduced
+the saved aggregate fields exactly:
+
+```text
+chunk count:                  10
+row0 coverage:                [0,126), no gaps
+nodes visited:                250,568
+full assignments:             0
+aborted any:                  false
+partial self-edge prunes:     599,372
+partial strict-cycle prunes:  939,395
+```
+
+The saved `n=5..9` summary is internally consistent as a completed enhanced
+run for each listed `n`:
+
+```text
+n=5 nodes: 1, full: 0
+n=6 nodes: 5, full: 0
+n=7 nodes: 33, full: 0
+n=8 nodes: 291, full: 0
+n=9 nodes: 6,213, full: 0
+```
+
+The saved `n=11` probe is explicitly incomplete: row0 slice `[0,1)` closed,
+while slice `[5,6)` aborted at `10,000` nodes. It is diagnostic only.
+
+The C++ verifier was not locally rebuilt or rerun in this pass: no `g++`,
+`clang++`, or `cl` compiler was available on the Windows path.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- Importing the reported `n <= 10` closure directly would promote a
+  review-pending finite claim beyond the repository's current source-of-truth
+  status.
+- The main result depends on a new pruning layer whose geometric inequality
+  direction, quotient cancellation logic, monotonicity under partial
+  assignments, and C++ implementation still need repo-native review.
+- The C++ checker could not be locally rebuilt in this environment.
+- The packet provides summary JSON, but not compact independent certificates
+  for the pruned branches.
+- The `n=11` probe is intentionally incomplete.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is more interesting than the duplicate `n=10` replay packets: the
+Kalmanson one-cancellation strict-edge filter is a plausible reviewer-facing
+follow-up. It is still not a source-of-truth status update.
+
+## Follow-Up
+
+The worthwhile follow-up is to implement the Kalmanson one-cancellation
+strict-edge filter as an optional repo-native checker, preferably first in
+Python for auditability. A maintained version should:
+
+- state the strict Kalmanson inequalities and cancellation rule in the repo
+  trust taxonomy;
+- cross-check the new strict edges against existing Kalmanson/Farkas tooling;
+- compare enhanced `n=9` and `n=10` runs against existing vertex-circle
+  artifacts;
+- emit compact generated JSON with provenance metadata; and
+- keep `n=10` review-pending unless independent review promotes the full
+  finite-case package.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip7-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip7-triage-2026-06-04.md
@@ -1,0 +1,116 @@
+# GPT-5.5 Pro Zip 7 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the seventh GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\7.zip
+sha256: 5adb4402cc858ac85f4b8ff18a484d775a612c826e27153336d5ceb2a04f78b6
+```
+
+The extracted `MANIFEST.json` listed `12` files and verified byte-for-byte
+with zero SHA-256 mismatches.
+
+## Contents
+
+The packet contains:
+
+- `src/compact_vertex_circle_replay.cpp`: standalone C++17 selected-witness
+  replay checker;
+- `scripts/run_replays.sh`: compile-and-rerun script;
+- `scripts/check_results.py`: expected-count validator for saved outputs;
+- `scripts/aggregate_n10_slices.py`: row0-slice aggregator and stable digest
+  calculator;
+- `results/n8_exact_four_compact.json`: compact `n=8` replay output;
+- `results/n9_exact_four_vertex_circle.json`: vertex-circle-pruned `n=9`
+  replay output;
+- `results/n9_pre_vertex_frontier.json`: `n=9` no-vertex-circle frontier
+  output plus terminal classification counts;
+- `results/n10_exact_four_row0_slices.jsonl`: one JSON object per `n=10`
+  row0 slice;
+- `results/n10_exact_four_row0_slices_summary.json`: aggregate `n=10`
+  summary and stable slice digest;
+- `docs/proof_note.md`, `docs/transcript.md`, `README.md`, and
+  `MANIFEST.json`.
+
+## Checks Run
+
+The packet's Python files compile with `py_compile`.
+
+The packet's expected-count validator passed:
+
+```text
+OK: compact replay result files match expected counts
+```
+
+Rerunning the `n=10` aggregator over the saved JSONL produced a passed
+summary:
+
+```text
+row0 slices:                 126
+row0 coverage:               [0,126)
+aborted slices:              0
+total nodes:                 4,142,738
+full assignments:            0
+partial self-edge prunes:    4,467,592
+partial strict-cycle prunes: 5,318,250
+slice digest sha256:         27116780a8808b5bf565a116b6f61439b4e5f9a6364bef18270e74a8279b41e8
+```
+
+Static comparison against checked-in repo artifacts found zero mismatches for
+the matching `n=9` and `n=10` scopes:
+
+```text
+n=9 vertex-circle nodes:       16,752
+n=9 vertex-circle full:        0
+n=9 vertex-circle split:       11,271 self-edge, 11,011 strict-cycle
+n=9 pre-vertex nodes:          100,817
+n=9 pre-vertex full frontier:  184
+n=9 pre-vertex status split:   158 self-edge, 26 strict-cycle
+n=10 row-level mismatches:     0 across 126 slices
+```
+
+The bundle's `n=8` compact replay was not treated as a replacement for the
+repo's `n <= 8` source-of-truth pipeline, which is the existing incidence and
+exact-obstruction artifact chain rather than this compact counter stream.
+
+The C++ verifier was not locally rebuilt or rerun in this pass: no `g++`,
+`clang++`, or `cl` compiler was available on the Windows path.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- The `n=9` and `n=10` numeric content duplicates checked-in review-pending
+  artifacts and previous June 4 GPT-5.5 Pro replay packets.
+- The `n=8` compact replay is not the repo's source-of-truth `n <= 8`
+  artifact path.
+- The C++ source may still be useful as a compact optional verifier, but it
+  should enter through a repo-native wrapper, local build verification, and
+  generated-artifact provenance metadata.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful corroborating provenance for the existing `n=9` and
+draft `n=10` audit trails, but it is not a source-of-truth status update.
+
+## Follow-Up
+
+If a maintained C++ replay is added later, this compact implementation is a
+reasonable candidate to compare against the other June 4 C++ packets. The
+maintained version should compile where available, emit compact generated JSON,
+and compare generated `n=9`/`n=10` summaries against the checked-in artifacts.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip8-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip8-triage-2026-06-04.md
@@ -1,0 +1,106 @@
+# GPT-5.5 Pro Zip 8 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the eighth GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\8.zip
+sha256: e8f2e4a16391f9687718d45f982248298ef3abc8362eb9b227e9bcf67090e1b2
+```
+
+The extracted `manifest.json` describes the packet as a standalone finite-case
+audit replay for the `n=10` selected-witness exclusion. It records the trust
+label `INDEPENDENT_AUDIT_REPLAY_OF_REPO_DRAFT_N10_SINGLETON_SLICES`, but it
+does not include per-file SHA-256 payload hashes.
+
+## Contents
+
+The packet contains:
+
+- `src/fast_generic_vertex_search.cpp`: standalone C++17 selected-witness
+  search;
+- `scripts/run_replays.sh`: compile-and-rerun shell script;
+- `scripts/verify_results.py`: aggregate-and-assert validator;
+- `results/n9_fast_vertex_pruned_replay.json`: saved `n=9`
+  vertex-circle-pruned replay output;
+- `results/chunks/n10_rows_*.json`: thirteen saved `n=10` row0 chunk outputs;
+- `results/n10_fast_chunked_replay_summary.json`: saved aggregate `n=10`
+  summary;
+- `notes/geometric_filters.md`, `notes/n10_audit_note.md`, `README.md`, and
+  `manifest.json`.
+
+## Checks Run
+
+The packet's Python verifier compiles with `py_compile`.
+
+The verifier passed when run against the extracted packet:
+
+```text
+ok: true
+n=9 nodes:                  16,752
+n=9 full assignments:       0
+n=9 split:                  11,271 self-edge, 11,011 strict-cycle
+n=10 row0 choices covered:  126
+n=10 chunks covered:        13
+n=10 total nodes:           4,142,738
+n=10 full assignments:      0
+n=10 split:                 4,467,592 self-edge, 5,318,250 strict-cycle
+n=10 aborted_any:           false
+```
+
+Static comparison against checked-in repo artifacts found that the saved
+results duplicate existing review-pending vertex-circle replay data:
+
+```text
+n=9 compared artifact:       data/certificates/n9_vertex_circle_exhaustive.json
+n=9 matching scope:          main_search
+n=10 compared artifact:      data/certificates/n10_vertex_circle_singleton_slices.json
+n=10 chunk mismatches:       0 across 13 packet chunks
+n=10 chunk coverage:         [0,126)
+```
+
+For `n=10`, the packet groups the repo's 126 singleton row0 slices into
+thirteen larger row ranges. Aggregating the repo rows over those same ranges
+matches every packet chunk for visited nodes, full assignments, abort status,
+partial self-edge prunes, and partial strict-cycle prunes.
+
+The C++ verifier was not locally rebuilt or rerun in this pass: no `g++`,
+`clang++`, or `cl` compiler was available on the Windows path.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- The `n=9` and `n=10` numeric content duplicates checked-in review-pending
+  artifacts and previous June 4 GPT-5.5 Pro replay packets.
+- The packet is useful as an independent audit/replay shape, but its C++ source
+  has not been locally rebuilt in this environment.
+- The manifest records provenance metadata but no per-file hashes.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful corroborating provenance for the existing review-pending
+`n=9` and draft `n=10` audit trails, but it is not a source-of-truth status
+update.
+
+## Follow-Up
+
+If a maintained C++ replay is added later, this implementation is another
+reasonable compact baseline to compare against the prior June 4 replay packets.
+The maintained version should compile in CI or a documented local toolchain,
+emit generated JSON, and compare generated `n=9`/`n=10` summaries against the
+checked-in artifacts.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/gpt55-pro-zip9-triage-2026-06-04.md
+++ b/docs/gpt55-pro-zip9-triage-2026-06-04.md
@@ -1,0 +1,160 @@
+# GPT-5.5 Pro Zip 9 Triage, 2026-06-04
+
+Status: provenance and task-selection guidance only; not mathematical
+evidence.
+
+This note triages the ninth GPT-5.5 Pro zip supplied on 2026-06-04. It does
+not promote any finite-case result, alter the source-of-truth status, or
+replace the checked repository artifacts. The repository still claims no
+general proof and no counterexample for Erdos Problem #97.
+
+## Input
+
+Local archive reviewed:
+
+```text
+C:\Users\User\Desktop\code\erd archive\04.06.2026\9.zip
+sha256: 393c38d6132c428957af9e924297d895095e17af9f6c3a3f02a7ba5be02644c2
+```
+
+The extracted `MANIFEST.json` lists `19` files. The accompanying
+`checksums.txt` verified byte-for-byte with zero SHA-256 mismatches, including
+the manifest itself.
+
+## Contents
+
+The packet contains:
+
+- `scripts/independent_n9_turn_replay.py`: self-contained fixed-order `n=9`
+  selected-witness incidence enumerator plus turn-capacity certificate finder;
+- `scripts/independent_vertex_circle_replay.py`: self-contained exact
+  selected-witness / vertex-circle replay;
+- `data/n9_turn_independent_replay.json`: saved turn-capacity certificate
+  artifact for the `184` `n=9` incidence-frontier assignments;
+- `data/n9_exact4_independent_replay.json`: saved `n=9` vertex-circle replay;
+- `data/n10_exact4_*.json`: sampled `n=10` row0 spot/chunk replays;
+- rebuilt JSON outputs, two small pytest files, `run_all.sh`, and proof-facing
+  notes under `docs/`.
+
+## Checks Run
+
+The packet's Python scripts compile with `py_compile`.
+
+The packet's tests passed:
+
+```text
+3 passed
+```
+
+Rerunning the main turn replay into scratch passed the packet's expected-count
+assertions:
+
+```text
+frontier assignments:             184
+enumerator nodes:                 104,399
+turn inequalities per assignment: 108
+missing certificates:             0
+lambda histogram:                 {"1": 180, "2": 4}
+term-count histogram:             {"5": 180, "9": 4}
+frontier sha256:                  dc28b32d93e721838a592d1f010f92720869191594dbcc40df2a00f96f213d55
+```
+
+Rerunning the packet's `n=9` vertex-circle replay also closed its selected
+scope:
+
+```text
+row0 slices checked:       70
+full assignments:          0
+nodes:                     11,066
+dead ends:                 15,663
+vertex-circle prunes:      12,305
+partial self-edge prunes:  5,371
+partial strict-cycle prunes: 6,934
+maximum depth reached:     6
+```
+
+The repo-native turn-inequality artifact check also passed:
+
+```text
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
+```
+
+## Repo Comparison
+
+The packet substantially overlaps the already tracked review-pending artifact:
+
+```text
+data/certificates/n9_turn_inequality_frontier.json
+scripts/check_n9_turn_inequality_frontier.py
+docs/n9-turn-inequality-frontier.md
+docs/turn-inequality-lemma.md
+```
+
+The headline turn-capacity data match the repo artifact:
+
+```text
+frontier assignment count: 184
+turn inequalities:         108 per assignment
+certificate missing count: 0
+lambda histogram:          {"1": 180, "2": 4}
+term-count histogram:      {"5": 180, "9": 4}
+```
+
+The packet's frontier SHA-256 differs from the repo artifact's
+`d7807b69b9de27da17fa851b3325b1e26cfa0b6d86277abeda4bc4e3454b8e01`, but this
+is due to ordering/canonicalization. After normalizing both frontiers to
+center-to-witness tuples, the two assignment sets are exactly equal:
+
+```text
+repo assignment count: 184
+zip assignment count:  184
+same order:            false
+same set:              true
+repo minus zip:        0
+zip minus repo:        0
+```
+
+The packet's selected turn-capacity certificate rows are not byte-for-byte the
+same as the repo's stored `farkas_certificates`; they use different selected
+interval indices and coverage vectors while reaching the same certificate
+histograms. This makes the packet useful as independent implementation
+provenance, but not a replacement for the repo-native registered artifact.
+
+The packet's secondary `n=9` vertex-circle replay closes the same selected
+case, but its node and prune counters differ from the repo-native checker. Treat
+those counters as implementation-specific audit data, not as replacement
+totals.
+
+The packet's `n=10` files cover only row0 indices `[0,10)`, `0`, `63`, and
+`125`. They report zero full assignments in those sampled scopes but do not
+match the repo singleton-slice counters and do not prove `n=10`.
+
+## Decision
+
+Do not import the raw packet as a tracked source artifact in this pass.
+
+Reasons:
+
+- The main `n=9` turn route is already represented by a repo-native generated
+  artifact, checker, tests, and documentation.
+- The packet is a useful independent-code replay, but not an independent human
+  review of the turn lemma or source frontier.
+- The proof-facing notes use stronger language than the repo should promote
+  while the turn lemma remains review-pending.
+- The `n=10` material is explicitly spot/chunk audit data only.
+- The zip does not provide exact coordinates, an exact algebraic certificate,
+  an interval certificate, an SMT certificate, or a formal proof.
+
+This packet is useful corroborating provenance for the review-pending `n=9`
+turn-inequality frontier route. It is not a source-of-truth status update.
+
+## Follow-Up
+
+The alternate certificate selection may be worth comparing against
+`data/certificates/n9_turn_inequality_frontier.json` if reviewers want a second
+stored certificate family. That should be done through a repo-native generator
+or explicit appendix with generated-artifact provenance, not by importing the
+zip payload directly.
+
+Do not update `README.md`, `STATE.md`, `RESULTS.md`, or
+`metadata/erdos97.yaml` from this packet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -614,6 +614,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip4-triage-2026-06-04.md`](gpt55-pro-zip4-triage-2026-06-04.md):
   triage of the fourth June 4 GPT-5.5 Pro zip; records a cap-free independent
   `n=9` frontier replay as provenance only.
+- [`gpt55-pro-zip5-triage-2026-06-04.md`](gpt55-pro-zip5-triage-2026-06-04.md):
+  triage of the fifth June 4 GPT-5.5 Pro zip; records another standalone
+  `n=10` C++ replay packet as duplicate corroborating provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -608,6 +608,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip2-triage-2026-06-04.md`](gpt55-pro-zip2-triage-2026-06-04.md):
   triage of the second June 4 GPT-5.5 Pro zip; records the standalone C++
   `n=10` full-slice rerun packet as stronger corroborating provenance only.
+- [`gpt55-pro-zip3-triage-2026-06-04.md`](gpt55-pro-zip3-triage-2026-06-04.md):
+  triage of the third June 4 GPT-5.5 Pro zip; records the expanded C++ replay
+  packet as corroborating provenance for existing `n=9` and `n=10` artifacts.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -611,6 +611,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip3-triage-2026-06-04.md`](gpt55-pro-zip3-triage-2026-06-04.md):
   triage of the third June 4 GPT-5.5 Pro zip; records the expanded C++ replay
   packet as corroborating provenance for existing `n=9` and `n=10` artifacts.
+- [`gpt55-pro-zip4-triage-2026-06-04.md`](gpt55-pro-zip4-triage-2026-06-04.md):
+  triage of the fourth June 4 GPT-5.5 Pro zip; records a cap-free independent
+  `n=9` frontier replay as provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -626,6 +626,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip8-triage-2026-06-04.md`](gpt55-pro-zip8-triage-2026-06-04.md):
   triage of the eighth June 4 GPT-5.5 Pro zip; records a fast chunked C++
   replay packet as duplicate corroborating provenance only.
+- [`gpt55-pro-zip9-triage-2026-06-04.md`](gpt55-pro-zip9-triage-2026-06-04.md):
+  triage of the ninth June 4 GPT-5.5 Pro zip; records an independent `n=9`
+  turn-capacity replay packet as corroborating provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -620,6 +620,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip6-triage-2026-06-04.md`](gpt55-pro-zip6-triage-2026-06-04.md):
   triage of the sixth June 4 GPT-5.5 Pro zip; records the Kalmanson
   one-cancellation strict-edge filter as a follow-up candidate only.
+- [`gpt55-pro-zip7-triage-2026-06-04.md`](gpt55-pro-zip7-triage-2026-06-04.md):
+  triage of the seventh June 4 GPT-5.5 Pro zip; records a compact C++ replay
+  bundle as duplicate corroborating provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -605,6 +605,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip1-triage-2026-06-04.md`](gpt55-pro-zip1-triage-2026-06-04.md):
   triage of the first June 4 GPT-5.5 Pro zip; records the compact `n=10`
   full-slice replay as duplicate provenance only, not a status update.
+- [`gpt55-pro-zip2-triage-2026-06-04.md`](gpt55-pro-zip2-triage-2026-06-04.md):
+  triage of the second June 4 GPT-5.5 Pro zip; records the standalone C++
+  `n=10` full-slice rerun packet as stronger corroborating provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -602,6 +602,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt-pro-followup-triage-2026-05-19.md`](gpt-pro-followup-triage-2026-05-19.md):
   triage of the May 19 GPT Pro output batch; imports only the scoped ellipse
   model-case note and keeps the parabolic descent as duplicate provenance.
+- [`gpt55-pro-zip1-triage-2026-06-04.md`](gpt55-pro-zip1-triage-2026-06-04.md):
+  triage of the first June 4 GPT-5.5 Pro zip; records the compact `n=10`
+  full-slice replay as duplicate provenance only, not a status update.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -629,6 +629,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip9-triage-2026-06-04.md`](gpt55-pro-zip9-triage-2026-06-04.md):
   triage of the ninth June 4 GPT-5.5 Pro zip; records an independent `n=9`
   turn-capacity replay packet as corroborating provenance only.
+- [`gpt55-pro-zip10-triage-2026-06-04.md`](gpt55-pro-zip10-triage-2026-06-04.md):
+  triage of the tenth June 4 GPT-5.5 Pro zip; records a localized-cap C++
+  vertex-circle replay packet as duplicate corroborating provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -617,6 +617,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip5-triage-2026-06-04.md`](gpt55-pro-zip5-triage-2026-06-04.md):
   triage of the fifth June 4 GPT-5.5 Pro zip; records another standalone
   `n=10` C++ replay packet as duplicate corroborating provenance only.
+- [`gpt55-pro-zip6-triage-2026-06-04.md`](gpt55-pro-zip6-triage-2026-06-04.md):
+  triage of the sixth June 4 GPT-5.5 Pro zip; records the Kalmanson
+  one-cancellation strict-edge filter as a follow-up candidate only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -623,6 +623,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip7-triage-2026-06-04.md`](gpt55-pro-zip7-triage-2026-06-04.md):
   triage of the seventh June 4 GPT-5.5 Pro zip; records a compact C++ replay
   bundle as duplicate corroborating provenance only.
+- [`gpt55-pro-zip8-triage-2026-06-04.md`](gpt55-pro-zip8-triage-2026-06-04.md):
+  triage of the eighth June 4 GPT-5.5 Pro zip; records a fast chunked C++
+  replay packet as duplicate corroborating provenance only.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search


### PR DESCRIPTION
## Summary

Adds claim-neutral triage notes for GPT-5.5 Pro zip packets 1 through 10 from 2026-06-04 and indexes them in `docs/index.md`.

Each note records archive provenance, local checks performed, comparison against existing repo artifacts, and the decision not to promote raw AI-generated packets as source-of-truth mathematical evidence.

## Scope

- Adds `docs/gpt55-pro-zip{1..10}-triage-2026-06-04.md`.
- Updates `docs/index.md` with provenance entries.
- Does not update `README.md`, `STATE.md`, `RESULTS.md`, or `metadata/erdos97.yaml`.
- Does not import raw zip payloads, compiled binaries, C++ replay packets, or generated JSON artifacts.

## Review Notes

The packet reviews preserve the repository no-overclaiming boundary: no general proof, no counterexample, and no promotion of review-pending `n=9`/draft `n=10` artifacts.

## Validation

Run locally after the docs changes:

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` -> `1292 passed, 502 deselected`

Caveat: included C++ replay sources from the zip packets were not rebuilt locally because no `g++`, `clang++`, or `cl` compiler was available on the Windows PATH.