### PR TITLE
[codex] Record T02 self-edge soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -500,6 +500,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t02-self-edge-lemma.md`](n9-vertex-circle-t02-self-edge-lemma.md):
   focused review-pending T02 multi-family self-edge local lemma packet for
   proof mining.
+- [`n9-vertex-circle-t02-soundness-review-2026-06-08.md`](n9-vertex-circle-t02-soundness-review-2026-06-08.md):
+  internal soundness review accepting only the four T02 local self-edge
+  implications under their displayed hypotheses; not an A10 or `n=9`
+  promotion.
 - [`n9-t02-self-edge-minireplay.md`](n9-t02-self-edge-minireplay.md):
   minimal input-data replay of the four T02 local self-edge family packets;
   proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -45,6 +45,7 @@ auditable.
 - `docs/n9-vertex-circle-t01-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md`
 - `docs/n9-vertex-circle-t02-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t03-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t04-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t05-self-edge-lemma.md`
@@ -149,8 +150,11 @@ and any `n=9` status movement review-pending.
 
 The 2026-06-07 T01 soundness review records
 `accepted_packet_soundness_T01` for the single T01/F09 self-edge implication
-under its displayed local hypotheses. This does not review the other T02-T12
-packets and does not promote A10 as a whole.
+under its displayed local hypotheses.
+
+The 2026-06-08 T02 soundness review records
+`accepted_packet_soundness_T02` for the four-family T02/F01,F04,F08,F14
+self-edge implication under its displayed local hypotheses.
 
 The 2026-06-08 T10 soundness review records
 `accepted_packet_soundness_T10` for the single T10/F12 strict-cycle implication
@@ -166,9 +170,9 @@ under its displayed local hypotheses. It is bridge-facing because current
 bootstrap/T12 diagnostics land on T12/F16, but it does not prove the missing
 row-forcing or rich-support forcing bridge step.
 
-Together with the T01 review, the three strict-cycle notes check one self-edge
-packet and all three strict-cycle packets. T02-T09, aggregate A10 review,
-`n=9`, and global status remain review-pending.
+Together, these notes check two self-edge packets and all three strict-cycle
+packets. T03-T09, aggregate A10 review, `n=9`, and global status remain
+review-pending.
 
 ## Aggregate bookkeeping obligations
 

--- a/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
+++ b/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
@@ -111,6 +111,6 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The next useful soundness review target is T10/F12, the smallest strict-cycle
-packet. It checks the other obstruction primitive: a directed cycle in the
-selected-distance quotient rather than a reflexive strict edge.
+Follow-up soundness reviews are now recorded for T02 and for the strict-cycle
+packets T10, T11, and T12. The remaining focused local-lemma packet soundness
+review targets are the self-edge packets T03-T09.

--- a/docs/n9-vertex-circle-t02-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t02-self-edge-lemma.md
@@ -16,6 +16,10 @@ It is derived from:
 - `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
 
