### PR TITLE
Add n9 reviewer dossier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ verify-n9-candidate:
 	$(PYTHON) scripts/check_n9_candidate_review_manifest.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_gate_ledger.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_evidence_matrix.py --check --summary-json
+	$(PYTHON) scripts/check_n9_review_dossier.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`../metadata/n9_review_evidence_matrix.yaml`](../metadata/n9_review_evidence_matrix.yaml):
   machine-readable output-invariant matrix for every command in the compact
   `n=9` review harness, including optional live replay.
+- [`../metadata/n9_review_dossier.yaml`](../metadata/n9_review_dossier.yaml):
+  machine-readable reviewer-dossier contract joining the compact n=9 command
+  surface, open gates, output invariants, and decision fields.
 - [`upstream-alignment.md`](upstream-alignment.md): alignment notes for
   `teorth/erdosproblems` and the official problem page.
 - [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case
@@ -31,6 +34,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-review-evidence-matrix.md`](n9-review-evidence-matrix.md): guide to the
   checked output-invariant matrix and optional live replay mode for the compact
   `n=9` review harness.
+- [`n9-review-dossier.md`](n9-review-dossier.md): guide to the checked
+  reviewer dossier and on-demand Markdown worksheet for the compact `n=9`
+  review harness.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -57,6 +57,22 @@ python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json
 
 Live replay is still harness validation, not independent mathematical review.
 
+Finally, the route contract points to the reviewer dossier contract
+`metadata/n9_review_dossier.yaml`, checked by:
+
+```bash
+python scripts/check_n9_review_dossier.py --check --summary-json
+```
+
+To render the on-demand Markdown worksheet, run:
+
+```bash
+python scripts/check_n9_review_dossier.py --markdown
+```
+
+The worksheet is a review aid only; it does not write a generated artifact and
+does not mark any gate accepted.
+
 Run:
 
 ```bash
@@ -77,17 +93,18 @@ The target first runs the Lean pilot guardrails:
 python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_n9_review_gate_ledger.py --check --summary-json
 python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+python scripts/check_n9_review_dossier.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
-The manifest, gate-ledger, and evidence-matrix checkers run before the Lean
-pilot guardrails. The Lean layer includes `lean/Erdos97/TurnPacking.lean`, a
-dependency-free formal contract for the turn-packing route. It pins the
-forward/reverse interval support convention and proves the small arithmetic
-kernel behind the stored dual certificates: a lower bound exceeding the total
-coefficient budget has no realization. It does not prove the Euclidean
-exterior-turn lemma.
+The manifest, gate-ledger, evidence-matrix, and dossier checkers run before
+the Lean pilot guardrails. The Lean layer includes
+`lean/Erdos97/TurnPacking.lean`, a dependency-free formal contract for the
+turn-packing route. It pins the forward/reverse interval support convention
+and proves the small arithmetic kernel behind the stored dual certificates: a
+lower bound exceeding the total coefficient budget has no realization. It does
+not prove the Euclidean exterior-turn lemma.
 
 The target then runs the compact vertex-circle route checks:
 

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -110,6 +110,10 @@ checked by
 pins the compact command outputs to expected reviewer-facing invariants. Use
 `--run` on that checker to replay those invariants live.
 
+The reviewer dossier `metadata/n9_review_dossier.yaml`, checked by
+`python scripts/check_n9_review_dossier.py --check --summary-json`, assembles
+the same dependencies into an on-demand Markdown worksheet for written review.
+
 The most important global gap is separate:
 
 ```text

--- a/docs/n9-review-dossier.md
+++ b/docs/n9-review-dossier.md
@@ -1,0 +1,57 @@
+# n=9 Reviewer Dossier
+
+Status: `REVIEW_DOSSIER_ONLY`.
+
+This note explains `metadata/n9_review_dossier.yaml` and
+`scripts/check_n9_review_dossier.py`. The dossier is a checked review worksheet
+for the compact `n=9` harness. It does not prove Erdos Problem #97, does not
+prove `n=9`, does not claim a counterexample, does not complete independent
+review, and does not update the official/global status.
+
+## Purpose
+
+The route manifest, review-gate ledger, and evidence matrix are useful as
+machine-readable contracts, but a reviewer also needs one coherent worksheet.
+The dossier checker assembles those contracts into a single view:
+
+- the compact command surface;
+- the open mathematical and infrastructure gates;
+- the output-invariant evidence records;
+- the allowed acceptance outcomes;
+- the decision fields a written review should fill in.
+
+## Commands
+
+Validate the dossier contract:
+
+```bash
+python scripts/check_n9_review_dossier.py --check --summary-json
+```
+
+Render the Markdown worksheet to stdout:
+
+```bash
+python scripts/check_n9_review_dossier.py --markdown
+```
+
+The Markdown renderer does not write a generated artifact. It is an on-demand
+review aid so the source contracts remain the source of truth.
+
+## Boundary
+
+The dossier can make a review easier to run, but it cannot replace the review.
+In particular, the worksheet keeps all of these open until a human reviewer
+accepts or rejects them in writing:
+
+- A6/A7 source-frontier enumeration;
+- A8 vertex-circle strict-edge geometry;
+- A10 quotient obstruction replay;
+- B1/B2 exterior-turn geometry;
+- B3/B4 turn-packing arithmetic replay;
+- stored-input Kalmanson corroboration;
+- Lean compilation on a machine with Lake installed;
+- independent review itself.
+
+Only `accepted_vertex_circle_route` or `accepted_turn_route`, recorded in a
+separate source-of-truth PR after review, could support a repo-local finite-case
+`n=9` status update. Neither outcome would prove the general problem.

--- a/docs/n9-review-evidence-matrix.md
+++ b/docs/n9-review-evidence-matrix.md
@@ -21,6 +21,8 @@ python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 The route manifest records the command sequence. The gate ledger records which
 independent-review gates those commands support. The evidence matrix records
 the expected compact output invariants for every command in the harness.
+The reviewer dossier in `metadata/n9_review_dossier.yaml` then assembles these
+contracts into an on-demand Markdown worksheet.
 
 This makes two kinds of drift visible:
 
@@ -59,6 +61,7 @@ The matrix covers all commands in `make verify-n9-candidate`:
 - the route manifest checker;
 - the review-gate ledger checker;
 - the evidence matrix checker itself in contract-only mode;
+- the reviewer dossier checker;
 - Lean sketch and optional Lean compilation guardrails;
 - the compact vertex-circle route commands;
 - the compact turn-packing route commands;

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -82,6 +82,12 @@ Run
 `python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json`
 when a live replay of the compact output invariants is needed.
 
+The machine-readable reviewer dossier is `metadata/n9_review_dossier.yaml`,
+checked by
+`python scripts/check_n9_review_dossier.py --check --summary-json`. Render the
+on-demand Markdown worksheet with
+`python scripts/check_n9_review_dossier.py --markdown`.
+
 ## Review routes
 
 ### Route A: vertex-circle closure
@@ -137,6 +143,7 @@ The target expands to the layer-specific commands below and includes
 python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_n9_review_gate_ledger.py --check --summary-json
 python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+python scripts/check_n9_review_dossier.py --check --summary-json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -5,6 +5,7 @@ target: verify-n9-candidate
 canonical_command: make verify-n9-candidate
 review_gate_ledger: metadata/n9_review_gate_ledger.yaml
 review_evidence_matrix: metadata/n9_review_evidence_matrix.yaml
+review_dossier: metadata/n9_review_dossier.yaml
 claim_scope: >
   Compact review manifest for the current review-pending n=9 selected-witness
   candidate. It records the command surface, documents, formalization-facing
@@ -36,6 +37,9 @@ source_of_truth_files:
 
 harness_documents:
   - docs/n9-candidate-promotion-harness.md
+  - docs/n9-review-gate-ledger.md
+  - docs/n9-review-evidence-matrix.md
+  - docs/n9-review-dossier.md
   - docs/n9-reduction-chain.md
   - docs/n9-review-packet.md
   - docs/turn-inequality-lemma.md
@@ -106,6 +110,8 @@ routes:
         command: python scripts/check_n9_review_gate_ledger.py --check --summary-json
       - id: n9_review_evidence_matrix
         command: python scripts/check_n9_review_evidence_matrix.py --check --summary-json
+      - id: n9_review_dossier
+        command: python scripts/check_n9_review_dossier.py --check --summary-json
 
   - id: lean_guardrails
     title: Lean pilot guardrails

--- a/metadata/n9_review_dossier.yaml
+++ b/metadata/n9_review_dossier.yaml
@@ -1,0 +1,131 @@
+schema: erdos97.n9_review_dossier.v1
+status: REVIEW_DOSSIER_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+candidate_manifest: metadata/n9_candidate_review.yaml
+review_gate_ledger: metadata/n9_review_gate_ledger.yaml
+review_evidence_matrix: metadata/n9_review_evidence_matrix.yaml
+canonical_command: python scripts/check_n9_review_dossier.py --check --summary-json
+markdown_command: python scripts/check_n9_review_dossier.py --markdown
+claim_scope: >
+  Machine-readable reviewer-dossier contract for the compact review-pending
+  n=9 selected-witness harness. It assembles the route manifest, review gates,
+  evidence-output matrix, acceptance outcomes, and open blockers into a single
+  review worksheet. It does not prove n=9, does not prove Erdos Problem #97,
+  does not claim a counterexample, does not complete independent review, and
+  does not update the official/global status.
+
+forbidden_promotions:
+  - "general proof of Erdos Problem #97"
+  - proof of n=9
+  - "counterexample to Erdos Problem #97"
+  - official/global status update
+  - completed independent review
+  - formal proof of the Euclidean turn lemma
+
+required_documents:
+  - docs/n9-candidate-promotion-harness.md
+  - docs/n9-review-packet.md
+  - docs/n9-review-gate-ledger.md
+  - docs/n9-review-evidence-matrix.md
+  - docs/n9-review-dossier.md
+  - docs/n9-reduction-chain.md
+
+sections:
+  - id: scope_boundary
+    title: Scope Boundary
+    source: candidate_manifest.claim_scope
+    required_phrases:
+      - does not prove n=9
+      - does not prove Erdos Problem #97
+      - does not claim a counterexample
+      - does not complete independent review
+      - does not update the official/global status
+  - id: command_surface
+    title: Compact Command Surface
+    source: candidate_manifest.routes
+    required_ids:
+      - manifest_contract
+      - lean_guardrails
+      - vertex_circle_route
+      - turn_packing_route
+      - kalmanson_corroboration
+  - id: review_gates
+    title: Open Review Gates
+    source: review_gate_ledger.review_gates
+    required_ids:
+      - frontier_enumeration
+      - vertex_circle_geometry
+      - quotient_obstruction_replay
+      - turn_geometry
+      - turn_arithmetic_replay
+      - kalmanson_corroboration
+  - id: infrastructure_gates
+    title: Infrastructure Gates
+    source: review_gate_ledger.infrastructure_gates
+    required_ids:
+      - lean_compilation
+      - independent_review
+  - id: evidence_matrix
+    title: Output Invariant Matrix
+    source: review_evidence_matrix.evidence_records
+    required_ids:
+      - n9_candidate_review_manifest
+      - n9_review_gate_ledger
+      - n9_review_evidence_matrix
+      - n9_review_dossier
+      - lean_sketch_integrity
+      - lean_files
+      - n9_vertex_circle_exhaustive
+      - n9_vertex_circle_input_audit
+      - n9_vertex_circle_incidence_filters
+      - n9_vertex_circle_mro_branching_replay
+      - n9_vertex_circle_frontier_coverage_crosswalk
+      - n9_vertex_circle_strict_edge_geometry
+      - n9_vertex_circle_quotient_soundness
+      - n9_vertex_circle_local_lemma_audit_path
+      - turn_inequality_indexing
+      - n9_turn_inequality_frontier
+      - n9_kalmanson_selfedge_independent_replay
+  - id: acceptance_outcomes
+    title: Acceptance Outcomes
+    source: review_gate_ledger.review_outcomes
+    required_ids:
+      - accepted_vertex_circle_route
+      - accepted_turn_route
+      - accepted_corrob_only
+      - gap_found
+
+review_questions:
+  - gate_id: frontier_enumeration
+    worksheet_prompt: >
+      Does the reviewer accept that A2-A5 are the intended selected-witness
+      filters and that the 184 frontier has no hidden symmetry quotient?
+  - gate_id: vertex_circle_geometry
+    worksheet_prompt: >
+      Does the reviewer accept the vertex-circle nested-chord strict-edge
+      geometry and the proper-interval convention?
+  - gate_id: quotient_obstruction_replay
+    worksheet_prompt: >
+      Does the reviewer accept the selected-distance quotient replay,
+      self-edge criterion, strict-cycle criterion, and local-lemma handoffs?
+  - gate_id: turn_geometry
+    worksheet_prompt: >
+      Does the reviewer accept the Euclidean exterior-turn lemma, interval
+      indexing, and weak-inequality boundary step?
+  - gate_id: turn_arithmetic_replay
+    worksheet_prompt: >
+      Does the reviewer accept the stored integer dual certificate arithmetic
+      for all 184 weak turn systems?
+  - gate_id: kalmanson_corroboration
+    worksheet_prompt: >
+      Does the reviewer accept the stored-input Kalmanson replay as
+      corroboration only, without treating it as a primary route?
+
+decision_fields:
+  - reviewer_name
+  - review_date
+  - accepted_gates
+  - rejected_gates
+  - precise_gaps
+  - recommended_outcome
+  - notes

--- a/metadata/n9_review_evidence_matrix.yaml
+++ b/metadata/n9_review_evidence_matrix.yaml
@@ -31,7 +31,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: command_count
-        equals: 16
+        equals: 17
       - path: review_gate_count
         equals: 8
       - path: review_gate_ledger
@@ -63,9 +63,26 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: evidence_record_count
-        equals: 16
+        equals: 17
       - path: live_replay_enabled
         equals: false
+
+  - id: n9_review_dossier
+    route_id: manifest_contract
+    command_id: n9_review_dossier
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: section_count
+        equals: 6
+      - path: review_gate_count
+        equals: 6
+      - path: evidence_record_count
+        equals: 17
+      - path: review_question_count
+        equals: 6
 
   - id: lean_sketch_integrity
     route_id: lean_guardrails

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -25,6 +25,7 @@ STATUS = "REVIEW_HARNESS_ONLY"
 TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 REVIEW_GATE_LEDGER = "metadata/n9_review_gate_ledger.yaml"
 REVIEW_EVIDENCE_MATRIX = "metadata/n9_review_evidence_matrix.yaml"
+REVIEW_DOSSIER = "metadata/n9_review_dossier.yaml"
 REQUIRED_FORBIDDEN_PROMOTIONS = {
     "general proof of Erdos Problem #97",
     "proof of n=9",
@@ -43,6 +44,7 @@ REQUIRED_CLAIM_SCOPE_PHRASES = (
 SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
     "python scripts/check_n9_review_gate_ledger.py",
     "python scripts/check_n9_review_evidence_matrix.py",
+    "python scripts/check_n9_review_dossier.py",
     "python scripts/check_n9_vertex_circle_input_audit.py",
     "python scripts/check_n9_vertex_circle_incidence_filters.py",
     "python scripts/check_n9_vertex_circle_mro_branching_replay.py",
@@ -239,6 +241,11 @@ def validate_manifest(
         errors.append(
             f"review_evidence_matrix does not exist: {REVIEW_EVIDENCE_MATRIX}"
         )
+    review_dossier = payload.get("review_dossier")
+    if review_dossier != REVIEW_DOSSIER:
+        errors.append(f"review_dossier must be {REVIEW_DOSSIER!r}")
+    elif not repo_path(REVIEW_DOSSIER).exists():
+        errors.append(f"review_dossier does not exist: {REVIEW_DOSSIER}")
 
     claim_scope = payload.get("claim_scope")
     if not isinstance(claim_scope, str) or not claim_scope.strip():
@@ -291,6 +298,7 @@ def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str,
         "target": payload.get("target"),
         "review_gate_ledger": payload.get("review_gate_ledger"),
         "review_evidence_matrix": payload.get("review_evidence_matrix"),
+        "review_dossier": payload.get("review_dossier"),
         "route_count": len(routes) if isinstance(routes, list) else 0,
         "route_ids": route_ids,
         "command_count": len(flatten_route_commands(payload)),

--- a/scripts/check_n9_review_dossier.py
+++ b/scripts/check_n9_review_dossier.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Validate and render the n=9 reviewer dossier contract."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_DOSSIER = REPO_ROOT / "metadata" / "n9_review_dossier.yaml"
+SCHEMA = "erdos97.n9_review_dossier.v1"
+STATUS = "REVIEW_DOSSIER_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CANONICAL_COMMAND = "python scripts/check_n9_review_dossier.py --check --summary-json"
+MARKDOWN_COMMAND = "python scripts/check_n9_review_dossier.py --markdown"
+REQUIRED_FORBIDDEN_PROMOTIONS = {
+    "general proof of Erdos Problem #97",
+    "proof of n=9",
+    "counterexample to Erdos Problem #97",
+    "official/global status update",
+    "completed independent review",
+    "formal proof of the Euclidean turn lemma",
+}
+REQUIRED_CLAIM_SCOPE_PHRASES = (
+    "does not prove n=9",
+    "does not prove Erdos Problem #97",
+    "does not claim a counterexample",
+    "does not complete independent review",
+    "does not update the official/global status",
+)
+REQUIRED_DECISION_FIELDS = {
+    "reviewer_name",
+    "review_date",
+    "accepted_gates",
+    "rejected_gates",
+    "precise_gaps",
+    "recommended_outcome",
+    "notes",
+}
+
+
+def _linked_validators() -> tuple[Any, Any, Any]:
+    from scripts.check_n9_candidate_review_manifest import validate_manifest
+    from scripts.check_n9_review_evidence_matrix import validate_matrix
+    from scripts.check_n9_review_gate_ledger import validate_ledger
+
+    return validate_manifest, validate_matrix, validate_ledger
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            f"PyYAML is required to parse {label}; install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} top level must be a mapping")
+    return payload
+
+
+def load_dossier(path: Path = DEFAULT_DOSSIER) -> dict[str, Any]:
+    return load_yaml_mapping(path, label="metadata/n9_review_dossier.yaml")
+
+
+def _load_linked_payloads(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], list[str]]:
+    errors: list[str] = []
+    linked: list[tuple[str, str]] = [
+        ("candidate_manifest", "metadata/n9_candidate_review.yaml"),
+        ("review_gate_ledger", "metadata/n9_review_gate_ledger.yaml"),
+        ("review_evidence_matrix", "metadata/n9_review_evidence_matrix.yaml"),
+    ]
+    loaded: dict[str, dict[str, Any]] = {}
+    for key, expected in linked:
+        value = payload.get(key)
+        if value != expected:
+            errors.append(f"{key} must be {expected!r}")
+            loaded[key] = {}
+            continue
+        try:
+            loaded[key] = load_yaml_mapping(repo_path(expected), label=expected)
+        except (OSError, ValueError, YAMLError) as exc:
+            errors.append(str(exc))
+            loaded[key] = {}
+    return (
+        loaded["candidate_manifest"],
+        loaded["review_gate_ledger"],
+        loaded["review_evidence_matrix"],
+        errors,
+    )
+
+
+def _ids_from_path(payload: dict[str, Any], source: str) -> set[str]:
+    parts = source.split(".")
+    current: Any = payload
+    for part in parts[1:]:
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return set()
+    if not isinstance(current, list):
+        return set()
+    return {item["id"] for item in current if isinstance(item, dict) and "id" in item}
+
+
+def _payload_for_source(
+    source: str,
+    *,
+    manifest: dict[str, Any],
+    ledger: dict[str, Any],
+    matrix: dict[str, Any],
+) -> dict[str, Any]:
+    if source.startswith("candidate_manifest."):
+        return manifest
+    if source.startswith("review_gate_ledger."):
+        return ledger
+    if source.startswith("review_evidence_matrix."):
+        return matrix
+    return {}
+
+
+def _validate_forbidden_promotions(payload: dict[str, Any]) -> list[str]:
+    forbidden = payload.get("forbidden_promotions")
+    if not isinstance(forbidden, list) or not forbidden:
+        return ["forbidden_promotions must be a nonempty list"]
+    missing = REQUIRED_FORBIDDEN_PROMOTIONS - set(forbidden)
+    return [
+        f"forbidden_promotions missing {phrase!r}"
+        for phrase in sorted(missing)
+    ]
+
+
+def _validate_required_documents(payload: dict[str, Any]) -> list[str]:
+    docs = payload.get("required_documents")
+    if not isinstance(docs, list) or not docs:
+        return ["required_documents must be a nonempty list"]
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, doc in enumerate(docs):
+        label = f"required_documents[{index}]"
+        if not isinstance(doc, str) or not doc.strip():
+            errors.append(f"{label} must be a nonempty string")
+            continue
+        if doc in seen:
+            errors.append(f"{label} duplicates {doc!r}")
+        seen.add(doc)
+        if not repo_path(doc).exists():
+            errors.append(f"{label} does not exist: {doc}")
+    return errors
+
+
+def _validate_sections(
+    payload: dict[str, Any],
+    *,
+    manifest: dict[str, Any],
+    ledger: dict[str, Any],
+    matrix: dict[str, Any],
+) -> list[str]:
+    sections = payload.get("sections")
+    if not isinstance(sections, list) or not sections:
+        return ["sections must be a nonempty list"]
+
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, section in enumerate(sections):
+        label = f"sections[{index}]"
+        if not isinstance(section, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        section_id = section.get("id")
+        if not isinstance(section_id, str) or not section_id.strip():
+            errors.append(f"{label}.id must be a nonempty string")
+        elif section_id in seen:
+            errors.append(f"{label}.id {section_id!r} is duplicated")
+        else:
+            seen.add(section_id)
+        title = section.get("title")
+        if not isinstance(title, str) or not title.strip():
+            errors.append(f"{label}.title must be a nonempty string")
+        source = section.get("source")
+        if not isinstance(source, str) or "." not in source:
+            errors.append(f"{label}.source must be a dotted source path")
+            continue
+        source_payload = _payload_for_source(
+            source,
+            manifest=manifest,
+            ledger=ledger,
+            matrix=matrix,
+        )
+        if not source_payload:
+            errors.append(f"{label}.source {source!r} is not recognized")
+            continue
+
+        required_ids = section.get("required_ids", [])
+        if required_ids:
+            if not isinstance(required_ids, list):
+                errors.append(f"{label}.required_ids must be a list")
+            else:
+                observed = _ids_from_path(source_payload, source)
+                missing = set(required_ids) - observed
+                for missing_id in sorted(missing):
+                    errors.append(
+                        f"{label}.required_ids missing {missing_id!r} from {source}"
+                    )
+
+        required_phrases = section.get("required_phrases", [])
+        if required_phrases:
+            if not isinstance(required_phrases, list):
+                errors.append(f"{label}.required_phrases must be a list")
+            else:
+                current: Any = source_payload
+                for part in source.split(".")[1:]:
+                    current = current.get(part) if isinstance(current, dict) else None
+                if not isinstance(current, str):
+                    errors.append(f"{label}.source must resolve to text")
+                else:
+                    for phrase in required_phrases:
+                        if phrase not in current:
+                            errors.append(
+                                f"{label}.required_phrases missing {phrase!r}"
+                            )
+    return errors
+
+
+def _validate_review_questions(
+    payload: dict[str, Any],
+    *,
+    ledger: dict[str, Any],
+) -> list[str]:
+    questions = payload.get("review_questions")
+    if not isinstance(questions, list) or not questions:
+        return ["review_questions must be a nonempty list"]
+    gate_ids = _ids_from_path(ledger, "review_gate_ledger.review_gates")
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, question in enumerate(questions):
+        label = f"review_questions[{index}]"
+        if not isinstance(question, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        gate_id = question.get("gate_id")
+        if not isinstance(gate_id, str) or not gate_id.strip():
+            errors.append(f"{label}.gate_id must be a nonempty string")
+        elif gate_id in seen:
+            errors.append(f"{label}.gate_id {gate_id!r} is duplicated")
+        else:
+            seen.add(gate_id)
+        if gate_id not in gate_ids:
+            errors.append(f"{label}.gate_id {gate_id!r} is not a review gate")
+        prompt = question.get("worksheet_prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            errors.append(f"{label}.worksheet_prompt must be a nonempty string")
+
+    missing = gate_ids - seen
+    for gate_id in sorted(missing):
+        errors.append(f"review_questions missing gate {gate_id!r}")
+    return errors
+
+
+def validate_dossier(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+    gate_ledger: dict[str, Any] | None = None,
+    evidence_matrix: dict[str, Any] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+    if payload.get("canonical_command") != CANONICAL_COMMAND:
+        errors.append(f"canonical_command must be {CANONICAL_COMMAND!r}")
+    if payload.get("markdown_command") != MARKDOWN_COMMAND:
+        errors.append(f"markdown_command must be {MARKDOWN_COMMAND!r}")
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+    else:
+        for phrase in REQUIRED_CLAIM_SCOPE_PHRASES:
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+    errors.extend(_validate_forbidden_promotions(payload))
+    errors.extend(_validate_required_documents(payload))
+
+    if (
+        candidate_manifest is None
+        or gate_ledger is None
+        or evidence_matrix is None
+    ):
+        manifest, ledger, matrix, link_errors = _load_linked_payloads(payload)
+        errors.extend(link_errors)
+        if candidate_manifest is not None:
+            manifest = candidate_manifest
+        if gate_ledger is not None:
+            ledger = gate_ledger
+        if evidence_matrix is not None:
+            matrix = evidence_matrix
+    else:
+        manifest = candidate_manifest
+        ledger = gate_ledger
+        matrix = evidence_matrix
+
+    validators: tuple[Any, Any, Any] | None = None
+
+    def linked_validators() -> tuple[Any, Any, Any]:
+        nonlocal validators
+        if validators is None:
+            validators = _linked_validators()
+        return validators
+
+    if manifest:
+        if manifest.get("review_dossier") != "metadata/n9_review_dossier.yaml":
+            errors.append(
+                "candidate manifest must reference metadata/n9_review_dossier.yaml"
+            )
+        validate_manifest, _, _ = linked_validators()
+        errors.extend(
+            f"candidate_manifest: {error}" for error in validate_manifest(manifest)
+        )
+    if ledger:
+        _, _, validate_ledger = linked_validators()
+        errors.extend(f"review_gate_ledger: {error}" for error in validate_ledger(ledger))
+    if matrix:
+        _, validate_matrix, _ = linked_validators()
+        errors.extend(
+            f"review_evidence_matrix: {error}"
+            for error in validate_matrix(
+                matrix,
+                candidate_manifest=manifest,
+                gate_ledger=ledger,
+            )
+        )
+
+    errors.extend(
+        _validate_sections(
+            payload,
+            manifest=manifest,
+            ledger=ledger,
+            matrix=matrix,
+        )
+    )
+    errors.extend(_validate_review_questions(payload, ledger=ledger))
+
+    decision_fields = payload.get("decision_fields")
+    if not isinstance(decision_fields, list) or not decision_fields:
+        errors.append("decision_fields must be a nonempty list")
+    else:
+        missing = REQUIRED_DECISION_FIELDS - set(decision_fields)
+        for field in sorted(missing):
+            errors.append(f"decision_fields missing {field!r}")
+    return errors
+
+
+def _records_by_id(items: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(items, list):
+        return {}
+    return {
+        item["id"]: item
+        for item in items
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+
+
+def build_dossier_payload(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+    gate_ledger: dict[str, Any] | None = None,
+    evidence_matrix: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if (
+        candidate_manifest is None
+        or gate_ledger is None
+        or evidence_matrix is None
+    ):
+        manifest, ledger, matrix, _ = _load_linked_payloads(payload)
+        if candidate_manifest is not None:
+            manifest = candidate_manifest
+        if gate_ledger is not None:
+            ledger = gate_ledger
+        if evidence_matrix is not None:
+            matrix = evidence_matrix
+    else:
+        manifest = candidate_manifest
+        ledger = gate_ledger
+        matrix = evidence_matrix
+
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "claim_scope": payload.get("claim_scope"),
+        "canonical_command": payload.get("canonical_command"),
+        "markdown_command": payload.get("markdown_command"),
+        "candidate_claim_under_review": manifest.get("candidate_claim_under_review"),
+        "routes": manifest.get("routes", []),
+        "review_gates": ledger.get("review_gates", []),
+        "infrastructure_gates": ledger.get("infrastructure_gates", []),
+        "review_outcomes": ledger.get("review_outcomes", []),
+        "evidence_records": matrix.get("evidence_records", []),
+        "review_questions": payload.get("review_questions", []),
+        "decision_fields": payload.get("decision_fields", []),
+    }
+
+
+def render_markdown(
+    payload: dict[str, Any],
+    errors: Sequence[str],
+) -> str:
+    dossier = build_dossier_payload(payload)
+    evidence_by_id = _records_by_id(dossier["evidence_records"])
+    question_by_gate = {
+        question["gate_id"]: question
+        for question in dossier["review_questions"]
+        if isinstance(question, dict) and isinstance(question.get("gate_id"), str)
+    }
+    lines: list[str] = [
+        "# n=9 Reviewer Dossier",
+        "",
+        "Status: `REVIEW_DOSSIER_ONLY`.",
+        "",
+        dossier.get("claim_scope", "").strip(),
+        "",
+        "## Validation",
+        "",
+        f"- Dossier checker: `{payload.get('canonical_command')}`",
+        f"- Markdown renderer: `{payload.get('markdown_command')}`",
+        f"- Contract status: `{'passed' if not errors else 'failed'}`",
+        "",
+        "## Candidate Claim Under Review",
+        "",
+        dossier.get("candidate_claim_under_review", "").strip(),
+        "",
+        "## Compact Command Surface",
+        "",
+    ]
+
+    for route in dossier["routes"]:
+        if not isinstance(route, dict):
+            continue
+        lines.append(f"### {route.get('title', route.get('id'))}")
+        lines.append("")
+        lines.append(str(route.get("claim_scope", "")).strip())
+        lines.append("")
+        for command in route.get("commands", []):
+            if not isinstance(command, dict):
+                continue
+            lines.append(f"- `{command.get('command')}`")
+        lines.append("")
+
+    lines.extend(["## Review Gate Worksheet", ""])
+    for gate in dossier["review_gates"]:
+        if not isinstance(gate, dict):
+            continue
+        gate_id = gate.get("id")
+        lines.append(f"### {gate.get('title', gate_id)}")
+        lines.append("")
+        lines.append(f"- Gate ID: `{gate_id}`")
+        lines.append(f"- Status: `{gate.get('status')}`")
+        lines.append(f"- Still open: `{gate.get('still_open')}`")
+        lines.append(f"- Reduction steps: `{', '.join(gate.get('reduction_steps', []))}`")
+        prompt = question_by_gate.get(gate_id, {}).get("worksheet_prompt", "")
+        if prompt:
+            lines.append(f"- Review prompt: {str(prompt).strip()}")
+        evidence_ids = gate.get("evidence_commands", [])
+        if evidence_ids:
+            lines.append("- Evidence records:")
+            for evidence_id in evidence_ids:
+                record = evidence_by_id.get(evidence_id, {})
+                lines.append(
+                    f"  - `{evidence_id}`: `{record.get('output_format', 'unknown')}`"
+                )
+        blockers = gate.get("blockers", [])
+        if blockers:
+            lines.append("- Open blockers:")
+            for blocker in blockers:
+                lines.append(f"  - {blocker}")
+        lines.append("")
+
+    lines.extend(["## Infrastructure Gates", ""])
+    for gate in dossier["infrastructure_gates"]:
+        if not isinstance(gate, dict):
+            continue
+        lines.append(f"- `{gate.get('id')}`: {str(gate.get('requirement', '')).strip()}")
+    lines.append("")
+
+    lines.extend(["## Acceptance Outcomes", ""])
+    for outcome in dossier["review_outcomes"]:
+        if not isinstance(outcome, dict):
+            continue
+        required = ", ".join(outcome.get("required_gates", [])) or "none"
+        lines.append(f"- `{outcome.get('id')}` requires `{required}`.")
+        lines.append(f"  {str(outcome.get('claim_boundary', '')).strip()}")
+    lines.append("")
+
+    lines.extend(["## Reviewer Decision Fields", ""])
+    for field in dossier["decision_fields"]:
+        lines.append(f"- `{field}`:")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str, Any]:
+    dossier = build_dossier_payload(payload)
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "section_count": len(payload.get("sections", []))
+        if isinstance(payload.get("sections"), list)
+        else 0,
+        "review_gate_count": len(dossier.get("review_gates", [])),
+        "infrastructure_gate_count": len(dossier.get("infrastructure_gates", [])),
+        "evidence_record_count": len(dossier.get("evidence_records", [])),
+        "review_question_count": len(payload.get("review_questions", []))
+        if isinstance(payload.get("review_questions"), list)
+        else 0,
+        "decision_field_count": len(payload.get("decision_fields", []))
+        if isinstance(payload.get("decision_fields"), list)
+        else 0,
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+        "claim_scope": payload.get("claim_scope"),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dossier", type=Path, default=DEFAULT_DOSSIER)
+    parser.add_argument("--check", action="store_true", help="fail on validation errors")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    output_group.add_argument("--markdown", action="store_true", help="print Markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    dossier_path = args.dossier
+    if not dossier_path.is_absolute():
+        dossier_path = REPO_ROOT / dossier_path
+    try:
+        payload = load_dossier(dossier_path)
+        errors = validate_dossier(payload)
+    except (OSError, ValueError, YAMLError) as exc:
+        payload = {"schema": SCHEMA, "status": "LOAD_FAILED"}
+        errors = [str(exc)]
+
+    if args.markdown:
+        print(render_markdown(payload, errors))
+    elif args.summary_json:
+        print(json.dumps(summary_payload(payload, errors), indent=2, sort_keys=True))
+    elif args.json:
+        full_payload = build_dossier_payload(payload)
+        full_payload["validation_errors"] = errors
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 reviewer dossier")
+        print(f"status: {payload.get('status')}")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if errors and args.check:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -25,6 +25,7 @@ def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
         "python scripts/check_n9_candidate_review_manifest.py --check --summary-json",
         "python scripts/check_n9_review_gate_ledger.py --check --summary-json",
         "python scripts/check_n9_review_evidence_matrix.py --check --summary-json",
+        "python scripts/check_n9_review_dossier.py --check --summary-json",
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_candidate_review_manifest.py
+++ b/tests/test_n9_candidate_review_manifest.py
@@ -68,6 +68,15 @@ def test_n9_candidate_review_manifest_requires_review_evidence_matrix() -> None:
     )
 
 
+def test_n9_candidate_review_manifest_requires_review_dossier() -> None:
+    payload = deepcopy(load_manifest(MANIFEST))
+    payload["review_dossier"] = "metadata/other.yaml"
+
+    errors = validate_manifest(payload)
+
+    assert "review_dossier must be 'metadata/n9_review_dossier.yaml'" in errors
+
+
 def test_n9_candidate_review_manifest_pins_summary_json_review_surfaces() -> None:
     payload = deepcopy(load_manifest(MANIFEST))
     command = payload["routes"][2]["commands"][1]

--- a/tests/test_n9_review_dossier.py
+++ b/tests/test_n9_review_dossier.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_review_dossier import (
+    build_dossier_payload,
+    load_dossier,
+    render_markdown,
+    validate_dossier,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOSSIER = ROOT / "metadata" / "n9_review_dossier.yaml"
+
+
+def test_n9_review_dossier_is_valid() -> None:
+    payload = load_dossier(DOSSIER)
+
+    errors = validate_dossier(payload)
+
+    assert errors == []
+
+
+def test_n9_review_dossier_payload_contains_expected_layers() -> None:
+    payload = load_dossier(DOSSIER)
+
+    dossier = build_dossier_payload(payload)
+
+    assert len(dossier["routes"]) == 5
+    assert len(dossier["review_gates"]) == 6
+    assert len(dossier["infrastructure_gates"]) == 2
+    assert len(dossier["evidence_records"]) == 17
+
+
+def test_n9_review_dossier_rejects_missing_section_id() -> None:
+    payload = deepcopy(load_dossier(DOSSIER))
+    payload["sections"][2]["required_ids"].append("missing_gate")
+
+    errors = validate_dossier(payload)
+
+    assert any("missing 'missing_gate'" in error for error in errors)
+
+
+def test_n9_review_dossier_rejects_missing_review_question() -> None:
+    payload = deepcopy(load_dossier(DOSSIER))
+    payload["review_questions"] = payload["review_questions"][:-1]
+
+    errors = validate_dossier(payload)
+
+    assert "review_questions missing gate 'kalmanson_corroboration'" in errors
+
+
+def test_n9_review_dossier_rejects_missing_decision_field() -> None:
+    payload = deepcopy(load_dossier(DOSSIER))
+    payload["decision_fields"].remove("precise_gaps")
+
+    errors = validate_dossier(payload)
+
+    assert "decision_fields missing 'precise_gaps'" in errors
+
+
+def test_n9_review_dossier_renders_markdown() -> None:
+    payload = load_dossier(DOSSIER)
+
+    markdown = render_markdown(payload, [])
+
+    assert "# n=9 Reviewer Dossier" in markdown
+    assert "## Review Gate Worksheet" in markdown
+    assert "`frontier_enumeration`" in markdown

--- a/tests/test_n9_review_evidence_matrix.py
+++ b/tests/test_n9_review_evidence_matrix.py
@@ -43,6 +43,7 @@ def test_n9_review_evidence_matrix_covers_manifest_commands() -> None:
     }
 
     assert record_command_ids == _manifest_command_ids()
+    assert len(record_command_ids) == 17
 
 
 def test_n9_review_evidence_matrix_rejects_missing_manifest_command() -> None:


### PR DESCRIPTION
## Summary
- add a machine-readable n=9 reviewer dossier contract and checker with summary JSON, full JSON, and on-demand Markdown worksheet output
- wire the dossier into the n=9 candidate manifest, evidence matrix, Makefile review target, docs, and regression tests
- preserve review-pending/no-overclaim boundaries while exposing open gates, evidence records, acceptance outcomes, and reviewer decision fields

## Validation
- `.venv/bin/python -m ruff check scripts/check_n9_review_dossier.py tests/test_n9_review_dossier.py`
- `.venv/bin/python scripts/check_n9_review_dossier.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_dossier.py --markdown`
- `.venv/bin/python -m pytest -q tests/test_n9_review_dossier.py tests/test_n9_review_evidence_matrix.py tests/test_n9_candidate_review_manifest.py tests/test_makefile_targets.py`
- `.venv/bin/python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json`
- `make verify-n9-candidate PYTHON=.venv/bin/python`
- `make verify-fast PYTHON=.venv/bin/python`