### PR TITLE
[codex] Add n9 local lemma review packet

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -25,7 +25,10 @@ Use this queue when no more specific issue is selected.
 1. Review the aggregate `n=9` vertex-circle local-lemma scan against the
    focused T01/T02/T03/T04/T05/T06/T07/T08/T09 self-edge packets and the focused T10/T11/T12
    strict-cycle packets, keeping it scoped as proof-mining scaffolding rather
-   than an `n=9` proof. The focused packet catalog audit command
+   than an `n=9` proof. Start from
+   `docs/n9-vertex-circle-local-lemma-review-packet.md`, which records the
+   current five-layer audit path and review boundary. The focused packet
+   catalog audit command
    `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
    now checks that the focused packet coverage, source template records,
    source catalog records, and aggregate focused-note crosschecks agree before

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -42,6 +42,7 @@ It would not prove the general problem for larger polygons.
 - `docs/n9-vertex-circle-strict-edge-geometry-audit.md`
 - `docs/n9-vertex-circle-quotient-soundness-audit.md`
 - `docs/n9-vertex-circle-local-lemmas.md`
+- `docs/n9-vertex-circle-local-lemma-review-packet.md`
 - `docs/relation-skeleton-catalog.md`
 - `docs/turn-inequality-lemma.md`
 - `docs/turn-packing-bridge.md`

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -1,0 +1,191 @@
+# n=9 Vertex-circle Local-lemma Reviewer Packet
+
+Status: `REVIEW_PACKET_ONLY`.
+
+Claim scope: review-pending `n=9` vertex-circle local-lemma packet chain.
+
+Source of truth: `docs/n9-reduction-chain.md`,
+`docs/n9-review-packet.md`, `docs/n9-vertex-circle-local-lemmas.md`,
+`docs/relation-skeleton-catalog.md`, and `metadata/erdos97.yaml`.
+
+Last assembled: 2026-06-04.
+
+## Non-claims
+
+- This packet does not prove Erdos Problem #97.
+- This packet does not claim a counterexample.
+- This packet does not prove the `n=9` finite case.
+- This packet does not independently review the exhaustive brancher.
+- This packet does not prove local-lemma completeness outside the stored
+  `n=9` frontier accounting.
+- This packet does not update the official/global status.
+
+## Review target
+
+This packet packages the local-lemma layer behind Step A10 of
+`docs/n9-reduction-chain.md`:
+
+```text
+Every one of the 184 pre-vertex-circle frontier assignments contains a
+selected-distance quotient self-edge or strict directed cycle.
+```
+
+The local-lemma layer is narrower than the full `n=9` route. It assumes the
+`184` frontier source rows and the vertex-circle strict-edge rule are already
+under review elsewhere. Its job is to make the quotient-obstruction packet
+auditable.
+
+## Main files to inspect
+
+- `docs/n9-vertex-circle-local-lemmas.md`
+- `docs/n9-vertex-circle-local-cores.md`
+- `docs/relation-skeleton-catalog.md`
+- `docs/n9-vertex-circle-self-edge-criterion.md`
+- `docs/n9-vertex-circle-strict-cycle-criterion.md`
+- `docs/n9-vertex-circle-t01-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t02-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t03-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t04-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t05-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t06-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t07-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t08-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t09-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
+- `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
+- `docs/n9-vertex-circle-t12-strict-cycle-lemma.md`
+
+The focused T-notes are reviewer-facing local arguments. The JSON artifacts
+and scripts below check their accounting and replay contracts.
+
+## Packet shape
+
+The current local-lemma packet has:
+
+- `12` template packets: `T01` through `T12`;
+- `16` dihedral motif families;
+- `184` labelled frontier assignments;
+- `13` self-edge families covering `158` assignments;
+- `3` strict-cycle families covering `26` assignments;
+- `16` relation-skeleton entries, one per motif family.
+
+The nine self-edge templates are `T01` through `T09`. The three strict-cycle
+templates are `T10`, `T11`, and `T12`.
+
+## Audit chain
+
+Run the combined audit first:
+
+```bash
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
+```
+
+Expected stable invariants:
+
+- `validation_status: passed`;
+- `audit_contract_summary.status: passed`;
+- `component_count: 10`;
+- `layer_count: 5`;
+- `template_count: 12`;
+- `template_ids: T01,...,T12`;
+- `family_count: 16`;
+- `assignment_count: 184`;
+- `self_edge_family_count: 13`;
+- `self_edge_assignment_count: 158`;
+- `strict_cycle_family_count: 3`;
+- `strict_cycle_assignment_count: 26`;
+- `relation_skeleton_count: 16`;
+- input manifest has `33` listed artifacts and no missing or unreferenced
+  paths.
+
+The combined audit is a chain of these layers:
+
+| layer | role | command |
+| --- | --- | --- |
+| `focused_packet_catalog` | checks the T01-T12 packet/catalog ledger | `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json` |
+| `focused_minireplay` | joins each focused packet to its packet-specific mini-replay | `python scripts/check_n9_vertex_circle_focused_minireplay_crosswalk.py --check --assert-expected --summary-json` |
+| `aggregate_simple_replay` | compares aggregate local-lemma scan with the simple replay | `python scripts/check_n9_vertex_circle_local_lemma_replay_crosswalk.py --check --assert-expected --summary-json` |
+| `exhaustive_local_lemma` | connects local-lemma accounting back to the 184-frontier motif classification | `python scripts/check_n9_vertex_circle_exhaustive_local_lemma_crosswalk.py --check --assert-expected --summary-json` |
+| `relation_skeleton_local_lemma` | checks the 16 relation skeletons against aggregate local-lemma accounting | `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json` |
+
+Companion check:
+
+```bash
+python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json
+```
+
+Expected stable invariants:
+
+- `family_count: 16`;
+- `orbit_size_sum: 184`;
+- contradiction counts `strict_self_edge: 13` and
+  `strict_directed_cycle: 3`;
+- region-class counts `1: 13`, `2: 1`, `3: 2`.
+
+## Local proof obligations
+
+For each focused packet or relation skeleton, a reviewer should check:
+
+- the displayed selected rows are exactly the local hypotheses being used;
+- each selected-distance equality step follows from one selected row;
+- each strict edge follows from the stated vertex-circle witness order and
+  chord-containment convention;
+- a self-edge really gives `D > D`;
+- a strict directed cycle really returns to its starting quotient class;
+- the local argument does not rely on template names as theorem names.
+
+The packet soundness review is mathematical. The audit commands check
+bookkeeping, replay consistency, and schema contracts; they do not replace the
+human review of each local relation.
+
+## Aggregate bookkeeping obligations
+
+For the aggregate layer, a reviewer should check:
+
+- the T01-T12 focused packets cover the same `16` families and `184`
+  assignments as the aggregate local-lemma scan;
+- focused mini-replays agree with the focused packet records;
+- the simple replay agrees with the aggregate scan without sharing the main
+  packet generator;
+- the exhaustive/local-lemma crosswalk links back to the stored
+  pre-vertex-circle frontier accounting;
+- relation skeletons preserve the same family ids, obstruction kinds, and
+  assignment counts;
+- manifest contracts localize any future digest, schema, provenance, metadata,
+  or claim-scope drift to a specific input layer.
+
+## Relation to the n=9 route
+
+If this packet survives review, it supports the A10 quotient-obstruction
+dependency in the vertex-circle route. It still does not review:
+
+- the A6/A7 brancher coverage of the `184` frontier;
+- the A8 vertex-circle strict-edge geometry;
+- the turn-packing route;
+- the algebraic Groebner route;
+- any bridge from larger counterexamples to `n=9`.
+
+Thus the strongest possible outcome of this packet alone is:
+
+```text
+The stored 184-frontier local-lemma quotient-obstruction accounting is
+reviewed, assuming the source frontier and strict-edge geometry.
+```
+
+It is not, by itself, a repo-local proof of `n=9`.
+
+## Acceptance outcomes
+
+A review should record one of these outcomes:
+
+- `accepted_packet_soundness`: each focused local packet or relation skeleton
+  is mathematically sound as a local obstruction.
+- `accepted_A10_bookkeeping`: the audit chain convincingly connects the
+  reviewed local packets to all `184` stored frontier assignments.
+- `accepted_diagnostic_only`: commands reproduce, but packet soundness or
+  aggregate completeness still needs review.
+- `gap_found`: a precise packet, handoff, schema, or mathematical gap is found.
+
+Only the first two outcomes together would support marking A10 as reviewed in a
+future source-of-truth PR. That future PR must still leave the global problem
+open and must not promote `n=9` unless A6/A7 and A8 have also survived review.

--- a/docs/n9-vertex-circle-local-lemmas.md
+++ b/docs/n9-vertex-circle-local-lemmas.md
@@ -7,6 +7,10 @@ review-pending `n=9` vertex-circle template packets. It does not prove `n=9`,
 does not claim a counterexample, does not independently review the exhaustive
 checker, and does not update the official/global status of Erdos Problem #97.
 
+For a reviewer-facing packet that ties the focused T01-T12 notes, relation
+skeletons, aggregate replay, exhaustive crosswalk, and manifest checks into one
+audit path, see `docs/n9-vertex-circle-local-lemma-review-packet.md`.
+
 The companion checker is:
 
 ```bash

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -341,6 +341,9 @@ when the full mismatch example block is needed.
 Target: `docs/n9-vertex-circle-obstruction-shapes.md` and
 `docs/n9-vertex-circle-motif-families.md`.
 
