### PR TITLE
[codex] Add n10 singleton review packet

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -905,6 +905,7 @@ Issue: none yet.
 
 Read first:
 
+- `docs/n10-vertex-circle-singleton-review-packet.md`
 - `docs/n10-vertex-circle-singleton-slices.md`
 - `src/erdos97/generic_vertex_search.py`
 - `src/erdos97/n10_vertex_circle_singletons.py`
@@ -921,6 +922,9 @@ python -m pytest tests/test_n10_vertex_circle_singletons.py -q -m "artifact"
 
 Expected artifacts:
 
+- a reviewer packet separating primary artifact counts, input-data audit,
+  selected spot replay, secondary first-five replay, and missing promotion
+  evidence;
 - independent review notes for the generic checker and the imported singleton rows;
 - an input-data audit checking the stored `[0,126)` row0 singleton coverage,
   witness masks/lists, and aggregate arithmetic without rerunning the search;

--- a/docs/n10-vertex-circle-singleton-review-packet.md
+++ b/docs/n10-vertex-circle-singleton-review-packet.md
@@ -1,0 +1,178 @@
+# n=10 Vertex-circle Singleton-slice Reviewer Packet
+
+Status: `REVIEW_PACKET_ONLY`.
+
+Claim scope: repo-local `n=10` selected-witness finite-case draft candidate.
+
+Source of truth: `README.md`, `STATE.md`, `RESULTS.md`, `docs/claims.md`,
+`docs/n10-vertex-circle-singleton-slices.md`, and
+`metadata/erdos97.yaml`.
+
+Last assembled: 2026-06-04.
+
+## Non-claims
+
+- This packet does not prove Erdos Problem #97.
+- This packet does not claim a counterexample.
+- This packet does not update the official/global status.
+- This packet does not promote the n=10 singleton artifact beyond draft.
+- Passing every command below is not a substitute for independent mathematical
+  review of the pruning lemmas, brancher implementation, and certificate path.
+
+## Candidate being reviewed
+
+The scoped draft candidate is:
+
+```text
+No strictly convex 10-gon has a selected 4-witness row at every vertex,
+provided the checked pair/crossing/count and vertex-circle filters are sound.
+```
+
+The checked-in primary artifact reports that all `126` singleton choices for
+row `0` close under the current vertex-circle selected-row search and that no
+full selected-witness assignment survives. This is evidence for a finite-case
+draft only. The current review packet is mainly a map of what has been
+checked, what has been cross-checked, and what is still missing.
+
+## Main files to inspect
+
+- `docs/n10-vertex-circle-singleton-slices.md`
+- `data/certificates/n10_vertex_circle_singleton_slices.json`
+- `data/certificates/2026-05-05/n10_secondary.json`
+- `src/erdos97/generic_vertex_search.py`
+- `src/erdos97/n10_vertex_circle_singletons.py`
+- `src/erdos97/n10_secondary_singleton_replay.py`
+- `scripts/check_n10_vertex_circle_singletons.py`
+- `scripts/check_n10_singleton_input_audit.py`
+- `scripts/check_n10_secondary_singleton_replay.py`
+- `tests/test_n10_vertex_circle_singletons.py`
+
+## Evidence layers
+
+### Layer A: primary singleton artifact
+
+Primary artifact:
+`data/certificates/n10_vertex_circle_singleton_slices.json`.
+
+The artifact stores one explicit row for each singleton slice of row `0` in
+the repo-native row-option order. Expected aggregate invariants:
+
+```text
+row0 choices covered:      126 / 126
+aborted slices:            0
+full assignments:          0
+nodes visited:             4,142,738
+partial self-edge prunes:  4,467,592
+partial strict cycles:     5,318,250
+```
+
+Reviewer burden: check that the recorded row0 split is genuinely a singleton
+split of all `4`-subsets of labels `1..9`, not a hidden symmetry quotient, and
+that aggregating independent singleton runs is equivalent to the unsplit
+row-0 search.
+
+### Layer B: input-data audit
+
+The input audit treats the primary JSON as stored data. It recomputes row0
+choices directly as lexicographic `4`-subsets of labels `1..9`, then checks
+row indices, singleton ranges, witness masks, witness lists, and aggregate
+count arithmetic. It deliberately does not rerun the search, import
+`GenericVertexSearch`, replay terminal conflicts, or prove the n=10 candidate.
+
+Run:
+
+```bash
+python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json
+```
+
+Acceptance outcome: this layer can accept row0 coverage and stored arithmetic
+only. It cannot accept pruning soundness or terminal closure.
+
+### Layer C: repo-native spot replay
+
+The generic Python checker can rerun selected singleton slices against the
+primary artifact. Current reviewer spot checks use the first, middle, and last
+row0 slices:
+
+```bash
+python scripts/check_n10_vertex_circle_singletons.py \
+  --assert-expected \
+  --spot-check-row0 0 \
+  --spot-check-row0 63 \
+  --spot-check-row0 125
+```
+
+Acceptance outcome: this layer can detect disagreement between the imported
+artifact and the repo-native checker at the sampled rows. It cannot replace an
+all-slice independent replay.
+
+### Layer D: secondary first-five replay
+
+Secondary artifact:
+`data/certificates/2026-05-05/n10_secondary.json`.
+
+This archived replay covers row0 singletons `0..4` only. It uses the same
+pair/crossing/indegree/vertex-circle filters and an additional
+triple-intersection necessary filter. The replay verifies exact agreement with
+the primary artifact for witness lists, node counts, full counts, and prune
+counts on those first five rows.
+
+Expected aggregate invariants:
+
+```text
+row0 choices covered:      5 / 126
+full assignments:          0
+nodes visited:             114,144
+partial self-edge prunes:  106,827
+partial strict cycles:     120,823
+```
+
+Run:
+
+```bash
+python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json
+```
+
+Acceptance outcome: this layer can accept prefix agreement only. Because it
+covers `5 / 126` row0 slices and adds an extra necessary filter, it cannot
+promote the primary artifact by itself.
+
+## Missing promotion evidence
+
+The current packet is intentionally incomplete. Before the n=10 candidate can
+move beyond draft, it still needs at least one of:
+
+- a second implementation that replays all `126` singleton slices and agrees
+  with the primary artifact;
+- a replayable terminal-conflict certificate for every terminal branch, with a
+  verifier that does not trust the brancher search history;
+- a smaller exact mathematical lemma that subsumes the singleton search and
+  has independently reviewed hypotheses.
+
+Any of those routes would still remain a repo-local finite-case review result,
+not a general proof of Erdos Problem #97.
+
+## Review checklist
+
+- Verify the geometric necessity of the pair/crossing, witness-pair capacity,
+  selected-indegree, and vertex-circle strict-edge filters.
+- Check that minimum-remaining-options branching changes only search order.
+- Check that partial vertex-circle pruning uses only already-fixed selected
+  rows and selected-distance equalities.
+- Confirm that the primary artifact has exact row0 singleton coverage
+  `[0,126)` with no symmetry quotient.
+- Confirm that the input-data audit, selected spot replay, and secondary
+  first-five replay are described with their actual scopes.
+- Require all-slice independent replay, terminal-conflict certificates, or an
+  independently reviewed replacement lemma before promoting the n=10 package.
+
+## Safe acceptance outcomes
+
+- `accepted_input_coverage`: row0 singleton coverage and stored aggregate
+  arithmetic are accepted.
+- `accepted_selected_spot_replay`: sampled rows match the repo-native checker.
+- `accepted_secondary_prefix`: rows `0..4` match the archived secondary replay.
+- `blocked_on_all_slice_replay`: promotion is blocked until all `126` slices
+  have independent replay or an equivalent replayable certificate.
+- `gap_found`: any mismatch or unsound pruning rule keeps the artifact as
+  diagnostic input only.

