### PR TITLE
[codex] Record T03 self-edge soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -510,6 +510,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t03-self-edge-lemma.md`](n9-vertex-circle-t03-self-edge-lemma.md):
   focused review-pending T03 multi-family self-edge local lemma packet for
   proof mining.
+- [`n9-vertex-circle-t03-soundness-review-2026-06-08.md`](n9-vertex-circle-t03-soundness-review-2026-06-08.md):
+  internal soundness review accepting only the two T03 local self-edge
+  implications under their displayed hypotheses; not an A10 or `n=9`
+  promotion.
 - [`n9-t03-self-edge-minireplay.md`](n9-t03-self-edge-minireplay.md):
   minimal input-data replay of the two T03 local self-edge family packets;
   proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -47,6 +47,7 @@ auditable.
 - `docs/n9-vertex-circle-t02-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t03-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t04-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t05-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t06-self-edge-lemma.md`
@@ -156,6 +157,10 @@ The 2026-06-08 T02 soundness review records
 `accepted_packet_soundness_T02` for the four-family T02/F01,F04,F08,F14
 self-edge implication under its displayed local hypotheses.
 
+The 2026-06-08 T03 soundness review records
+`accepted_packet_soundness_T03` for the two-family T03/F05,F15 self-edge
+implication under its displayed local hypotheses.
+
 The 2026-06-08 T10 soundness review records
 `accepted_packet_soundness_T10` for the single T10/F12 strict-cycle implication
 under its displayed local hypotheses.
@@ -170,8 +175,8 @@ under its displayed local hypotheses. It is bridge-facing because current
 bootstrap/T12 diagnostics land on T12/F16, but it does not prove the missing
 row-forcing or rich-support forcing bridge step.
 
-Together, these notes check two self-edge packets and all three strict-cycle
-packets. T03-T09, aggregate A10 review, `n=9`, and global status remain
+Together, these notes check three self-edge packets and all three strict-cycle
+packets. T04-T09, aggregate A10 review, `n=9`, and global status remain
 review-pending.
 
 ## Aggregate bookkeeping obligations

--- a/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
+++ b/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
@@ -111,6 +111,6 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-Follow-up soundness reviews are now recorded for T02 and for the strict-cycle
-packets T10, T11, and T12. The remaining focused local-lemma packet soundness
-review targets are the self-edge packets T03-T09.
+Follow-up soundness reviews are now recorded for T02, T03, and for the
+strict-cycle packets T10, T11, and T12. The remaining focused local-lemma
+packet soundness review targets are the self-edge packets T04-T09.

--- a/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
@@ -205,6 +205,6 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review targets are T03-T09. After
-T02, the reviewed packet-soundness set is T01, T02, and T10-T12, while
+The remaining focused self-edge soundness review targets are T04-T09. After
+T03, the reviewed packet-soundness set is T01, T02, T03, and T10-T12, while
 aggregate A10 review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t03-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t03-self-edge-lemma.md
@@ -16,6 +16,10 @@ It is derived from:
 - `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
 
