### PR TITLE
Add n9 candidate promotion review harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: verify-lint verify-fast verify-lean verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review verify-artifacts audit-artifacts verify-all
+.PHONY: verify-lint verify-fast verify-lean verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-candidate verify-n9-review verify-bridge-frontier verify-n10-review verify-artifacts audit-artifacts verify-all
 
 verify-lint:
 	$(PYTHON) scripts/check_text_clean.py
@@ -38,6 +38,21 @@ verify-kalmanson:
 	$(PYTHON) scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json
 	$(PYTHON) scripts/analyze_kalmanson_inverse_pair_templates.py --assert-expected --json
 	$(PYTHON) scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
+
+verify-n9-candidate:
+	$(PYTHON) scripts/check_lean_sketch_integrity.py
+	$(PYTHON) scripts/check_lean_files.py
+	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+	$(PYTHON) scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
 
 verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/formalization.md
+++ b/docs/formalization.md
@@ -19,6 +19,9 @@ official problem. Its first layer is deliberately abstract:
   `HasFourEquidistantProperty` interface;
 - `lean/Erdos97/CertificateFormats.lean` records tiny certificate shapes for
   later Python-to-Lean kernels;
+- `lean/Erdos97/TurnPacking.lean` records the formalization-facing contract for
+  the review-pending turn-packing route: forward/reverse weak interval supports
+  and the elementary dual-certificate arithmetic kernel;
 - `lean/Erdos97/Sketches/` contains AI-editable sketch shells marked with
   `-- EVOLVE-BLOCK-START` and `-- EVOLVE-BLOCK-END`.
 
@@ -55,16 +58,22 @@ between:
 Do not start by formalizing the entire open problem. Start with local finite
 and geometric lemmas:
 
-1. Two-circle intersection cap: if two distinct circles share at least three
+1. Exterior-turn inequality bridge: instantiate the abstract
+   `TurnLemmaForcesWeakIntervals` contract in `lean/Erdos97/TurnPacking.lean`
+   from a real Euclidean strict-convex polygon model, matching
+   `docs/turn-inequality-lemma.md`.
+2. Two-circle intersection cap: if two distinct circles share at least three
    points, contradiction.
-2. Pair-sharing cap: for distinct centers `a,b`, `|S_a cap S_b| <= 2`.
-3. Incidence count ruling out `n <= 6`.
-4. `n=7` Fano/parity obstruction, if feasible.
-5. Certificate checker for `n=8` survivor obstruction.
+3. Pair-sharing cap: for distinct centers `a,b`, `|S_a cap S_b| <= 2`.
+4. Incidence count ruling out `n <= 6`.
+5. `n=7` Fano/parity obstruction, if feasible.
+6. Certificate checker for `n=8` survivor obstruction.
 
 ## Longer-term targets
 
 - A Lean-readable certificate format for finite incidence patterns.
+- A Lean-readable turn-packing certificate format connected to the Python
+  `n9_turn_inequality_frontier` integer dual records.
 - A verified checker for perpendicularity/equal-distance obstruction steps.
 - A bridge from local selected-witness artifacts to the Lean
   `HasNEquidistantProperty 4` statement.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ put detailed reconciliation in the canonical synthesis.
   artifacts and exact certificates.
 - [`review-priorities.md`](review-priorities.md): current independent-review
   priorities; planning guidance only, not mathematical evidence.
