### PR TITLE
[codex] Record T11 strict-cycle soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -557,6 +557,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t11-strict-cycle-lemma.md`](n9-vertex-circle-t11-strict-cycle-lemma.md):
   focused review-pending T11/F07 strict-cycle local lemma packet for proof
   mining.
+- [`n9-vertex-circle-t11-soundness-review-2026-06-08.md`](n9-vertex-circle-t11-soundness-review-2026-06-08.md):
+  internal soundness review accepting only the T11/F07 local strict-cycle
+  implication under its displayed hypotheses; not an A10 or `n=9` promotion.
 - [`n9-t11-strict-cycle-minireplay.md`](n9-t11-strict-cycle-minireplay.md):
   minimal input-data replay of the T11/F07 local strict-cycle equality
   connectors and chord containments; proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -55,6 +55,7 @@ auditable.
 - `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
+- `docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t12-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-local-lemma-audit-note-2026-06-07.md`
@@ -153,16 +154,21 @@ packets and does not promote A10 as a whole.
 
 The 2026-06-08 T10 soundness review records
 `accepted_packet_soundness_T10` for the single T10/F12 strict-cycle implication
-under its displayed local hypotheses. Together with the T01 review, this
-checks one self-edge packet and one strict-cycle packet, while leaving T02-T09,
-T11, T12, aggregate A10 review, `n=9`, and global status review-pending.
+under its displayed local hypotheses.
+
+The 2026-06-08 T11 soundness review records
+`accepted_packet_soundness_T11` for the single T11/F07 strict-cycle implication
+under its displayed local hypotheses.
 
 The 2026-06-08 T12 soundness review records
 `accepted_packet_soundness_T12` for the single T12/F16 strict-cycle implication
 under its displayed local hypotheses. It is bridge-facing because current
 bootstrap/T12 diagnostics land on T12/F16, but it does not prove the missing
-row-forcing or rich-support forcing bridge step. T02-T09, T11, aggregate A10
-review, `n=9`, and global status remain review-pending.
+row-forcing or rich-support forcing bridge step.
+
+Together with the T01 review, the three strict-cycle notes check one self-edge
+packet and all three strict-cycle packets. T02-T09, aggregate A10 review,
+`n=9`, and global status remain review-pending.
 
 ## Aggregate bookkeeping obligations
 

--- a/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
@@ -162,5 +162,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The next useful soundness review targets are T11/F07 and T12/F16, the two
-remaining strict-cycle packets.
+The follow-up T11/F07 and T12/F16 soundness reviews are now recorded, so the
+strict-cycle packet family has one internal soundness note for each of T10,
+T11, and T12. The remaining focused local-lemma packet soundness review
+targets are the self-edge packets T02-T09.

