### PR TITLE
[codex] Add turn inequality indexing audit

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -84,6 +84,10 @@ Use this queue when no more specific issue is selected.
    inputs. The T10 paired-square entry audit
    `python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
    remains a diagnostic companion, not a theorem.
+   The turn-inequality indexing audit
+   `python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json`
+   checks the n=9 weak-turn interval indexing convention against the term
+   emitter before certificate replay; it does not prove the geometric lemma.
    The turn-inequality frontier replay
    `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
    checks stored integer dual certificates for all 184 regenerated

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -103,6 +103,7 @@ python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --a
 python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
+python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 ```
 
@@ -167,6 +168,9 @@ The quotient/local-lemma audits should confirm:
 
 The turn-packing replay should confirm:
 
+- the indexing audit checks `70` row-offset subsets, `630` row instances, `504`
+  unique center/pair/orientation records, and `7560` emitted term records with
+  no mismatches;
 - source frontier assignment count is `184`;
 - integer dual certificate count is `184`;
 - all weak turn systems are infeasible by stored integer arithmetic;

--- a/docs/n9-turn-inequality-frontier.md
+++ b/docs/n9-turn-inequality-frontier.md
@@ -27,12 +27,18 @@ data/certificates/n9_turn_inequality_frontier.json
 The generator and checker are:
 
 ```bash
+python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
 python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 ```
 
-The check command is also registered in `scripts/run_artifact_audit.py` and
-listed in the raw audit command set in `README.md`.
+The first command is source-level indexing scaffolding. It does not read or
+write the frontier artifact; it exhaustively checks that the term emitter uses
+the two interval supports stated in `docs/turn-inequality-lemma.md`.
+
+The frontier artifact check command is also registered in
+`scripts/run_artifact_audit.py` and listed in the raw audit command set in
+`README.md`.
 Use `--json` instead when the full stored certificate rows are needed.
 
 ## Candidate Turn Lemma
@@ -96,6 +102,8 @@ status `self_edge`, and is also `unsat` under the weak turn system.
 Before this can support a theorem-style n=9 claim, reviewers should check:
 
 - the geometric turn lemma and all offset/index conventions;
+- the indexing audit command above, which verifies the implementation
+  convention but not the geometry;
 - that the regenerated 184-assignment frontier is the intended source frontier
   and is not hiding symmetry quotient assumptions;
 - the stored integer dual certificates and their arithmetic verifier;
@@ -107,7 +115,8 @@ Before this can support a theorem-style n=9 claim, reviewers should check:
 ## Fast Reproduction
 
 ```bash
+python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
 python scripts/check_n9_turn_inequality_frontier.py --assert-expected --json
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
-python -m pytest tests/test_n9_turn_inequality_frontier.py -q
+python -m pytest tests/test_turn_inequality_indexing.py tests/test_n9_turn_inequality_frontier.py -q
 ```

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -476,6 +476,11 @@ handoffs rather than re-extracting T01 or T10.
   `scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
   as a T10/F12 diagnostic companion only, not a theorem;
 - use
+  `scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json`
+  to audit the n=9 weak-turn offset/indexing convention against the current
+  term emitter; this is implementation-convention scaffolding only, not a
+  proof of the geometric turn lemma;
+- use
   `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
   to audit the stored integer dual certificates for the candidate weak
   turn-inequality system on all 184 regenerated n=9 frontier assignments,

--- a/docs/turn-inequality-lemma.md
+++ b/docs/turn-inequality-lemma.md
@@ -56,6 +56,34 @@ sum_{h=a+1}^{n-1} t_{i+h} >= 1.
 The actual geometry gives strict inequalities; the machine replay intentionally
 uses the weaker closed halfspaces.
 
+## Indexing Convention
+
+The replay treats `t_j` as the exterior turn at vertex `p_j`, with indices
+modulo `n`. For one center `i` and one selected offset pair `a < b`, the two
+forced weak inequalities have this convention:
+
+| orientation | geometric arc | cyclic support before sorting | weak inequality |
+| --- | --- | --- | --- |
+| `forward` | from `p_i` through `p_{i+b}` | `i+1, ..., i+b-1` | `sum_{h=1}^{b-1} t_{i+h} >= 1` |
+| `reverse` | from `p_{i+a}` back to `p_i` | `i+a+1, ..., i+n-1` | `sum_{h=a+1}^{n-1} t_{i+h} >= 1` |
+
+The stored replay sorts supports because the inequalities are sums of turn
+variables. For example, in `n=9`, center `i=7`, and offsets `a=1`, `b=4`,
+the forward cyclic support is `8,0,1`, stored as `[0,1,8]`; the reverse
+support is `0,1,2,3,4,5,6`.
+
+The indexing audit
+
+```bash
+python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
+```
+
+exhaustively checks this convention against the current term emitter for all
+`70` row-offset subsets and `9` centers in `n=9`. It verifies `630` row
+instances, `504` unique center/pair/orientation records, and `7560` emitted
+term records. This is an indexing audit only; it does not prove the geometric
+lemma.
+
 ## Proof Sketch
 
 Let
@@ -94,8 +122,8 @@ nonnegative, forcing `u.v >= 0`, contradiction.
 Therefore the turn along that arc is strictly greater than `pi/2`, proving the
 first inequality.
 
-For the second inequality, apply the same dot-product argument to the arc from
-`p_{i+a}` back to `p_i`, using
+For the second inequality, apply the same dot-product argument to the
+complementary arc from `p_{i+a}` back to `p_i`, using
 
 ```text
 u' = p_{i+b} - p_{i+a},

