### PR TITLE
[codex] Record T12 strict-cycle soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -563,6 +563,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t12-strict-cycle-lemma.md`](n9-vertex-circle-t12-strict-cycle-lemma.md):
   focused review-pending T12/F16 strict-cycle local lemma packet for proof
   mining.
+- [`n9-vertex-circle-t12-soundness-review-2026-06-08.md`](n9-vertex-circle-t12-soundness-review-2026-06-08.md):
+  internal soundness review accepting only the T12/F16 local strict-cycle
+  implication under its displayed hypotheses; not a bootstrap bridge, A10, or
+  `n=9` promotion.
 - [`n9-t12-strict-cycle-minireplay.md`](n9-t12-strict-cycle-minireplay.md):
   minimal input-data replay of the T12/F16 local strict-cycle equality
   connectors and chord containments; proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -56,6 +56,7 @@ auditable.
 - `docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-t12-strict-cycle-lemma.md`
+- `docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-local-lemma-audit-note-2026-06-07.md`
 
 The focused T-notes are reviewer-facing local arguments. The JSON artifacts
@@ -155,6 +156,13 @@ The 2026-06-08 T10 soundness review records
 under its displayed local hypotheses. Together with the T01 review, this
 checks one self-edge packet and one strict-cycle packet, while leaving T02-T09,
 T11, T12, aggregate A10 review, `n=9`, and global status review-pending.
+
+The 2026-06-08 T12 soundness review records
+`accepted_packet_soundness_T12` for the single T12/F16 strict-cycle implication
+under its displayed local hypotheses. It is bridge-facing because current
+bootstrap/T12 diagnostics land on T12/F16, but it does not prove the missing
+row-forcing or rich-support forcing bridge step. T02-T09, T11, aggregate A10
+review, `n=9`, and global status remain review-pending.
 
 ## Aggregate bookkeeping obligations
 

--- a/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
@@ -1,0 +1,186 @@
+# n=9 Vertex-circle T12 Soundness Review - 2026-06-08
+
+Status: `INTERNAL_REVIEW_NOTE`.
+
+Claim scope: focused internal soundness review of the T12/F16 local
+strict-cycle implication in
+`docs/n9-vertex-circle-t12-strict-cycle-lemma.md`. This note does not prove
+`n=9`, does not claim a counterexample, does not review the exhaustive
+brancher, does not review all T01-T12 packets, and does not update the
+official/global status of Erdos Problem #97.
+
+## Outcome
+
+Outcome: `accepted_packet_soundness_T12`.
+
+The T12/F16 local implication is sound under exactly the displayed
+hypotheses: natural cyclic order on labels `0,...,8` and the six selected
+rows
+
+```text
+0 -> {1,3,6,7}
+1 -> {2,4,7,8}
+2 -> {0,3,5,8}
+3 -> {0,1,4,6}
+4 -> {1,2,5,7}
+8 -> {0,2,5,6}
+```
+
+This is an internal review of one local obstruction packet. It is not an
+external independent review and it does not promote the aggregate A10
+local-lemma layer beyond the existing review-pending status.
+
+This packet is bridge-facing because current bootstrap/T12 diagnostics land on
+the T12/F16 template. The review here checks only the local contradiction once
+the six displayed rows are genuinely available; it does not prove that any
+minimal or rich-support counterexample must supply those rows.
+
+## Local Check
+
+Row `8` forces the selected-distance equality
+
+```text
+[0,8] = [2,8].
+```
+
+At vertex `2`, the selected witnesses occur in angular order
+
+```text
+[3,5,8,0].
+```
+
+The witnesses lie on the circle centered at `p_2`. The chord `[0,3]` spans
+positions `0` to `3`, while `[0,8]` spans the proper subinterval `2` to `3`.
+Strict convexity puts this inside an angle below `pi`, so row `2` gives
+
+```text
+[0,3] > [0,8].
+```
+
+Using row `8`, this becomes
+
+```text
+[0,3] > [2,8].                         (1)
+```
+
+Rows `4` and `1` force the selected-distance equality chain
+
+```text
+row 4: [2,4] = [1,4]
+row 1: [1,4] = [1,7]
+```
+
+so
+
+```text
+[2,4] = [1,4] = [1,7].
+```
+
+At vertex `1`, the selected witnesses occur in angular order
+
+```text
+[2,4,7,8].
+```
+
+The chord `[2,8]` spans positions `0` to `3`, while `[2,4]` spans the proper
+subinterval `0` to `1`. The same vertex-circle monotonicity gives
+
+```text
+[2,8] > [2,4].
+```
+
+Using the equality chain above, this gives
+
+```text
+[2,8] > [1,7].                         (2)
+```
+
+Row `3` forces the selected-distance equality
+
+```text
+[1,3] = [0,3].
+```
+
+At vertex `0`, the selected witnesses occur in angular order
+
+```text
+[1,3,6,7].
+```
+
+The chord `[1,7]` spans positions `0` to `3`, while `[1,3]` spans the proper
+subinterval `0` to `1`. Therefore row `0` gives
+
+```text
+[1,7] > [1,3].
+```
+
+Using row `3`, this becomes
+
+```text
+[1,7] > [0,3].                         (3)
+```
+
+The inequalities (1), (2), and (3) form the directed strict cycle
+
+```text
+[0,3] > [2,8] > [1,7] > [0,3].
+```
+
+No strictly convex Euclidean configuration can satisfy a directed strict cycle
+of ordinary distances after selected-distance quotienting.
+
+## Packet/Data Agreement
+
+The stored packet, strict-cycle source packet, template catalog, and
+mini-replay agree with the proof above:
+
+- template/family: `T12/F16`;
+- assignment ids: `A082`, `A152`;
+- assignment count: `2`;
+- core centers: `0`, `1`, `2`, `3`, `4`, `8`;
+- cycle length: `3`;
+- equality chains: `[0,8] = [2,8]`, `[2,4] = [1,4] = [1,7]`, and
+  `[1,3] = [0,3]`;
+- strict edges: row `2` gives outer pair `[0,3]`, inner pair `[0,8]`; row
+  `1` gives outer pair `[2,8]`, inner pair `[2,4]`; row `0` gives outer pair
+  `[1,7]`, inner pair `[1,3]`;
+- replay status: `strict_cycle`.
+
+## Commands Run
+
+```bash
+python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python -m pytest tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py tests/test_n9_t12_strict_cycle_minireplay.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+```
+
+All commands passed.
+
+## Review Boundary
+
+This review supports only the following narrow statement:
+
+```text
+Any strictly convex configuration satisfying the T12/F16 local cyclic-order
+and selected-row hypotheses is impossible by a selected-distance quotient
+directed strict cycle.
+```
+
+It does not support any of the following stronger statements:
+
+- all T01-T12 packets have been mathematically reviewed;
+- the A10 local-lemma layer is fully reviewed;
+- the 184-assignment frontier is complete;
+- the vertex-circle strict-edge generator is fully reviewed;
+- the bootstrap/T12 bridge row-forcing targets are proved;
+- no bad nonagon exists as a promoted source-of-truth claim;
+- Erdos Problem #97 is proved;
+- a counterexample is produced or certified.
+
+## Next Packet
+
+The remaining strict-cycle soundness review target is T11/F07. After T11, the
+strict-cycle packet family will have one internal soundness note for each of
+T10, T11, and T12, while the self-edge packets T02-T09 will still need review.

--- a/docs/n9-vertex-circle-t12-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t12-strict-cycle-lemma.md
@@ -57,6 +57,9 @@ derived from the strict-cycle template packet and the template lemma catalog,
 but the local argument below uses only the six displayed selected rows plus
 the displayed cyclic order.
 
+The 2026-06-08 internal soundness review for this packet is
+`docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md`.
+
 ## Vertex-circle Strict Inequalities
 
 At vertex `2`, the selected witnesses occur in boundary/angular order


### PR DESCRIPTION
## Summary

- Add an internal soundness review note for the focused T12/F16 strict-cycle local lemma packet.
- Link the new review note from the T12 lemma, the local-lemma reviewer packet, and the docs index.
- Preserve the review-pending boundary: this accepts only the displayed local T12/F16 implication and does not prove the bootstrap row/rich-support forcing bridge, A10, n=9, or the global Erdos #97 status.

## Validation

- `python scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t12_strict_cycle_lemma_packet.py tests/test_n9_t12_strict_cycle_minireplay.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`