### PR TITLE
Add n9 review run bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ verify-n9-candidate:
 	$(PYTHON) scripts/check_n9_review_gate_ledger.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_evidence_matrix.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_dossier.py --check --summary-json
+	$(PYTHON) scripts/check_n9_review_run_bundle.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -74,6 +74,11 @@ minimal/rich-class hypotheses.
    adjacent handoff checks that identify where any future count/schema drift
    first appears. Use `--json` instead when the full layer and manifest
    records are needed.
+   The compact review run-bundle checker
+   `python scripts/check_n9_review_run_bundle.py --check --run --summary-json`
+   executes the current compact n=9 manifest command surface and records
+   digest-level provenance for one reviewer run. It is drift detection and
+   execution evidence only, not independent mathematical review.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`../metadata/n9_review_dossier.yaml`](../metadata/n9_review_dossier.yaml):
   machine-readable reviewer-dossier contract joining the compact n=9 command
   surface, open gates, output invariants, and decision fields.
+- [`../metadata/n9_review_run_bundle.yaml`](../metadata/n9_review_run_bundle.yaml):
+  machine-readable run-capture contract for digesting one compact `n=9`
+  reviewer run without writing a generated artifact.
 - [`upstream-alignment.md`](upstream-alignment.md): alignment notes for
   `teorth/erdosproblems` and the official problem page.
 - [`reviewer-guide.md`](reviewer-guide.md): audit route for finite-case
@@ -37,6 +40,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-review-dossier.md`](n9-review-dossier.md): guide to the checked
   reviewer dossier and on-demand Markdown worksheet for the compact `n=9`
   review harness.
+- [`n9-review-run-bundle.md`](n9-review-run-bundle.md): guide to the checked
+  reviewer run-capture contract and optional live digest replay for the compact
+  `n=9` review harness.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -73,6 +73,23 @@ python scripts/check_n9_review_dossier.py --markdown
 The worksheet is a review aid only; it does not write a generated artifact and
 does not mark any gate accepted.
 
+The run-capture contract is `metadata/n9_review_run_bundle.yaml`, checked by:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --check --summary-json
+```
+
+To execute the compact command surface and emit digest-level provenance for one
+reviewer run, use:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+```
+
+The live capture validates compact outputs against the evidence matrix and
+records hashes/previews only. It does not write a generated artifact and does
+not accept any review gate.
+
 Run:
 
 ```bash
@@ -94,12 +111,13 @@ python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_n9_review_gate_ledger.py --check --summary-json
 python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 python scripts/check_n9_review_dossier.py --check --summary-json
+python scripts/check_n9_review_run_bundle.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
-The manifest, gate-ledger, evidence-matrix, and dossier checkers run before
-the Lean pilot guardrails. The Lean layer includes
+The manifest, gate-ledger, evidence-matrix, dossier, and run-bundle checkers
+run before the Lean pilot guardrails. The Lean layer includes
 `lean/Erdos97/TurnPacking.lean`, a dependency-free formal contract for the
 turn-packing route. It pins the forward/reverse interval support convention
 and proves the small arithmetic kernel behind the stored dual certificates: a

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -114,6 +114,11 @@ The reviewer dossier `metadata/n9_review_dossier.yaml`, checked by
 `python scripts/check_n9_review_dossier.py --check --summary-json`, assembles
 the same dependencies into an on-demand Markdown worksheet for written review.
 
+The run-capture contract `metadata/n9_review_run_bundle.yaml`, checked by
+`python scripts/check_n9_review_run_bundle.py --check --summary-json`, can also
+execute the compact command surface with `--run` and emit digest-level
+provenance for one reviewer run.
+
 The most important global gap is separate:
 
 ```text

--- a/docs/n9-review-dossier.md
+++ b/docs/n9-review-dossier.md
@@ -20,6 +20,9 @@ The dossier checker assembles those contracts into a single view:
 - the allowed acceptance outcomes;
 - the decision fields a written review should fill in.
 
+The separate run-bundle checker records digest-level provenance for one actual
+execution of the same compact command surface.
+
 ## Commands
 
 Validate the dossier contract:
@@ -36,6 +39,15 @@ python scripts/check_n9_review_dossier.py --markdown
 
 The Markdown renderer does not write a generated artifact. It is an on-demand
 review aid so the source contracts remain the source of truth.
+
+For a live command-run capture, use:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+```
+
+That command records hashes and short previews only. It is execution
+provenance, not a review decision.
 
 ## Boundary
 

--- a/docs/n9-review-evidence-matrix.md
+++ b/docs/n9-review-evidence-matrix.md
@@ -23,6 +23,8 @@ independent-review gates those commands support. The evidence matrix records
 the expected compact output invariants for every command in the harness.
 The reviewer dossier in `metadata/n9_review_dossier.yaml` then assembles these
 contracts into an on-demand Markdown worksheet.
+The run bundle in `metadata/n9_review_run_bundle.yaml` captures one live
+reviewer run as command statuses, durations, output hashes, and short previews.
 
 This makes two kinds of drift visible:
 
@@ -62,6 +64,7 @@ The matrix covers all commands in `make verify-n9-candidate`:
 - the review-gate ledger checker;
 - the evidence matrix checker itself in contract-only mode;
 - the reviewer dossier checker;
+- the reviewer run-bundle checker in contract-only mode;
 - Lean sketch and optional Lean compilation guardrails;
 - the compact vertex-circle route commands;
 - the compact turn-packing route commands;

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -88,6 +88,12 @@ checked by
 on-demand Markdown worksheet with
 `python scripts/check_n9_review_dossier.py --markdown`.
 
+The machine-readable reviewer run bundle is
+`metadata/n9_review_run_bundle.yaml`, checked by
+`python scripts/check_n9_review_run_bundle.py --check --summary-json`. Capture
+one live run as digest-level provenance with
+`python scripts/check_n9_review_run_bundle.py --check --run --summary-json`.
+
 ## Review routes
 
 ### Route A: vertex-circle closure
@@ -144,6 +150,7 @@ python scripts/check_n9_candidate_review_manifest.py --check --summary-json
 python scripts/check_n9_review_gate_ledger.py --check --summary-json
 python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 python scripts/check_n9_review_dossier.py --check --summary-json
+python scripts/check_n9_review_run_bundle.py --check --summary-json
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json