--- a/docs/turn-packing-bridge.md
+++ b/docs/turn-packing-bridge.md
@@ -67,16 +67,18 @@ a contradiction.
 The replay command
 
 ```bash
+python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
 python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 ```
 
-checks the stored `n=9` frontier artifact. Use `--json` instead when the full
-certificate rows are needed. It regenerates the 184 complete
-selected-witness assignments surviving the pair/crossing/count filters before
-vertex-circle pruning and verifies one integer turn-packing certificate for
-each assignment. The replay is arithmetic after the stored interval choices:
-180 certificates use `lambda = 1` and five intervals; 4 use `lambda = 2` and
-nine intervals.
+first checks the offset/indexing convention used to generate weak turn
+intervals, then checks the stored `n=9` frontier artifact. Use `--json`
+instead when the full certificate rows are needed. The frontier replay
+regenerates the 184 complete selected-witness assignments surviving the
+pair/crossing/count filters before vertex-circle pruning and verifies one
+integer turn-packing certificate for each assignment. The replay is arithmetic
+after the stored interval choices: 180 certificates use `lambda = 1` and five
+intervals; 4 use `lambda = 2` and nine intervals.
 
 This is review-pending finite-case evidence only. It does not promote the
 repo source-of-truth status, and it does not imply a general theorem without a