--- a/docs/n10-vertex-circle-singleton-slices.md
+++ b/docs/n10-vertex-circle-singleton-slices.md
@@ -9,6 +9,11 @@ established source-of-truth local result remains the repo-local,
 machine-checked selected-witness `n <= 8` artifact; the n=9 and n=10
 vertex-circle packages are still review-pending.
 
+Reviewer packet: `docs/n10-vertex-circle-singleton-review-packet.md` collects
+the current evidence layers, reproduction commands, missing promotion evidence,
+and safe acceptance outcomes. It is a worksheet only and does not promote the
+n=10 singleton artifact beyond draft.
+
 ## What is checked
 
 The checker labels a hypothetical bad decagon in cyclic order `0,...,9` and
@@ -158,8 +163,8 @@ should check:
 - that vertex-circle partial pruning uses only already-fixed selected rows and
   selected-distance equalities;
 - that the generic repo-native checker and the archived C++ checker agree
-  beyond the selected n=10 singleton spot-checks, or that a second independent verifier
-  replays all terminal conflicts;
+  beyond the selected n=10 singleton spot-checks, or that a second independent
+  verifier replays all terminal conflicts;
 - that the secondary first-five replay is treated only as prefix agreement
   under an extra necessary filter, not as all-slice coverage;
 - that the artifact remains scoped to the selected-witness n=10 finite case

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -507,6 +507,11 @@ selected-witness assignments.
 Target: `docs/n10-vertex-circle-singleton-slices.md` and
 `data/certificates/n10_vertex_circle_singleton_slices.json`.
 
