### PR TITLE
[codex] Record T10 strict-cycle soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -548,6 +548,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t10-strict-cycle-lemma.md`](n9-vertex-circle-t10-strict-cycle-lemma.md):
   focused review-pending T10/F12 strict-cycle local lemma packet for proof
   mining.
+- [`n9-vertex-circle-t10-soundness-review-2026-06-08.md`](n9-vertex-circle-t10-soundness-review-2026-06-08.md):
+  internal soundness review accepting only the T10/F12 local strict-cycle
+  implication under its displayed hypotheses; not an A10 or `n=9` promotion.
 - [`n9-t10-strict-cycle-minireplay.md`](n9-t10-strict-cycle-minireplay.md):
   minimal input-data replay of the T10/F12 local strict-cycle equality
   connectors and chord containments; proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -53,6 +53,7 @@ auditable.
 - `docs/n9-vertex-circle-t08-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t09-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
+- `docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-t12-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-local-lemma-audit-note-2026-06-07.md`
@@ -148,6 +149,12 @@ The 2026-06-07 T01 soundness review records
 `accepted_packet_soundness_T01` for the single T01/F09 self-edge implication
 under its displayed local hypotheses. This does not review the other T02-T12
 packets and does not promote A10 as a whole.
+
+The 2026-06-08 T10 soundness review records
+`accepted_packet_soundness_T10` for the single T10/F12 strict-cycle implication
+under its displayed local hypotheses. Together with the T01 review, this
+checks one self-edge packet and one strict-cycle packet, while leaving T02-T09,
+T11, T12, aggregate A10 review, `n=9`, and global status review-pending.
 
 ## Aggregate bookkeeping obligations
 

