### PR TITLE
Wire turn indexing audit into n9 review checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ verify-n9-review:
 	$(PYTHON) scripts/analyze_n9_vertex_circle_obstruction_shapes.py --check --assert-expected --json
 	$(PYTHON) scripts/analyze_n9_vertex_circle_motif_families.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_inversive_incidence_pilot.py --check --assert-expected --json
-	$(PYTHON) scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+	$(PYTHON) scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
 	$(PYTHON) scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_branch_options.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -683,7 +683,7 @@ artifacts:
     generator: scripts/check_n9_turn_inequality_frontier.py
     command: python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write
     checker: scripts/check_n9_turn_inequality_frontier.py
-    check_command: python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --json
+    check_command: python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -400,13 +400,29 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="turn_inequality_indexing",
+        command=(
+            "python",
+            "scripts/check_turn_inequality_indexing.py",
+            "--check",
+            "--assert-expected",
+            "--summary-json",
+        ),
+        claim_scope=(
+            "Indexing-convention audit for the review-pending n=9 "
+            "turn-inequality frontier replay; checks weak interval supports "
+            "only and does not prove the geometric turn lemma, n=9, "
+            "counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_turn_inequality_frontier",
         command=(
             "python",
             "scripts/check_n9_turn_inequality_frontier.py",
             "--check",
             "--assert-expected",
-            "--json",
+            "--summary-json",
         ),
         claim_scope=(
             "Review-pending n=9 turn-inequality frontier replay with stored "

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -36,8 +36,12 @@ def test_verify_n9_review_includes_documented_frontier_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_turn_inequality_indexing.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
             "python scripts/check_n9_turn_inequality_frontier.py "
-            "--check --assert-expected --json"
+            "--check --assert-expected --summary-json"
         ),
         (
             "python scripts/check_n9_vertex_circle_input_audit.py "

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -491,8 +491,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_turn_inequality_indexing.py --check "
+        "--assert-expected --summary-json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n9_turn_inequality_frontier.py --check "
-        "--assert-expected --json"
+        "--assert-expected --summary-json"
         in command_texts
     )
     assert (
@@ -549,12 +554,19 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/analyze_n9_vertex_circle_motif_families.py --check "
         "--assert-expected --json"
     ) < ordered_command_texts.index(
+        "python scripts/check_turn_inequality_indexing.py --check "
+        "--assert-expected --summary-json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_turn_inequality_indexing.py --check "
+        "--assert-expected --summary-json"
+    ) < ordered_command_texts.index(
         "python scripts/check_n9_turn_inequality_frontier.py --check "
-        "--assert-expected --json"
+        "--assert-expected --summary-json"
     )
     assert ordered_command_texts.index(
         "python scripts/check_n9_turn_inequality_frontier.py --check "
-        "--assert-expected --json"
+        "--assert-expected --summary-json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_vertex_circle_input_audit.py --check "
         "--assert-expected --json"


### PR DESCRIPTION
## Summary
- Add the turn-inequality indexing audit to `verify-n9-review` immediately before the turn frontier replay.
- Register the indexing audit in `scripts/run_artifact_audit.py` with claim-neutral scope text.
- Align the stored `n9_turn_inequality_frontier` check command and audit runner to use reviewer-facing `--summary-json`, matching the docs.
- Update Makefile/audit command-order tests so the indexing handoff stays pinned before frontier replay.

## Validation
- `.venv/bin/python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json`
- `.venv/bin/python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
- `.venv/bin/python -m pytest -q tests/test_turn_inequality_indexing.py tests/test_n9_turn_inequality_frontier.py tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `make verify-fast PYTHON=.venv/bin/python` (`1302 passed, 502 deselected`)

## Claim Scope
This is audit wiring and reviewer-output alignment only. It does not prove the geometric turn lemma, does not prove `n=9`, does not prove Erdos Problem #97, does not provide a counterexample, and does not change the official/global status.