### PR TITLE
Add n9 review gate ledger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ verify-kalmanson:
 
 verify-n9-candidate:
 	$(PYTHON) scripts/check_n9_candidate_review_manifest.py --check --summary-json
+	$(PYTHON) scripts/check_n9_review_gate_ledger.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`../metadata/n9_candidate_review.yaml`](../metadata/n9_candidate_review.yaml):
   machine-readable route contract for the compact `n=9` candidate review
   harness; not mathematical evidence and not a status promotion.
+- [`../metadata/n9_review_gate_ledger.yaml`](../metadata/n9_review_gate_ledger.yaml):
+  machine-readable review-gate ledger mapping the compact `n=9` harness to
+  still-open independent-review gates and acceptance outcomes.
 - [`upstream-alignment.md`](upstream-alignment.md): alignment notes for
   `teorth/erdosproblems` and the official problem page.
 - [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case
@@ -20,6 +23,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-candidate-promotion-harness.md`](n9-candidate-promotion-harness.md):
   compact review harness for the current review-pending `n=9`
   selected-witness candidate; command surface only, not a status promotion.
+- [`n9-review-gate-ledger.md`](n9-review-gate-ledger.md): guide to the checked
+  review-gate ledger for A6/A7, A8, A10, B1/B3, and corroborating n=9 routes.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -28,6 +28,18 @@ That checker compares the manifest command list with the Makefile target,
 verifies referenced docs and Lean files exist, and keeps the review gates
 explicitly open. It does not run the mathematical replay commands.
 
+The route contract points to the review-gate ledger
+`metadata/n9_review_gate_ledger.yaml`, checked by:
+
+```bash
+python scripts/check_n9_review_gate_ledger.py --check --summary-json
+```
+
+That checker maps the compact harness to the A6/A7, A8, A10, B1/B3, and
+corroborating Kalmanson review gates, then checks those gates against
+`docs/n9-reduction-chain.md`, `docs/n9-review-packet.md`, and the route
+manifest. It is review bookkeeping only, not mathematical evidence.
+
 Run:
 
 ```bash
@@ -46,16 +58,17 @@ The target first runs the Lean pilot guardrails:
 
 ```bash
 python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+python scripts/check_n9_review_gate_ledger.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
-The manifest checker runs before the Lean pilot guardrails. The Lean layer
-includes `lean/Erdos97/TurnPacking.lean`, a dependency-free formal contract
-for the turn-packing route. It pins the forward/reverse interval support
-convention and proves the small arithmetic kernel behind the stored dual
-certificates: a lower bound exceeding the total coefficient budget has no
-realization. It does not prove the Euclidean exterior-turn lemma.
+The manifest and gate-ledger checkers run before the Lean pilot guardrails.
+The Lean layer includes `lean/Erdos97/TurnPacking.lean`, a dependency-free
+formal contract for the turn-packing route. It pins the forward/reverse
+interval support convention and proves the small arithmetic kernel behind the
+stored dual certificates: a lower bound exceeding the total coefficient budget
+has no realization. It does not prove the Euclidean exterior-turn lemma.
 
 The target then runs the compact vertex-circle route checks:
 

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -97,6 +97,13 @@ The most important finite-case review targets are:
   source frontier;
 - for the turn route, the exterior-turn lemma and interval indexing.
 
+The machine-readable review-gate ledger
+`metadata/n9_review_gate_ledger.yaml`, checked by
+`python scripts/check_n9_review_gate_ledger.py --check --summary-json`, maps
+these targets to the compact harness evidence commands and to the acceptance
+outcomes in `docs/n9-review-packet.md`. The ledger is review bookkeeping only;
+it does not mark any gate accepted.
+
 The most important global gap is separate:
 
 ```text

--- a/docs/n9-review-gate-ledger.md
+++ b/docs/n9-review-gate-ledger.md
@@ -1,0 +1,80 @@
+# n=9 Review Gate Ledger
+
+Status: `REVIEW_GATE_LEDGER_ONLY`.
+
+This note explains the machine-readable review-gate ledger in
+`metadata/n9_review_gate_ledger.yaml`. The ledger is planning and audit
+infrastructure only. It does not prove Erdos Problem #97, does not prove
+`n=9`, does not claim a counterexample, does not complete independent review,
+and does not update the official/global status.
+
+## Purpose
+
+The compact `n=9` candidate harness now has two checked metadata layers:
+
+```bash
+python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+python scripts/check_n9_review_gate_ledger.py --check --summary-json
+```
+
+The route manifest records which commands the harness runs. The gate ledger
+records why those commands matter for independent review: which reduction-chain
+steps they support, which review gate remains open, and which acceptance
+outcome would consume the gate.
+
+This separation keeps the review surface honest. A command can be reproducible
+and still leave a proof-facing gate open.
+
+## Gate Families
+
+The ledger tracks six mathematical review gates:
+
+| Gate | Reduction steps | Route | Status |
+| --- | --- | --- | --- |
+| `frontier_enumeration` | A6, A7, B0 | shared source frontier | machine-checked review-pending |
+| `vertex_circle_geometry` | A8 | vertex-circle | proof-facing review-pending |
+| `quotient_obstruction_replay` | A9, A10 | vertex-circle | machine-checked review-pending |
+| `turn_geometry` | B1, B2 | turn-packing | proof-facing review-pending |
+| `turn_arithmetic_replay` | B3, B4 | turn-packing | machine-checked review-pending |
+| `kalmanson_corroboration` | C0, C4 | corroboration | machine-checked review-pending |
+
+It also tracks two infrastructure gates:
+
+| Gate | Boundary |
+| --- | --- |
+| `lean_compilation` | Lake is required before treating Lean pilot files as compile-checked |
+| `independent_review` | written independent review is required before theorem-style use |
+
+Every listed gate remains open.
+
+## Acceptance Outcomes
+
+The ledger mirrors the acceptance standard in `docs/n9-review-packet.md`:
+
+- `accepted_vertex_circle_route` requires `frontier_enumeration`,
+  `vertex_circle_geometry`, and `quotient_obstruction_replay`.
+- `accepted_turn_route` requires `frontier_enumeration`, `turn_geometry`, and
+  `turn_arithmetic_replay`.
+- `accepted_corrob_only` requires only the corroborating Kalmanson gate and
+  does not justify status promotion.
+- `gap_found` records a precise mathematical or implementation gap.
+
+Only the first two outcomes would justify a separate source-of-truth PR
+proposing a repo-local `n=9` finite-case status change. Neither outcome would
+prove the general problem for larger polygons.
+
+## Checker Contract
+
+`scripts/check_n9_review_gate_ledger.py` validates that:
+
+- all source-of-truth files referenced by the ledger exist;
+- all gate IDs, outcome IDs, and forbidden promotions are present;
+- each mathematical gate points to reduction-chain steps that exist in
+  `docs/n9-reduction-chain.md`;
+- each evidence command is present in `metadata/n9_candidate_review.yaml`;
+- every review gate in the route manifest is covered by either a mathematical
+  gate or an infrastructure gate;
+- the acceptance outcomes remain documented in `docs/n9-review-packet.md`.
+
+The checker does not run the mathematical replay commands. It is a contract
+checker for review bookkeeping, not mathematical evidence.

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -69,6 +69,12 @@ checked by
 It keeps the Makefile command sequence, referenced review files, and open
 review gates synchronized.
 
+The machine-readable gate ledger is `metadata/n9_review_gate_ledger.yaml`,
+checked by
+`python scripts/check_n9_review_gate_ledger.py --check --summary-json`. It maps
+the compact harness commands to the open A6/A7, A8, A10, B1/B3, and
+corroborating Kalmanson review gates plus the acceptance outcomes below.
+
 ## Review routes
 
 ### Route A: vertex-circle closure
@@ -121,6 +127,8 @@ The target expands to the layer-specific commands below and includes
 `make verify-lean`-equivalent guardrails for the local Lean pilot.
 
 ```bash
+python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+python scripts/check_n9_review_gate_ledger.py --check --summary-json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -3,6 +3,7 @@ status: REVIEW_HARNESS_ONLY
 trust: REVIEW_PENDING_DIAGNOSTIC
 target: verify-n9-candidate
 canonical_command: make verify-n9-candidate
+review_gate_ledger: metadata/n9_review_gate_ledger.yaml
 claim_scope: >
   Compact review manifest for the current review-pending n=9 selected-witness
   candidate. It records the command surface, documents, formalization-facing
@@ -55,13 +56,30 @@ review_gates:
     still_open: true
   - id: vertex_circle_geometry
     review_requirement: >
-      Review the vertex-circle strict-edge geometry rule and quotient replay
-      soundness before treating the vertex-circle route as theorem-grade.
+      Review the vertex-circle strict-edge geometry rule before treating the
+      vertex-circle route as theorem-grade.
+    still_open: true
+  - id: quotient_replay
+    review_requirement: >
+      Review the selected-distance quotient replay, self-edge criterion,
+      strict-cycle criterion, and local-lemma handoffs before treating the
+      vertex-circle route as theorem-grade.
     still_open: true
   - id: turn_geometry
     review_requirement: >
       Review the Euclidean exterior-turn lemma and interval indexing before
       treating the turn-packing route as theorem-grade.
+    still_open: true
+  - id: turn_arithmetic
+    review_requirement: >
+      Review the integer dual certificate arithmetic for all 184 weak turn
+      systems before treating the turn-packing route as theorem-grade.
+    still_open: true
+  - id: kalmanson_corroboration
+    review_requirement: >
+      Review the stored-input Kalmanson replay only as corroborating
+      stored-certificate audit support unless the primary route dependencies
+      are separately accepted.
     still_open: true
   - id: lean_compilation
     review_requirement: >
@@ -83,6 +101,8 @@ routes:
     commands:
       - id: n9_candidate_review_manifest
         command: python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+      - id: n9_review_gate_ledger
+        command: python scripts/check_n9_review_gate_ledger.py --check --summary-json
 
   - id: lean_guardrails
     title: Lean pilot guardrails

--- a/metadata/n9_review_gate_ledger.yaml
+++ b/metadata/n9_review_gate_ledger.yaml
@@ -1,0 +1,246 @@
+schema: erdos97.n9_review_gate_ledger.v1
+status: REVIEW_GATE_LEDGER_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+candidate_manifest: metadata/n9_candidate_review.yaml
+canonical_command: python scripts/check_n9_review_gate_ledger.py --check --summary-json
+claim_scope: >
+  Machine-readable review-gate ledger for the current review-pending n=9
+  selected-witness candidate. It records the exact independent-review gates,
+  evidence commands, acceptance paths, and still-open blockers. It does not
+  prove n=9, does not prove Erdos Problem #97, does not claim a counterexample,
+  does not complete independent review, and does not update the official/global
+  status.
+
+forbidden_promotions:
+  - "general proof of Erdos Problem #97"
+  - proof of n=9
+  - "counterexample to Erdos Problem #97"
+  - official/global status update
+  - completed independent review
+  - formal proof of the Euclidean turn lemma
+
+source_of_truth_files:
+  - README.md
+  - STATE.md
+  - RESULTS.md
+  - metadata/erdos97.yaml
+  - metadata/n9_candidate_review.yaml
+  - docs/claims.md
+  - docs/review-priorities.md
+  - docs/n9-reduction-chain.md
+  - docs/n9-review-packet.md
+  - docs/n9-candidate-promotion-harness.md
+
+review_outcomes:
+  - id: accepted_vertex_circle_route
+    title: Vertex-circle route accepted
+    required_gates:
+      - frontier_enumeration
+      - vertex_circle_geometry
+      - quotient_obstruction_replay
+    claim_boundary: >
+      Would support a follow-up source-of-truth proposal for the repo-local n=9
+      finite case only, not the general Erdos Problem #97 status.
+  - id: accepted_turn_route
+    title: Turn-packing route accepted
+    required_gates:
+      - frontier_enumeration
+      - turn_geometry
+      - turn_arithmetic_replay
+    claim_boundary: >
+      Would support a follow-up source-of-truth proposal for the repo-local n=9
+      finite case only, conditional on the accepted Euclidean turn lemma.
+  - id: accepted_corrob_only
+    title: Corroborating artifacts accepted only
+    required_gates:
+      - kalmanson_corroboration
+    claim_boundary: >
+      Reproduces corroborating stored-certificate evidence while leaving at
+      least one proof-facing route dependency unreviewed.
+  - id: gap_found
+    title: Precise gap found
+    required_gates: []
+    claim_boundary: >
+      Records a mathematical or implementation gap and blocks any theorem-style
+      promotion until the gap is resolved and reviewed.
+
+review_gates:
+  - id: frontier_enumeration
+    title: A6/A7 source frontier enumeration
+    route: shared_source_frontier
+    manifest_gate: source_frontier
+    status: machine_checked_review_pending
+    still_open: true
+    reduction_steps:
+      - A6
+      - A7
+      - B0
+    review_question: >
+      Do the row filters and brancher enumerate exactly the intended 184
+      selected-witness source-frontier assignments without hidden symmetry
+      quotient assumptions?
+    evidence_commands:
+      - n9_vertex_circle_exhaustive
+      - n9_vertex_circle_input_audit
+      - n9_vertex_circle_incidence_filters
+      - n9_vertex_circle_mro_branching_replay
+      - n9_vertex_circle_frontier_coverage_crosswalk
+    referenced_docs:
+      - docs/n9-reduction-chain.md
+      - docs/n9-review-packet.md
+      - docs/n9-vertex-circle-exhaustive.md
+      - docs/n9-vertex-circle-independent-recheck.md
+    blockers:
+      - Independent agreement that A2-A5 match the selected-witness formulation.
+      - Independent agreement that row0 coverage and MRO branching do not hide
+        a symmetry quotient.
+
+  - id: vertex_circle_geometry
+    title: A8 vertex-circle strict-edge geometry
+    route: vertex_circle
+    manifest_gate: vertex_circle_geometry
+    status: proof_facing_review_pending
+    still_open: true
+    reduction_steps:
+      - A8
+    review_question: >
+      Does the vertex-circle nested-chord rule force the strict ordinary-distance
+      inequalities emitted by the checker?
+    evidence_commands:
+      - n9_vertex_circle_strict_edge_geometry
+    referenced_docs:
+      - docs/n9-reduction-chain.md
+      - docs/n9-review-packet.md
+      - docs/n9-vertex-circle-strict-edge-geometry-audit.md
+      - docs/claims.md
+    blockers:
+      - Written independent review of the chord-nesting geometry.
+      - Agreement that the proper-interval containment convention is exact.
+
+  - id: quotient_obstruction_replay
+    title: A10 quotient obstruction replay
+    route: vertex_circle
+    manifest_gate: quotient_replay
+    status: machine_checked_review_pending
+    still_open: true
+    reduction_steps:
+      - A9
+      - A10
+    review_question: >
+      Do the selected-distance quotients and local-lemma handoffs faithfully
+      replay strict self-edge and strict-cycle contradictions for all 184
+      frontier assignments?
+    evidence_commands:
+      - n9_vertex_circle_quotient_soundness
+      - n9_vertex_circle_local_lemma_audit_path
+    referenced_docs:
+      - docs/n9-reduction-chain.md
+      - docs/n9-review-packet.md
+      - docs/n9-vertex-circle-certificate-chain.md
+      - docs/n9-vertex-circle-quotient-soundness-audit.md
+      - docs/n9-vertex-circle-local-lemma-review-packet.md
+      - docs/relation-skeleton-catalog.md
+    blockers:
+      - Independent review of self-edge and strict-cycle impossibility criteria.
+      - Independent review that focused packets are faithful transformations of
+        the full frontier records they cite.
+
+  - id: turn_geometry
+    title: B1/B2 exterior-turn geometry
+    route: turn_packing
+    manifest_gate: turn_geometry
+    status: proof_facing_review_pending
+    still_open: true
+    reduction_steps:
+      - B1
+      - B2
+    review_question: >
+      Does each equidistant witness pair force the two indexed exterior-turn
+      intervals used by the weak turn system?
+    evidence_commands:
+      - turn_inequality_indexing
+    referenced_docs:
+      - docs/n9-reduction-chain.md
+      - docs/n9-review-packet.md
+      - docs/turn-inequality-lemma.md
+      - docs/turn-packing-bridge.md
+    blockers:
+      - Proof-facing review of the Euclidean exterior-turn lemma.
+      - Boundary-case review for replacing strict inequalities by weak
+        normalized inequalities.
+
+  - id: turn_arithmetic_replay
+    title: B3/B4 turn-packing arithmetic replay
+    route: turn_packing
+    manifest_gate: turn_arithmetic
+    status: machine_checked_review_pending
+    still_open: true
+    reduction_steps:
+      - B3
+      - B4
+    review_question: >
+      Do the stored integer dual certificates contradict every regenerated weak
+      turn system over the 184 source-frontier assignments?
+    evidence_commands:
+      - n9_turn_inequality_frontier
+    referenced_docs:
+      - docs/n9-reduction-chain.md
+      - docs/n9-review-packet.md
+      - docs/n9-turn-inequality-frontier.md
+      - docs/turn-packing-bridge.md
+      - docs/formalization.md
+    blockers:
+      - Independent review of the arithmetic replay without relying on Z3.
+      - Compile-check the Lean pilot on a machine with Lake installed before
+        treating it as formalized support.
+
+  - id: kalmanson_corroboration
+    title: Stored-input Kalmanson corroboration
+    route: corroboration
+    manifest_gate: kalmanson_corroboration
+    status: machine_checked_review_pending
+    still_open: true
+    reduction_steps:
+      - C0
+      - C4
+    review_question: >
+      Does the stored-input Kalmanson replay corroborate the same frontier
+      without replacing either primary route?
+    evidence_commands:
+      - n9_kalmanson_selfedge_independent_replay
+    referenced_docs:
+      - docs/n9-reduction-chain.md
+      - docs/n9-review-packet.md
+      - docs/n9-vertex-circle-certificate-chain.md
+    blockers:
+      - Independent review of the stored-certificate inputs if this route is
+        used beyond corroboration.
+      - No standalone claim unless the family reduction and primary route
+        dependencies are separately accepted.
+
+infrastructure_gates:
+  - id: lean_compilation
+    title: Lean pilot compilation
+    manifest_gate: lean_compilation
+    still_open: true
+    requirement: >
+      Run python scripts/check_lean_files.py --require-lean on a machine with
+      Lake installed before treating Lean pilot files as compile-checked.
+    referenced_docs:
+      - docs/formalization.md
+      - docs/turn-packing-bridge.md
+      - docs/turn-inequality-lemma.md
+    evidence_commands:
+      - lean_sketch_integrity
+      - lean_files
+  - id: independent_review
+    title: Written independent review
+    manifest_gate: independent_review
+    still_open: true
+    requirement: >
+      Obtain written independent review that identifies accepted lemmas,
+      accepted replay boundaries, and exact gaps before any theorem-style use.
+    referenced_docs:
+      - docs/review-priorities.md
+      - docs/n9-review-packet.md
+      - docs/n9-reduction-chain.md

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -23,6 +23,7 @@ SCHEMA = "erdos97.n9_candidate_review.v1"
 TARGET = "verify-n9-candidate"
 STATUS = "REVIEW_HARNESS_ONLY"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+REVIEW_GATE_LEDGER = "metadata/n9_review_gate_ledger.yaml"
 REQUIRED_FORBIDDEN_PROMOTIONS = {
     "general proof of Erdos Problem #97",
     "proof of n=9",
@@ -39,6 +40,7 @@ REQUIRED_CLAIM_SCOPE_PHRASES = (
     "does not update the official/global status",
 )
 SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
+    "python scripts/check_n9_review_gate_ledger.py",
     "python scripts/check_n9_vertex_circle_input_audit.py",
     "python scripts/check_n9_vertex_circle_incidence_filters.py",
     "python scripts/check_n9_vertex_circle_mro_branching_replay.py",
@@ -223,6 +225,11 @@ def validate_manifest(
         errors.append(f"target is {payload.get('target')!r}, expected {TARGET!r}")
     if payload.get("canonical_command") != f"make {TARGET}":
         errors.append(f"canonical_command must be 'make {TARGET}'")
+    review_gate_ledger = payload.get("review_gate_ledger")
+    if review_gate_ledger != REVIEW_GATE_LEDGER:
+        errors.append(f"review_gate_ledger must be {REVIEW_GATE_LEDGER!r}")
+    elif not repo_path(REVIEW_GATE_LEDGER).exists():
+        errors.append(f"review_gate_ledger does not exist: {REVIEW_GATE_LEDGER}")
 
     claim_scope = payload.get("claim_scope")
     if not isinstance(claim_scope, str) or not claim_scope.strip():
@@ -273,6 +280,7 @@ def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str,
         "status": payload.get("status"),
         "trust": payload.get("trust"),
         "target": payload.get("target"),
+        "review_gate_ledger": payload.get("review_gate_ledger"),
         "route_count": len(routes) if isinstance(routes, list) else 0,
         "route_ids": route_ids,
         "command_count": len(flatten_route_commands(payload)),

--- a/scripts/check_n9_review_gate_ledger.py
+++ b/scripts/check_n9_review_gate_ledger.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Validate the n=9 independent-review gate ledger."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LEDGER = REPO_ROOT / "metadata" / "n9_review_gate_ledger.yaml"
+SCHEMA = "erdos97.n9_review_gate_ledger.v1"
+STATUS = "REVIEW_GATE_LEDGER_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CANONICAL_COMMAND = (
+    "python scripts/check_n9_review_gate_ledger.py --check --summary-json"
+)
+REQUIRED_FORBIDDEN_PROMOTIONS = {
+    "general proof of Erdos Problem #97",
+    "proof of n=9",
+    "counterexample to Erdos Problem #97",
+    "official/global status update",
+    "completed independent review",
+    "formal proof of the Euclidean turn lemma",
+}
+REQUIRED_CLAIM_SCOPE_PHRASES = (
+    "does not prove n=9",
+    "does not prove Erdos Problem #97",
+    "does not claim a counterexample",
+    "does not complete independent review",
+    "does not update the official/global status",
+)
+REQUIRED_REVIEW_GATES = {
+    "frontier_enumeration",
+    "vertex_circle_geometry",
+    "quotient_obstruction_replay",
+    "turn_geometry",
+    "turn_arithmetic_replay",
+    "kalmanson_corroboration",
+}
+REQUIRED_INFRASTRUCTURE_GATES = {
+    "lean_compilation",
+    "independent_review",
+}
+REQUIRED_OUTCOMES = {
+    "accepted_vertex_circle_route": {
+        "frontier_enumeration",
+        "vertex_circle_geometry",
+        "quotient_obstruction_replay",
+    },
+    "accepted_turn_route": {
+        "frontier_enumeration",
+        "turn_geometry",
+        "turn_arithmetic_replay",
+    },
+    "accepted_corrob_only": {"kalmanson_corroboration"},
+    "gap_found": set(),
+}
+ALLOWED_ROUTES = {
+    "shared_source_frontier",
+    "vertex_circle",
+    "turn_packing",
+    "corroboration",
+}
+ALLOWED_STATUSES = {
+    "machine_checked_review_pending",
+    "proof_facing_review_pending",
+}
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            f"PyYAML is required to parse {label}; install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} top level must be a mapping")
+    return payload
+
+
+def load_ledger(path: Path = DEFAULT_LEDGER) -> dict[str, Any]:
+    return load_yaml_mapping(path, label="metadata/n9_review_gate_ledger.yaml")
+
+
+def _validate_path_list(payload: dict[str, Any], key: str) -> list[str]:
+    values = payload.get(key)
+    if not isinstance(values, list) or not values:
+        return [f"{key} must be a nonempty list"]
+
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, value in enumerate(values):
+        label = f"{key}[{index}]"
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{label} must be a nonempty string")
+            continue
+        if value in seen:
+            errors.append(f"{label} duplicates {value!r}")
+        seen.add(value)
+        if not repo_path(value).exists():
+            errors.append(f"{label} does not exist: {value}")
+    return errors
+
+
+def _candidate_manifest_command_ids(manifest: dict[str, Any]) -> set[str]:
+    command_ids: set[str] = set()
+    routes = manifest.get("routes", [])
+    if not isinstance(routes, list):
+        return command_ids
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        commands = route.get("commands", [])
+        if not isinstance(commands, list):
+            continue
+        for command in commands:
+            if isinstance(command, dict) and isinstance(command.get("id"), str):
+                command_ids.add(command["id"])
+    return command_ids
+
+
+def _candidate_manifest_review_gate_ids(manifest: dict[str, Any]) -> set[str]:
+    gate_ids: set[str] = set()
+    gates = manifest.get("review_gates", [])
+    if not isinstance(gates, list):
+        return gate_ids
+    for gate in gates:
+        if isinstance(gate, dict) and isinstance(gate.get("id"), str):
+            gate_ids.add(gate["id"])
+    return gate_ids
+
+
+def _reduction_chain_step_ids() -> set[str]:
+    text = (REPO_ROOT / "docs" / "n9-reduction-chain.md").read_text(
+        encoding="utf-8"
+    )
+    step_ids: set[str] = set()
+    for line in text.splitlines():
+        match = re.match(r"\| (A\d+|B\d+|C\d+) \|", line)
+        if match:
+            step_ids.add(match.group(1))
+    return step_ids
+
+
+def _review_packet_outcome_ids() -> set[str]:
+    text = (REPO_ROOT / "docs" / "n9-review-packet.md").read_text(
+        encoding="utf-8"
+    )
+    outcome_ids: set[str] = set()
+    for line in text.splitlines():
+        match = re.match(r"- `([^`]+)`:", line)
+        if match:
+            outcome_ids.add(match.group(1))
+    return outcome_ids
+
+
+def _string_list(value: Any, label: str, *, allow_empty: bool = False) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    strings: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            strings.append(item)
+    if allow_empty or strings:
+        return strings
+    return []
+
+
+def _validate_forbidden_promotions(payload: dict[str, Any]) -> list[str]:
+    forbidden = payload.get("forbidden_promotions")
+    if not isinstance(forbidden, list) or not forbidden:
+        return ["forbidden_promotions must be a nonempty list"]
+    missing = REQUIRED_FORBIDDEN_PROMOTIONS - set(forbidden)
+    return [
+        f"forbidden_promotions missing {phrase!r}"
+        for phrase in sorted(missing)
+    ]
+
+
+def _validate_review_gates(
+    payload: dict[str, Any],
+    *,
+    manifest_command_ids: set[str],
+    manifest_review_gate_ids: set[str],
+    reduction_step_ids: set[str],
+) -> tuple[list[str], set[str], set[str]]:
+    errors: list[str] = []
+    gate_ids: set[str] = set()
+    manifest_gate_refs: set[str] = set()
+    gates = payload.get("review_gates")
+    if not isinstance(gates, list) or not gates:
+        return ["review_gates must be a nonempty list"], gate_ids, manifest_gate_refs
+
+    for index, gate in enumerate(gates):
+        label = f"review_gates[{index}]"
+        if not isinstance(gate, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+
+        gate_id = gate.get("id")
+        if not isinstance(gate_id, str) or not gate_id.strip():
+            errors.append(f"{label}.id must be a nonempty string")
+        elif gate_id in gate_ids:
+            errors.append(f"{label}.id {gate_id!r} is duplicated")
+        else:
+            gate_ids.add(gate_id)
+
+        for key in ("title", "review_question"):
+            value = gate.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{label}.{key} must be a nonempty string")
+
+        route = gate.get("route")
+        if route not in ALLOWED_ROUTES:
+            errors.append(f"{label}.route {route!r} is not recognized")
+
+        status = gate.get("status")
+        if status not in ALLOWED_STATUSES:
+            errors.append(f"{label}.status {status!r} is not recognized")
+
+        if gate.get("still_open") is not True:
+            errors.append(f"{label}.still_open must be true")
+
+        manifest_gate = gate.get("manifest_gate")
+        if not isinstance(manifest_gate, str) or not manifest_gate.strip():
+            errors.append(f"{label}.manifest_gate must be a nonempty string")
+        elif manifest_gate not in manifest_review_gate_ids:
+            errors.append(
+                f"{label}.manifest_gate {manifest_gate!r} is not in "
+                "metadata/n9_candidate_review.yaml"
+            )
+        else:
+            manifest_gate_refs.add(manifest_gate)
+
+        steps = _string_list(gate.get("reduction_steps"), f"{label}.reduction_steps")
+        if not steps:
+            errors.append(f"{label}.reduction_steps must be a nonempty list")
+        for step in steps:
+            if step not in reduction_step_ids:
+                errors.append(f"{label}.reduction_steps references missing {step!r}")
+
+        commands = _string_list(gate.get("evidence_commands"), f"{label}.commands")
+        if not commands:
+            errors.append(f"{label}.evidence_commands must be a nonempty list")
+        for command_id in commands:
+            if command_id not in manifest_command_ids:
+                errors.append(
+                    f"{label}.evidence_commands references unknown command "
+                    f"{command_id!r}"
+                )
+
+        docs = _string_list(gate.get("referenced_docs"), f"{label}.referenced_docs")
+        if not docs:
+            errors.append(f"{label}.referenced_docs must be a nonempty list")
+        for doc in docs:
+            if not repo_path(doc).exists():
+                errors.append(f"{label}.referenced_docs missing {doc}")
+
+        blockers = _string_list(gate.get("blockers"), f"{label}.blockers")
+        if not blockers:
+            errors.append(f"{label}.blockers must be a nonempty list")
+
+    missing_gates = REQUIRED_REVIEW_GATES - gate_ids
+    extra_gates = gate_ids - REQUIRED_REVIEW_GATES
+    for gate_id in sorted(missing_gates):
+        errors.append(f"review_gates missing required gate {gate_id!r}")
+    for gate_id in sorted(extra_gates):
+        errors.append(f"review_gates contains unknown gate {gate_id!r}")
+
+    return errors, gate_ids, manifest_gate_refs
+
+
+def _validate_infrastructure_gates(
+    payload: dict[str, Any],
+    *,
+    manifest_command_ids: set[str],
+    manifest_review_gate_ids: set[str],
+) -> tuple[list[str], set[str], set[str]]:
+    errors: list[str] = []
+    gate_ids: set[str] = set()
+    manifest_gate_refs: set[str] = set()
+    gates = payload.get("infrastructure_gates")
+    if not isinstance(gates, list) or not gates:
+        return ["infrastructure_gates must be a nonempty list"], gate_ids, manifest_gate_refs
+
+    for index, gate in enumerate(gates):
+        label = f"infrastructure_gates[{index}]"
+        if not isinstance(gate, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        gate_id = gate.get("id")
+        if not isinstance(gate_id, str) or not gate_id.strip():
+            errors.append(f"{label}.id must be a nonempty string")
+        elif gate_id in gate_ids:
+            errors.append(f"{label}.id {gate_id!r} is duplicated")
+        else:
+            gate_ids.add(gate_id)
+
+        for key in ("title", "requirement"):
+            value = gate.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{label}.{key} must be a nonempty string")
+
+        if gate.get("still_open") is not True:
+            errors.append(f"{label}.still_open must be true")
+
+        manifest_gate = gate.get("manifest_gate")
+        if not isinstance(manifest_gate, str) or not manifest_gate.strip():
+            errors.append(f"{label}.manifest_gate must be a nonempty string")
+        elif manifest_gate not in manifest_review_gate_ids:
+            errors.append(
+                f"{label}.manifest_gate {manifest_gate!r} is not in "
+                "metadata/n9_candidate_review.yaml"
+            )
+        else:
+            manifest_gate_refs.add(manifest_gate)
+
+        docs = _string_list(gate.get("referenced_docs"), f"{label}.referenced_docs")
+        if not docs:
+            errors.append(f"{label}.referenced_docs must be a nonempty list")
+        for doc in docs:
+            if not repo_path(doc).exists():
+                errors.append(f"{label}.referenced_docs missing {doc}")
+
+        commands = _string_list(
+            gate.get("evidence_commands"),
+            f"{label}.evidence_commands",
+            allow_empty=True,
+        )
+        for command_id in commands:
+            if command_id not in manifest_command_ids:
+                errors.append(
+                    f"{label}.evidence_commands references unknown command "
+                    f"{command_id!r}"
+                )
+
+    missing_gates = REQUIRED_INFRASTRUCTURE_GATES - gate_ids
+    extra_gates = gate_ids - REQUIRED_INFRASTRUCTURE_GATES
+    for gate_id in sorted(missing_gates):
+        errors.append(f"infrastructure_gates missing required gate {gate_id!r}")
+    for gate_id in sorted(extra_gates):
+        errors.append(f"infrastructure_gates contains unknown gate {gate_id!r}")
+
+    return errors, gate_ids, manifest_gate_refs
+
+
+def _validate_outcomes(
+    payload: dict[str, Any],
+    *,
+    gate_ids: set[str],
+    documented_outcome_ids: set[str],
+) -> list[str]:
+    errors: list[str] = []
+    outcomes = payload.get("review_outcomes")
+    if not isinstance(outcomes, list) or not outcomes:
+        return ["review_outcomes must be a nonempty list"]
+
+    seen: set[str] = set()
+    for index, outcome in enumerate(outcomes):
+        label = f"review_outcomes[{index}]"
+        if not isinstance(outcome, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        outcome_id = outcome.get("id")
+        if not isinstance(outcome_id, str) or not outcome_id.strip():
+            errors.append(f"{label}.id must be a nonempty string")
+            continue
+        if outcome_id in seen:
+            errors.append(f"{label}.id {outcome_id!r} is duplicated")
+        seen.add(outcome_id)
+
+        for key in ("title", "claim_boundary"):
+            value = outcome.get(key)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{label}.{key} must be a nonempty string")
+
+        required = set(
+            _string_list(
+                outcome.get("required_gates"),
+                f"{label}.required_gates",
+                allow_empty=True,
+            )
+        )
+        if outcome_id in REQUIRED_OUTCOMES:
+            expected = REQUIRED_OUTCOMES[outcome_id]
+            if required != expected:
+                errors.append(
+                    f"{label}.required_gates for {outcome_id!r} must be "
+                    f"{sorted(expected)!r}"
+                )
+        for gate_id in required:
+            if gate_id not in gate_ids:
+                errors.append(
+                    f"{label}.required_gates references unknown gate {gate_id!r}"
+                )
+        if outcome_id not in documented_outcome_ids:
+            errors.append(
+                f"{label}.id {outcome_id!r} is not documented in "
+                "docs/n9-review-packet.md"
+            )
+
+    missing = set(REQUIRED_OUTCOMES) - seen
+    extra = seen - set(REQUIRED_OUTCOMES)
+    for outcome_id in sorted(missing):
+        errors.append(f"review_outcomes missing required outcome {outcome_id!r}")
+    for outcome_id in sorted(extra):
+        errors.append(f"review_outcomes contains unknown outcome {outcome_id!r}")
+
+    return errors
+
+
+def validate_ledger(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+    reduction_step_ids: set[str] | None = None,
+    documented_outcome_ids: set[str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+    if payload.get("canonical_command") != CANONICAL_COMMAND:
+        errors.append(f"canonical_command must be {CANONICAL_COMMAND!r}")
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+    else:
+        for phrase in REQUIRED_CLAIM_SCOPE_PHRASES:
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    errors.extend(_validate_forbidden_promotions(payload))
+    errors.extend(_validate_path_list(payload, "source_of_truth_files"))
+
+    manifest_path = payload.get("candidate_manifest")
+    if not isinstance(manifest_path, str) or not manifest_path.strip():
+        errors.append("candidate_manifest must be a nonempty string")
+        manifest_payload = {}
+    elif candidate_manifest is not None:
+        manifest_payload = candidate_manifest
+    else:
+        try:
+            manifest_payload = load_yaml_mapping(
+                repo_path(manifest_path),
+                label=manifest_path,
+            )
+        except (OSError, ValueError, YAMLError) as exc:
+            manifest_payload = {}
+            errors.append(str(exc))
+
+    if manifest_payload:
+        if manifest_payload.get("review_gate_ledger") != "metadata/n9_review_gate_ledger.yaml":
+            errors.append(
+                "candidate manifest must reference metadata/n9_review_gate_ledger.yaml"
+            )
+        manifest_command_ids = _candidate_manifest_command_ids(manifest_payload)
+        manifest_review_gate_ids = _candidate_manifest_review_gate_ids(manifest_payload)
+        if "n9_review_gate_ledger" not in manifest_command_ids:
+            errors.append("candidate manifest missing n9_review_gate_ledger command")
+    else:
+        manifest_command_ids = set()
+        manifest_review_gate_ids = set()
+
+    steps = reduction_step_ids if reduction_step_ids is not None else _reduction_chain_step_ids()
+    outcomes = (
+        documented_outcome_ids
+        if documented_outcome_ids is not None
+        else _review_packet_outcome_ids()
+    )
+
+    gate_errors, gate_ids, gate_manifest_refs = _validate_review_gates(
+        payload,
+        manifest_command_ids=manifest_command_ids,
+        manifest_review_gate_ids=manifest_review_gate_ids,
+        reduction_step_ids=steps,
+    )
+    errors.extend(gate_errors)
+    infra_errors, infra_ids, infra_manifest_refs = _validate_infrastructure_gates(
+        payload,
+        manifest_command_ids=manifest_command_ids,
+        manifest_review_gate_ids=manifest_review_gate_ids,
+    )
+    errors.extend(infra_errors)
+
+    covered_manifest_gates = gate_manifest_refs | infra_manifest_refs
+    missing_manifest_gates = manifest_review_gate_ids - covered_manifest_gates
+    extra_manifest_refs = covered_manifest_gates - manifest_review_gate_ids
+    for gate_id in sorted(missing_manifest_gates):
+        errors.append(f"candidate manifest review gate {gate_id!r} is not covered")
+    for gate_id in sorted(extra_manifest_refs):
+        errors.append(f"ledger references unknown manifest review gate {gate_id!r}")
+
+    errors.extend(
+        _validate_outcomes(
+            payload,
+            gate_ids=gate_ids | infra_ids,
+            documented_outcome_ids=outcomes,
+        )
+    )
+
+    return errors
+
+
+def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str, Any]:
+    gates = payload.get("review_gates", [])
+    infra = payload.get("infrastructure_gates", [])
+    outcomes = payload.get("review_outcomes", [])
+    gate_ids = [gate.get("id") for gate in gates if isinstance(gate, dict)]
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "candidate_manifest": payload.get("candidate_manifest"),
+        "review_gate_count": len(gates) if isinstance(gates, list) else 0,
+        "infrastructure_gate_count": len(infra) if isinstance(infra, list) else 0,
+        "review_gate_ids": gate_ids,
+        "review_outcome_count": len(outcomes) if isinstance(outcomes, list) else 0,
+        "review_outcome_ids": [
+            outcome.get("id") for outcome in outcomes if isinstance(outcome, dict)
+        ],
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+        "claim_scope": payload.get("claim_scope"),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ledger", type=Path, default=DEFAULT_LEDGER)
+    parser.add_argument("--check", action="store_true", help="fail on validation errors")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    ledger = args.ledger
+    if not ledger.is_absolute():
+        ledger = REPO_ROOT / ledger
+
+    try:
+        payload = load_ledger(ledger)
+        errors = validate_ledger(payload)
+    except (OSError, ValueError, YAMLError) as exc:
+        payload = {"schema": SCHEMA, "status": "LOAD_FAILED"}
+        errors = [str(exc)]
+
+    if args.summary_json:
+        print(json.dumps(summary_payload(payload, errors), indent=2, sort_keys=True))
+    elif args.json:
+        full_payload = dict(payload)
+        full_payload["validation_errors"] = errors
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 review gate ledger")
+        print(f"candidate_manifest: {payload.get('candidate_manifest')}")
+        print(
+            "review_gates: "
+            f"{len(payload.get('review_gates', [])) if isinstance(payload.get('review_gates'), list) else 0}"
+        )
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if errors and args.check:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -23,6 +23,7 @@ def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
     commands = _make_target_commands("verify-n9-candidate")
     expected_chain = [
         "python scripts/check_n9_candidate_review_manifest.py --check --summary-json",
+        "python scripts/check_n9_review_gate_ledger.py --check --summary-json",
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_candidate_review_manifest.py
+++ b/tests/test_n9_candidate_review_manifest.py
@@ -47,6 +47,15 @@ def test_n9_candidate_review_manifest_requires_forbidden_promotions() -> None:
     assert any("forbidden_promotions missing" in error for error in errors)
 
 
+def test_n9_candidate_review_manifest_requires_review_gate_ledger() -> None:
+    payload = deepcopy(load_manifest(MANIFEST))
+    payload["review_gate_ledger"] = "metadata/other.yaml"
+
+    errors = validate_manifest(payload)
+
+    assert "review_gate_ledger must be 'metadata/n9_review_gate_ledger.yaml'" in errors
+
+
 def test_n9_candidate_review_manifest_pins_summary_json_review_surfaces() -> None:
     payload = deepcopy(load_manifest(MANIFEST))
     command = payload["routes"][2]["commands"][1]

--- a/tests/test_n9_review_gate_ledger.py
+++ b/tests/test_n9_review_gate_ledger.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_candidate_review_manifest import load_manifest
+from scripts.check_n9_review_gate_ledger import load_ledger, validate_ledger
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEDGER = ROOT / "metadata" / "n9_review_gate_ledger.yaml"
+MANIFEST = ROOT / "metadata" / "n9_candidate_review.yaml"
+
+
+def test_n9_review_gate_ledger_is_valid() -> None:
+    payload = load_ledger(LEDGER)
+
+    errors = validate_ledger(payload)
+
+    assert errors == []
+
+
+def test_n9_review_gate_ledger_rejects_outcome_drift() -> None:
+    payload = deepcopy(load_ledger(LEDGER))
+    payload["review_outcomes"][0]["required_gates"] = ["frontier_enumeration"]
+
+    errors = validate_ledger(payload)
+
+    assert any("accepted_vertex_circle_route" in error for error in errors)
+
+
+def test_n9_review_gate_ledger_rejects_unknown_reduction_step() -> None:
+    payload = deepcopy(load_ledger(LEDGER))
+    payload["review_gates"][0]["reduction_steps"].append("A12")
+
+    errors = validate_ledger(payload)
+
+    assert any("references missing 'A12'" in error for error in errors)
+
+
+def test_n9_review_gate_ledger_rejects_unknown_evidence_command() -> None:
+    payload = deepcopy(load_ledger(LEDGER))
+    payload["review_gates"][0]["evidence_commands"].append("missing_command")
+
+    errors = validate_ledger(payload)
+
+    assert any("references unknown command 'missing_command'" in error for error in errors)
+
+
+def test_n9_review_gate_ledger_covers_manifest_review_gates() -> None:
+    payload = load_ledger(LEDGER)
+    manifest = deepcopy(load_manifest(MANIFEST))
+    manifest["review_gates"].append(
+        {
+            "id": "new_review_gate",
+            "review_requirement": "Synthetic test gate.",
+            "still_open": True,
+        }
+    )
+
+    errors = validate_ledger(payload, candidate_manifest=manifest)
+
+    assert "candidate manifest review gate 'new_review_gate' is not covered" in errors


### PR DESCRIPTION
## Summary
- Add `metadata/n9_review_gate_ledger.yaml`, a checked review-gate ledger mapping the compact `n=9` harness to A6/A7, A8, A10, B1/B3, Kalmanson corroboration, Lean compilation, and independent-review gates.
- Add `scripts/check_n9_review_gate_ledger.py` to validate gate IDs, acceptance outcomes, reduction-chain step references, manifest command IDs, manifest review-gate coverage, referenced files, and no-promotion boundaries.
- Wire the ledger checker into `make verify-n9-candidate` immediately after the route manifest checker.
- Link the gate ledger from the n=9 harness, review packet, reduction chain, and docs index, with focused drift tests.

## Validation
- `.venv/bin/python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_gate_ledger.py --check --summary-json`
- `.venv/bin/python -m pytest -q tests/test_n9_review_gate_ledger.py tests/test_n9_candidate_review_manifest.py tests/test_makefile_targets.py`
- `make verify-n9-candidate PYTHON=.venv/bin/python`
- `make verify-fast PYTHON=.venv/bin/python` (`1314 passed, 502 deselected`)

## Claim Scope
This is review-gate bookkeeping and harness infrastructure only. It does not prove `n=9`, does not prove Erdos Problem #97, does not claim a counterexample, does not complete independent review, and does not update the official/global status.