+- [`n9-candidate-promotion-harness.md`](n9-candidate-promotion-harness.md):
+  compact review harness for the current review-pending `n=9`
+  selected-witness candidate; command surface only, not a status promotion.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -1,0 +1,99 @@
+# n=9 Candidate Promotion Harness
+
+Status: `REVIEW_HARNESS_ONLY`.
+
+This note records the compact command surface for reviewing the current
+repo-local `n=9` selected-witness candidate. It does not prove Erdos Problem
+#97, does not claim a counterexample, does not update the official/global
+status, and does not promote the review-pending `n=9` artifacts. Independent
+mathematical review remains required before any theorem-style use.
+
+## Purpose
+
+The repository now has several independent-looking `n=9` obstruction routes:
+the vertex-circle quotient route, the turn-packing route, and algebraic /
+Kalmanson corroboration. The useful promotion-grade surface is not the full
+artifact audit, which is intentionally broad. It is the shortest command chain
+that exercises the current finite-case review bottlenecks and the
+formalization-facing turn-packing contract.
+
+Run:
+
+```bash
+make verify-n9-candidate
+```
+
+Use `PYTHON=.venv/bin/python` if working in the local virtual environment:
+
+```bash
+make verify-n9-candidate PYTHON=.venv/bin/python
+```
+
+## What It Checks
+
+The target first runs the Lean pilot guardrails:
+
+```bash
+python scripts/check_lean_sketch_integrity.py
+python scripts/check_lean_files.py
+```
+
+The Lean layer includes `lean/Erdos97/TurnPacking.lean`, a dependency-free
+formal contract for the turn-packing route. It pins the forward/reverse
+interval support convention and proves the small arithmetic kernel behind the
+stored dual certificates: a lower bound exceeding the total coefficient budget
+has no realization. It does not prove the Euclidean exterior-turn lemma.
+
+The target then runs the compact vertex-circle route checks:
+
+```bash
+python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
+python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
+```
+
+These commands cover row-0/input conventions, incidence filters, branch-order
+agreement, frontier coverage, strict-edge geometry, quotient replay, and the
+local-lemma handoff path. They are review aids, not an independent review by
+themselves.
+
+The target then runs the compact turn-packing route checks:
+
+```bash
+python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
+python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
+```
+
+These commands check the machine indexing convention and the stored integer
+dual certificates for all `184` regenerated frontier assignments. They still
+depend on independent review of the geometric turn lemma in
+`docs/turn-inequality-lemma.md`.
+
+Finally, the target runs the stored-input Kalmanson replay:
+
+```bash
+python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
+```
+
+This is corroborating stored-certificate audit support. It does not replace
+the vertex-circle or turn-packing review routes.
+
+## Promotion Boundary
+
+Passing `make verify-n9-candidate` means the compact review harness is
+internally consistent at the current repository revision. It does not mean:
+
+- Erdos Problem #97 is solved;
+- the official/global status changed;
+- the general problem for larger polygons is proved;
+- the `n=9` candidate has completed independent review;
+- the exterior-turn lemma has been formally proved in Lean.
+
+The intended next promotion step is a written independent review that accepts
+or rejects the specific dependencies listed in `docs/n9-reduction-chain.md`
+and `docs/n9-review-packet.md`.

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -52,7 +52,7 @@ if its geometric turn lemma is accepted.
 | B1 | If two selected witnesses at offsets `1 <= a < b <= 8` are equidistant from center `i`, then two exterior-turn sums are strictly greater than `pi/2`. | `docs/turn-inequality-lemma.md`. | proof-facing review-pending |
 | B2 | Replacing the strict inequalities by weak normalized inequalities `>= 1` is legitimate. | Strict geometry implies the weaker closed halfspace, if B1 is correct. | conditional on B1 |
 | B3 | For each of the 184 assignments, the weak turn system has an integer turn-packing/Farkas contradiction. | `data/certificates/n9_turn_inequality_frontier.json` checked by `scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`; use `--json` for full certificate rows. | machine-checked review-pending |
-| B4 | The certificate principle is elementary: if `m > 4*lambda` intervals are forced and each turn variable appears at most `lambda` times, then `sum t_i = 4` is contradicted. | `docs/turn-packing-bridge.md`. | proved, assuming stored intervals are forced |
+| B4 | The certificate principle is elementary: if `m > 4*lambda` intervals are forced and each turn variable appears at most `lambda` times, then `sum t_i = 4` is contradicted. | `docs/turn-packing-bridge.md` and the dependency-free arithmetic kernel in `lean/Erdos97/TurnPacking.lean`. | proved, assuming stored intervals are forced |
 | B5 | Therefore no true bad nonagon exists, assuming A6-A7, B1, and B3 survive independent review. | Follows from the chain above. | review-pending conditional |
 
 This route has a different bottleneck from Chain A. Its final contradictions
@@ -106,6 +106,17 @@ There is no bridge from arbitrary larger counterexamples to the n=9 frontier.
 Thus none of these artifacts proves Erdos Problem #97.
 
 ## Minimal Review Command Set
