### PR TITLE
Harden Kalmanson summary JSON review outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
-	$(PYTHON) scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json
-	$(PYTHON) scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json
+	$(PYTHON) scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1072,19 +1072,20 @@ all 184 regenerated pair/crossing/count frontier assignments. It records all
 indexing conventions remain review-pending, so this does not promote `n=9`.
 Use `--json` instead when the full certificate rows are needed.
 The compact Kalmanson self-edge replay
-`scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json`
+`scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json`
 checks a separate certificate in which each of those 184 terminal assignments
 has a single strict Kalmanson inequality whose two sides become the same
 quotient multiset after selected-distance quotienting. This is a
 review-pending audit aid only; it does not independently complete review of the
-brancher or promote `n=9`.
+brancher or promote `n=9`. Use `--json` when the full replay payload is needed.
 The independent replay
-`scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json`
+`scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json`
 treats that stored certificate as input data and rechecks row shape, row-pair
 crossing, witness-pair capacity, selected-distance quotienting, the stored
 self-edge records, assignment uniqueness, and digest agreement without
 importing the Kalmanson generator module. It is still stored-certificate
-bookkeeping only, not brancher coverage or a proof of `n=9`.
+bookkeeping only, not brancher coverage or a proof of `n=9`. Use `--json` when
+the first stored self-edge example record is needed.
 A fixed-center-order replay command,
 `scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json`,
 also closes the vertex-circle-pruned search and reaches the same

--- a/STATE.md
+++ b/STATE.md
@@ -657,16 +657,18 @@ review-pending finite-case evidence only: the geometric turn lemma and
 indexing conventions remain the review bottleneck, and this does not promote
 `n=9`. Use `--json` instead when the full certificate rows are needed.
 The compact Kalmanson self-edge replay
-`scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json`
+`scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json`
 checks a stored certificate with one strict Kalmanson self-edge for each of the
 same 184 terminal assignments. It is a certificate replay and audit aid only,
-not an independent completion of brancher review or a promotion of `n=9`.
+not an independent completion of brancher review or a promotion of `n=9`. Use
+`--json` when the full replay payload is needed.
 The independent stored-input replay
-`scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json`
+`scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json`
 checks the same JSON without importing the Kalmanson generator module: row
 shape, incidence filters, selected-distance quotients, stored self-edges, and
 the digest. It is still stored-certificate auditing only, not brancher
-coverage or a promotion of `n=9`.
+coverage or a promotion of `n=9`. Use `--json` when the first stored self-edge
+example record is needed.
 The fixed-order Kalmanson branch cuts now cover both no-reciprocal and
 exactly-one-reciprocal selected-pair regimes. The no-reciprocal regular
 tournament audit forces at least one reciprocal selected pair; the

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -880,11 +880,12 @@ stable certificate-list digest is
 `8e5344265e774ce352d64e16e0480eaff4ad6051a69051a304a3f9145db0e3c5`.
 
 Check the certificate replay with
-`python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json`.
+`python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json`.
 This is a compact audit aid for the review-pending `n=9` frontier only. It does
 not independently complete review of the brancher filters, does not promote
 `n=9` to source-of-truth theorem status, does not prove Erdos Problem #97, and
-does not provide a counterexample. See `docs/n9-kalmanson-selfedge.md`.
+does not provide a counterexample. Use `--json` when the full replay payload is
+needed. See `docs/n9-kalmanson-selfedge.md`.
 
 ### n=9 compact independent brancher audit
 

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -111,11 +111,12 @@ Use this queue when no more specific issue is selected.
    and frontier rows; use `--json` when the full per-view status and mismatch
    example blocks are needed.
    The Kalmanson self-edge independent replay
-   `python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json`
+   `python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json`
    treats the stored `n9_kalmanson_selfedge` certificate as input data and
    replays row shape, pair/crossing filters, witness-pair capacity,
    selected-distance quotienting, stored Kalmanson self-edges, and digest