--- a/scripts/check_turn_inequality_indexing.py
+++ b/scripts/check_turn_inequality_indexing.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Check the n=9 turn-inequality indexing convention."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.turn_inequality_indexing import (  # noqa: E402
+    assert_expected_payload,
+    audit_turn_inequality_indexing,
+    summary_payload,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    parser.add_argument("--check", action="store_true", help="validate generated audit data")
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = audit_turn_inequality_indexing()
+    if args.check and payload["validation_status"] != "passed":
+        raise SystemExit("; ".join(str(error) for error in payload["validation_errors"][:5]))
+    if args.assert_expected:
+        assert_expected_payload(payload)
+
+    if args.summary_json:
+        print(json.dumps(summary_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("review-pending n=9 turn-inequality indexing audit")
+        print(f"row offset subsets: {payload['row_offset_subset_count']}")
+        print(f"row instances: {payload['row_instance_count']}")
+        print(f"terms: {payload['observed_term_count']}")
+        print(f"orientation counts: {payload['orientation_counts']}")
+        print(f"support size histogram: {payload['support_size_histogram']}")
+        print(f"mismatches: {payload['mismatch_count']}")
+        print(f"validation_status: {payload['validation_status']}")
+        if args.assert_expected:
+            print("OK: turn-inequality indexing audit matches expected data")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/turn_inequality_indexing.py
+++ b/src/erdos97/turn_inequality_indexing.py
@@ -1,0 +1,291 @@
+"""Exact indexing audit for the turn-inequality convention.
+
+This module is review scaffolding for the proof-facing turn lemma. It checks
+only indexing conventions for the weak turn inequalities; it does not prove
+the geometric lemma, the n=9 finite case, or Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Sequence
+from itertools import combinations
+from math import comb
+from typing import Any
+
+N = 9
+ROW_SIZE = 4
+STATUS = "REVIEW_PENDING_TURN_INEQUALITY_INDEXING_AUDIT"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Indexing-convention audit for the review-pending n=9 turn-inequality "
+    "frontier replay. It checks the two weak interval supports emitted for "
+    "each selected offset pair; it does not prove the geometric turn lemma, "
+    "does not prove n=9, is not a counterexample, and is not a global status "
+    "update."
+)
+
+TermGenerator = Callable[[Sequence[Sequence[int]], int], list[dict[str, object]]]
+
+
+def row_from_offsets(center: int, offsets: Sequence[int], *, n: int = N) -> list[int]:
+    """Return one selected row from positive cyclic offsets."""
+
+    return sorted((center + int(offset)) % n for offset in offsets)
+
+
+def expected_turn_terms_for_offsets(
+    center: int,
+    offsets: Sequence[int],
+    *,
+    n: int = N,
+) -> list[dict[str, object]]:
+    """Return the two expected weak turn terms for every offset pair.
+
+    For ``1 <= a < b <= n-1`` at center ``i``, the convention is:
+
+    - forward support: ``{i+1, ..., i+b-1}``;
+    - reverse support: ``{i+a+1, ..., i+n-1}``.
+
+    Supports are sorted because the stored replay treats them as sums of turn
+    variables, while this audit records cyclic supports separately in
+    ``index_records``.
+    """
+
+    sorted_offsets = sorted(int(offset) for offset in offsets)
+    terms: list[dict[str, object]] = []
+    for a, b in combinations(sorted_offsets, 2):
+        forward = sorted((center + h) % n for h in range(1, b))
+        reverse = sorted((center + h) % n for h in range(a + 1, n))
+        terms.append(
+            {
+                "center": center,
+                "selected_offsets": [a, b],
+                "support": forward,
+                "bound": 1,
+                "orientation": "forward",
+            }
+        )
+        terms.append(
+            {
+                "center": center,
+                "selected_offsets": [a, b],
+                "support": reverse,
+                "bound": 1,
+                "orientation": "reverse",
+            }
+        )
+    return terms
+
+
+def index_records(*, n: int = N) -> list[dict[str, object]]:
+    """Return the unique center/offset-pair/orientation indexing table."""
+
+    records: list[dict[str, object]] = []
+    for center in range(n):
+        for a, b in combinations(range(1, n), 2):
+            forward_cyclic = [(center + h) % n for h in range(1, b)]
+            reverse_cyclic = [(center + h) % n for h in range(a + 1, n)]
+            records.append(
+                {
+                    "center": center,
+                    "selected_offsets": [a, b],
+                    "orientation": "forward",
+                    "cyclic_support": forward_cyclic,
+                    "stored_support": sorted(forward_cyclic),
+                    "support_size": len(forward_cyclic),
+                    "includes_left_witness_turn": (center + a) % n in forward_cyclic,
+                    "includes_right_witness_turn": (center + b) % n in forward_cyclic,
+                }
+            )
+            records.append(
+                {
+                    "center": center,
+                    "selected_offsets": [a, b],
+                    "orientation": "reverse",
+                    "cyclic_support": reverse_cyclic,
+                    "stored_support": sorted(reverse_cyclic),
+                    "support_size": len(reverse_cyclic),
+                    "includes_left_witness_turn": (center + a) % n in reverse_cyclic,
+                    "includes_right_witness_turn": (center + b) % n in reverse_cyclic,
+                }
+            )
+    return records
+
+
+def _normalise_term(term: dict[str, object]) -> dict[str, object]:
+    return {
+        "center": int(term["center"]),
+        "selected_offsets": [int(value) for value in term["selected_offsets"]],  # type: ignore[index]
+        "support": sorted(int(value) for value in term["support"]),  # type: ignore[index]
+        "bound": int(term["bound"]),
+        "orientation": str(term["orientation"]),
+    }
+
+
+def _default_term_generator(
+    rows: Sequence[Sequence[int]],
+    n: int,
+) -> list[dict[str, object]]:
+    from erdos97.n9_turn_inequality_frontier import (  # noqa: PLC0415
+        turn_inequality_terms_for_pattern,
+    )
+
+    return turn_inequality_terms_for_pattern(rows, n=n)
+
+
+def _validate_index_records(records: Sequence[dict[str, object]], *, n: int) -> list[str]:
+    errors: list[str] = []
+    for record_index, record in enumerate(records):
+        center = int(record["center"])
+        a, b = [int(value) for value in record["selected_offsets"]]  # type: ignore[index]
+        orientation = str(record["orientation"])
+        cyclic_support = [int(value) for value in record["cyclic_support"]]  # type: ignore[index]
+        stored_support = [int(value) for value in record["stored_support"]]  # type: ignore[index]
+        support_set = set(cyclic_support)
+        if not cyclic_support:
+            errors.append(f"record {record_index}: empty support")
+        if sorted(cyclic_support) != stored_support:
+            errors.append(f"record {record_index}: stored support is not sorted cyclic support")
+        if center in support_set:
+            errors.append(f"record {record_index}: support includes center")
+        if orientation == "forward":
+            if len(cyclic_support) != b - 1:
+                errors.append(f"record {record_index}: wrong forward support length")
+            if (center + a) % n not in support_set:
+                errors.append(f"record {record_index}: forward support omits left witness turn")
+            if (center + b) % n in support_set:
+                errors.append(f"record {record_index}: forward support includes right endpoint")
+        elif orientation == "reverse":
+            if len(cyclic_support) != n - a - 1:
+                errors.append(f"record {record_index}: wrong reverse support length")
+            if (center + a) % n in support_set:
+                errors.append(f"record {record_index}: reverse support includes left endpoint")
+            if (center + b) % n not in support_set:
+                errors.append(f"record {record_index}: reverse support omits right witness turn")
+        else:
+            errors.append(f"record {record_index}: unknown orientation {orientation!r}")
+    return errors
+
+
+def audit_turn_inequality_indexing(
+    *,
+    n: int = N,
+    row_size: int = ROW_SIZE,
+    term_generator: TermGenerator | None = None,
+) -> dict[str, Any]:
+    """Compare the independent indexing table with the frontier term emitter."""
+
+    if n != N or row_size != ROW_SIZE:
+        raise ValueError("this audit currently has expected invariants only for n=9, row_size=4")
+    generator = term_generator or _default_term_generator
+    records = index_records(n=n)
+    validation_errors = _validate_index_records(records, n=n)
+    mismatches: list[dict[str, object]] = []
+    orientation_counts: Counter[str] = Counter()
+    support_size_histogram: Counter[str] = Counter()
+    expected_term_count = 0
+    observed_term_count = 0
+
+    for offsets in combinations(range(1, n), row_size):
+        rows = [row_from_offsets(center, offsets, n=n) for center in range(n)]
+        expected_terms: list[dict[str, object]] = []
+        for center in range(n):
+            expected_terms.extend(expected_turn_terms_for_offsets(center, offsets, n=n))
+        observed_terms = [_normalise_term(term) for term in generator(rows, n)]
+        expected_terms = [_normalise_term(term) for term in expected_terms]
+        expected_term_count += len(expected_terms)
+        observed_term_count += len(observed_terms)
+
+        for term in observed_terms:
+            orientation_counts[str(term["orientation"])] += 1
+            support_size_histogram[str(len(term["support"]))] += 1
+
+        if expected_terms != observed_terms:
+            mismatches.append(
+                {
+                    "offsets": list(offsets),
+                    "expected_term_count": len(expected_terms),
+                    "observed_term_count": len(observed_terms),
+                    "first_expected": expected_terms[:4],
+                    "first_observed": observed_terms[:4],
+                }
+            )
+
+    payload: dict[str, Any] = {
+        "schema": "erdos97.turn_inequality_indexing.v1",
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": n,
+        "row_size": row_size,
+        "center_count": n,
+        "offset_count": n - 1,
+        "offset_pair_count": comb(n - 1, 2),
+        "row_offset_subset_count": comb(n - 1, row_size),
+        "row_instance_count": n * comb(n - 1, row_size),
+        "unique_center_pair_orientation_count": len(records),
+        "expected_term_count": expected_term_count,
+        "observed_term_count": observed_term_count,
+        "orientation_counts": dict(sorted(orientation_counts.items())),
+        "support_size_histogram": dict(sorted(support_size_histogram.items())),
+        "mismatch_count": len(mismatches),
+        "first_mismatches": mismatches[:5],
+        "validation_errors": validation_errors,
+        "validation_status": (
+            "passed" if not mismatches and not validation_errors else "failed"
+        ),
+        "weak_inequality_template": [
+            "sum_{h=1}^{b-1} t_{i+h} >= 1",
+            "sum_{h=a+1}^{n-1} t_{i+h} >= 1",
+        ],
+        "index_record_count": len(records),
+        "index_records": records,
+    }
+    return payload
+
+
+def summary_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return compact JSON for reviewer-facing command output."""
+
+    return {
+        key: value
+        for key, value in payload.items()
+        if key not in {"index_records", "first_mismatches"}
+    }
+
+
+def assert_expected_payload(payload: dict[str, Any]) -> None:
+    """Assert stable n=9 indexing invariants."""
+
+    expected_values: dict[str, object] = {
+        "n": 9,
+        "row_size": 4,
+        "center_count": 9,
+        "offset_count": 8,
+        "offset_pair_count": 28,
+        "row_offset_subset_count": 70,
+        "row_instance_count": 630,
+        "unique_center_pair_orientation_count": 504,
+        "expected_term_count": 7560,
+        "observed_term_count": 7560,
+        "orientation_counts": {"forward": 3780, "reverse": 3780},
+        "support_size_histogram": {
+            "1": 270,
+            "2": 540,
+            "3": 810,
+            "4": 1080,
+            "5": 1350,
+            "6": 1620,
+            "7": 1890,
+        },
+        "mismatch_count": 0,
+        "validation_status": "passed",
+        "index_record_count": 504,
+    }
+    for key, expected in expected_values.items():
+        observed = payload.get(key)
+        if observed != expected:
+            raise AssertionError(f"{key}: expected {expected!r}, observed {observed!r}")
+    if payload.get("validation_errors") != []:
+        raise AssertionError(f"validation_errors: {payload.get('validation_errors')!r}")

--- a/tests/test_turn_inequality_indexing.py
+++ b/tests/test_turn_inequality_indexing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from erdos97.turn_inequality_indexing import (
+    assert_expected_payload,
+    audit_turn_inequality_indexing,
+    expected_turn_terms_for_offsets,
+    row_from_offsets,
+    summary_payload,
+)
+
+
+def test_turn_inequality_indexing_matches_expected_invariants() -> None:
+    payload = audit_turn_inequality_indexing()
+    assert_expected_payload(payload)
+    assert payload["validation_status"] == "passed"
+    assert payload["mismatch_count"] == 0
+
+
+def test_turn_inequality_indexing_summary_omits_large_records() -> None:
+    payload = audit_turn_inequality_indexing()
+    summary = summary_payload(payload)
+    assert "index_records" not in summary
+    assert "first_mismatches" not in summary
+    assert summary["expected_term_count"] == 7560
+
+
+def test_expected_terms_pin_forward_and_reverse_supports() -> None:
+    terms = expected_turn_terms_for_offsets(center=7, offsets=[1, 4, 6, 8], n=9)
+    first_forward = terms[0]
+    first_reverse = terms[1]
+    assert first_forward == {
+        "center": 7,
+        "selected_offsets": [1, 4],
+        "support": [0, 1, 8],
+        "bound": 1,
+        "orientation": "forward",
+    }
+    assert first_reverse == {
+        "center": 7,
+        "selected_offsets": [1, 4],
+        "support": [0, 1, 2, 3, 4, 5, 6],
+        "bound": 1,
+        "orientation": "reverse",
+    }
+
+
+def test_row_from_offsets_wraps_modulo_n() -> None:
+    assert row_from_offsets(7, [1, 4, 6, 8], n=9) == [2, 4, 6, 8]
+
+
+def test_turn_inequality_indexing_rejects_term_support_drift() -> None:
+    def tampered_terms(rows: list[list[int]], n: int) -> list[dict[str, object]]:
+        terms = expected_turn_terms_for_offsets(0, [1, 2, 3, 4], n=n)
+        for center in range(1, n):
+            terms.extend(expected_turn_terms_for_offsets(center, [1, 2, 3, 4], n=n))
+        terms[0] = {**terms[0], "support": [0]}
+        return terms
+
+    payload = audit_turn_inequality_indexing(term_generator=tampered_terms)
+    assert payload["validation_status"] == "failed"
+    assert payload["mismatch_count"] > 0
+    with pytest.raises(AssertionError):
+        assert_expected_payload(payload)


### PR DESCRIPTION
## Summary

Adds a source-level audit for the `n=9` weak turn-inequality indexing convention.

The new checker exhaustively compares the independent interval convention against the current turn term emitter across all `70` row-offset subsets and `9` centers, covering `630` row instances, `504` unique center/pair/orientation records, and `7560` emitted term records.

The PR also tightens the proof-facing turn lemma note with an explicit indexing table and wires the new command into the turn-frontier note, turn-packing bridge, `n=9` reviewer packet, review priorities, and backlog.

## Claim discipline

This is review scaffolding only. It does not prove the geometric turn lemma, does not promote `n=9`, does not claim a proof of Erdos Problem #97, does not claim a counterexample, and does not update official/global status.

## Validation

- `python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json`
- `python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
- `python -m pytest tests/test_turn_inequality_indexing.py tests/test_n9_turn_inequality_frontier.py -q` (`14 passed`)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1297 passed, 502 deselected`)