+An internal soundness review of this focused multi-family implication is
+recorded in
+`docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md`.
+
 The packet covers 40 assignment ids across four families:
 
 ```text

--- a/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
@@ -1,0 +1,210 @@
+# n=9 Vertex-circle T02 Soundness Review - 2026-06-08
+
+Status: `INTERNAL_REVIEW_NOTE`.
+
+Claim scope: focused internal soundness review of the T02/F01,F04,F08,F14
+local self-edge implications in
+`docs/n9-vertex-circle-t02-self-edge-lemma.md`. This note does not prove
+`n=9`, does not claim a counterexample, does not review the exhaustive
+brancher, does not review all T01-T12 packets, and does not update the
+official/global status of Erdos Problem #97.
+
+## Outcome
+
+Outcome: `accepted_packet_soundness_T02`.
+
+The T02 local implications are sound under exactly the displayed hypotheses:
+natural cyclic order on labels `0,...,8` and one of the four three-row cores
+listed below.
+
+```text
+T02/F01:
+0 -> {1,2,3,8}
+1 -> {0,2,4,7}
+8 -> {0,1,4,5}
+
+T02/F04:
+0 -> {1,2,4,6}
+1 -> {0,2,3,5}
+2 -> {1,3,4,8}
+
+T02/F08:
+0 -> {1,2,4,8}
+1 -> {0,2,3,5}
+8 -> {0,1,3,7}
+
+T02/F14:
+0 -> {1,2,6,8}
+1 -> {0,2,3,7}
+8 -> {0,1,5,7}
+```
+
+This is an internal review of one multi-family local obstruction packet. It is
+not an external independent review and it does not promote the aggregate A10
+local-lemma layer beyond the existing review-pending status.
+
+## Local Check
+
+The four families share the same proof shape: a selected-distance equality
+path identifies one row-circle outer chord with a proper subinterval chord,
+while vertex-circle monotonicity makes the outer chord strictly longer.
+
+For `F01`, rows `8`, `0`, and `1` force
+
+```text
+row 8: [1,8] = [0,8]
+row 0: [0,8] = [0,1]
+row 1: [0,1] = [1,2]
+```
+
+so
+
+```text
+[1,8] = [0,8] = [0,1] = [1,2].
+```
+
+At vertex `0`, the selected witnesses occur in angular order
+
+```text
+[1,2,3,8].
+```
+
+The chord `[1,8]` spans positions `0` to `3`, while `[1,2]` spans the proper
+subinterval `0` to `1`. Strict convexity puts this inside an angle below `pi`,
+so row `0` gives
+
+```text
+[1,8] > [1,2],
+```
+
+contradicting the equality chain.
+
+For `F04`, rows `0`, `1`, and `2` force
+
+```text
+row 0: [0,2] = [0,1]
+row 1: [0,1] = [1,2]
+row 2: [1,2] = [2,3]
+```
+
+so
+
+```text
+[0,2] = [0,1] = [1,2] = [2,3].
+```
+
+At vertex `1`, the selected witnesses occur in angular order
+
+```text
+[2,3,5,0].
+```
+
+The chord `[0,2]` spans positions `0` to `3`, while `[2,3]` spans the proper
+subinterval `0` to `1`. Therefore row `1` gives
+
+```text
+[0,2] > [2,3],
+```
+
+contradicting the equality chain.
+
+For `F08`, the equality path is the same as `F01`:
+
+```text
+[1,8] = [0,8] = [0,1] = [1,2].
+```
+
+At vertex `0`, the selected witnesses occur in angular order
+
+```text
+[1,2,4,8].
+```
+
+Thus row `0` gives the strict inequality
+
+```text
+[1,8] > [1,2],
+```
+
+again contradicting the equality chain.
+
+For `F14`, the equality path is again
+
+```text
+[1,8] = [0,8] = [0,1] = [1,2].
+```
+
+At vertex `0`, the selected witnesses occur in angular order
+
+```text
+[1,2,6,8].
+```
+
+Thus row `0` gives the strict inequality
+
+```text
+[1,8] > [1,2],
+```
+
+again contradicting the equality chain.
+
+Equivalently, each family creates a reflexive strict edge in the
+selected-distance quotient graph. No strictly convex Euclidean configuration
+can satisfy any one of the four displayed local cores.
+
+## Packet/Data Agreement
+
+The stored packet, self-edge source packet, template catalog, and mini-replay
+agree with the proof above:
+
+- template/families: `T02/F01`, `T02/F04`, `T02/F08`, and `T02/F14`;
+- assignment ids: `A001`, `A004`, `A006`, `A009`, `A011`, `A019`, `A022`,
+  `A025`, `A034`, `A035`, `A045`, `A051`, `A056`, `A058`, `A060`, `A061`,
+  `A063`, `A065`, `A070`, `A076`, `A078`, `A087`, `A092`, `A099`, `A101`,
+  `A103`, `A114`, `A115`, `A118`, `A119`, `A121`, `A136`, `A138`, `A145`,
+  `A163`, `A173`, `A176`, `A178`, `A182`, `A184`;
+- assignment counts: `F01: 18`, `F04: 18`, `F08: 2`, `F14: 2`, total `40`;
+- core size: `3` selected rows in each family;
+- equality path length: `3` selected-distance equality steps in each family;
+- strict edges: `F01`, `F08`, and `F14` use row `0` with outer pair
+  `[1,8]` and inner pair `[1,2]`; `F04` uses row `1` with outer pair `[0,2]`
+  and inner pair `[2,3]`;
+- replay statuses: all four family packets replay to `self_edge`;
+- strict edge count in the focused packet: `27`.
+
+## Commands Run
+
+```bash
+python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python -m pytest tests/test_n9_vertex_circle_t02_self_edge_lemma_packet.py tests/test_n9_t02_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+```
+
+All commands passed.
+
+## Review Boundary
+
+This review supports only the following narrow statement:
+
+```text
+Any strictly convex configuration satisfying one of the T02 local cyclic-order
+and selected-row cores is impossible by a selected-distance quotient self-edge.
+```
+
+It does not support any of the following stronger statements:
+
+- all T01-T12 packets have been mathematically reviewed;
+- the A10 local-lemma layer is fully reviewed;
+- the 184-assignment frontier is complete;
+- the vertex-circle strict-edge generator is fully reviewed;
+- no bad nonagon exists as a promoted source-of-truth claim;
+- Erdos Problem #97 is proved;
+- a counterexample is produced or certified.
+
+## Next Packet
+
+The remaining focused self-edge soundness review targets are T03-T09. After
+T02, the reviewed packet-soundness set is T01, T02, and T10-T12, while
+aggregate A10 review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
@@ -165,4 +165,4 @@ It does not support any of the following stronger statements:
 The follow-up T11/F07 and T12/F16 soundness reviews are now recorded, so the
 strict-cycle packet family has one internal soundness note for each of T10,
 T11, and T12. The remaining focused local-lemma packet soundness review
-targets are the self-edge packets T02-T09.
+targets are the self-edge packets T03-T09.

--- a/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
@@ -165,5 +165,5 @@ It does not support any of the following stronger statements:
 
 The strict-cycle packet family now has one internal soundness note for each of
 T10, T11, and T12. The remaining focused local-lemma packet soundness review
-targets are the self-edge packets T02-T09, while aggregate A10 review, `n=9`,
+targets are the self-edge packets T03-T09, while aggregate A10 review, `n=9`,
 and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
@@ -184,4 +184,4 @@ It does not support any of the following stronger statements:
 The follow-up T11/F07 soundness review is now recorded, so the strict-cycle
 packet family has one internal soundness note for each of T10, T11, and T12.
 The remaining focused local-lemma packet soundness review targets are the
-self-edge packets T02-T09.
+self-edge packets T03-T09.


### PR DESCRIPTION
## Summary

- Add an internal soundness review note for the focused T02/F01,F04,F08,F14 self-edge local lemma packet.
- Link the review from the T02 lemma, the local-lemma reviewer packet, and the docs index.
- Update existing soundness-review breadcrumbs so the reviewed packet set is T01, T02, and T10-T12, while T03-T09, aggregate A10, n=9, and global Erdos #97 status remain review-pending/open.

## Validation

- `python scripts/check_n9_vertex_circle_t02_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t02_self_edge_lemma_packet.py tests/test_n9_t02_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`