+An internal soundness review of this focused multi-family implication is
+recorded in
+`docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md`.
+
 The packet covers 20 assignment ids across two families:
 
 ```text

--- a/docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md
@@ -1,0 +1,161 @@
+# n=9 Vertex-circle T03 Soundness Review - 2026-06-08
+
+Status: `INTERNAL_REVIEW_NOTE`.
+
+Claim scope: focused internal soundness review of the T03/F05,F15 local
+self-edge implications in
+`docs/n9-vertex-circle-t03-self-edge-lemma.md`. This note does not prove
+`n=9`, does not claim a counterexample, does not review the exhaustive
+brancher, does not review all T01-T12 packets, and does not update the
+official/global status of Erdos Problem #97.
+
+## Outcome
+
+Outcome: `accepted_packet_soundness_T03`.
+
+The T03 local implications are sound under exactly the displayed hypotheses:
+natural cyclic order on labels `0,...,8` and one of the two four-row cores
+listed below.
+
+```text
+T03/F05:
+1 -> {2,5,7,8}
+2 -> {1,3,4,8}
+3 -> {0,2,4,7}
+6 -> {1,3,5,7}
+
+T03/F15:
+0 -> {1,3,4,8}
+1 -> {0,2,4,5}
+2 -> {1,3,5,6}
+3 -> {2,4,6,7}
+```
+
+This is an internal review of one multi-family local obstruction packet. It is
+not an external independent review and it does not promote the aggregate A10
+local-lemma layer beyond the existing review-pending status.
+
+## Local Check
+
+The two families share the same proof shape: a selected-distance equality path
+identifies one row-circle outer chord with a proper subinterval chord, while
+vertex-circle monotonicity makes the outer chord strictly longer.
+
+For `F05`, rows `3`, `2`, and `1` force
+
+```text
+row 3: [3,7] = [2,3]
+row 2: [2,3] = [1,2]
+row 1: [1,2] = [1,7]
+```
+
+so
+
+```text
+[3,7] = [2,3] = [1,2] = [1,7].
+```
+
+At vertex `6`, the selected witnesses occur in angular order
+
+```text
+[7,1,3,5].
+```
+
+The chord `[3,7]` spans positions `0` to `2`, while `[1,7]` spans the proper
+subinterval `0` to `1`. Strict convexity puts this inside an angle below `pi`,
+so row `6` gives
+
+```text
+[3,7] > [1,7],
+```
+
+contradicting the equality chain.
+
+For `F15`, rows `1`, `2`, and `3` force
+
+```text
+row 1: [1,4] = [1,2]
+row 2: [1,2] = [2,3]
+row 3: [2,3] = [3,4]
+```
+
+so
+
+```text
+[1,4] = [1,2] = [2,3] = [3,4].
+```
+
+At vertex `0`, the selected witnesses occur in angular order
+
+```text
+[1,3,4,8].
+```
+
+The chord `[1,4]` spans positions `0` to `2`, while `[3,4]` spans the proper
+subinterval `1` to `2`. Therefore row `0` gives
+
+```text
+[1,4] > [3,4],
+```
+
+contradicting the equality chain.
+
+Equivalently, each family creates a reflexive strict edge in the
+selected-distance quotient graph. No strictly convex Euclidean configuration
+can satisfy either displayed local core.
+
+## Packet/Data Agreement
+
+The stored packet, self-edge source packet, template catalog, and mini-replay
+agree with the proof above:
+
+- template/families: `T03/F05` and `T03/F15`;
+- assignment ids: `A005`, `A021`, `A042`, `A048`, `A054`, `A068`, `A074`,
+  `A077`, `A079`, `A104`, `A110`, `A116`, `A117`, `A124`, `A131`, `A148`,
+  `A155`, `A156`, `A181`, `A183`;
+- assignment counts: `F05: 18`, `F15: 2`, total `20`;
+- core size: `4` selected rows in each family;
+- equality path length: `3` selected-distance equality steps in each family,
+  and path length `3` for all `20` focused packet assignments;
+- strict edges: `F05` uses row `6` with outer pair `[3,7]` and inner pair
+  `[1,7]`; `F15` uses row `0` with outer pair `[1,4]` and inner pair
+  `[3,4]`;
+- replay statuses: both family packets replay to `self_edge`;
+- strict edge count in the focused packet: `36`.
+
+## Commands Run
+
+```bash
+python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
+python -m pytest tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py tests/test_n9_t03_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+```
+
+All commands passed.
+
+## Review Boundary
+
+This review supports only the following narrow statement:
+
+```text
+Any strictly convex configuration satisfying one of the T03 local cyclic-order
+and selected-row cores is impossible by a selected-distance quotient self-edge.
+```
+
+It does not support any of the following stronger statements:
+
+- all T01-T12 packets have been mathematically reviewed;
+- the A10 local-lemma layer is fully reviewed;
+- the 184-assignment frontier is complete;
+- the vertex-circle strict-edge generator is fully reviewed;
+- no bad nonagon exists as a promoted source-of-truth claim;
+- Erdos Problem #97 is proved;
+- a counterexample is produced or certified.
+
+## Next Packet
+
+The remaining focused self-edge soundness review targets are T04-T09. After
+T03, the reviewed packet-soundness set is T01, T02, T03, and T10-T12, while
+aggregate A10 review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
@@ -165,4 +165,4 @@ It does not support any of the following stronger statements:
 The follow-up T11/F07 and T12/F16 soundness reviews are now recorded, so the
 strict-cycle packet family has one internal soundness note for each of T10,
 T11, and T12. The remaining focused local-lemma packet soundness review
-targets are the self-edge packets T03-T09.
+targets are the self-edge packets T04-T09.

--- a/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
@@ -165,5 +165,5 @@ It does not support any of the following stronger statements:
 
 The strict-cycle packet family now has one internal soundness note for each of
 T10, T11, and T12. The remaining focused local-lemma packet soundness review
-targets are the self-edge packets T03-T09, while aggregate A10 review, `n=9`,
+targets are the self-edge packets T04-T09, while aggregate A10 review, `n=9`,
 and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
@@ -184,4 +184,4 @@ It does not support any of the following stronger statements:
 The follow-up T11/F07 soundness review is now recorded, so the strict-cycle
 packet family has one internal soundness note for each of T10, T11, and T12.
 The remaining focused local-lemma packet soundness review targets are the
-self-edge packets T03-T09.
+self-edge packets T04-T09.


### PR DESCRIPTION
## Summary

- add an internal T03/F05,F15 self-edge soundness review note with the narrow outcome `accepted_packet_soundness_T03`
- link the new review from the T03 lemma, the local-lemma reviewer packet, and the docs index
- update prior packet-review breadcrumbs so the remaining focused self-edge targets are T04-T09

## Validation

- `python scripts/check_n9_vertex_circle_t03_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t03_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t03_self_edge_lemma_packet.py tests/test_n9_t03_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`