-   agreement without importing the Kalmanson generator module.
+   agreement without importing the Kalmanson generator module; use `--json`
+   when the first stored self-edge example record is needed.
    The incidence-filter replay
    `python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json`
    checks the row-level two-overlap crossing, witness-pair cap, and

--- a/docs/n9-kalmanson-selfedge.md
+++ b/docs/n9-kalmanson-selfedge.md
@@ -82,25 +82,26 @@ Replay the checked-in certificate without rerunning the brancher:
 ```bash
 python scripts/check_n9_kalmanson_selfedge.py \
   --verify-certificate data/certificates/n9_kalmanson_selfedge.json \
-  --assert-expected --json
+  --assert-expected --summary-json
 ```
 
 The replay mode verifies the stored self-edge rows and the stable digest from
 the certificate list. It is a certificate replay, not an independent proof of
-the brancher filters.
+the brancher filters. Use `--json` when the full replay payload is needed.
 
 Independent reviewer-facing replay:
 
 ```bash
 python scripts/check_n9_kalmanson_selfedge_independent_replay.py \
-  --check --assert-expected --json
+  --check --assert-expected --summary-json
 ```
 
 This second replay intentionally does not import
 `erdos97.n9_kalmanson_selfedge` and does not run the search brancher. It treats
 the checked-in JSON as input data, then independently checks row shape,
 two-overlap crossing, witness-pair capacity, selected-distance quotienting,
-the stored strict Kalmanson self-edge, and the certificate-list digest.
+the stored strict Kalmanson self-edge, and the certificate-list digest. Use
+`--json` when the first stored self-edge example record is needed.
 
 ## Audit boundary
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -202,7 +202,7 @@ geometry, selected-distance quotient soundness, `n=9`, or complete review. Use
 Current Kalmanson self-edge replay:
 
 ```bash
-python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json
+python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json
 ```
 
 This command treats the stored 184 terminal assignments as certificate inputs
@@ -210,12 +210,12 @@ and checks that each has one strict Kalmanson inequality whose two sides reduce
 to the same selected-distance quotient multiset. It is a compact certificate
 replay only; it does not independently audit brancher coverage, the
 pair/crossing filters, the Kalmanson geometric convention, `n=9`, or complete
-review.
+review. Use `--json` when the full replay payload is needed.
 
 Independent Kalmanson self-edge input replay:
 
 ```bash
-python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json
+python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
 ```
 
 This command intentionally avoids importing the Kalmanson self-edge generator
@@ -224,7 +224,8 @@ rechecks row shape, row-pair crossing, witness-pair capacity,
 selected-distance quotienting, stored strict Kalmanson self-edges, assignment
 uniqueness, and the certificate digest. It is still a stored-certificate audit:
 it does not regenerate the 184 frontier, audit brancher coverage, prove `n=9`,
-or complete independent review.
+or complete independent review. Use `--json` when the first stored self-edge
+example record is needed.
 
 Current dihedral-orbit audit:
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -536,9 +536,9 @@ artifacts:
     generator: scripts/check_n9_kalmanson_selfedge.py
     command: python scripts/check_n9_kalmanson_selfedge.py --write --assert-expected --summary-only
     checker: scripts/check_n9_kalmanson_selfedge.py
-    check_command: python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json
+    check_command: python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json
     independent_replay: scripts/check_n9_kalmanson_selfedge_independent_replay.py
-    independent_replay_command: python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json
+    independent_replay_command: python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING

--- a/scripts/check_kalmanson_two_order_z3.py
+++ b/scripts/check_kalmanson_two_order_z3.py
@@ -31,7 +31,10 @@ from typing import NamedTuple, Sequence
 try:
     from z3 import Distinct, Int, Or, Solver, sat, unsat
 except ImportError as exc:  # pragma: no cover - depends on optional dev dep