+Local-lemma reviewer packet:
+`docs/n9-vertex-circle-local-lemma-review-packet.md`.
+
 The n=9 obstruction-shape diagnostic shows that the 184 pre-vertex-circle
 frontier assignments are killed by 158 self-edges and 26 strict cycles, all
 strict cycles having length 2 or 3. This makes the most promising proof push a

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -263,6 +263,7 @@ Check:
 Primary references:
 
 - `docs/n9-review-packet.md`
+- `docs/n9-vertex-circle-local-lemma-review-packet.md`
 - `docs/n9-vertex-circle-local-lemmas.md`
 - `docs/relation-skeleton-catalog.md`
 - `docs/n9-reduction-chain.md`


### PR DESCRIPTION
## Summary

Adds `docs/n9-vertex-circle-local-lemma-review-packet.md`, a reviewer-facing packet for the `n=9` vertex-circle local-lemma audit path.

The packet packages the A10 quotient-obstruction layer: focused T01-T12 packets, relation skeletons, aggregate/simple replay, exhaustive/local-lemma crosswalk, closed-descent companion, expected invariants, review obligations, and acceptance outcomes. It also links the packet from the broad `n=9` reviewer packet, local-lemma note, reviewer guide, review priorities, and backlog.

## Claim discipline

This is documentation and review scaffolding only. It supports review of the A10 local-lemma packet chain, but it does not prove `n=9`, does not review A6/A7 brancher coverage, does not review A8 strict-edge geometry, does not claim a counterexample, and does not update official/global status.

## Validation

- `python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json`
- `python scripts/check_relation_skeleton_local_lemma_crosswalk.py --check --assert-expected --summary-json`
- `python scripts/check_n9_relation_skeleton_closed_descent_crosswalk.py --check --assert-expected --summary-json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1297 passed, 502 deselected`)