--- a/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
@@ -1,0 +1,169 @@
+# n=9 Vertex-circle T11 Soundness Review - 2026-06-08
+
+Status: `INTERNAL_REVIEW_NOTE`.
+
+Claim scope: focused internal soundness review of the T11/F07 local
+strict-cycle implication in
+`docs/n9-vertex-circle-t11-strict-cycle-lemma.md`. This note does not prove
+`n=9`, does not claim a counterexample, does not review the exhaustive
+brancher, does not review all T01-T12 packets, and does not update the
+official/global status of Erdos Problem #97.
+
+## Outcome
+
+Outcome: `accepted_packet_soundness_T11`.
+
+The T11/F07 local implication is sound under exactly the displayed
+hypotheses: natural cyclic order on labels `0,...,8` and the four selected
+rows
+
+```text
+0 -> {1,2,4,8}
+1 -> {0,2,3,5}
+5 -> {0,3,4,7}
+6 -> {1,5,7,8}
+```
+
+This is an internal review of one local obstruction packet. It is not an
+external independent review and it does not promote the aggregate A10
+local-lemma layer beyond the existing review-pending status.
+
+## Local Check
+
+At vertex `1`, the selected witnesses occur in angular order
+
+```text
+[2,3,5,0].
+```
+
+The witnesses lie on the circle centered at `p_1`. The chord `[0,2]` spans
+positions `0` to `3`, while `[0,3]` spans the proper subinterval `1` to `3`.
+Strict convexity puts this inside an angle below `pi`, so row `1` gives
+
+```text
+[0,2] > [0,3].                         (1)
+```
+
+The first connector is the identity chain
+
+```text
+[0,3] = [0,3].
+```
+
+The same row-`1` witness order also has chord `[0,3]` spanning positions
+`1` to `3`, while `[0,5]` spans the proper subinterval `2` to `3`. Therefore
+row `1` gives
+
+```text
+[0,3] > [0,5].
+```
+
+Row `5` forces the selected-distance equality
+
+```text
+[0,5] = [5,7],
+```
+
+so the second strict edge becomes
+
+```text
+[0,3] > [5,7].                         (2)
+```
+
+At vertex `6`, the selected witnesses occur in angular order
+
+```text
+[7,8,1,5].
+```
+
+The chord `[5,7]` spans positions `0` to `3`, while `[1,5]` spans the proper
+subinterval `2` to `3`. The same vertex-circle monotonicity gives
+
+```text
+[5,7] > [1,5].
+```
+
+Rows `1` and `0` force the selected-distance equality chain
+
+```text
+row 1: [1,5] = [0,1]
+row 0: [0,1] = [0,2]
+```
+
+so
+
+```text
+[1,5] = [0,1] = [0,2].
+```
+
+Thus the third strict edge becomes
+
+```text
+[5,7] > [0,2].                         (3)
+```
+
+The inequalities (1), (2), and (3) form the directed strict cycle
+
+```text
+[0,2] > [0,3] > [5,7] > [0,2].
+```
+
+No strictly convex Euclidean configuration can satisfy a directed strict cycle
+of ordinary distances after selected-distance quotienting.
+
+## Packet/Data Agreement
+
+The stored packet, strict-cycle source packet, template catalog, and
+mini-replay agree with the proof above:
+
+- template/family: `T11/F07`;
+- assignment ids: `A008`, `A015`, `A032`, `A137`, `A141`, `A167`;
+- assignment count: `6`;
+- core centers: `0`, `1`, `5`, `6`;
+- cycle length: `3`;
+- equality chains: `[0,3] = [0,3]`, `[0,5] = [5,7]`, and
+  `[1,5] = [0,1] = [0,2]`;
+- strict edges: row `1` gives outer pair `[0,2]`, inner pair `[0,3]`; row
+  `1` gives outer pair `[0,3]`, inner pair `[0,5]`; row `6` gives outer pair
+  `[5,7]`, inner pair `[1,5]`;
+- replay status: `strict_cycle`;
+- strict edge count in the focused packet: `36`.
+
+## Commands Run
+
+```bash
+python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python -m pytest tests/test_n9_vertex_circle_t11_strict_cycle_lemma_packet.py tests/test_n9_t11_strict_cycle_minireplay.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+```
+
+All commands passed.
+
+## Review Boundary
+
+This review supports only the following narrow statement:
+
+```text
+Any strictly convex configuration satisfying the T11/F07 local cyclic-order
+and selected-row hypotheses is impossible by a selected-distance quotient
+directed strict cycle.
+```
+
+It does not support any of the following stronger statements:
+
+- all T01-T12 packets have been mathematically reviewed;
+- the A10 local-lemma layer is fully reviewed;
+- the 184-assignment frontier is complete;
+- the vertex-circle strict-edge generator is fully reviewed;
+- no bad nonagon exists as a promoted source-of-truth claim;
+- Erdos Problem #97 is proved;
+- a counterexample is produced or certified.
+
+## Next Packet
+
+The strict-cycle packet family now has one internal soundness note for each of
+T10, T11, and T12. The remaining focused local-lemma packet soundness review
+targets are the self-edge packets T02-T09, while aggregate A10 review, `n=9`,
+and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t11-strict-cycle-lemma.md
+++ b/docs/n9-vertex-circle-t11-strict-cycle-lemma.md
@@ -56,6 +56,9 @@ derived from the strict-cycle template packet and the template lemma catalog,
 but the local argument below uses only the four displayed selected rows plus
 the displayed cyclic order.
 
+An internal soundness review of this focused implication is recorded in
+`docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md`.
+
 ## Vertex-circle Strict Inequalities
 
 At vertex `1`, the selected witnesses occur in boundary/angular order

--- a/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
@@ -181,6 +181,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining strict-cycle soundness review target is T11/F07. After T11, the
-strict-cycle packet family will have one internal soundness note for each of
-T10, T11, and T12, while the self-edge packets T02-T09 will still need review.
+The follow-up T11/F07 soundness review is now recorded, so the strict-cycle
+packet family has one internal soundness note for each of T10, T11, and T12.
+The remaining focused local-lemma packet soundness review targets are the
+self-edge packets T02-T09.


### PR DESCRIPTION
## Summary

- Add an internal soundness review note for the focused T11/F07 strict-cycle local lemma packet.
- Link the review from the T11 lemma, the local-lemma reviewer packet, and the docs index.
- Update the T10/T12 review breadcrumbs so the strict-cycle packet family is recorded as internally reviewed while preserving the boundary that T02-T09, aggregate A10, n=9, and global Erdos #97 status remain review-pending/open.

## Validation

- `python scripts/check_n9_vertex_circle_t11_strict_cycle_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_strict_cycle_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t11_strict_cycle_lemma_packet.py tests/test_n9_t11_strict_cycle_minireplay.py tests/test_n9_vertex_circle_strict_cycle_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`