### PR TITLE
Add n9 candidate review manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ verify-kalmanson:
 	$(PYTHON) scripts/analyze_kalmanson_sparse_frontier_templates.py --assert-expected --json
 
 verify-n9-candidate:
+	$(PYTHON) scripts/check_n9_candidate_review_manifest.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`../STATE.md`](../STATE.md): short working dashboard.
 - [`../metadata/erdos97.yaml`](../metadata/erdos97.yaml): canonical status
   metadata separating official/global status from local repo claims.
+- [`../metadata/n9_candidate_review.yaml`](../metadata/n9_candidate_review.yaml):
+  machine-readable route contract for the compact `n=9` candidate review
+  harness; not mathematical evidence and not a status promotion.
 - [`upstream-alignment.md`](upstream-alignment.md): alignment notes for
   `teorth/erdosproblems` and the official problem page.
 - [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -17,6 +17,17 @@ artifact audit, which is intentionally broad. It is the shortest command chain
 that exercises the current finite-case review bottlenecks and the
 formalization-facing turn-packing contract.
 
+The machine-readable route contract is
+`metadata/n9_candidate_review.yaml`, checked by:
+
+```bash
+python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+```
+
+That checker compares the manifest command list with the Makefile target,
+verifies referenced docs and Lean files exist, and keeps the review gates
+explicitly open. It does not run the mathematical replay commands.
+
 Run:
 
 ```bash
@@ -34,15 +45,17 @@ make verify-n9-candidate PYTHON=.venv/bin/python
 The target first runs the Lean pilot guardrails:
 
 ```bash
+python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
-The Lean layer includes `lean/Erdos97/TurnPacking.lean`, a dependency-free
-formal contract for the turn-packing route. It pins the forward/reverse
-interval support convention and proves the small arithmetic kernel behind the
-stored dual certificates: a lower bound exceeding the total coefficient budget
-has no realization. It does not prove the Euclidean exterior-turn lemma.
+The manifest checker runs before the Lean pilot guardrails. The Lean layer
+includes `lean/Erdos97/TurnPacking.lean`, a dependency-free formal contract
+for the turn-packing route. It pins the forward/reverse interval support
+convention and proves the small arithmetic kernel behind the stored dual
+certificates: a lower bound exceeding the total coefficient budget has no
+realization. It does not prove the Euclidean exterior-turn lemma.
 
 The target then runs the compact vertex-circle route checks:
 

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -63,6 +63,12 @@ make verify-n9-candidate
 Passing this target is not a status promotion; it only confirms that the
 current compact review harness is internally consistent.
 
+The machine-readable route contract is `metadata/n9_candidate_review.yaml`,
+checked by
+`python scripts/check_n9_candidate_review_manifest.py --check --summary-json`.
+It keeps the Makefile command sequence, referenced review files, and open
+review gates synchronized.
+
 ## Review routes
 
 ### Route A: vertex-circle closure

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -1,0 +1,144 @@
+schema: erdos97.n9_candidate_review.v1
+status: REVIEW_HARNESS_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+target: verify-n9-candidate
+canonical_command: make verify-n9-candidate
+claim_scope: >
+  Compact review manifest for the current review-pending n=9 selected-witness
+  candidate. It records the command surface, documents, formalization-facing
+  files, and review gates for independent audit. It does not prove n=9, does
+  not prove Erdos Problem #97, does not claim a counterexample, does not
+  complete independent review, and does not update the official/global status.
+
+candidate_claim_under_review: >
+  No strictly convex 9-gon has a selected 4-witness row at every vertex.
+  This is a repo-local finite-case candidate only.
+
+forbidden_promotions:
+  - "general proof of Erdos Problem #97"
+  - proof of n=9
+  - "counterexample to Erdos Problem #97"
+  - official/global status update
+  - completed independent review
+  - formal proof of the Euclidean turn lemma
+
+source_of_truth_files:
+  - README.md
+  - STATE.md
+  - RESULTS.md
+  - metadata/erdos97.yaml
+  - docs/claims.md
+  - docs/review-priorities.md
+  - docs/n9-reduction-chain.md
+  - docs/n9-review-packet.md
+
+harness_documents:
+  - docs/n9-candidate-promotion-harness.md
+  - docs/n9-reduction-chain.md
+  - docs/n9-review-packet.md
+  - docs/turn-inequality-lemma.md
+  - docs/turn-packing-bridge.md
+  - docs/formalization.md
+
+formalization_files:
+  - lean/Erdos97/TurnPacking.lean
+  - lean/Erdos97/CertificateFormats.lean
+  - docs/formalization.md
+  - docs/turn-inequality-lemma.md
+
+review_gates:
+  - id: source_frontier
+    review_requirement: >
+      Review that the 184 regenerated pair/crossing/count frontier assignments
+      are the intended pre-obstruction source frontier and do not hide symmetry
+      quotient assumptions.
+    still_open: true
+  - id: vertex_circle_geometry
+    review_requirement: >
+      Review the vertex-circle strict-edge geometry rule and quotient replay
+      soundness before treating the vertex-circle route as theorem-grade.
+    still_open: true
+  - id: turn_geometry
+    review_requirement: >
+      Review the Euclidean exterior-turn lemma and interval indexing before
+      treating the turn-packing route as theorem-grade.
+    still_open: true
+  - id: lean_compilation
+    review_requirement: >
+      Run python scripts/check_lean_files.py --require-lean on a machine with
+      Lake installed before treating Lean pilot files as compile-checked.
+    still_open: true
+  - id: independent_review
+    review_requirement: >
+      Obtain written independent review identifying accepted lemmas and exact
+      gaps before any public theorem-style use.
+    still_open: true
+
+routes:
+  - id: manifest_contract
+    title: Review manifest contract
+    claim_scope: >
+      Checks this manifest against the Makefile target and filesystem. It does
+      not run the mathematical replay commands and does not promote any claim.
+    commands:
+      - id: n9_candidate_review_manifest
+        command: python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+
+  - id: lean_guardrails
+    title: Lean pilot guardrails
+    claim_scope: >
+      Checks Lean sketch block integrity and compiles Lean files only when Lake
+      is available. This is a formalization guardrail only, not a proof of the
+      Euclidean turn lemma.
+    commands:
+      - id: lean_sketch_integrity
+        command: python scripts/check_lean_sketch_integrity.py
+      - id: lean_files
+        command: python scripts/check_lean_files.py
+
+  - id: vertex_circle_route
+    title: Compact vertex-circle review path
+    claim_scope: >
+      Exercises row0/input conventions, incidence filters, branch-order
+      agreement, frontier coverage, strict-edge geometry, quotient replay, and
+      local-lemma handoffs. This is review-pending finite-case audit support
+      only.
+    commands:
+      - id: n9_vertex_circle_exhaustive
+        command: python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
+      - id: n9_vertex_circle_input_audit
+        command: python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
+      - id: n9_vertex_circle_incidence_filters
+        command: python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json
+      - id: n9_vertex_circle_mro_branching_replay
+        command: python scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --summary-json
+      - id: n9_vertex_circle_frontier_coverage_crosswalk
+        command: python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --summary-json
+      - id: n9_vertex_circle_strict_edge_geometry
+        command: python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
+      - id: n9_vertex_circle_quotient_soundness
+        command: python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json
+      - id: n9_vertex_circle_local_lemma_audit_path
+        command: python scripts/check_n9_vertex_circle_local_lemma_audit_path.py --check --assert-expected --summary-json
+
+  - id: turn_packing_route
+    title: Compact turn-packing review path
+    claim_scope: >
+      Checks machine interval indexing and stored integer dual certificates for
+      the same 184 source-frontier assignments. It remains conditional on the
+      Euclidean turn lemma and independent review.
+    commands:
+      - id: turn_inequality_indexing
+        command: python scripts/check_turn_inequality_indexing.py --check --assert-expected --summary-json
+      - id: n9_turn_inequality_frontier
+        command: python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json
+
+  - id: kalmanson_corroboration
+    title: Stored-input Kalmanson corroboration
+    claim_scope: >
+      Replays stored n=9 Kalmanson self-edge certificates without importing the
+      generator module. This is corroborating stored-certificate audit support
+      only.
+    commands:
+      - id: n9_kalmanson_selfedge_independent_replay
+        command: python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Validate the n=9 candidate review manifest."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dev dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "metadata" / "n9_candidate_review.yaml"
+SCHEMA = "erdos97.n9_candidate_review.v1"
+TARGET = "verify-n9-candidate"
+STATUS = "REVIEW_HARNESS_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+REQUIRED_FORBIDDEN_PROMOTIONS = {
+    "general proof of Erdos Problem #97",
+    "proof of n=9",
+    "counterexample to Erdos Problem #97",
+    "official/global status update",
+    "completed independent review",
+    "formal proof of the Euclidean turn lemma",
+}
+REQUIRED_CLAIM_SCOPE_PHRASES = (
+    "does not prove n=9",
+    "does not prove Erdos Problem #97",
+    "does not claim a counterexample",
+    "does not complete independent review",
+    "does not update the official/global status",
+)
+SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
+    "python scripts/check_n9_vertex_circle_input_audit.py",
+    "python scripts/check_n9_vertex_circle_incidence_filters.py",
+    "python scripts/check_n9_vertex_circle_mro_branching_replay.py",
+    "python scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py",
+    "python scripts/check_n9_vertex_circle_strict_edge_geometry.py",
+    "python scripts/check_n9_vertex_circle_quotient_soundness.py",
+    "python scripts/check_n9_vertex_circle_local_lemma_audit_path.py",
+    "python scripts/check_turn_inequality_indexing.py",
+    "python scripts/check_n9_turn_inequality_frontier.py",
+    "python scripts/check_n9_kalmanson_selfedge_independent_replay.py",
+)
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            "PyYAML is required to parse metadata/n9_candidate_review.yaml; "
+            "install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("manifest top level must be a mapping")
+    return payload
+
+
+def make_target_commands(target: str = TARGET) -> list[str]:
+    lines = (REPO_ROOT / "Makefile").read_text(encoding="utf-8").splitlines()
+    header = f"{target}:"
+    try:
+        start = lines.index(header) + 1
+    except ValueError:
+        return []
+
+    commands: list[str] = []
+    for line in lines[start:]:
+        if line and not line.startswith("\t"):
+            break
+        if line.startswith("\t"):
+            commands.append(line.strip().replace("$(PYTHON)", "python"))
+    return commands
+
+
+def flatten_route_commands(payload: dict[str, Any]) -> list[str]:
+    commands: list[str] = []
+    routes = payload.get("routes", [])
+    if not isinstance(routes, list):
+        return commands
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        route_commands = route.get("commands", [])
+        if not isinstance(route_commands, list):
+            continue
+        for command in route_commands:
+            if isinstance(command, dict) and isinstance(command.get("command"), str):
+                commands.append(command["command"])
+    return commands
+
+
+def _validate_path_list(payload: dict[str, Any], key: str) -> list[str]:
+    errors: list[str] = []
+    values = payload.get(key)
+    if not isinstance(values, list) or not values:
+        return [f"{key} must be a nonempty list"]
+    seen: set[str] = set()
+    for index, value in enumerate(values):
+        label = f"{key}[{index}]"
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{label} must be a nonempty string")
+            continue
+        if value in seen:
+            errors.append(f"{label} duplicates {value!r}")
+        seen.add(value)
+        if not repo_path(value).exists():
+            errors.append(f"{label} does not exist: {value}")
+    return errors
+
+
+def _validate_route_commands(routes: list[Any]) -> list[str]:
+    errors: list[str] = []
+    seen_route_ids: set[str] = set()
+    seen_command_ids: set[str] = set()
+    for route_index, route in enumerate(routes):
+        route_label = f"routes[{route_index}]"
+        if not isinstance(route, dict):
+            errors.append(f"{route_label} must be a mapping")
+            continue
+        route_id = route.get("id")
+        if not isinstance(route_id, str) or not route_id.strip():
+            errors.append(f"{route_label}.id must be a nonempty string")
+        elif route_id in seen_route_ids:
+            errors.append(f"{route_label}.id {route_id!r} is duplicated")
+        else:
+            seen_route_ids.add(route_id)
+        for key in ("title", "claim_scope"):
+            value = route.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{route_label}.{key} must be a nonempty string")
+        commands = route.get("commands")
+        if not isinstance(commands, list) or not commands:
+            errors.append(f"{route_label}.commands must be a nonempty list")
+            continue
+        for command_index, command in enumerate(commands):
+            command_label = f"{route_label}.commands[{command_index}]"
+            if not isinstance(command, dict):
+                errors.append(f"{command_label} must be a mapping")
+                continue
+            command_id = command.get("id")
+            command_text = command.get("command")
+            if not isinstance(command_id, str) or not command_id.strip():
+                errors.append(f"{command_label}.id must be a nonempty string")
+            elif command_id in seen_command_ids:
+                errors.append(f"{command_label}.id {command_id!r} is duplicated")
+            else:
+                seen_command_ids.add(command_id)
+            if not isinstance(command_text, str) or not command_text.strip():
+                errors.append(f"{command_label}.command must be a nonempty string")
+                continue
+            errors.extend(_validate_command_file(command_text, command_label))
+            if command_text.startswith(SUMMARY_JSON_REVIEW_COMMAND_PREFIXES):
+                if "--summary-json" not in command_text.split():
+                    errors.append(f"{command_label}.command must use --summary-json")
+    return errors
+
+
+def _validate_command_file(command_text: str, label: str) -> list[str]:
+    parts = command_text.split()
+    if len(parts) < 2 or parts[0] != "python":
+        return []
+    script = parts[1]
+    if script.startswith("scripts/") and not repo_path(script).exists():
+        return [f"{label}.command references missing script: {script}"]
+    return []
+
+
+def _validate_review_gates(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    gates = payload.get("review_gates")
+    if not isinstance(gates, list) or not gates:
+        return ["review_gates must be a nonempty list"]
+    seen: set[str] = set()
+    for index, gate in enumerate(gates):
+        label = f"review_gates[{index}]"
+        if not isinstance(gate, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        gate_id = gate.get("id")
+        if not isinstance(gate_id, str) or not gate_id.strip():
+            errors.append(f"{label}.id must be a nonempty string")
+        elif gate_id in seen:
+            errors.append(f"{label}.id {gate_id!r} is duplicated")
+        else:
+            seen.add(gate_id)
+        requirement = gate.get("review_requirement")
+        if not isinstance(requirement, str) or not requirement.strip():
+            errors.append(f"{label}.review_requirement must be a nonempty string")
+        if gate.get("still_open") is not True:
+            errors.append(f"{label}.still_open must be true")
+    return errors
+
+
+def validate_manifest(
+    payload: dict[str, Any],
+    *,
+    makefile_commands: Sequence[str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+    if payload.get("target") != TARGET:
+        errors.append(f"target is {payload.get('target')!r}, expected {TARGET!r}")
+    if payload.get("canonical_command") != f"make {TARGET}":
+        errors.append(f"canonical_command must be 'make {TARGET}'")
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+    else:
+        for phrase in REQUIRED_CLAIM_SCOPE_PHRASES:
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    forbidden = payload.get("forbidden_promotions")
+    if not isinstance(forbidden, list) or not forbidden:
+        errors.append("forbidden_promotions must be a nonempty list")
+    else:
+        missing = REQUIRED_FORBIDDEN_PROMOTIONS - set(forbidden)
+        for phrase in sorted(missing):
+            errors.append(f"forbidden_promotions missing {phrase!r}")
+
+    for key in (
+        "source_of_truth_files",
+        "harness_documents",
+        "formalization_files",
+    ):
+        errors.extend(_validate_path_list(payload, key))
+
+    routes = payload.get("routes")
+    if not isinstance(routes, list) or not routes:
+        errors.append("routes must be a nonempty list")
+    else:
+        errors.extend(_validate_route_commands(routes))
+
+    errors.extend(_validate_review_gates(payload))
+
+    manifest_commands = flatten_route_commands(payload)
+    target_commands = list(makefile_commands) if makefile_commands is not None else make_target_commands()
+    if not target_commands:
+        errors.append(f"Makefile target {TARGET!r} has no commands")
+    elif manifest_commands != target_commands:
+        errors.append("manifest route commands do not match Makefile verify-n9-candidate commands")
+
+    return errors
+
+
+def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str, Any]:
+    routes = payload.get("routes", [])
+    route_ids = [route.get("id") for route in routes if isinstance(route, dict)]
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "target": payload.get("target"),
+        "route_count": len(routes) if isinstance(routes, list) else 0,
+        "route_ids": route_ids,
+        "command_count": len(flatten_route_commands(payload)),
+        "review_gate_count": (
+            len(payload.get("review_gates", []))
+            if isinstance(payload.get("review_gates"), list)
+            else 0
+        ),
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+        "claim_scope": payload.get("claim_scope"),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--check", action="store_true", help="fail when validation fails")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON payload")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = args.manifest
+    if not manifest.is_absolute():
+        manifest = REPO_ROOT / manifest
+    try:
+        payload = load_manifest(manifest)
+        errors = validate_manifest(payload)
+    except (OSError, ValueError, YAMLError) as exc:
+        payload = {"schema": SCHEMA, "status": "LOAD_FAILED", "target": TARGET}
+        errors = [str(exc)]
+
+    if args.summary_json:
+        print(json.dumps(summary_payload(payload, errors), indent=2, sort_keys=True))
+    elif args.json:
+        full_payload = dict(payload)
+        full_payload["validation_errors"] = errors
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 candidate review manifest")
+        print(f"target: {payload.get('target')}")
+        print(f"routes: {len(payload.get('routes', [])) if isinstance(payload.get('routes'), list) else 0}")
+        print(f"commands: {len(flatten_route_commands(payload))}")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if errors and args.check:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -22,6 +22,7 @@ def _make_target_commands(target: str) -> list[str]:
 def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
     commands = _make_target_commands("verify-n9-candidate")
     expected_chain = [
+        "python scripts/check_n9_candidate_review_manifest.py --check --summary-json",
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_candidate_review_manifest.py
+++ b/tests/test_n9_candidate_review_manifest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_candidate_review_manifest import (
+    flatten_route_commands,
+    load_manifest,
+    make_target_commands,
+    validate_manifest,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "metadata" / "n9_candidate_review.yaml"
+
+
+def test_n9_candidate_review_manifest_is_valid() -> None:
+    payload = load_manifest(MANIFEST)
+
+    errors = validate_manifest(payload)
+
+    assert errors == []
+
+
+def test_n9_candidate_review_manifest_commands_match_make_target() -> None:
+    payload = load_manifest(MANIFEST)
+
+    assert flatten_route_commands(payload) == make_target_commands("verify-n9-candidate")
+
+
+def test_n9_candidate_review_manifest_rejects_makefile_drift() -> None:
+    payload = load_manifest(MANIFEST)
+    drifted_commands = make_target_commands("verify-n9-candidate")[:-1]
+
+    errors = validate_manifest(payload, makefile_commands=drifted_commands)
+
+    assert "manifest route commands do not match Makefile verify-n9-candidate commands" in errors
+
+
+def test_n9_candidate_review_manifest_requires_forbidden_promotions() -> None:
+    payload = deepcopy(load_manifest(MANIFEST))
+    payload["forbidden_promotions"] = ["general proof of Erdos Problem #97"]
+
+    errors = validate_manifest(payload)
+
+    assert any("forbidden_promotions missing" in error for error in errors)
+
+
+def test_n9_candidate_review_manifest_pins_summary_json_review_surfaces() -> None:
+    payload = deepcopy(load_manifest(MANIFEST))
+    command = payload["routes"][2]["commands"][1]
+    command["command"] = command["command"].replace(" --summary-json", " --json")
+
+    errors = validate_manifest(payload)
+
+    assert any("must use --summary-json" in error for error in errors)


### PR DESCRIPTION
## Summary
- Add `metadata/n9_candidate_review.yaml`, a machine-readable route contract for the compact `n=9` candidate review harness.
- Add `scripts/check_n9_candidate_review_manifest.py` to validate the manifest against `verify-n9-candidate`, referenced docs/Lean files, open review gates, forbidden promotions, and reviewer-facing `--summary-json` command surfaces.
- Wire the manifest checker into `make verify-n9-candidate` as the first gate.
- Link the route contract from the harness docs, n=9 review packet, and docs index, with focused tests for drift and guardrail failures.

## Validation
- `.venv/bin/python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `.venv/bin/python -m pytest -q tests/test_n9_candidate_review_manifest.py tests/test_makefile_targets.py`
- `make verify-n9-candidate PYTHON=.venv/bin/python`
- `make verify-fast PYTHON=.venv/bin/python` (`1308 passed, 502 deselected`)

## Claim Scope
This is route-manifest and review-harness infrastructure only. It does not prove `n=9`, does not prove Erdos Problem #97, does not claim a counterexample, does not complete independent review, and does not update the official/global status.