--- a/docs/n9-review-run-bundle.md
+++ b/docs/n9-review-run-bundle.md
@@ -1,0 +1,66 @@
+# n=9 Review Run Bundle
+
+Status: `REVIEW_RUN_BUNDLE_ONLY`.
+
+This note explains `metadata/n9_review_run_bundle.yaml` and
+`scripts/check_n9_review_run_bundle.py`. The run bundle is a checked execution
+provenance layer for the compact `n=9` review harness. It does not prove Erdos
+Problem #97, does not prove `n=9`, does not claim a counterexample, does not
+complete independent review, and does not update the official/global status.
+
+## Purpose
+
+The reviewer dossier describes what to inspect. The run bundle records what a
+specific checkout actually did when the compact manifest command surface was
+executed.
+
+In live mode, the checker:
+
+- executes every compact manifest command in order;
+- validates each compact output against `metadata/n9_review_evidence_matrix.yaml`;
+- records return codes and durations;
+- records SHA-256 digests for stdout and stderr;
+- records short stdout/stderr previews for triage;
+- writes no generated artifact.
+
+The digest capture is useful for comparing review runs without placing large
+command outputs in docs or metadata.
+
+## Commands
+
+Validate the static run-bundle contract:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --check --summary-json
+```
+
+Capture a live reviewer run:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+```
+
+Render the Markdown worksheet to stdout:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --markdown
+```
+
+Use `--json` with `--run` when the per-command digest records are needed.
+Those records still contain only hashes and previews, not full command output.
+
+## Boundary
+
+A passed live capture says the compact `n=9` manifest commands completed in
+that checkout and matched the output invariants known to the evidence matrix.
+It does not accept any review gate. In particular, all of these remain open
+until a written independent review accepts or rejects them:
+
+- A6/A7 source-frontier enumeration;
+- A8 vertex-circle strict-edge geometry;
+- A10 quotient obstruction replay;
+- B1/B2 exterior-turn geometry;
+- B3/B4 turn-packing arithmetic replay;
+- stored-input Kalmanson corroboration;
+- Lean compilation on a machine with Lake installed;
+- independent review itself.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -124,6 +124,9 @@ Target: `docs/n9-vertex-circle-exhaustive.md`.
 Reviewer packet: `docs/n9-review-packet.md` collects the current dependency
 map, reproduction commands, expected invariants, and acceptance outcomes for
 the review. It is a worksheet only and does not promote any `n=9` claim.
+The run-capture aid `docs/n9-review-run-bundle.md` records digest-level
+provenance for one execution of the compact command surface; it is drift
+detection only and does not replace written independent review.
 
 The 2026-05-03 archive bundle has been refactored into a repo-native checker
 that leaves 0 full `n=9` selected-witness assignments after exact

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -6,6 +6,7 @@ canonical_command: make verify-n9-candidate
 review_gate_ledger: metadata/n9_review_gate_ledger.yaml
 review_evidence_matrix: metadata/n9_review_evidence_matrix.yaml
 review_dossier: metadata/n9_review_dossier.yaml
+review_run_bundle: metadata/n9_review_run_bundle.yaml
 claim_scope: >
   Compact review manifest for the current review-pending n=9 selected-witness
   candidate. It records the command surface, documents, formalization-facing
@@ -40,6 +41,7 @@ harness_documents:
   - docs/n9-review-gate-ledger.md
   - docs/n9-review-evidence-matrix.md
   - docs/n9-review-dossier.md
+  - docs/n9-review-run-bundle.md
   - docs/n9-reduction-chain.md
   - docs/n9-review-packet.md
   - docs/turn-inequality-lemma.md
@@ -112,6 +114,8 @@ routes:
         command: python scripts/check_n9_review_evidence_matrix.py --check --summary-json
       - id: n9_review_dossier
         command: python scripts/check_n9_review_dossier.py --check --summary-json
+      - id: n9_review_run_bundle
+        command: python scripts/check_n9_review_run_bundle.py --check --summary-json
 
   - id: lean_guardrails
     title: Lean pilot guardrails

--- a/metadata/n9_review_dossier.yaml
+++ b/metadata/n9_review_dossier.yaml
@@ -28,6 +28,7 @@ required_documents:
   - docs/n9-review-gate-ledger.md
   - docs/n9-review-evidence-matrix.md
   - docs/n9-review-dossier.md
+  - docs/n9-review-run-bundle.md
   - docs/n9-reduction-chain.md
 
 sections:
@@ -73,6 +74,7 @@ sections:
       - n9_review_gate_ledger
       - n9_review_evidence_matrix
       - n9_review_dossier
+      - n9_review_run_bundle
       - lean_sketch_integrity
       - lean_files
       - n9_vertex_circle_exhaustive

--- a/metadata/n9_review_evidence_matrix.yaml
+++ b/metadata/n9_review_evidence_matrix.yaml
@@ -31,7 +31,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: command_count
-        equals: 17
+        equals: 18
       - path: review_gate_count
         equals: 8
       - path: review_gate_ledger
@@ -63,7 +63,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: evidence_record_count
-        equals: 17
+        equals: 18
       - path: live_replay_enabled
         equals: false
 
@@ -80,9 +80,26 @@ evidence_records:
       - path: review_gate_count
         equals: 6
       - path: evidence_record_count
-        equals: 17
+        equals: 18
       - path: review_question_count
         equals: 6
+
+  - id: n9_review_run_bundle
+    route_id: manifest_contract
+    command_id: n9_review_run_bundle
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: route_count
+        equals: 5
+      - path: command_count
+        equals: 18
+      - path: evidence_record_count
+        equals: 18
+      - path: run_capture_enabled
+        equals: false
 
   - id: lean_sketch_integrity
     route_id: lean_guardrails

--- a/metadata/n9_review_run_bundle.yaml
+++ b/metadata/n9_review_run_bundle.yaml
@@ -1,0 +1,94 @@
+schema: erdos97.n9_review_run_bundle.v1
+status: REVIEW_RUN_BUNDLE_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+candidate_manifest: metadata/n9_candidate_review.yaml
+review_gate_ledger: metadata/n9_review_gate_ledger.yaml
+review_evidence_matrix: metadata/n9_review_evidence_matrix.yaml
+review_dossier: metadata/n9_review_dossier.yaml
+canonical_command: python scripts/check_n9_review_run_bundle.py --check --summary-json
+live_replay_command: python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+markdown_command: python scripts/check_n9_review_run_bundle.py --markdown
+claim_scope: >
+  Machine-readable run-capture contract for the compact review-pending n=9
+  selected-witness harness. It records the manifest command surface, linked
+  review contracts, command-output digests, return codes, durations, and
+  evidence-matrix validation status for one reviewer run. It does not prove
+  n=9, does not prove Erdos Problem #97, does not claim a counterexample, does
+  not complete independent review, and does not update the official/global
+  status.
+
+forbidden_promotions:
+  - "general proof of Erdos Problem #97"
+  - proof of n=9
+  - "counterexample to Erdos Problem #97"
+  - official/global status update
+  - completed independent review
+  - formal proof of the Euclidean turn lemma
+
+required_documents:
+  - docs/n9-candidate-promotion-harness.md
+  - docs/n9-review-packet.md
+  - docs/n9-review-gate-ledger.md
+  - docs/n9-review-evidence-matrix.md
+  - docs/n9-review-dossier.md
+  - docs/n9-review-run-bundle.md
+  - docs/n9-reduction-chain.md
+
+expected_route_ids:
+  - manifest_contract
+  - lean_guardrails
+  - vertex_circle_route
+  - turn_packing_route
+  - kalmanson_corroboration
+
+output_modes:
+  - summary-json
+  - json
+  - markdown
+
+capture_contract:
+  executes_manifest_commands: true
+  validates_evidence_matrix_expectations: true
+  writes_generated_artifacts: false
+  records_stdout_sha256: true
+  records_stderr_sha256: true
+  records_duration_seconds: true
+  output_preview_chars: 240
+  required_record_fields:
+    - id
+    - route_id
+    - command_id
+    - command
+    - returncode
+    - duration_seconds
+    - stdout_sha256
+    - stderr_sha256
+    - stdout_preview
+    - stderr_preview
+    - output_format
+    - validation_status
+    - error_count
+    - first_errors
+  required_summary_fields:
+    - schema
+    - status
+    - trust
+    - route_count
+    - command_count
+    - evidence_record_count
+    - run_capture_enabled
+    - run_record_count
+    - failed_run_record_count
+    - run_record_digest
+    - validation_status
+    - validation_error_count
+
+reviewer_use:
+  static_contract: python scripts/check_n9_review_run_bundle.py --check --summary-json
+  live_capture: python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+  worksheet: python scripts/check_n9_review_run_bundle.py --markdown
+  interpretation: >
+    A passed live capture says the compact n=9 manifest commands completed in
+    the current checkout and their compact outputs matched the evidence matrix.
+    It is execution provenance and drift detection only, not mathematical
+    acceptance of any open review gate.

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -26,6 +26,7 @@ TRUST = "REVIEW_PENDING_DIAGNOSTIC"
 REVIEW_GATE_LEDGER = "metadata/n9_review_gate_ledger.yaml"
 REVIEW_EVIDENCE_MATRIX = "metadata/n9_review_evidence_matrix.yaml"
 REVIEW_DOSSIER = "metadata/n9_review_dossier.yaml"
+REVIEW_RUN_BUNDLE = "metadata/n9_review_run_bundle.yaml"
 REQUIRED_FORBIDDEN_PROMOTIONS = {
     "general proof of Erdos Problem #97",
     "proof of n=9",
@@ -45,6 +46,7 @@ SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
     "python scripts/check_n9_review_gate_ledger.py",
     "python scripts/check_n9_review_evidence_matrix.py",
     "python scripts/check_n9_review_dossier.py",
+    "python scripts/check_n9_review_run_bundle.py",
     "python scripts/check_n9_vertex_circle_input_audit.py",
     "python scripts/check_n9_vertex_circle_incidence_filters.py",
     "python scripts/check_n9_vertex_circle_mro_branching_replay.py",
@@ -246,6 +248,11 @@ def validate_manifest(
         errors.append(f"review_dossier must be {REVIEW_DOSSIER!r}")
     elif not repo_path(REVIEW_DOSSIER).exists():
         errors.append(f"review_dossier does not exist: {REVIEW_DOSSIER}")
+    review_run_bundle = payload.get("review_run_bundle")
+    if review_run_bundle != REVIEW_RUN_BUNDLE:
+        errors.append(f"review_run_bundle must be {REVIEW_RUN_BUNDLE!r}")
+    elif not repo_path(REVIEW_RUN_BUNDLE).exists():
+        errors.append(f"review_run_bundle does not exist: {REVIEW_RUN_BUNDLE}")
 
     claim_scope = payload.get("claim_scope")
     if not isinstance(claim_scope, str) or not claim_scope.strip():
@@ -299,6 +306,7 @@ def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str,
         "review_gate_ledger": payload.get("review_gate_ledger"),
         "review_evidence_matrix": payload.get("review_evidence_matrix"),
         "review_dossier": payload.get("review_dossier"),
+        "review_run_bundle": payload.get("review_run_bundle"),
         "route_count": len(routes) if isinstance(routes, list) else 0,
         "route_ids": route_ids,
         "command_count": len(flatten_route_commands(payload)),

--- a/scripts/check_n9_review_run_bundle.py
+++ b/scripts/check_n9_review_run_bundle.py
@@ -1,0 +1,827 @@
+#!/usr/bin/env python3
+"""Validate and optionally capture an n=9 reviewer run bundle."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_BUNDLE = REPO_ROOT / "metadata" / "n9_review_run_bundle.yaml"
+SCHEMA = "erdos97.n9_review_run_bundle.v1"
+STATUS = "REVIEW_RUN_BUNDLE_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CANDIDATE_MANIFEST = "metadata/n9_candidate_review.yaml"
+REVIEW_GATE_LEDGER = "metadata/n9_review_gate_ledger.yaml"
+REVIEW_EVIDENCE_MATRIX = "metadata/n9_review_evidence_matrix.yaml"
+REVIEW_DOSSIER = "metadata/n9_review_dossier.yaml"
+CANONICAL_COMMAND = (
+    "python scripts/check_n9_review_run_bundle.py --check --summary-json"
+)
+LIVE_REPLAY_COMMAND = (
+    "python scripts/check_n9_review_run_bundle.py --check --run --summary-json"
+)
+MARKDOWN_COMMAND = "python scripts/check_n9_review_run_bundle.py --markdown"
+REQUIRED_FORBIDDEN_PROMOTIONS = {
+    "general proof of Erdos Problem #97",
+    "proof of n=9",
+    "counterexample to Erdos Problem #97",
+    "official/global status update",
+    "completed independent review",
+    "formal proof of the Euclidean turn lemma",
+}
+REQUIRED_CLAIM_SCOPE_PHRASES = (
+    "does not prove n=9",
+    "does not prove Erdos Problem #97",
+    "does not claim a counterexample",
+    "does not complete independent review",
+    "does not update the official/global status",
+)
+REQUIRED_CAPTURE_FIELDS = {
+    "id",
+    "route_id",
+    "command_id",
+    "command",
+    "returncode",
+    "duration_seconds",
+    "stdout_sha256",
+    "stderr_sha256",
+    "stdout_preview",
+    "stderr_preview",
+    "output_format",
+    "validation_status",
+    "error_count",
+    "first_errors",
+}
+REQUIRED_SUMMARY_FIELDS = {
+    "schema",
+    "status",
+    "trust",
+    "route_count",
+    "command_count",
+    "evidence_record_count",
+    "run_capture_enabled",
+    "run_record_count",
+    "failed_run_record_count",
+    "run_record_digest",
+    "validation_status",
+    "validation_error_count",
+}
+REQUIRED_OUTPUT_MODES = {"summary-json", "json", "markdown"}
+REQUIRED_ROUTE_IDS = {
+    "manifest_contract",
+    "lean_guardrails",
+    "vertex_circle_route",
+    "turn_packing_route",
+    "kalmanson_corroboration",
+}
+
+
+def _linked_validators() -> tuple[Any, Any, Any, Any]:
+    from scripts.check_n9_candidate_review_manifest import validate_manifest
+    from scripts.check_n9_review_dossier import validate_dossier
+    from scripts.check_n9_review_evidence_matrix import validate_matrix
+    from scripts.check_n9_review_gate_ledger import validate_ledger
+
+    return validate_manifest, validate_ledger, validate_matrix, validate_dossier
+
+
+def _expectation_helpers() -> tuple[Any, Any]:
+    from scripts.check_n9_review_evidence_matrix import (
+        _check_json_expectations,
+        _check_text_expectations,
+    )
+
+    return _check_json_expectations, _check_text_expectations
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            f"PyYAML is required to parse {label}; install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} top level must be a mapping")
+    return payload
+
+
+def load_bundle(path: Path = DEFAULT_BUNDLE) -> dict[str, Any]:
+    return load_yaml_mapping(path, label="metadata/n9_review_run_bundle.yaml")
+
+
+def _load_linked_payloads(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], list[str]]:
+    errors: list[str] = []
+    linked: list[tuple[str, str]] = [
+        ("candidate_manifest", CANDIDATE_MANIFEST),
+        ("review_gate_ledger", REVIEW_GATE_LEDGER),
+        ("review_evidence_matrix", REVIEW_EVIDENCE_MATRIX),
+        ("review_dossier", REVIEW_DOSSIER),
+    ]
+    loaded: dict[str, dict[str, Any]] = {}
+    for key, expected in linked:
+        value = payload.get(key)
+        if value != expected:
+            errors.append(f"{key} must be {expected!r}")
+            loaded[key] = {}
+            continue
+        try:
+            loaded[key] = load_yaml_mapping(repo_path(expected), label=expected)
+        except (OSError, ValueError, YAMLError) as exc:
+            errors.append(str(exc))
+            loaded[key] = {}
+    return (
+        loaded["candidate_manifest"],
+        loaded["review_gate_ledger"],
+        loaded["review_evidence_matrix"],
+        loaded["review_dossier"],
+        errors,
+    )
+
+
+def _validate_forbidden_promotions(payload: dict[str, Any]) -> list[str]:
+    forbidden = payload.get("forbidden_promotions")
+    if not isinstance(forbidden, list) or not forbidden:
+        return ["forbidden_promotions must be a nonempty list"]
+    missing = REQUIRED_FORBIDDEN_PROMOTIONS - set(forbidden)
+    return [
+        f"forbidden_promotions missing {phrase!r}"
+        for phrase in sorted(missing)
+    ]
+
+
+def _validate_required_documents(payload: dict[str, Any]) -> list[str]:
+    docs = payload.get("required_documents")
+    if not isinstance(docs, list) or not docs:
+        return ["required_documents must be a nonempty list"]
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, doc in enumerate(docs):
+        label = f"required_documents[{index}]"
+        if not isinstance(doc, str) or not doc.strip():
+            errors.append(f"{label} must be a nonempty string")
+            continue
+        if doc in seen:
+            errors.append(f"{label} duplicates {doc!r}")
+        seen.add(doc)
+        if not repo_path(doc).exists():
+            errors.append(f"{label} does not exist: {doc}")
+    return errors
+
+
+def _manifest_command_records(manifest: dict[str, Any]) -> list[dict[str, str]]:
+    command_records: list[dict[str, str]] = []
+    routes = manifest.get("routes", [])
+    if not isinstance(routes, list):
+        return command_records
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        route_id = route.get("id")
+        route_title = route.get("title", route_id)
+        if not isinstance(route_id, str):
+            continue
+        commands = route.get("commands", [])
+        if not isinstance(commands, list):
+            continue
+        for command in commands:
+            if not isinstance(command, dict):
+                continue
+            command_id = command.get("id")
+            command_text = command.get("command")
+            if isinstance(command_id, str) and isinstance(command_text, str):
+                command_records.append(
+                    {
+                        "id": command_id,
+                        "route_id": route_id,
+                        "route_title": str(route_title),
+                        "command_id": command_id,
+                        "command": command_text,
+                    }
+                )
+    return command_records
+
+
+def _evidence_records_by_command(matrix: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    records = matrix.get("evidence_records", [])
+    if not isinstance(records, list):
+        return {}
+    return {
+        record["command_id"]: record
+        for record in records
+        if isinstance(record, dict) and isinstance(record.get("command_id"), str)
+    }
+
+
+def _route_ids(manifest: dict[str, Any]) -> set[str]:
+    routes = manifest.get("routes", [])
+    if not isinstance(routes, list):
+        return set()
+    return {
+        route["id"]
+        for route in routes
+        if isinstance(route, dict) and isinstance(route.get("id"), str)
+    }
+
+
+def _validate_capture_contract(payload: dict[str, Any]) -> list[str]:
+    contract = payload.get("capture_contract")
+    if not isinstance(contract, dict):
+        return ["capture_contract must be a mapping"]
+
+    errors: list[str] = []
+    expected_true = {
+        "executes_manifest_commands",
+        "validates_evidence_matrix_expectations",
+        "records_stdout_sha256",
+        "records_stderr_sha256",
+        "records_duration_seconds",
+    }
+    for key in sorted(expected_true):
+        if contract.get(key) is not True:
+            errors.append(f"capture_contract.{key} must be true")
+    if contract.get("writes_generated_artifacts") is not False:
+        errors.append("capture_contract.writes_generated_artifacts must be false")
+
+    preview_chars = contract.get("output_preview_chars")
+    if not isinstance(preview_chars, int) or not 80 <= preview_chars <= 1000:
+        errors.append("capture_contract.output_preview_chars must be an int in [80, 1000]")
+
+    record_fields = contract.get("required_record_fields")
+    if not isinstance(record_fields, list) or not record_fields:
+        errors.append("capture_contract.required_record_fields must be a nonempty list")
+    else:
+        missing = REQUIRED_CAPTURE_FIELDS - set(record_fields)
+        for field in sorted(missing):
+            errors.append(f"capture_contract.required_record_fields missing {field!r}")
+
+    summary_fields = contract.get("required_summary_fields")
+    if not isinstance(summary_fields, list) or not summary_fields:
+        errors.append("capture_contract.required_summary_fields must be a nonempty list")
+    else:
+        missing = REQUIRED_SUMMARY_FIELDS - set(summary_fields)
+        for field in sorted(missing):
+            errors.append(f"capture_contract.required_summary_fields missing {field!r}")
+    return errors
+
+
+def validate_bundle(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+    gate_ledger: dict[str, Any] | None = None,
+    evidence_matrix: dict[str, Any] | None = None,
+    dossier: dict[str, Any] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+    if payload.get("canonical_command") != CANONICAL_COMMAND:
+        errors.append(f"canonical_command must be {CANONICAL_COMMAND!r}")
+    if payload.get("live_replay_command") != LIVE_REPLAY_COMMAND:
+        errors.append(f"live_replay_command must be {LIVE_REPLAY_COMMAND!r}")
+    if payload.get("markdown_command") != MARKDOWN_COMMAND:
+        errors.append(f"markdown_command must be {MARKDOWN_COMMAND!r}")
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+    else:
+        for phrase in REQUIRED_CLAIM_SCOPE_PHRASES:
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    errors.extend(_validate_forbidden_promotions(payload))
+    errors.extend(_validate_required_documents(payload))
+    errors.extend(_validate_capture_contract(payload))
+
+    output_modes = payload.get("output_modes")
+    if not isinstance(output_modes, list) or set(output_modes) != REQUIRED_OUTPUT_MODES:
+        errors.append(
+            "output_modes must be exactly "
+            f"{', '.join(sorted(REQUIRED_OUTPUT_MODES))}"
+        )
+
+    if (
+        candidate_manifest is None
+        or gate_ledger is None
+        or evidence_matrix is None
+        or dossier is None
+    ):
+        manifest, ledger, matrix, loaded_dossier, link_errors = _load_linked_payloads(
+            payload
+        )
+        errors.extend(link_errors)
+        if candidate_manifest is not None:
+            manifest = candidate_manifest
+        if gate_ledger is not None:
+            ledger = gate_ledger
+        if evidence_matrix is not None:
+            matrix = evidence_matrix
+        if dossier is not None:
+            loaded_dossier = dossier
+    else:
+        manifest = candidate_manifest
+        ledger = gate_ledger
+        matrix = evidence_matrix
+        loaded_dossier = dossier
+
+    validators: tuple[Any, Any, Any, Any] | None = None
+
+    def linked_validators() -> tuple[Any, Any, Any, Any]:
+        nonlocal validators
+        if validators is None:
+            validators = _linked_validators()
+        return validators
+
+    if manifest:
+        if manifest.get("review_run_bundle") != "metadata/n9_review_run_bundle.yaml":
+            errors.append(
+                "candidate manifest must reference metadata/n9_review_run_bundle.yaml"
+            )
+        validate_manifest, _, _, _ = linked_validators()
+        errors.extend(
+            f"candidate_manifest: {error}" for error in validate_manifest(manifest)
+        )
+
+        expected_route_ids = payload.get("expected_route_ids")
+        if not isinstance(expected_route_ids, list):
+            errors.append("expected_route_ids must be a list")
+        else:
+            expected_route_id_set = {
+                route_id for route_id in expected_route_ids if isinstance(route_id, str)
+            }
+            if expected_route_id_set != REQUIRED_ROUTE_IDS:
+                errors.append("expected_route_ids does not match required route set")
+            observed_route_ids = _route_ids(manifest)
+            missing = expected_route_id_set - observed_route_ids
+            extra = observed_route_ids - expected_route_id_set
+            for route_id in sorted(missing):
+                errors.append(f"expected_route_ids missing manifest route {route_id!r}")
+            for route_id in sorted(extra):
+                errors.append(f"manifest route {route_id!r} is not expected")
+
+    if ledger:
+        _, validate_ledger, _, _ = linked_validators()
+        errors.extend(f"review_gate_ledger: {error}" for error in validate_ledger(ledger))
+    if matrix:
+        _, _, validate_matrix, _ = linked_validators()
+        errors.extend(
+            f"review_evidence_matrix: {error}"
+            for error in validate_matrix(
+                matrix,
+                candidate_manifest=manifest,
+                gate_ledger=ledger,
+            )
+        )
+    if loaded_dossier:
+        _, _, _, validate_dossier = linked_validators()
+        errors.extend(
+            f"review_dossier: {error}" for error in validate_dossier(loaded_dossier)
+        )
+
+    if manifest and matrix:
+        command_ids = {record["command_id"] for record in _manifest_command_records(manifest)}
+        matrix_command_ids = set(_evidence_records_by_command(matrix))
+        if command_ids != matrix_command_ids:
+            errors.append("manifest commands and evidence-matrix commands differ")
+    return errors
+
+
+def _subprocess_args(command: str) -> list[str]:
+    parts = shlex.split(command)
+    if parts and parts[0] == "python":
+        parts[0] = sys.executable
+    return parts
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _preview(text: str, limit: int) -> str:
+    return text[:limit]
+
+
+def _preview_limit(payload: dict[str, Any]) -> int:
+    contract = payload.get("capture_contract", {})
+    if isinstance(contract, dict) and isinstance(contract.get("output_preview_chars"), int):
+        return int(contract["output_preview_chars"])
+    return 240
+
+
+def git_head() -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def git_tracked_dirty_count() -> int | None:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return len([line for line in completed.stdout.splitlines() if line.strip()])
+
+
+def run_manifest_commands(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any],
+    evidence_matrix: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    evidence_by_command = _evidence_records_by_command(evidence_matrix)
+    check_json_expectations, check_text_expectations = _expectation_helpers()
+    run_records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    preview_limit = _preview_limit(payload)
+
+    for command_record in _manifest_command_records(candidate_manifest):
+        command_id = command_record["command_id"]
+        evidence_record = evidence_by_command.get(command_id)
+        label = f"command {command_id!r}"
+        start = time.perf_counter()
+        completed = subprocess.run(
+            _subprocess_args(command_record["command"]),
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        duration_seconds = time.perf_counter() - start
+        stdout = completed.stdout
+        stderr = completed.stderr
+        record_errors: list[str] = []
+        output_format = (
+            evidence_record.get("output_format")
+            if isinstance(evidence_record, dict)
+            else None
+        )
+
+        if evidence_record is None:
+            record_errors.append(f"{label} has no evidence-matrix record")
+        if completed.returncode != 0:
+            record_errors.append(
+                f"{label} exited with {completed.returncode}: "
+                f"{command_record['command']}"
+            )
+        elif output_format == "json":
+            try:
+                output_payload = json.loads(stdout)
+            except json.JSONDecodeError as exc:
+                record_errors.append(f"{label} output is not JSON: {exc}")
+            else:
+                expectations = evidence_record.get("expectations", [])
+                if isinstance(expectations, list):
+                    record_errors.extend(
+                        check_json_expectations(
+                            output_payload,
+                            expectations,
+                            label=command_id,
+                        )
+                    )
+        elif output_format == "text":
+            text_expectations = evidence_record.get("text_expectations", [])
+            if isinstance(text_expectations, list):
+                record_errors.extend(
+                    check_text_expectations(
+                        stdout,
+                        text_expectations,
+                        label=command_id,
+                    )
+                )
+        elif output_format is not None:
+            record_errors.append(f"{label} has unsupported output format {output_format!r}")
+
+        if record_errors:
+            errors.extend(record_errors)
+        run_records.append(
+            {
+                "id": command_record["id"],
+                "route_id": command_record["route_id"],
+                "command_id": command_id,
+                "command": command_record["command"],
+                "returncode": completed.returncode,
+                "duration_seconds": round(duration_seconds, 6),
+                "stdout_sha256": _sha256_text(stdout),
+                "stderr_sha256": _sha256_text(stderr),
+                "stdout_preview": _preview(stdout.strip(), preview_limit),
+                "stderr_preview": _preview(stderr.strip(), preview_limit),
+                "output_format": output_format,
+                "validation_status": "passed" if not record_errors else "failed",
+                "error_count": len(record_errors),
+                "first_errors": record_errors[:3],
+            }
+        )
+    return run_records, errors
+
+
+def _run_records_digest(run_records: Sequence[dict[str, Any]]) -> str | None:
+    if not run_records:
+        return None
+    stable_records = []
+    stable_keys = (
+        "id",
+        "route_id",
+        "command_id",
+        "returncode",
+        "stdout_sha256",
+        "stderr_sha256",
+        "validation_status",
+        "error_count",
+        "first_errors",
+    )
+    for record in run_records:
+        stable_records.append({key: record.get(key) for key in stable_keys})
+    encoded = json.dumps(stable_records, sort_keys=True, separators=(",", ":"))
+    return _sha256_text(encoded)
+
+
+def build_bundle_payload(
+    payload: dict[str, Any],
+    *,
+    candidate_manifest: dict[str, Any] | None = None,
+    gate_ledger: dict[str, Any] | None = None,
+    evidence_matrix: dict[str, Any] | None = None,
+    dossier: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if (
+        candidate_manifest is None
+        or gate_ledger is None
+        or evidence_matrix is None
+        or dossier is None
+    ):
+        manifest, ledger, matrix, loaded_dossier, _ = _load_linked_payloads(payload)
+        if candidate_manifest is not None:
+            manifest = candidate_manifest
+        if gate_ledger is not None:
+            ledger = gate_ledger
+        if evidence_matrix is not None:
+            matrix = evidence_matrix
+        if dossier is not None:
+            loaded_dossier = dossier
+    else:
+        manifest = candidate_manifest
+        ledger = gate_ledger
+        matrix = evidence_matrix
+        loaded_dossier = dossier
+
+    command_records = _manifest_command_records(manifest)
+    evidence_records = matrix.get("evidence_records", [])
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "claim_scope": payload.get("claim_scope"),
+        "canonical_command": payload.get("canonical_command"),
+        "live_replay_command": payload.get("live_replay_command"),
+        "markdown_command": payload.get("markdown_command"),
+        "candidate_manifest": payload.get("candidate_manifest"),
+        "review_gate_ledger": payload.get("review_gate_ledger"),
+        "review_evidence_matrix": payload.get("review_evidence_matrix"),
+        "review_dossier": payload.get("review_dossier"),
+        "candidate_claim_under_review": manifest.get("candidate_claim_under_review"),
+        "routes": manifest.get("routes", []),
+        "command_records": command_records,
+        "review_gates": ledger.get("review_gates", []),
+        "infrastructure_gates": ledger.get("infrastructure_gates", []),
+        "evidence_records": evidence_records if isinstance(evidence_records, list) else [],
+        "dossier_sections": loaded_dossier.get("sections", []),
+        "capture_contract": payload.get("capture_contract", {}),
+    }
+
+
+def summary_payload(
+    payload: dict[str, Any],
+    errors: Sequence[str],
+    *,
+    run_capture_enabled: bool,
+    run_records: Sequence[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    bundle = build_bundle_payload(payload)
+    run_records = list(run_records or [])
+    failed_records = [
+        record for record in run_records if record.get("validation_status") != "passed"
+    ]
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "route_count": len(bundle.get("routes", [])),
+        "command_count": len(bundle.get("command_records", [])),
+        "evidence_record_count": len(bundle.get("evidence_records", [])),
+        "review_gate_count": len(bundle.get("review_gates", [])),
+        "infrastructure_gate_count": len(bundle.get("infrastructure_gates", [])),
+        "run_capture_enabled": run_capture_enabled,
+        "run_record_count": len(run_records),
+        "failed_run_record_count": len(failed_records),
+        "failed_run_record_ids": [record.get("id") for record in failed_records[:10]],
+        "run_record_digest": _run_records_digest(run_records),
+        "git_head": git_head(),
+        "git_tracked_dirty_count": git_tracked_dirty_count(),
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+        "claim_scope": payload.get("claim_scope"),
+    }
+
+
+def render_markdown(
+    payload: dict[str, Any],
+    errors: Sequence[str],
+    *,
+    run_records: Sequence[dict[str, Any]] | None = None,
+) -> str:
+    bundle = build_bundle_payload(payload)
+    run_records = list(run_records or [])
+    lines: list[str] = [
+        "# n=9 Review Run Bundle",
+        "",
+        "Status: `REVIEW_RUN_BUNDLE_ONLY`.",
+        "",
+        str(payload.get("claim_scope", "")).strip(),
+        "",
+        "## Commands",
+        "",
+        f"- Static contract: `{payload.get('canonical_command')}`",
+        f"- Live capture: `{payload.get('live_replay_command')}`",
+        f"- Markdown renderer: `{payload.get('markdown_command')}`",
+        f"- Contract status: `{'passed' if not errors else 'failed'}`",
+        "",
+        "## Linked Contracts",
+        "",
+        f"- Candidate manifest: `{payload.get('candidate_manifest')}`",
+        f"- Review gate ledger: `{payload.get('review_gate_ledger')}`",
+        f"- Evidence matrix: `{payload.get('review_evidence_matrix')}`",
+        f"- Reviewer dossier: `{payload.get('review_dossier')}`",
+        "",
+        "## Run Capture Contract",
+        "",
+        "- Executes every compact manifest command in order.",
+        "- Validates compact outputs against the evidence matrix.",
+        "- Captures return codes, durations, stdout/stderr SHA-256 digests, and previews.",
+        "- Writes no generated artifact.",
+        "",
+        "## Manifest Command Surface",
+        "",
+    ]
+
+    for route in bundle["routes"]:
+        if not isinstance(route, dict):
+            continue
+        lines.append(f"### {route.get('title', route.get('id'))}")
+        lines.append("")
+        for command in route.get("commands", []):
+            if isinstance(command, dict):
+                lines.append(f"- `{command.get('id')}`: `{command.get('command')}`")
+        lines.append("")
+
+    if run_records:
+        lines.extend(["## Captured Run Records", ""])
+        for record in run_records:
+            lines.append(
+                f"- `{record.get('id')}`: `{record.get('validation_status')}`; "
+                f"stdout `{str(record.get('stdout_sha256', ''))[:12]}`; "
+                f"stderr `{str(record.get('stderr_sha256', ''))[:12]}`"
+            )
+        lines.append("")
+        lines.append(f"Run digest: `{_run_records_digest(run_records)}`")
+        lines.append("")
+
+    lines.extend(["## Boundary", ""])
+    lines.append(
+        "A passed live capture is execution provenance and drift detection. "
+        "It does not accept any review gate, prove `n=9`, prove Erdos Problem "
+        "#97, claim a counterexample, or update the official/global status."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", type=Path, default=DEFAULT_BUNDLE)
+    parser.add_argument("--check", action="store_true", help="fail on validation errors")
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="execute the compact manifest command chain and capture digests",
+    )
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    output_group.add_argument("--markdown", action="store_true", help="print Markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    bundle_path = args.bundle
+    if not bundle_path.is_absolute():
+        bundle_path = REPO_ROOT / bundle_path
+
+    run_records: list[dict[str, Any]] = []
+    try:
+        payload = load_bundle(bundle_path)
+        errors = validate_bundle(payload)
+        if args.run and not errors:
+            manifest, _, matrix, _, link_errors = _load_linked_payloads(payload)
+            errors.extend(link_errors)
+            if not errors:
+                run_records, run_errors = run_manifest_commands(
+                    payload,
+                    candidate_manifest=manifest,
+                    evidence_matrix=matrix,
+                )
+                errors.extend(run_errors)
+    except (OSError, ValueError, YAMLError) as exc:
+        payload = {"schema": SCHEMA, "status": "LOAD_FAILED"}
+        errors = [str(exc)]
+
+    if args.markdown:
+        print(render_markdown(payload, errors, run_records=run_records))
+    elif args.summary_json:
+        print(
+            json.dumps(
+                summary_payload(
+                    payload,
+                    errors,
+                    run_capture_enabled=args.run,
+                    run_records=run_records,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif args.json:
+        full_payload = build_bundle_payload(payload)
+        full_payload["run_capture_enabled"] = args.run
+        full_payload["run_records"] = run_records
+        full_payload["run_record_digest"] = _run_records_digest(run_records)
+        full_payload["git_head"] = git_head()
+        full_payload["git_tracked_dirty_count"] = git_tracked_dirty_count()
+        full_payload["validation_errors"] = errors
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 review run bundle")
+        print(f"status: {payload.get('status')}")
+        print(f"run_capture_enabled: {args.run}")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if errors and args.check:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -26,6 +26,7 @@ def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
         "python scripts/check_n9_review_gate_ledger.py --check --summary-json",
         "python scripts/check_n9_review_evidence_matrix.py --check --summary-json",
         "python scripts/check_n9_review_dossier.py --check --summary-json",
+        "python scripts/check_n9_review_run_bundle.py --check --summary-json",
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_candidate_review_manifest.py
+++ b/tests/test_n9_candidate_review_manifest.py
@@ -77,6 +77,18 @@ def test_n9_candidate_review_manifest_requires_review_dossier() -> None:
     assert "review_dossier must be 'metadata/n9_review_dossier.yaml'" in errors
 
 
+def test_n9_candidate_review_manifest_requires_review_run_bundle() -> None:
+    payload = deepcopy(load_manifest(MANIFEST))
+    payload["review_run_bundle"] = "metadata/other.yaml"
+
+    errors = validate_manifest(payload)
+
+    assert (
+        "review_run_bundle must be 'metadata/n9_review_run_bundle.yaml'"
+        in errors
+    )
+
+
 def test_n9_candidate_review_manifest_pins_summary_json_review_surfaces() -> None:
     payload = deepcopy(load_manifest(MANIFEST))
     command = payload["routes"][2]["commands"][1]

--- a/tests/test_n9_review_dossier.py
+++ b/tests/test_n9_review_dossier.py
@@ -31,7 +31,7 @@ def test_n9_review_dossier_payload_contains_expected_layers() -> None:
     assert len(dossier["routes"]) == 5
     assert len(dossier["review_gates"]) == 6
     assert len(dossier["infrastructure_gates"]) == 2
-    assert len(dossier["evidence_records"]) == 17
+    assert len(dossier["evidence_records"]) == 18
 
 
 def test_n9_review_dossier_rejects_missing_section_id() -> None:

--- a/tests/test_n9_review_evidence_matrix.py
+++ b/tests/test_n9_review_evidence_matrix.py
@@ -43,7 +43,7 @@ def test_n9_review_evidence_matrix_covers_manifest_commands() -> None:
     }
 
     assert record_command_ids == _manifest_command_ids()
-    assert len(record_command_ids) == 17
+    assert len(record_command_ids) == 18
 
 
 def test_n9_review_evidence_matrix_rejects_missing_manifest_command() -> None:

--- a/tests/test_n9_review_run_bundle.py
+++ b/tests/test_n9_review_run_bundle.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_review_run_bundle import (
+    build_bundle_payload,
+    load_bundle,
+    render_markdown,
+    run_manifest_commands,
+    summary_payload,
+    validate_bundle,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLE = ROOT / "metadata" / "n9_review_run_bundle.yaml"
+
+
+def test_n9_review_run_bundle_is_valid() -> None:
+    payload = load_bundle(BUNDLE)
+
+    errors = validate_bundle(payload)
+
+    assert errors == []
+
+
+def test_n9_review_run_bundle_payload_contains_expected_layers() -> None:
+    payload = load_bundle(BUNDLE)
+
+    bundle = build_bundle_payload(payload)
+
+    assert len(bundle["routes"]) == 5
+    assert len(bundle["command_records"]) == 18
+    assert len(bundle["review_gates"]) == 6
+    assert len(bundle["infrastructure_gates"]) == 2
+    assert len(bundle["evidence_records"]) == 18
+
+
+def test_n9_review_run_bundle_rejects_missing_capture_field() -> None:
+    payload = deepcopy(load_bundle(BUNDLE))
+    payload["capture_contract"]["required_record_fields"].remove("stdout_sha256")
+
+    errors = validate_bundle(payload)
+
+    assert (
+        "capture_contract.required_record_fields missing 'stdout_sha256'"
+        in errors
+    )
+
+
+def test_n9_review_run_bundle_rejects_manifest_without_pointer() -> None:
+    payload = load_bundle(BUNDLE)
+    manifest = deepcopy(build_bundle_payload(payload)["routes"])
+    candidate_manifest = {
+        "schema": "ignored",
+        "routes": manifest,
+    }
+
+    errors = validate_bundle(payload, candidate_manifest=candidate_manifest)
+
+    assert (
+        "candidate manifest must reference metadata/n9_review_run_bundle.yaml"
+        in errors
+    )
+
+
+def test_n9_review_run_bundle_summary_is_static_by_default() -> None:
+    payload = load_bundle(BUNDLE)
+
+    summary = summary_payload(payload, [], run_capture_enabled=False)
+
+    assert summary["command_count"] == 18
+    assert summary["evidence_record_count"] == 18
+    assert summary["run_capture_enabled"] is False
+    assert summary["run_record_count"] == 0
+
+
+def test_n9_review_run_bundle_renders_markdown() -> None:
+    payload = load_bundle(BUNDLE)
+
+    markdown = render_markdown(payload, [])
+
+    assert "# n=9 Review Run Bundle" in markdown
+    assert "## Run Capture Contract" in markdown
+    assert "`n9_review_run_bundle`" in markdown
+
+
+def test_n9_review_run_bundle_can_capture_a_small_command() -> None:
+    payload = load_bundle(BUNDLE)
+    manifest = {
+        "routes": [
+            {
+                "id": "sample_route",
+                "title": "Sample route",
+                "commands": [
+                    {
+                        "id": "sample_command",
+                        "command": (
+                            "python -c \"import json; "
+                            "print(json.dumps({'validation_status': 'passed'}))\""
+                        ),
+                    }
+                ],
+            }
+        ]
+    }
+    matrix = {
+        "evidence_records": [
+            {
+                "id": "sample_command",
+                "command_id": "sample_command",
+                "output_format": "json",
+                "expectations": [
+                    {"path": "validation_status", "equals": "passed"},
+                ],
+            }
+        ]
+    }
+
+    records, errors = run_manifest_commands(
+        payload,
+        candidate_manifest=manifest,
+        evidence_matrix=matrix,
+    )
+
+    assert errors == []
+    assert len(records) == 1
+    assert records[0]["validation_status"] == "passed"
+    assert len(records[0]["stdout_sha256"]) == 64


### PR DESCRIPTION
## Summary
- add a machine-readable n=9 review run-bundle contract and checker with static validation, Markdown output, and optional live command capture
- record digest-level provenance for live reviewer runs: return codes, durations, stdout/stderr SHA-256 hashes, previews, and evidence-matrix validation status
- wire the new static checker into the compact n=9 manifest, evidence matrix, dossier, Makefile target, docs, and regression tests while preserving the review-pending/no-overclaim boundary

## Validation
- `.venv/bin/python -m ruff check scripts/check_n9_review_run_bundle.py tests/test_n9_review_run_bundle.py scripts/check_n9_candidate_review_manifest.py tests/test_n9_candidate_review_manifest.py`
- `.venv/bin/python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_run_bundle.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_dossier.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_run_bundle.py --markdown`
- `.venv/bin/python scripts/check_n9_review_evidence_matrix.py --check --summary-json`
- `.venv/bin/python -m pytest -q tests/test_n9_review_run_bundle.py tests/test_n9_review_dossier.py tests/test_n9_review_evidence_matrix.py tests/test_n9_candidate_review_manifest.py tests/test_makefile_targets.py`
- `.venv/bin/python scripts/check_n9_review_run_bundle.py --check --run --summary-json`
- `.venv/bin/python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json`
- `make verify-n9-candidate PYTHON=.venv/bin/python`
- `make verify-fast PYTHON=.venv/bin/python`