+
+The compact promotion-review harness runs the Lean pilot guardrails, the
+vertex-circle review path, the turn-packing route, and the stored-input
+Kalmanson replay:
+
+```bash
+make verify-n9-candidate
+```
+
+Passing this target does not complete independent review or promote the
+source-of-truth status.
 
 For the vertex-circle route:
 

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -51,6 +51,18 @@ It would not prove the general problem for larger polygons.
 The canonical dependency map is `docs/n9-reduction-chain.md`. This packet is a
 review worksheet for that map, not a replacement for it.
 
+The compact promotion-review harness is
+`docs/n9-candidate-promotion-harness.md`. It provides a single command surface
+for the Lean pilot guardrails, the vertex-circle route, the turn-packing route,
+and the stored-input Kalmanson replay:
+
+```bash
+make verify-n9-candidate
+```
+
+Passing this target is not a status promotion; it only confirms that the
+current compact review harness is internally consistent.
+
 ## Review routes
 
 ### Route A: vertex-circle closure
@@ -94,6 +106,13 @@ reduction and decoder replay are independently audited.
 
 Run these first. They are the shortest current command set that exercises the
 main `n=9` route boundaries without running the whole artifact audit.
+
+```bash
+make verify-n9-candidate
+```
+
+The target expands to the layer-specific commands below and includes
+`make verify-lean`-equivalent guardrails for the local Lean pilot.
 
 ```bash
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/turn-inequality-lemma.md
+++ b/docs/turn-inequality-lemma.md
@@ -84,6 +84,14 @@ instances, `504` unique center/pair/orientation records, and `7560` emitted
 term records. This is an indexing audit only; it does not prove the geometric
 lemma.
 
+The Lean pilot file `lean/Erdos97/TurnPacking.lean` now records the
+formalization-facing version of this machine contract. It defines the
+forward/reverse support functions and the abstract
+`TurnLemmaForcesWeakIntervals` predicate that a future Euclidean proof should
+instantiate. It also proves the elementary arithmetic kernel behind the stored
+turn-packing dual certificates. This is still not a Lean proof of the
+geometric lemma.
+
 ## Proof Sketch
 
 Let

--- a/lean/Erdos97/TurnPacking.lean
+++ b/lean/Erdos97/TurnPacking.lean
@@ -1,0 +1,197 @@
+/-!
+# Turn-Packing Contract
+
+This module is the formalization-facing shell for the review-pending
+turn-inequality route. It does not prove the Euclidean turn lemma. Instead, it
+pins the indexing and arithmetic contract consumed by the Python checker:
+
+* equal-radius offset pairs should force two weak interval inequalities;
+* the machine replay stores sorted sums of exterior-turn variables; and
+* a dual certificate is contradictory when its lower bound is larger than its
+  total coefficient budget.
+
+The intended geometry bridge is documented in `docs/turn-inequality-lemma.md`.
+-/
+
+namespace Erdos97
+
+/-- The two interval orientations extracted from one equal-radius offset pair. -/
+inductive TurnOrientation where
+  | forward
+  | reverse
+deriving Repr, BEq
+
+namespace TurnOrientation
+
+/-- Stable reviewer-facing names used by the Python JSON payloads. -/
+def name : TurnOrientation -> String
+  | forward => "forward"
+  | reverse => "reverse"
+
+theorem name_forward : TurnOrientation.forward.name = "forward" := by
+  rfl
+
+theorem name_reverse : TurnOrientation.reverse.name = "reverse" := by
+  rfl
+
+theorem forward_ne_reverse : Not (TurnOrientation.forward = TurnOrientation.reverse) := by
+  intro h
+  cases h
+
+end TurnOrientation
+
+/-- Cyclic index convention for a turn variable `h` steps after center `i`. -/
+def cyclicTurnIndex (n i h : Nat) : Nat :=
+  (i + h) % n
+
+/--
+The forward support for offsets `a < b`: turns at `i+1, ..., i+b-1`.
+
+The left witness turn `i+a` is included when `a > 0`; the right endpoint
+`i+b` is excluded. The support is cyclic-order, not sorted storage order.
+-/
+def forwardTurnSupport (n i b : Nat) : List Nat :=
+  (List.range (b - 1)).map (fun k => cyclicTurnIndex n i (k + 1))
+
+/--
+The reverse support for offsets `a < b`: turns at `i+a+1, ..., i+n-1`.
+
+The left endpoint `i+a` is excluded; the right witness turn `i+b` is included
+when `b < n`. The support is cyclic-order, not sorted storage order.
+-/
+def reverseTurnSupport (n i a : Nat) : List Nat :=
+  (List.range (n - a - 1)).map (fun k => cyclicTurnIndex n i (a + 1 + k))
+
+theorem forwardTurnSupport_length (n i b : Nat) :
+    (forwardTurnSupport n i b).length = b - 1 := by
+  simp [forwardTurnSupport]
+
+theorem reverseTurnSupport_length (n i a : Nat) :
+    (reverseTurnSupport n i a).length = n - a - 1 := by
+  simp [reverseTurnSupport]
+
+/-- Offset-pair hypotheses for the proof-facing turn lemma. -/
+def ValidTurnOffsetPair (n a b : Nat) : Prop :=
+  And (1 <= a) (And (a < b) (b < n))
+
+/-- One weak machine-facing interval inequality. -/
+structure WeakTurnInterval where
+  n : Nat
+  center : Nat
+  leftOffset : Nat
+  rightOffset : Nat
+  orientation : TurnOrientation
+  cyclicSupport : List Nat
+  bound : Nat
+deriving Repr
+
+/-- Build the expected weak interval record for one orientation. -/
+def expectedWeakTurnInterval
+    (n center leftOffset rightOffset : Nat)
+    (orientation : TurnOrientation) : WeakTurnInterval :=
+  match orientation with
+  | TurnOrientation.forward =>
+      { n := n
+        center := center
+        leftOffset := leftOffset
+        rightOffset := rightOffset
+        orientation := TurnOrientation.forward
+        cyclicSupport := forwardTurnSupport n center rightOffset
+        bound := 1 }
+  | TurnOrientation.reverse =>
+      { n := n
+        center := center
+        leftOffset := leftOffset
+        rightOffset := rightOffset
+        orientation := TurnOrientation.reverse
+        cyclicSupport := reverseTurnSupport n center leftOffset
+        bound := 1 }
+
+theorem expectedWeakTurnInterval_bound
+    (n center leftOffset rightOffset : Nat) (orientation : TurnOrientation) :
+    (expectedWeakTurnInterval n center leftOffset rightOffset orientation).bound = 1 := by
+  cases orientation <;> rfl
+
+theorem expectedWeakTurnInterval_forward_support
+    (n center leftOffset rightOffset : Nat) :
+    (expectedWeakTurnInterval n center leftOffset rightOffset
+      TurnOrientation.forward).cyclicSupport =
+        forwardTurnSupport n center rightOffset := by
+  rfl
+
+theorem expectedWeakTurnInterval_reverse_support
+    (n center leftOffset rightOffset : Nat) :
+    (expectedWeakTurnInterval n center leftOffset rightOffset
+      TurnOrientation.reverse).cyclicSupport =
+        reverseTurnSupport n center leftOffset := by
+  rfl
+
+/--
+Proof-facing assumption shape for the geometric turn lemma.
+
+`EqualRadiusPair center a b` is supplied by selected-distance equality.
+`ForcesWeakInterval interval` means the geometric lemma justifies the stored
+weak inequality. The module deliberately leaves both predicates abstract.
+-/
+def TurnLemmaForcesWeakIntervals
+    (EqualRadiusPair : Nat -> Nat -> Nat -> Prop)
+    (ForcesWeakInterval : WeakTurnInterval -> Prop) : Prop :=
+  forall n center a b : Nat,
+    ValidTurnOffsetPair n a b ->
+      EqualRadiusPair center a b ->
+        And
+          (ForcesWeakInterval
+            (expectedWeakTurnInterval n center a b TurnOrientation.forward))
+          (ForcesWeakInterval
+            (expectedWeakTurnInterval n center a b TurnOrientation.reverse))
+
+/-- A compact arithmetic certificate shape for a weak turn-packing replay. -/
+structure TurnPackingDualCertificate where
+  lambda : Nat
+  turnTotalBudget : Nat
+  selectedIntervalCount : Nat
+deriving Repr
+
+namespace TurnPackingDualCertificate
+
+/--
+The maximum possible left side when each turn variable appears at most
+`lambda` times and the normalized total turn is `turnTotalBudget`.
+-/
+def coefficientBudget (cert : TurnPackingDualCertificate) : Nat :=
+  cert.turnTotalBudget * cert.lambda
+
+/--
+Semantic arithmetic realization of the certificate summary. The selected weak
+intervals force `selectedIntervalCount <= lhs`, while coefficient counting
+gives `lhs <= coefficientBudget`.
+-/
+def RealizedBy (cert : TurnPackingDualCertificate) (lhs : Nat) : Prop :=
+  And (cert.selectedIntervalCount <= lhs) (lhs <= cert.coefficientBudget)
+
+/-- The stored summary is contradictory when its lower bound exceeds the cap. -/
+def HasGap (cert : TurnPackingDualCertificate) : Prop :=
+  cert.coefficientBudget < cert.selectedIntervalCount
+
+/-- A turn-packing certificate with a strict gap has no arithmetic realization. -/
+theorem no_realization (cert : TurnPackingDualCertificate) (lhs : Nat)
+    (hrealized : cert.RealizedBy lhs) (hgap : cert.HasGap) : False := by
+  have hle : cert.selectedIntervalCount <= cert.coefficientBudget :=
+    Nat.le_trans hrealized.left hrealized.right
+  exact (Nat.not_lt_of_ge hle) hgap
+
+/-- The normalized n=9 turn replay uses total turn budget `4`. -/
+def normalizedN9 (lambda selectedIntervalCount : Nat) :
+    TurnPackingDualCertificate :=
+  { lambda := lambda
+    turnTotalBudget := 4
+    selectedIntervalCount := selectedIntervalCount }
+
+theorem normalizedN9_coefficientBudget
+    (lambda selectedIntervalCount : Nat) :
+    (normalizedN9 lambda selectedIntervalCount).coefficientBudget = 4 * lambda := by
+  rfl
+
+end TurnPackingDualCertificate
+
+end Erdos97

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -19,6 +19,57 @@ def _make_target_commands(target: str) -> list[str]:
     return commands
 
 
+def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
+    commands = _make_target_commands("verify-n9-candidate")
+    expected_chain = [
+        "python scripts/check_lean_sketch_integrity.py",
+        "python scripts/check_lean_files.py",
+        "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",
+        (
+            "python scripts/check_n9_vertex_circle_input_audit.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_incidence_filters.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_mro_branching_replay.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_strict_edge_geometry.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_quotient_soundness.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_vertex_circle_local_lemma_audit_path.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_turn_inequality_indexing.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_turn_inequality_frontier.py "
+            "--check --assert-expected --summary-json"
+        ),
+        (
+            "python scripts/check_n9_kalmanson_selfedge_independent_replay.py "
+            "--check --assert-expected --summary-json"
+        ),
+    ]
+
+    assert commands == expected_chain
+
+
 def test_verify_n9_review_includes_documented_frontier_audits() -> None:
     commands = _make_target_commands("verify-n9-review")
     expected_chain = [


### PR DESCRIPTION
## Summary
- Add `make verify-n9-candidate` as a compact promotion-review harness for the current review-pending `n=9` selected-witness candidate.
- Add `lean/Erdos97/TurnPacking.lean`, a dependency-free Lean pilot contract for the turn-packing route: forward/reverse weak interval supports plus the elementary dual-certificate arithmetic kernel.
- Document the harness in `docs/n9-candidate-promotion-harness.md` and link it from the n=9 review packet, reduction chain, formalization notes, turn-inequality lemma, and docs index.
- Add a Makefile target test that pins the compact command sequence and keeps reviewer-facing `--summary-json` surfaces stable.

## Validation
- `make verify-n9-candidate PYTHON=.venv/bin/python`
- `make verify-fast PYTHON=.venv/bin/python` (`1303 passed, 502 deselected`)

## Lean Tooling Note
- This environment does not have `lake`, `lean`, or `elan` installed. The repository's existing `scripts/check_lean_files.py` therefore reports `lake not found; skipped Lean compilation` unless `--require-lean` is used. The new harness exercises the existing guardrail behavior, but a machine with Lean installed should run `python scripts/check_lean_files.py --require-lean` before treating the Lean pilot as compile-checked.

## Claim Scope
This is review harness and formalization-facing scaffolding only. It does not prove the Euclidean turn lemma, does not prove `n=9`, does not prove Erdos Problem #97, does not claim a counterexample, and does not update the official/global status.