+Reviewer packet: `docs/n10-vertex-circle-singleton-review-packet.md` collects
+the current evidence layers, reproduction commands, missing promotion evidence,
+and safe acceptance outcomes. It is a worksheet only and does not promote the
+n=10 singleton artifact beyond draft.
+
 The incoming n=10 continuation covers all 126 row0 singleton slices and records
 zero full selected-witness assignments under the pair/crossing/count plus
 vertex-circle filters. Treat this as a draft until an independent audit checks:

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -323,6 +323,37 @@ Check:
   artifacts, not as incidence completeness, geometric realizability,
   a proof of `n=9`, a counterexample, or an official/global status update.
 
+## Review target I - `n=10` singleton-slice draft
+
+Primary references:
+
+- `docs/n10-vertex-circle-singleton-review-packet.md`
+- `docs/n10-vertex-circle-singleton-slices.md`
+- `scripts/check_n10_singleton_input_audit.py`
+- `scripts/check_n10_vertex_circle_singletons.py`
+- `scripts/check_n10_secondary_singleton_replay.py`
+
+Run:
+
+```bash
+python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json
+python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125
+python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json
+```
+
+Check:
+
+- that row0 singleton coverage is exactly `[0,126)` with no hidden symmetry
+  quotient;
+- that the input-data audit is only stored-data validation, not a terminal
+  conflict replay;
+- that the selected spot replay covers only rows `0`, `63`, and `125`;
+- that the secondary replay covers only rows `0..4` and uses an extra
+  necessary filter;
+- that all-slice independent replay, terminal-conflict certificates, or an
+  independently reviewed replacement lemma are still required before the n=10
+  package can move beyond draft.
+
 ## Known weak points / independent review requests
 
 - Independent audit of `scripts/enumerate_n8_incidence.py`.
@@ -341,6 +372,9 @@ Check:
 - Independent review of the `n=9` base-apex audit path should check the
   low-excess ledger arithmetic, D=3 handoffs, selected-baseline crosswalk, and
   vertex-circle frontier connection before using it as bridge evidence.
+- Independent review of the `n=10` singleton-slice draft should check the
+  primary search implementation, row0 singleton split, partial vertex-circle
+  pruning, and all-slice replay gap before any n=10 promotion.
 - Independent reproduction of `certificates/n8_exact_analysis.json`.
 - A Lean, SMT, interval, or algebraic certificate checker would be high value.
 


### PR DESCRIPTION
## Summary

- add an n=10 vertex-circle singleton-slice reviewer packet
- link the packet from the n=10 draft note, review priorities, reviewer guide, and backlog
- keep the scope explicit: input-data audit, selected spot replay, and secondary first-five replay are evidence layers, while all-slice independent replay or terminal-conflict certificates remain missing promotion evidence

## Validation

- `python scripts/check_n10_singleton_input_audit.py --check --assert-expected --json`
- `python scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json`
- `python scripts/check_n10_vertex_circle_singletons.py --assert-expected`
- `python scripts/check_n10_vertex_circle_singletons.py --assert-expected --spot-check-row0 0 --spot-check-row0 63 --spot-check-row0 125`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`