-    raise SystemExit("z3-solver is required for this checker") from exc
+    Distinct = Int = Or = Solver = sat = unsat = None  # type: ignore[assignment]
+    Z3_IMPORT_ERROR: ImportError | None = exc
+else:
+    Z3_IMPORT_ERROR = None
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(Path(__file__).resolve().parent) not in sys.path:
@@ -45,6 +48,13 @@ Quad = tuple[int, int, int, int]
 Clause = tuple[Quad, Quad]
 
 
+def require_z3() -> None:
+    """Raise a clear error when the optional Z3 dependency is unavailable."""
+
+    if Z3_IMPORT_ERROR is not None:
+        raise RuntimeError("z3-solver is required for this checker") from Z3_IMPORT_ERROR
+
+
 class Conflict(NamedTuple):
     left_kind: int
     left_quad: Quad
@@ -53,6 +63,10 @@ class Conflict(NamedTuple):
 
 
 def _make_solver(n: int, random_seed: int) -> tuple[Solver, list[object]]:
+    require_z3()
+    assert Distinct is not None
+    assert Int is not None
+    assert Solver is not None
     positions = [Int(f"p{label}") for label in range(n)]
     solver = Solver()
     solver.set("random_seed", random_seed)
@@ -72,6 +86,8 @@ def _clause_key(left: Quad, right: Quad) -> Clause:
 
 
 def _add_clause(solver: Solver, positions: Sequence[object], clause: Clause) -> None:
+    require_z3()
+    assert Or is not None
     left, right = clause
     solver.add(
         Or(
@@ -365,25 +381,30 @@ def main() -> int:
     parser.add_argument("--random-seed", type=int, default=7)
     args = parser.parse_args()
 
-    if args.certificate:
-        payload = verify_certificate(json.loads(args.certificate.read_text(encoding="utf-8")))
-    else:
-        if args.name is None or args.n is None or args.offsets is None:
-            raise SystemExit("--name, --n, and --offsets are required unless --certificate is used")
-        if args.n <= 0:
-            raise SystemExit("--n must be positive")
-        if args.max_iterations <= 0:
-            raise SystemExit("--max-iterations must be positive")
-        if args.conflict_cap <= 0:
-            raise SystemExit("--conflict-cap must be positive")
-        payload = generate_certificate(
-            args.name,
-            args.n,
-            args.offsets,
-            max_iterations=args.max_iterations,
-            conflict_cap=args.conflict_cap,
-            random_seed=args.random_seed,
-        )
+    try:
+        if args.certificate:
+            payload = verify_certificate(json.loads(args.certificate.read_text(encoding="utf-8")))
+        else:
+            if args.name is None or args.n is None or args.offsets is None:
+                raise SystemExit("--name, --n, and --offsets are required unless --certificate is used")
+            if args.n <= 0:
+                raise SystemExit("--n must be positive")
+            if args.max_iterations <= 0:
+                raise SystemExit("--max-iterations must be positive")
+            if args.conflict_cap <= 0:
+                raise SystemExit("--conflict-cap must be positive")
+            payload = generate_certificate(
+                args.name,
+                args.n,
+                args.offsets,
+                max_iterations=args.max_iterations,
+                conflict_cap=args.conflict_cap,
+                random_seed=args.random_seed,
+            )
+    except RuntimeError as exc:
+        if "z3-solver is required" in str(exc):
+            parser.error(str(exc))
+        raise
 
     if args.assert_unsat:
         assert_unsat(payload)

--- a/scripts/check_n9_kalmanson_selfedge.py
+++ b/scripts/check_n9_kalmanson_selfedge.py
@@ -40,7 +40,13 @@ def write_json(path: Path, payload: dict[str, object]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--n", type=int, default=9)
-    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print stable JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print stable JSON without certificate arrays",
+    )
     parser.add_argument("--summary-only", action="store_true", help="omit certificate arrays")
     parser.add_argument("--write", action="store_true", help="write the full artifact")
     parser.add_argument("--out", default=str(DEFAULT_OUT), help="path used by --write")
@@ -73,7 +79,9 @@ def main() -> int:
         write_json(Path(args.out), payload)
 
     elapsed = perf_counter() - start
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_payload(result), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
     else:
         print("review-pending n=9 Kalmanson self-edge checker")

--- a/scripts/check_n9_kalmanson_selfedge_independent_replay.py
+++ b/scripts/check_n9_kalmanson_selfedge_independent_replay.py
@@ -33,6 +33,20 @@ EXPECTED_UNKILLED = 0
 EXPECTED_CERTIFICATE_SHA256 = (
     "8e5344265e774ce352d64e16e0480eaff4ad6051a69051a304a3f9145db0e3c5"
 )
+SUMMARY_JSON_KEYS = (
+    "schema",
+    "source_schema",
+    "status",
+    "trust",
+    "claim_scope",
+    "n",
+    "certificates_checked",
+    "unique_assignments_checked",
+    "incidence_filter_failures",
+    "self_edge_failures",
+    "certificate_sha256",
+    "digest_matches",
+)
 
 Pair = tuple[int, int]
 
@@ -313,13 +327,25 @@ def audit_certificate_payload(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def summary_json_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing JSON view without example records."""
+
+    return {key: payload[key] for key in SUMMARY_JSON_KEYS if key in payload}
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--certificate", type=Path, default=DEFAULT_CERTIFICATE)
     parser.add_argument("--check", action="store_true", help="run the replay audit")
     parser.add_argument("--assert-expected", action="store_true")
-    parser.add_argument("--json", action="store_true")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="emit compact reviewer-facing JSON without example records",
+    )
     return parser.parse_args(argv)
 
 
@@ -337,7 +363,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         expect_equal("certificates_checked", summary["certificates_checked"], EXPECTED_TERMINALS)
         expect_equal("unique_assignments_checked", summary["unique_assignments_checked"], EXPECTED_TERMINALS)
         expect_equal("digest_matches", summary["digest_matches"], True)
-    if args.json:
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(summary), indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:
         print("independent n=9 Kalmanson self-edge certificate replay")

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -327,7 +327,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--verify-certificate",
             "data/certificates/n9_kalmanson_selfedge.json",
             "--assert-expected",
-            "--json",
+            "--summary-json",
         ),
         claim_scope=(
             "Review-pending n=9 selected-witness Kalmanson self-edge "
@@ -342,7 +342,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "scripts/check_n9_kalmanson_selfedge_independent_replay.py",
             "--check",
             "--assert-expected",
-            "--json",
+            "--summary-json",
         ),
         claim_scope=(
             "Independent stored-input replay for the review-pending n=9 "

--- a/tests/test_kalmanson_inverse_pair_templates.py
+++ b/tests/test_kalmanson_inverse_pair_templates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -14,7 +15,13 @@ from scripts.analyze_kalmanson_inverse_pair_templates import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-pytestmark = pytest.mark.slow
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        importlib.util.find_spec("z3") is None,
+        reason="z3-solver is required for this diagnostic",
+    ),
+]
 
 
 def test_kalmanson_inverse_pair_template_diagnostic_expected_counts() -> None:

--- a/tests/test_kalmanson_two_order_z3.py
+++ b/tests/test_kalmanson_two_order_z3.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 C19_Z3_CERTIFICATE = ROOT / "data" / "certificates" / "c19_skew_all_orders_kalmanson_z3.json"
@@ -29,6 +31,8 @@ def test_c19_kalmanson_z3_certificate_shape() -> None:
 
 
 def test_c19_kalmanson_z3_certificate_replays_unsat() -> None:
+    pytest.importorskip("z3")
+
     result = subprocess.run(
         [
             sys.executable,

--- a/tests/test_kalmanson_z3_clause_diagnostics.py
+++ b/tests/test_kalmanson_z3_clause_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -16,7 +17,13 @@ from scripts.analyze_kalmanson_z3_clauses import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
-pytestmark = pytest.mark.artifact
+pytestmark = [
+    pytest.mark.artifact,
+    pytest.mark.skipif(
+        importlib.util.find_spec("z3") is None,
+        reason="z3-solver is required for this diagnostic",
+    ),
+]
 
 
 def test_c19_z3_clause_diagnostic_matches_artifact() -> None:

--- a/tests/test_n9_kalmanson_selfedge.py
+++ b/tests/test_n9_kalmanson_selfedge.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -80,3 +82,46 @@ def test_certificate_artifact_replays_without_brancher() -> None:
     assert summary_payload(payload)["killed_by_kalmanson_self_edge"] == EXPECTED_KILLS
     assert summary_payload(payload)["unkilled"] == EXPECTED_UNKILLED
     assert summary_payload(payload)["certificate_sha256"] == EXPECTED_CERTIFICATE_SHA256
+
+
+def test_certificate_verify_cli_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_kalmanson_selfedge.py",
+            "--verify-certificate",
+            "data/certificates/n9_kalmanson_selfedge.json",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = json.loads(result.stdout)
+    assert summary["mode"] == "verify_certificate"
+    assert summary["verified_certificates"] == EXPECTED_KILLS
+    assert summary["certificate_sha256"] == EXPECTED_CERTIFICATE_SHA256
+    assert "certificates" not in summary
+    assert "unkilled_assignments" not in summary
+
+
+def test_certificate_verify_cli_rejects_json_and_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_n9_kalmanson_selfedge.py",
+            "--verify-certificate",
+            "data/certificates/n9_kalmanson_selfedge.json",
+            "--json",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "not allowed with argument --json" in result.stderr

--- a/tests/test_n9_kalmanson_selfedge_independent_replay.py
+++ b/tests/test_n9_kalmanson_selfedge_independent_replay.py
@@ -37,6 +37,19 @@ def test_independent_replay_payload_checks_certificate() -> None:
     assert summary["first_self_edge"]["inequality"] == "K1"
 
 
+def test_independent_replay_summary_json_payload_omits_example() -> None:
+    module = load_replay_module()
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    summary = module.summary_json_payload(module.audit_certificate_payload(payload))
+
+    assert summary["status"] == "ok"
+    assert summary["certificates_checked"] == 184
+    assert summary["unique_assignments_checked"] == 184
+    assert summary["digest_matches"] is True
+    assert "first_self_edge" not in summary
+
+
 def test_independent_replay_rejects_mutated_self_edge() -> None:
     module = load_replay_module()
     payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
@@ -69,3 +82,43 @@ def test_independent_replay_cli_json() -> None:
     assert payload["status"] == "ok"
     assert payload["certificates_checked"] == 184
     assert payload["unique_assignments_checked"] == 184
+
+
+def test_independent_replay_cli_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        check=True,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["status"] == "ok"
+    assert payload["certificates_checked"] == 184
+    assert payload["unique_assignments_checked"] == 184
+    assert "first_self_edge" not in payload
+
+
+def test_independent_replay_cli_rejects_json_and_summary_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--check",
+            "--json",
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "not allowed with argument --json" in result.stderr


### PR DESCRIPTION
## Summary
- Add compact `--summary-json` output for the n=9 Kalmanson self-edge certificate verifier and independent replay while keeping full `--json` payloads available.
- Align docs, Makefile, generated-artifact metadata, and artifact-audit registration to use reviewer-facing summary JSON for these checks.
- Make the C19 Kalmanson Z3 checker import-safe when `z3-solver` is absent, with Z3-dependent tests skipped in that environment and the CLI still reporting a clear dependency error.

## Validation
- `make verify-fast PYTHON=.venv/bin/python`
- focused system-Python optional-dependency checks: Z3 tests skip cleanly when `z3-solver` is absent

## Claim Scope
This is reviewer-output and validation-surface hardening only. It does not prove `n=9`, does not prove Erdos Problem #97, does not provide a counterexample, and does not change the official/global status.