--- a/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
@@ -1,0 +1,166 @@
+# n=9 Vertex-circle T10 Soundness Review - 2026-06-08
+
+Status: `INTERNAL_REVIEW_NOTE`.
+
+Claim scope: focused internal soundness review of the T10/F12 local
+strict-cycle implication in
+`docs/n9-vertex-circle-t10-strict-cycle-lemma.md`. This note does not prove
+`n=9`, does not claim a counterexample, does not review the exhaustive
+brancher, does not review all T01-T12 packets, and does not update the
+official/global status of Erdos Problem #97.
+
+## Outcome
+
+Outcome: `accepted_packet_soundness_T10`.
+
+The T10/F12 local implication is sound under exactly the displayed
+hypotheses: natural cyclic order on labels `0,...,8` and the four selected
+rows
+
+```text
+0 -> {1,2,5,6}
+3 -> {0,1,4,6}
+6 -> {1,3,4,7}
+8 -> {0,3,6,7}
+```
+
+This is an internal review of one local obstruction packet. It is not an
+external independent review and it does not promote the aggregate A10
+local-lemma layer beyond the existing review-pending status.
+
+## Local Check
+
+Rows `3` and `6` force the selected-distance equality chain
+
+```text
+row 3: [0,3] = [3,6]
+row 6: [3,6] = [1,6]
+```
+
+so
+
+```text
+[0,3] = [3,6] = [1,6].
+```
+
+At vertex `8`, the selected witnesses occur in angular order
+
+```text
+[0,3,6,7].
+```
+
+The witnesses lie on the circle centered at `p_8`. The chord `[0,6]` spans
+positions `0` to `2`, while `[0,3]` spans the proper subinterval `0` to `1`.
+Strict convexity puts this inside an angle below `pi`, so row `8` gives
+
+```text
+[0,6] > [0,3].
+```
+
+Using the equality chain above, this gives
+
+```text
+[0,6] > [1,6].                         (1)
+```
+
+Row `0` forces the selected-distance equality
+
+```text
+[0,1] = [0,6].
+```
+
+At vertex `3`, the selected witnesses occur in angular order
+
+```text
+[4,6,0,1].
+```
+
+The chord `[1,6]` spans positions `1` to `3`, while `[0,1]` spans the proper
+subinterval `2` to `3`. The same vertex-circle monotonicity gives
+
+```text
+[1,6] > [0,1].
+```
+
+Using row `0`, this becomes
+
+```text
+[1,6] > [0,6].                         (2)
+```
+
+The inequalities (1) and (2) form the directed strict cycle
+
+```text
+[0,6] > [1,6] > [0,6].
+```
+
+Using the packet's canonical selected-distance quotient representatives, this
+is the two-class cycle
+
+```text
+[0,1] > [0,3] > [0,1].
+```
+
+No strictly convex Euclidean configuration can satisfy a directed strict cycle
+of ordinary distances after selected-distance quotienting.
+
+## Packet/Data Agreement
+
+The stored packet, strict-cycle source packet, template catalog, mini-replay,
+and paired-square diagnostic agree with the proof above:
+
+- template/family: `T10/F12`;
+- assignment ids: `A020`, `A040`, `A047`, `A071`, `A080`, `A081`, `A083`,
+  `A093`, `A095`, `A111`, `A126`, `A147`, `A151`, `A153`, `A154`, `A157`,
+  `A164`, `A180`;
+- assignment count: `18`;
+- core centers: `0`, `3`, `6`, `8`;
+- cycle length: `2`;
+- equality chains: `[0,3] = [3,6] = [1,6]` and `[0,1] = [0,6]`;
+- strict edges: row `8` gives outer pair `[0,6]`, inner pair `[0,3]`; row
+  `3` gives outer pair `[1,6]`, inner pair `[0,1]`;
+- replay status: `strict_cycle`;
+- paired-square companion audit: all `18` T10 assignments have a representative
+  paired-square entry, with `54` total entries.
+
+The paired-square audit is diagnostic corroboration only. The local soundness
+acceptance above relies on the selected-row equalities, the two
+vertex-circle strict inequalities, and the quotient-cycle closure.
+
+## Commands Run
+
+```bash
+python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json
+python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python -m pytest tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py tests/test_n9_t10_strict_cycle_minireplay.py tests/test_n9_t10_paired_square_entry.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+```
+
+All commands passed.
+
+## Review Boundary
+
+This review supports only the following narrow statement:
+
+```text
+Any strictly convex configuration satisfying the T10/F12 local cyclic-order
+and selected-row hypotheses is impossible by a selected-distance quotient
+directed strict cycle.
+```
+
+It does not support any of the following stronger statements:
+
+- all T01-T12 packets have been mathematically reviewed;
+- the A10 local-lemma layer is fully reviewed;
+- the 184-assignment frontier is complete;
+- the vertex-circle strict-edge generator is fully reviewed;
+- no bad nonagon exists as a promoted source-of-truth claim;
+- Erdos Problem #97 is proved;
+- a counterexample is produced or certified.
+
+## Next Packet
+
+The next useful soundness review targets are T11/F07 and T12/F16, the two
+remaining strict-cycle packets.

--- a/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t10-strict-cycle-lemma.md
@@ -53,6 +53,9 @@ derived from the strict-cycle template packet and the template lemma catalog,
 but the local argument below uses only the four displayed selected rows plus
 the displayed cyclic order.
 
+The 2026-06-08 internal soundness review for this packet is
+`docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md`.
+
 ## Vertex-circle Strict Inequalities
 
 At vertex `8`, the selected witnesses occur in boundary/angular order


### PR DESCRIPTION
## Summary

- Add an internal soundness review note for the focused T10/F12 strict-cycle local lemma packet.
- Link the new review note from the T10 lemma, the local-lemma reviewer packet, and the docs index.
- Preserve the review-pending boundary: this accepts only the displayed local T10/F12 implication and does not promote A10, n=9, or the global Erdos #97 status.

## Validation

- `python scripts/check_n9_vertex_circle_t10_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t10_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_t10_paired_square_entry.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t10_strict_cycle_lemma_packet.py tests/test_n9_t10_strict_cycle_minireplay.py tests/test_n9_t10_paired_square_entry.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`