### PR TITLE
Add n9 review evidence matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ verify-kalmanson:
 verify-n9-candidate:
 	$(PYTHON) scripts/check_n9_candidate_review_manifest.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_gate_ledger.py --check --summary-json
+	$(PYTHON) scripts/check_n9_review_evidence_matrix.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`../metadata/n9_review_gate_ledger.yaml`](../metadata/n9_review_gate_ledger.yaml):
   machine-readable review-gate ledger mapping the compact `n=9` harness to
   still-open independent-review gates and acceptance outcomes.
+- [`../metadata/n9_review_evidence_matrix.yaml`](../metadata/n9_review_evidence_matrix.yaml):
+  machine-readable output-invariant matrix for every command in the compact
+  `n=9` review harness, including optional live replay.
 - [`upstream-alignment.md`](upstream-alignment.md): alignment notes for
   `teorth/erdosproblems` and the official problem page.
 - [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case
@@ -25,6 +28,9 @@ put detailed reconciliation in the canonical synthesis.
   selected-witness candidate; command surface only, not a status promotion.
 - [`n9-review-gate-ledger.md`](n9-review-gate-ledger.md): guide to the checked
   review-gate ledger for A6/A7, A8, A10, B1/B3, and corroborating n=9 routes.
+- [`n9-review-evidence-matrix.md`](n9-review-evidence-matrix.md): guide to the
+  checked output-invariant matrix and optional live replay mode for the compact
+  `n=9` review harness.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -40,6 +40,23 @@ corroborating Kalmanson review gates, then checks those gates against
 `docs/n9-reduction-chain.md`, `docs/n9-review-packet.md`, and the route
 manifest. It is review bookkeeping only, not mathematical evidence.
 
+The route contract also points to the evidence matrix
+`metadata/n9_review_evidence_matrix.yaml`, checked by:
+
+```bash
+python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+```
+
+That checker validates the expected reviewer-facing output invariants for
+every command in this harness. To execute the command chain and check the live
+outputs against the matrix, run:
+
+```bash
+python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json
+```
+
+Live replay is still harness validation, not independent mathematical review.
+
 Run:
 
 ```bash
@@ -59,16 +76,18 @@ The target first runs the Lean pilot guardrails:
 ```bash
 python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_n9_review_gate_ledger.py --check --summary-json
+python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
-The manifest and gate-ledger checkers run before the Lean pilot guardrails.
-The Lean layer includes `lean/Erdos97/TurnPacking.lean`, a dependency-free
-formal contract for the turn-packing route. It pins the forward/reverse
-interval support convention and proves the small arithmetic kernel behind the
-stored dual certificates: a lower bound exceeding the total coefficient budget
-has no realization. It does not prove the Euclidean exterior-turn lemma.
+The manifest, gate-ledger, and evidence-matrix checkers run before the Lean
+pilot guardrails. The Lean layer includes `lean/Erdos97/TurnPacking.lean`, a
+dependency-free formal contract for the turn-packing route. It pins the
+forward/reverse interval support convention and proves the small arithmetic
+kernel behind the stored dual certificates: a lower bound exceeding the total
+coefficient budget has no realization. It does not prove the Euclidean
+exterior-turn lemma.
 
 The target then runs the compact vertex-circle route checks:
 

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -104,6 +104,12 @@ these targets to the compact harness evidence commands and to the acceptance
 outcomes in `docs/n9-review-packet.md`. The ledger is review bookkeeping only;
 it does not mark any gate accepted.
 
+The companion evidence matrix `metadata/n9_review_evidence_matrix.yaml`,
+checked by
+`python scripts/check_n9_review_evidence_matrix.py --check --summary-json`,
+pins the compact command outputs to expected reviewer-facing invariants. Use
+`--run` on that checker to replay those invariants live.
+
 The most important global gap is separate:
 
 ```text

--- a/docs/n9-review-evidence-matrix.md
+++ b/docs/n9-review-evidence-matrix.md
@@ -1,0 +1,82 @@
+# n=9 Review Evidence Matrix
+
+Status: `REVIEW_EVIDENCE_MATRIX_ONLY`.
+
+This note explains `metadata/n9_review_evidence_matrix.yaml`, a
+machine-readable output contract for the compact `n=9` review harness. The
+matrix is review infrastructure only. It does not prove Erdos Problem #97, does
+not prove `n=9`, does not claim a counterexample, does not complete independent
+review, and does not update the official/global status.
+
+## Purpose
+
+The compact harness now has three checked metadata layers:
+
+```bash
+python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+python scripts/check_n9_review_gate_ledger.py --check --summary-json
+python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+```
+
+The route manifest records the command sequence. The gate ledger records which
+independent-review gates those commands support. The evidence matrix records
+the expected compact output invariants for every command in the harness.
+
+This makes two kinds of drift visible:
+
+- command drift, when the Makefile, route manifest, and matrix disagree;
+- evidence drift, when a command still runs but no longer reports the expected
+  reviewer-facing counts or status fields.
+
+## Live Replay
+
+The checker can run in contract-only mode or live replay mode.
+
+Contract-only mode:
+
+```bash
+python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+```
+
+Live replay mode:
+
+```bash
+python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json
+```
+
+Live replay mode executes the compact harness commands in manifest order,
+using the current Python interpreter for `python ...` commands. It checks JSON
+commands against matrix paths such as `validation_status`,
+`source_frontier.assignment_count`, and
+`frontier_full_assignments_summary.status_counts.self_edge`. It checks text
+commands with substring expectations, including the current Lake-missing Lean
+compilation skip message.
+
+## Matrix Coverage
+
+The matrix covers all commands in `make verify-n9-candidate`:
+
+- the route manifest checker;
+- the review-gate ledger checker;
+- the evidence matrix checker itself in contract-only mode;
+- Lean sketch and optional Lean compilation guardrails;
+- the compact vertex-circle route commands;
+- the compact turn-packing route commands;
+- the stored-input Kalmanson corroboration command.
+
+The matrix also checks that every evidence command named by
+`metadata/n9_review_gate_ledger.yaml` has a linked matrix record. Metadata-only
+commands intentionally have an empty ledger-gate list because they guard the
+harness rather than a mathematical review step.
+
+## Boundary
+
+Passing the matrix in live replay mode means the current compact harness
+outputs match the expected reviewer-facing invariants. It does not mean:
+
+- the source-frontier enumeration has completed independent review;
+- the vertex-circle strict-edge geometry has been accepted;
+- the quotient replay has been accepted as theorem-grade;
+- the exterior-turn lemma has been proved;
+- the Lean pilot has been compile-checked on this machine when Lake is absent;
+- any source-of-truth claim or official/global status should change.

--- a/docs/n9-review-gate-ledger.md
+++ b/docs/n9-review-gate-ledger.md
@@ -22,6 +22,10 @@ records why those commands matter for independent review: which reduction-chain
 steps they support, which review gate remains open, and which acceptance
 outcome would consume the gate.
 
+The companion evidence matrix is
+`metadata/n9_review_evidence_matrix.yaml`. It records the expected output
+invariants for each command named by the route manifest and this gate ledger.
+
 This separation keeps the review surface honest. A command can be reproducible
 and still leave a proof-facing gate open.
 

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -75,6 +75,13 @@ checked by
 the compact harness commands to the open A6/A7, A8, A10, B1/B3, and
 corroborating Kalmanson review gates plus the acceptance outcomes below.
 
+The machine-readable evidence matrix is
+`metadata/n9_review_evidence_matrix.yaml`, checked by
+`python scripts/check_n9_review_evidence_matrix.py --check --summary-json`.
+Run
+`python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json`
+when a live replay of the compact output invariants is needed.
+
 ## Review routes
 
 ### Route A: vertex-circle closure
@@ -129,6 +136,7 @@ The target expands to the layer-specific commands below and includes
 ```bash
 python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_n9_review_gate_ledger.py --check --summary-json
+python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -4,6 +4,7 @@ trust: REVIEW_PENDING_DIAGNOSTIC
 target: verify-n9-candidate
 canonical_command: make verify-n9-candidate
 review_gate_ledger: metadata/n9_review_gate_ledger.yaml
+review_evidence_matrix: metadata/n9_review_evidence_matrix.yaml
 claim_scope: >
   Compact review manifest for the current review-pending n=9 selected-witness
   candidate. It records the command surface, documents, formalization-facing
@@ -103,6 +104,8 @@ routes:
         command: python scripts/check_n9_candidate_review_manifest.py --check --summary-json
       - id: n9_review_gate_ledger
         command: python scripts/check_n9_review_gate_ledger.py --check --summary-json
+      - id: n9_review_evidence_matrix
+        command: python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 
   - id: lean_guardrails
     title: Lean pilot guardrails

--- a/metadata/n9_review_evidence_matrix.yaml
+++ b/metadata/n9_review_evidence_matrix.yaml
@@ -1,0 +1,295 @@
+schema: erdos97.n9_review_evidence_matrix.v1
+status: REVIEW_EVIDENCE_MATRIX_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+candidate_manifest: metadata/n9_candidate_review.yaml
+review_gate_ledger: metadata/n9_review_gate_ledger.yaml
+canonical_command: python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+live_replay_command: python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json
+claim_scope: >
+  Machine-readable evidence-output contract for the compact review-pending n=9
+  selected-witness harness. It maps every harness command to expected compact
+  output invariants and can optionally replay the commands live. It does not
+  prove n=9, does not prove Erdos Problem #97, does not claim a counterexample,
+  does not complete independent review, and does not update the official/global
+  status.
+
+forbidden_promotions:
+  - "general proof of Erdos Problem #97"
+  - proof of n=9
+  - "counterexample to Erdos Problem #97"
+  - official/global status update
+  - completed independent review
+  - formal proof of the Euclidean turn lemma
+
+evidence_records:
+  - id: n9_candidate_review_manifest
+    route_id: manifest_contract
+    command_id: n9_candidate_review_manifest
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: command_count
+        equals: 16
+      - path: review_gate_count
+        equals: 8
+      - path: review_gate_ledger
+        equals: metadata/n9_review_gate_ledger.yaml
+      - path: review_evidence_matrix
+        equals: metadata/n9_review_evidence_matrix.yaml
+
+  - id: n9_review_gate_ledger
+    route_id: manifest_contract
+    command_id: n9_review_gate_ledger
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: review_gate_count
+        equals: 6
+      - path: infrastructure_gate_count
+        equals: 2
+      - path: review_outcome_count
+        equals: 4
+
+  - id: n9_review_evidence_matrix
+    route_id: manifest_contract
+    command_id: n9_review_evidence_matrix
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: evidence_record_count
+        equals: 16
+      - path: live_replay_enabled
+        equals: false
+
+  - id: lean_sketch_integrity
+    route_id: lean_guardrails
+    command_id: lean_sketch_integrity
+    output_format: text
+    ledger_gate_ids:
+      - lean_compilation
+    text_expectations:
+      - contains: Lean sketch integrity checks passed
+
+  - id: lean_files
+    route_id: lean_guardrails
+    command_id: lean_files
+    output_format: text
+    ledger_gate_ids:
+      - lean_compilation
+    text_expectations:
+      - contains_any:
+          - lake not found; skipped Lean compilation
+          - checked
+
+  - id: n9_vertex_circle_exhaustive
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_exhaustive
+    output_format: json
+    ledger_gate_ids:
+      - frontier_enumeration
+    expectations:
+      - path: main_search.full_assignments
+        equals: 0
+      - path: main_search.row0_choices
+        equals: 70
+      - path: cross_check_without_vertex_circle_pruning.full_assignments
+        equals: 184
+      - path: cross_check_without_vertex_circle_pruning.counts.self_edge
+        equals: 158
+      - path: cross_check_without_vertex_circle_pruning.counts.strict_cycle
+        equals: 26
+      - path: trust
+        equals: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING
+
+  - id: n9_vertex_circle_input_audit
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_input_audit
+    output_format: json
+    ledger_gate_ids:
+      - frontier_enumeration
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: coverage_summary.expected_row0_choices
+        equals: 70
+      - path: coverage_summary.cross_check_full_assignments
+        equals: 184
+      - path: coverage_summary.main_full_assignments
+        equals: 0
+
+  - id: n9_vertex_circle_incidence_filters
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_incidence_filters
+    output_format: json
+    ledger_gate_ids:
+      - frontier_enumeration
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: n
+        equals: 9
+      - path: row_size
+        equals: 4
+      - path: max_indegree
+        equals: 5
+      - path: selected_indegree_cap_summary.local_column_predicate_mismatches
+        equals: 0
+      - path: witness_pair_cap_summary.local_cap_predicate_mismatches
+        equals: 0
+
+  - id: n9_vertex_circle_mro_branching_replay
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_mro_branching_replay
+    output_format: json
+    ledger_gate_ids:
+      - frontier_enumeration
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: comparison_summary.main_full_assignments_match
+        equals: true
+      - path: comparison_summary.cross_check_full_assignments_match
+        equals: true
+      - path: fixed_center_order_cross_check_summary.full_assignments
+        equals: 184
+      - path: fixed_center_order_main_summary.full_assignments
+        equals: 0
+
+  - id: n9_vertex_circle_frontier_coverage_crosswalk
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_frontier_coverage_crosswalk
+    output_format: json
+    ledger_gate_ids:
+      - frontier_enumeration
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: frontier_coverage_crosswalk_summary.generated_assignment_count
+        equals: 184
+      - path: frontier_coverage_crosswalk_summary.stored_assignment_count
+        equals: 184
+      - path: frontier_coverage_crosswalk_summary.set_matches
+        equals: true
+      - path: frontier_coverage_crosswalk_summary.sequence_matches
+        equals: true
+      - path: frontier_coverage_crosswalk_summary.status_mismatches
+        equals: 0
+
+  - id: n9_vertex_circle_strict_edge_geometry
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_strict_edge_geometry
+    output_format: json
+    ledger_gate_ids:
+      - vertex_circle_geometry
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: selected_rows_checked
+        equals: 630
+      - path: total_strict_edges
+        equals: 5670
+      - path: strict_edge_mismatches
+        equals: 0
+      - path: quotient_replay_strict_edge_mismatches
+        equals: 0
+
+  - id: n9_vertex_circle_quotient_soundness
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_quotient_soundness
+    output_format: json
+    ledger_gate_ids:
+      - quotient_obstruction_replay
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: frontier_full_assignments_summary.row_set_count
+        equals: 184
+      - path: frontier_full_assignments_summary.status_counts.self_edge
+        equals: 158
+      - path: frontier_full_assignments_summary.status_counts.strict_cycle
+        equals: 26
+      - path: frontier_full_assignments_summary.status_mismatches
+        equals: 0
+
+  - id: n9_vertex_circle_local_lemma_audit_path
+    route_id: vertex_circle_route
+    command_id: n9_vertex_circle_local_lemma_audit_path
+    output_format: json
+    ledger_gate_ids:
+      - quotient_obstruction_replay
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: coverage_summary.assignment_count
+        equals: 184
+      - path: coverage_summary.family_count
+        equals: 16
+      - path: coverage_summary.template_count
+        equals: 12
+      - path: audit_contract_summary.status
+        equals: passed
+      - path: manifest_contract_summary.status
+        equals: passed
+
+  - id: turn_inequality_indexing
+    route_id: turn_packing_route
+    command_id: turn_inequality_indexing
+    output_format: json
+    ledger_gate_ids:
+      - turn_geometry
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: row_offset_subset_count
+        equals: 70
+      - path: row_instance_count
+        equals: 630
+      - path: index_record_count
+        equals: 504
+      - path: observed_term_count
+        equals: 7560
+      - path: mismatch_count
+        equals: 0
+
+  - id: n9_turn_inequality_frontier
+    route_id: turn_packing_route
+    command_id: n9_turn_inequality_frontier
+    output_format: json
+    ledger_gate_ids:
+      - frontier_enumeration
+      - turn_arithmetic_replay
+    expectations:
+      - path: source_frontier.assignment_count
+        equals: 184
+      - path: farkas_replay.certificate_count
+        equals: 184
+      - path: farkas_replay.deficit_histogram.1
+        equals: 184
+      - path: z3_replay.status_counts.unsat
+        equals: 184
+      - path: trust
+        equals: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING
+
+  - id: n9_kalmanson_selfedge_independent_replay
+    route_id: kalmanson_corroboration
+    command_id: n9_kalmanson_selfedge_independent_replay
+    output_format: json
+    ledger_gate_ids:
+      - kalmanson_corroboration
+    expectations:
+      - path: status
+        equals: ok
+      - path: certificates_checked
+        equals: 184
+      - path: unique_assignments_checked
+        equals: 184
+      - path: digest_matches
+        equals: true
+      - path: self_edge_failures
+        equals: 0

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -24,6 +24,7 @@ TARGET = "verify-n9-candidate"
 STATUS = "REVIEW_HARNESS_ONLY"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 REVIEW_GATE_LEDGER = "metadata/n9_review_gate_ledger.yaml"
+REVIEW_EVIDENCE_MATRIX = "metadata/n9_review_evidence_matrix.yaml"
 REQUIRED_FORBIDDEN_PROMOTIONS = {
     "general proof of Erdos Problem #97",
     "proof of n=9",
@@ -41,6 +42,7 @@ REQUIRED_CLAIM_SCOPE_PHRASES = (
 )
 SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
     "python scripts/check_n9_review_gate_ledger.py",
+    "python scripts/check_n9_review_evidence_matrix.py",
     "python scripts/check_n9_vertex_circle_input_audit.py",
     "python scripts/check_n9_vertex_circle_incidence_filters.py",
     "python scripts/check_n9_vertex_circle_mro_branching_replay.py",
@@ -230,6 +232,13 @@ def validate_manifest(
         errors.append(f"review_gate_ledger must be {REVIEW_GATE_LEDGER!r}")
     elif not repo_path(REVIEW_GATE_LEDGER).exists():
         errors.append(f"review_gate_ledger does not exist: {REVIEW_GATE_LEDGER}")
+    review_evidence_matrix = payload.get("review_evidence_matrix")
+    if review_evidence_matrix != REVIEW_EVIDENCE_MATRIX:
+        errors.append(f"review_evidence_matrix must be {REVIEW_EVIDENCE_MATRIX!r}")
+    elif not repo_path(REVIEW_EVIDENCE_MATRIX).exists():
+        errors.append(
+            f"review_evidence_matrix does not exist: {REVIEW_EVIDENCE_MATRIX}"
+        )
 
     claim_scope = payload.get("claim_scope")
     if not isinstance(claim_scope, str) or not claim_scope.strip():
@@ -281,6 +290,7 @@ def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str,
         "trust": payload.get("trust"),
         "target": payload.get("target"),
         "review_gate_ledger": payload.get("review_gate_ledger"),
+        "review_evidence_matrix": payload.get("review_evidence_matrix"),
         "route_count": len(routes) if isinstance(routes, list) else 0,
         "route_ids": route_ids,
         "command_count": len(flatten_route_commands(payload)),

--- a/scripts/check_n9_review_evidence_matrix.py
+++ b/scripts/check_n9_review_evidence_matrix.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""Validate and optionally replay the n=9 review evidence matrix."""
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MATRIX = REPO_ROOT / "metadata" / "n9_review_evidence_matrix.yaml"
+SCHEMA = "erdos97.n9_review_evidence_matrix.v1"
+STATUS = "REVIEW_EVIDENCE_MATRIX_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CANONICAL_COMMAND = (
+    "python scripts/check_n9_review_evidence_matrix.py --check --summary-json"
+)
+LIVE_REPLAY_COMMAND = (
+    "python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json"
+)
+REQUIRED_FORBIDDEN_PROMOTIONS = {
+    "general proof of Erdos Problem #97",
+    "proof of n=9",
+    "counterexample to Erdos Problem #97",
+    "official/global status update",
+    "completed independent review",
+    "formal proof of the Euclidean turn lemma",
+}
+REQUIRED_CLAIM_SCOPE_PHRASES = (
+    "does not prove n=9",
+    "does not prove Erdos Problem #97",
+    "does not claim a counterexample",
+    "does not complete independent review",
+    "does not update the official/global status",
+)
+SUPPORTED_OUTPUT_FORMATS = {"json", "text"}
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            f"PyYAML is required to parse {label}; install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} top level must be a mapping")
+    return payload
+
+
+def load_matrix(path: Path = DEFAULT_MATRIX) -> dict[str, Any]:
+    return load_yaml_mapping(path, label="metadata/n9_review_evidence_matrix.yaml")
+
+
+def _candidate_manifest_commands(manifest: dict[str, Any]) -> dict[str, dict[str, str]]:
+    commands: dict[str, dict[str, str]] = {}
+    routes = manifest.get("routes", [])
+    if not isinstance(routes, list):
+        return commands
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        route_id = route.get("id")
+        if not isinstance(route_id, str):
+            continue
+        route_commands = route.get("commands", [])
+        if not isinstance(route_commands, list):
+            continue
+        for command in route_commands:
+            if not isinstance(command, dict):
+                continue
+            command_id = command.get("id")
+            command_text = command.get("command")
+            if isinstance(command_id, str) and isinstance(command_text, str):
+                commands[command_id] = {
+                    "route_id": route_id,
+                    "command": command_text,
+                }
+    return commands
+
+
+def _ledger_gate_ids(ledger: dict[str, Any]) -> set[str]:
+    gate_ids: set[str] = set()
+    for key in ("review_gates", "infrastructure_gates"):
+        gates = ledger.get(key, [])
+        if not isinstance(gates, list):
+            continue
+        for gate in gates:
+            if isinstance(gate, dict) and isinstance(gate.get("id"), str):
+                gate_ids.add(gate["id"])
+    return gate_ids
+
+
+def _ledger_evidence_commands(ledger: dict[str, Any]) -> set[str]:
+    command_ids: set[str] = set()
+    for key in ("review_gates", "infrastructure_gates"):
+        gates = ledger.get(key, [])
+        if not isinstance(gates, list):
+            continue
+        for gate in gates:
+            if not isinstance(gate, dict):
+                continue
+            commands = gate.get("evidence_commands", [])
+            if not isinstance(commands, list):
+                continue
+            for command_id in commands:
+                if isinstance(command_id, str):
+                    command_ids.add(command_id)
+    return command_ids
+
+
+def _load_linked_manifests(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    errors: list[str] = []
+    manifest_path = payload.get("candidate_manifest")
+    ledger_path = payload.get("review_gate_ledger")
+    manifest: dict[str, Any] = {}
+    ledger: dict[str, Any] = {}
+
+    if not isinstance(manifest_path, str) or not manifest_path.strip():
+        errors.append("candidate_manifest must be a nonempty string")
+    else:
+        try:
+            manifest = load_yaml_mapping(repo_path(manifest_path), label=manifest_path)
+        except (OSError, ValueError, YAMLError) as exc:
+            errors.append(str(exc))
+
+    if not isinstance(ledger_path, str) or not ledger_path.strip():
+        errors.append("review_gate_ledger must be a nonempty string")
+    else:
+        try:
+            ledger = load_yaml_mapping(repo_path(ledger_path), label=ledger_path)
+        except (OSError, ValueError, YAMLError) as exc:
+            errors.append(str(exc))
+
+    return manifest, ledger, errors
+
+
+def _validate_forbidden_promotions(payload: dict[str, Any]) -> list[str]:
+    forbidden = payload.get("forbidden_promotions")
+    if not isinstance(forbidden, list) or not forbidden:
+        return ["forbidden_promotions must be a nonempty list"]
+    missing = REQUIRED_FORBIDDEN_PROMOTIONS - set(forbidden)
+    return [
+        f"forbidden_promotions missing {phrase!r}"
+        for phrase in sorted(missing)
+    ]
+
+
+def _validate_expectation_shape(record: dict[str, Any], label: str) -> list[str]:
+    errors: list[str] = []
+    output_format = record.get("output_format")
+    expectations = record.get("expectations", [])
+    text_expectations = record.get("text_expectations", [])
+
+    if output_format == "json":
+        if not isinstance(expectations, list) or not expectations:
+            errors.append(f"{label}.expectations must be a nonempty list")
+        for index, expectation in enumerate(expectations):
+            expectation_label = f"{label}.expectations[{index}]"
+            if not isinstance(expectation, dict):
+                errors.append(f"{expectation_label} must be a mapping")
+                continue
+            if not isinstance(expectation.get("path"), str) or not expectation["path"]:
+                errors.append(f"{expectation_label}.path must be a nonempty string")
+            if "equals" not in expectation and "contains" not in expectation:
+                errors.append(
+                    f"{expectation_label} must define equals or contains"
+                )
+        if text_expectations:
+            errors.append(f"{label}.text_expectations is only valid for text output")
+    elif output_format == "text":
+        if not isinstance(text_expectations, list) or not text_expectations:
+            errors.append(f"{label}.text_expectations must be a nonempty list")
+        for index, expectation in enumerate(text_expectations):
+            expectation_label = f"{label}.text_expectations[{index}]"
+            if not isinstance(expectation, dict):
+                errors.append(f"{expectation_label} must be a mapping")
+                continue
+            has_contains = isinstance(expectation.get("contains"), str)
+            contains_any = expectation.get("contains_any")
+            has_contains_any = (
+                isinstance(contains_any, list)
+                and all(isinstance(item, str) for item in contains_any)
+                and bool(contains_any)
+            )
+            if not has_contains and not has_contains_any:
+                errors.append(
+                    f"{expectation_label} must define contains or contains_any"
+                )
+        if expectations:
+            errors.append(f"{label}.expectations is only valid for JSON output")
+    return errors
+
+
+def validate_matrix(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+    gate_ledger: dict[str, Any] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+    if payload.get("canonical_command") != CANONICAL_COMMAND:
+        errors.append(f"canonical_command must be {CANONICAL_COMMAND!r}")
+    if payload.get("live_replay_command") != LIVE_REPLAY_COMMAND:
+        errors.append(f"live_replay_command must be {LIVE_REPLAY_COMMAND!r}")
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+    else:
+        for phrase in REQUIRED_CLAIM_SCOPE_PHRASES:
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+    errors.extend(_validate_forbidden_promotions(payload))
+
+    manifest: dict[str, Any]
+    ledger: dict[str, Any]
+    if candidate_manifest is None or gate_ledger is None:
+        manifest, ledger, link_errors = _load_linked_manifests(payload)
+        errors.extend(link_errors)
+        if candidate_manifest is not None:
+            manifest = candidate_manifest
+        if gate_ledger is not None:
+            ledger = gate_ledger
+    else:
+        manifest = candidate_manifest
+        ledger = gate_ledger
+
+    if manifest:
+        if manifest.get("review_evidence_matrix") != "metadata/n9_review_evidence_matrix.yaml":
+            errors.append(
+                "candidate manifest must reference metadata/n9_review_evidence_matrix.yaml"
+            )
+        manifest_commands = _candidate_manifest_commands(manifest)
+    else:
+        manifest_commands = {}
+
+    if ledger:
+        gate_ids = _ledger_gate_ids(ledger)
+        ledger_evidence_commands = _ledger_evidence_commands(ledger)
+    else:
+        gate_ids = set()
+        ledger_evidence_commands = set()
+
+    records = payload.get("evidence_records")
+    if not isinstance(records, list) or not records:
+        return errors + ["evidence_records must be a nonempty list"]
+
+    seen_record_ids: set[str] = set()
+    record_command_ids: set[str] = set()
+    command_to_gates: dict[str, set[str]] = {}
+    for index, record in enumerate(records):
+        label = f"evidence_records[{index}]"
+        if not isinstance(record, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+
+        record_id = record.get("id")
+        if not isinstance(record_id, str) or not record_id.strip():
+            errors.append(f"{label}.id must be a nonempty string")
+        elif record_id in seen_record_ids:
+            errors.append(f"{label}.id {record_id!r} is duplicated")
+        else:
+            seen_record_ids.add(record_id)
+
+        command_id = record.get("command_id")
+        if not isinstance(command_id, str) or not command_id.strip():
+            errors.append(f"{label}.command_id must be a nonempty string")
+            continue
+        if command_id in record_command_ids:
+            errors.append(f"{label}.command_id {command_id!r} is duplicated")
+        record_command_ids.add(command_id)
+
+        manifest_command = manifest_commands.get(command_id)
+        if manifest_commands and manifest_command is None:
+            errors.append(f"{label}.command_id {command_id!r} is not in manifest")
+        else:
+            route_id = record.get("route_id")
+            if not isinstance(route_id, str) or not route_id.strip():
+                errors.append(f"{label}.route_id must be a nonempty string")
+            elif manifest_command and route_id != manifest_command["route_id"]:
+                errors.append(
+                    f"{label}.route_id {route_id!r} does not match manifest "
+                    f"route {manifest_command['route_id']!r}"
+                )
+
+        output_format = record.get("output_format")
+        if output_format not in SUPPORTED_OUTPUT_FORMATS:
+            errors.append(f"{label}.output_format {output_format!r} is not supported")
+
+        ledger_gate_ids = record.get("ledger_gate_ids")
+        if not isinstance(ledger_gate_ids, list):
+            errors.append(f"{label}.ledger_gate_ids must be a list")
+            ledger_gate_id_set: set[str] = set()
+        else:
+            ledger_gate_id_set = {
+                gate_id for gate_id in ledger_gate_ids if isinstance(gate_id, str)
+            }
+            if len(ledger_gate_id_set) != len(ledger_gate_ids):
+                errors.append(f"{label}.ledger_gate_ids must contain only strings")
+            for gate_id in ledger_gate_id_set:
+                if gate_ids and gate_id not in gate_ids:
+                    errors.append(f"{label}.ledger_gate_ids unknown gate {gate_id!r}")
+        command_to_gates.setdefault(command_id, set()).update(ledger_gate_id_set)
+
+        errors.extend(_validate_expectation_shape(record, label))
+
+    missing_manifest_commands = set(manifest_commands) - record_command_ids
+    extra_record_commands = record_command_ids - set(manifest_commands)
+    for command_id in sorted(missing_manifest_commands):
+        errors.append(f"manifest command {command_id!r} is not covered by matrix")
+    for command_id in sorted(extra_record_commands):
+        errors.append(f"matrix command {command_id!r} is not present in manifest")
+
+    missing_ledger_commands = ledger_evidence_commands - record_command_ids
+    for command_id in sorted(missing_ledger_commands):
+        errors.append(f"ledger evidence command {command_id!r} is not covered")
+    for command_id in sorted(ledger_evidence_commands & record_command_ids):
+        if not command_to_gates.get(command_id):
+            errors.append(
+                f"ledger evidence command {command_id!r} has no matrix gate link"
+            )
+
+    return errors
+
+
+def _extract_path(payload: Any, path: str) -> tuple[bool, Any]:
+    current = payload
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return False, None
+    return True, current
+
+
+def _check_json_expectations(
+    payload: dict[str, Any],
+    expectations: Sequence[dict[str, Any]],
+    *,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+    for index, expectation in enumerate(expectations):
+        expectation_label = f"{label}.expectations[{index}]"
+        path = expectation.get("path")
+        if not isinstance(path, str):
+            errors.append(f"{expectation_label}.path must be a string")
+            continue
+        found, actual = _extract_path(payload, path)
+        if not found:
+            errors.append(f"{expectation_label} missing output path {path!r}")
+            continue
+        if "equals" in expectation and actual != expectation["equals"]:
+            errors.append(
+                f"{expectation_label} expected {path!r} == "
+                f"{expectation['equals']!r}, got {actual!r}"
+            )
+        if "contains" in expectation:
+            needle = expectation["contains"]
+            if isinstance(actual, str):
+                ok = isinstance(needle, str) and needle in actual
+            elif isinstance(actual, list):
+                ok = needle in actual
+            else:
+                ok = False
+            if not ok:
+                errors.append(
+                    f"{expectation_label} expected {path!r} to contain {needle!r}"
+                )
+    return errors
+
+
+def _check_text_expectations(
+    text: str,
+    expectations: Sequence[dict[str, Any]],
+    *,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+    for index, expectation in enumerate(expectations):
+        expectation_label = f"{label}.text_expectations[{index}]"
+        if "contains" in expectation:
+            needle = expectation["contains"]
+            if not isinstance(needle, str) or needle not in text:
+                errors.append(
+                    f"{expectation_label} expected output to contain {needle!r}"
+                )
+        if "contains_any" in expectation:
+            needles = expectation["contains_any"]
+            if not isinstance(needles, list) or not any(
+                isinstance(needle, str) and needle in text for needle in needles
+            ):
+                errors.append(
+                    f"{expectation_label} expected output to contain one of "
+                    f"{needles!r}"
+                )
+    return errors
+
+
+def _command_for_record(record: dict[str, Any], manifest_commands: dict[str, dict[str, str]]) -> str:
+    command_id = record["command_id"]
+    return manifest_commands[command_id]["command"]
+
+
+def _subprocess_args(command: str) -> list[str]:
+    parts = shlex.split(command)
+    if parts and parts[0] == "python":
+        parts[0] = sys.executable
+    return parts
+
+
+def run_evidence_records(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    if candidate_manifest is None:
+        manifest_path = payload.get("candidate_manifest")
+        if not isinstance(manifest_path, str):
+            return [], ["candidate_manifest must be a nonempty string"]
+        candidate_manifest = load_yaml_mapping(repo_path(manifest_path), label=manifest_path)
+
+    manifest_commands = _candidate_manifest_commands(candidate_manifest)
+    records = payload.get("evidence_records", [])
+    if not isinstance(records, list):
+        return [], ["evidence_records must be a list before live replay"]
+
+    run_records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for record in records:
+        if not isinstance(record, dict) or not isinstance(record.get("command_id"), str):
+            continue
+        record_id = record.get("id", record.get("command_id"))
+        label = f"evidence_record {record_id!r}"
+        command_id = record["command_id"]
+        if command_id not in manifest_commands:
+            errors.append(f"{label} references missing manifest command")
+            continue
+        command = _command_for_record(record, manifest_commands)
+        completed = subprocess.run(
+            _subprocess_args(command),
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        stdout = completed.stdout.strip()
+        stderr = completed.stderr.strip()
+        record_errors: list[str] = []
+        if completed.returncode != 0:
+            record_errors.append(
+                f"{label} command exited with {completed.returncode}: {command}"
+            )
+        output_format = record.get("output_format")
+        if output_format == "json" and completed.returncode == 0:
+            try:
+                output_payload = json.loads(stdout)
+            except json.JSONDecodeError as exc:
+                record_errors.append(f"{label} output is not JSON: {exc}")
+            else:
+                expectations = record.get("expectations", [])
+                if isinstance(expectations, list):
+                    record_errors.extend(
+                        _check_json_expectations(
+                            output_payload,
+                            expectations,
+                            label=str(record_id),
+                        )
+                    )
+        elif output_format == "text" and completed.returncode == 0:
+            text_expectations = record.get("text_expectations", [])
+            if isinstance(text_expectations, list):
+                record_errors.extend(
+                    _check_text_expectations(
+                        stdout,
+                        text_expectations,
+                        label=str(record_id),
+                    )
+                )
+        if record_errors:
+            errors.extend(record_errors)
+        run_records.append(
+            {
+                "id": record_id,
+                "command_id": command_id,
+                "returncode": completed.returncode,
+                "validation_status": "passed" if not record_errors else "failed",
+                "error_count": len(record_errors),
+                "first_errors": record_errors[:3],
+                "stdout_preview": stdout[:240],
+                "stderr_preview": stderr[:240],
+            }
+        )
+    return run_records, errors
+
+
+def summary_payload(
+    payload: dict[str, Any],
+    errors: Sequence[str],
+    *,
+    live_replay_enabled: bool,
+    run_records: Sequence[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    records = payload.get("evidence_records", [])
+    run_records = list(run_records or [])
+    failed_run_records = [
+        record for record in run_records if record.get("validation_status") != "passed"
+    ]
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "candidate_manifest": payload.get("candidate_manifest"),
+        "review_gate_ledger": payload.get("review_gate_ledger"),
+        "evidence_record_count": len(records) if isinstance(records, list) else 0,
+        "evidence_record_ids": [
+            record.get("id") for record in records if isinstance(record, dict)
+        ],
+        "live_replay_enabled": live_replay_enabled,
+        "live_replay_record_count": len(run_records),
+        "failed_live_replay_count": len(failed_run_records),
+        "failed_live_replay_ids": [
+            record.get("id") for record in failed_run_records[:10]
+        ],
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+        "claim_scope": payload.get("claim_scope"),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix", type=Path, default=DEFAULT_MATRIX)
+    parser.add_argument("--check", action="store_true", help="fail on validation errors")
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="execute the matrix command chain and validate live outputs",
+    )
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    matrix = args.matrix
+    if not matrix.is_absolute():
+        matrix = REPO_ROOT / matrix
+
+    run_records: list[dict[str, Any]] = []
+    try:
+        payload = load_matrix(matrix)
+        errors = validate_matrix(payload)
+        if args.run and not errors:
+            run_records, run_errors = run_evidence_records(payload)
+            errors.extend(run_errors)
+    except (OSError, ValueError, YAMLError) as exc:
+        payload = {"schema": SCHEMA, "status": "LOAD_FAILED"}
+        errors = [str(exc)]
+
+    if args.summary_json:
+        print(
+            json.dumps(
+                summary_payload(
+                    payload,
+                    errors,
+                    live_replay_enabled=args.run,
+                    run_records=run_records,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif args.json:
+        full_payload = dict(payload)
+        full_payload["live_replay_enabled"] = args.run
+        full_payload["live_replay_records"] = run_records
+        full_payload["validation_errors"] = errors
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 review evidence matrix")
+        print(f"candidate_manifest: {payload.get('candidate_manifest')}")
+        print(
+            "evidence_records: "
+            f"{len(payload.get('evidence_records', [])) if isinstance(payload.get('evidence_records'), list) else 0}"
+        )
+        print(f"live_replay_enabled: {args.run}")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if errors and args.check:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -24,6 +24,7 @@ def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
     expected_chain = [
         "python scripts/check_n9_candidate_review_manifest.py --check --summary-json",
         "python scripts/check_n9_review_gate_ledger.py --check --summary-json",
+        "python scripts/check_n9_review_evidence_matrix.py --check --summary-json",
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_candidate_review_manifest.py
+++ b/tests/test_n9_candidate_review_manifest.py
@@ -56,6 +56,18 @@ def test_n9_candidate_review_manifest_requires_review_gate_ledger() -> None:
     assert "review_gate_ledger must be 'metadata/n9_review_gate_ledger.yaml'" in errors
 
 
+def test_n9_candidate_review_manifest_requires_review_evidence_matrix() -> None:
+    payload = deepcopy(load_manifest(MANIFEST))
+    payload["review_evidence_matrix"] = "metadata/other.yaml"
+
+    errors = validate_manifest(payload)
+
+    assert (
+        "review_evidence_matrix must be 'metadata/n9_review_evidence_matrix.yaml'"
+        in errors
+    )
+
+
 def test_n9_candidate_review_manifest_pins_summary_json_review_surfaces() -> None:
     payload = deepcopy(load_manifest(MANIFEST))
     command = payload["routes"][2]["commands"][1]

--- a/tests/test_n9_review_evidence_matrix.py
+++ b/tests/test_n9_review_evidence_matrix.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_candidate_review_manifest import load_manifest
+from scripts.check_n9_review_evidence_matrix import (
+    _check_json_expectations,
+    _check_text_expectations,
+    load_matrix,
+    validate_matrix,
+)
+from scripts.check_n9_review_gate_ledger import load_ledger
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX = ROOT / "metadata" / "n9_review_evidence_matrix.yaml"
+MANIFEST = ROOT / "metadata" / "n9_candidate_review.yaml"
+LEDGER = ROOT / "metadata" / "n9_review_gate_ledger.yaml"
+
+
+def _manifest_command_ids() -> set[str]:
+    payload = load_manifest(MANIFEST)
+    ids: set[str] = set()
+    for route in payload["routes"]:
+        for command in route["commands"]:
+            ids.add(command["id"])
+    return ids
+
+
+def test_n9_review_evidence_matrix_is_valid() -> None:
+    payload = load_matrix(MATRIX)
+
+    errors = validate_matrix(payload)
+
+    assert errors == []
+
+
+def test_n9_review_evidence_matrix_covers_manifest_commands() -> None:
+    payload = load_matrix(MATRIX)
+    record_command_ids = {
+        record["command_id"] for record in payload["evidence_records"]
+    }
+
+    assert record_command_ids == _manifest_command_ids()
+
+
+def test_n9_review_evidence_matrix_rejects_missing_manifest_command() -> None:
+    payload = deepcopy(load_matrix(MATRIX))
+    payload["evidence_records"] = [
+        record
+        for record in payload["evidence_records"]
+        if record["command_id"] != "n9_turn_inequality_frontier"
+    ]
+
+    errors = validate_matrix(payload)
+
+    assert "manifest command 'n9_turn_inequality_frontier' is not covered by matrix" in errors
+
+
+def test_n9_review_evidence_matrix_rejects_unknown_gate_link() -> None:
+    payload = deepcopy(load_matrix(MATRIX))
+    payload["evidence_records"][5]["ledger_gate_ids"].append("missing_gate")
+
+    errors = validate_matrix(payload)
+
+    assert any("unknown gate 'missing_gate'" in error for error in errors)
+
+
+def test_n9_review_evidence_matrix_rejects_manifest_without_pointer() -> None:
+    payload = load_matrix(MATRIX)
+    manifest = deepcopy(load_manifest(MANIFEST))
+    manifest.pop("review_evidence_matrix")
+
+    errors = validate_matrix(
+        payload,
+        candidate_manifest=manifest,
+        gate_ledger=load_ledger(LEDGER),
+    )
+
+    assert (
+        "candidate manifest must reference metadata/n9_review_evidence_matrix.yaml"
+        in errors
+    )
+
+
+def test_n9_review_evidence_matrix_checks_json_expectations() -> None:
+    errors = _check_json_expectations(
+        {"outer": {"count": 184, "status": "passed"}},
+        [
+            {"path": "outer.count", "equals": 184},
+            {"path": "outer.status", "contains": "pass"},
+        ],
+        label="sample",
+    )
+
+    assert errors == []
+
+
+def test_n9_review_evidence_matrix_reports_json_expectation_mismatch() -> None:
+    errors = _check_json_expectations(
+        {"outer": {"count": 183}},
+        [{"path": "outer.count", "equals": 184}],
+        label="sample",
+    )
+
+    assert any("expected 'outer.count' == 184" in error for error in errors)
+
+
+def test_n9_review_evidence_matrix_checks_text_expectations() -> None:
+    errors = _check_text_expectations(
+        "lake not found; skipped Lean compilation",
+        [{"contains_any": ["checked", "lake not found; skipped Lean compilation"]}],
+        label="lean_files",
+    )
+
+    assert errors == []


### PR DESCRIPTION
## Summary
- Add `metadata/n9_review_evidence_matrix.yaml`, a checked output-invariant matrix covering every command in the compact `n=9` review harness.
- Add `scripts/check_n9_review_evidence_matrix.py` with contract-only validation plus optional `--run` live replay that executes the harness commands and checks their JSON/text outputs against matrix invariants.
- Wire the matrix checker into `make verify-n9-candidate` after the route manifest and review-gate ledger checks.
- Link the evidence matrix from the n=9 harness docs, review packet, reduction chain, gate-ledger guide, and docs index, with focused drift tests.

## Validation
- `.venv/bin/python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_evidence_matrix.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json`
- `.venv/bin/python -m pytest -q tests/test_n9_review_evidence_matrix.py tests/test_n9_review_gate_ledger.py tests/test_n9_candidate_review_manifest.py tests/test_makefile_targets.py`
- `make verify-n9-candidate PYTHON=.venv/bin/python`
- `make verify-fast PYTHON=.venv/bin/python` (`1323 passed, 502 deselected`)

## Claim Scope
This is evidence-output contract and harness infrastructure only. It does not prove `n=9`, does not prove Erdos Problem #97, does not claim a counterexample, does not complete independent review, and does not update the official/global status.