### PR TITLE
[codex] Record T08 self-edge soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -558,6 +558,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t08-self-edge-lemma.md`](n9-vertex-circle-t08-self-edge-lemma.md):
   focused review-pending T08/F02 self-edge local lemma packet for proof
   mining.
+- [`n9-vertex-circle-t08-soundness-review-2026-06-09.md`](n9-vertex-circle-t08-soundness-review-2026-06-09.md):
+  internal soundness review accepting only the T08/F02 local self-edge
+  implication under its displayed hypotheses; no A10 or `n=9` status
+  promotion.
 - [`n9-t08-self-edge-minireplay.md`](n9-t08-self-edge-minireplay.md):
   minimal input-data replay of the T08/F02 local self-edge family packet;
   proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -57,6 +57,7 @@ auditable.
 - `docs/n9-vertex-circle-t07-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t07-soundness-review-2026-06-09.md`
 - `docs/n9-vertex-circle-t08-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t08-soundness-review-2026-06-09.md`
 - `docs/n9-vertex-circle-t09-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md`
@@ -181,6 +182,10 @@ The 2026-06-09 T07 soundness review records
 `accepted_packet_soundness_T07` for the single T07/F06 self-edge implication
 under its displayed local hypotheses.
 
+The 2026-06-09 T08 soundness review records
+`accepted_packet_soundness_T08` for the single T08/F02 self-edge implication
+under its displayed local hypotheses.
+
 The 2026-06-08 T10 soundness review records
 `accepted_packet_soundness_T10` for the single T10/F12 strict-cycle implication
 under its displayed local hypotheses.
@@ -195,8 +200,8 @@ under its displayed local hypotheses. It is bridge-facing because current
 bootstrap/T12 diagnostics land on T12/F16, but it does not prove the missing
 row-forcing or rich-support forcing bridge step.
 
-Together, these notes check seven self-edge packets and all three strict-cycle
-packets. T08-T09, aggregate A10 review, `n=9`, and global status remain
+Together, these notes check eight self-edge packets and all three strict-cycle
+packets. T09, aggregate A10 review, `n=9`, and global status remain
 review-pending.
 
 ## Aggregate bookkeeping obligations

--- a/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
+++ b/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
@@ -112,5 +112,5 @@ It does not support any of the following stronger statements:
 ## Next Packet
 
 Follow-up soundness reviews are now recorded for T02, T03, T04, T05, T06, T07,
-and for the strict-cycle packets T10, T11, and T12. The remaining focused
-local-lemma packet soundness review targets are the self-edge packets T08-T09.
+T08, and for the strict-cycle packets T10, T11, and T12. The remaining focused
+local-lemma packet soundness review target is the self-edge packet T09.

--- a/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
@@ -205,7 +205,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review targets are T08-T09. After
-T07, the reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07,
-and T10-T12, while aggregate A10 review, `n=9`, and global status all remain
+The remaining focused self-edge soundness review target is T09. After T08, the
+reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
+T10-T12, while aggregate A10 review, `n=9`, and global status all remain
 review-pending.

--- a/docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md
@@ -156,7 +156,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review targets are T08-T09. After
-T07, the reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07,
-and T10-T12, while aggregate A10 review, `n=9`, and global status all remain
+The remaining focused self-edge soundness review target is T09. After T08, the
+reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
+T10-T12, while aggregate A10 review, `n=9`, and global status all remain
 review-pending.

--- a/docs/n9-vertex-circle-t05-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t05-soundness-review-2026-06-09.md
@@ -118,7 +118,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review targets are T08-T09. After
-T07, the reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07,
-and T10-T12, while aggregate A10 review, `n=9`, and global status all remain
+The remaining focused self-edge soundness review target is T09. After T08, the
+reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
+T10-T12, while aggregate A10 review, `n=9`, and global status all remain
 review-pending.

--- a/docs/n9-vertex-circle-t06-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t06-soundness-review-2026-06-09.md
@@ -120,7 +120,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review targets are T08-T09. After
-T07, the reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07,
-and T10-T12, while aggregate A10 review, `n=9`, and global status all remain
+The remaining focused self-edge soundness review target is T09. After T08, the
+reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
+T10-T12, while aggregate A10 review, `n=9`, and global status all remain
 review-pending.

--- a/docs/n9-vertex-circle-t07-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t07-soundness-review-2026-06-09.md
@@ -120,7 +120,7 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review targets are T08-T09. After
-T07, the reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07,
-and T10-T12, while aggregate A10 review, `n=9`, and global status all remain
+The remaining focused self-edge soundness review target is T09. After T08, the
+reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
+T10-T12, while aggregate A10 review, `n=9`, and global status all remain
 review-pending.

--- a/docs/n9-vertex-circle-t08-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t08-self-edge-lemma.md
@@ -16,6 +16,9 @@ derived from:
 - `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
 
+An internal soundness review of this focused implication is recorded in
+`docs/n9-vertex-circle-t08-soundness-review-2026-06-09.md`.
+
 The template covers 18 assignment ids:
 
 ```text

--- a/docs/n9-vertex-circle-t08-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t08-soundness-review-2026-06-09.md
@@ -1,26 +1,28 @@
-# n=9 Vertex-circle T04 Soundness Review - 2026-06-08
+# n=9 Vertex-circle T08 Soundness Review - 2026-06-09
 
 Status: `INTERNAL_REVIEW_NOTE`.
 
-Claim scope: focused internal soundness review of the T04/F13 local self-edge
-implication in `docs/n9-vertex-circle-t04-self-edge-lemma.md`. This note does
+Claim scope: focused internal soundness review of the T08/F02 local self-edge
+implication in `docs/n9-vertex-circle-t08-self-edge-lemma.md`. This note does
 not prove `n=9`, does not claim a counterexample, does not review the
 exhaustive brancher, does not review all T01-T12 packets, and does not update
 the official/global status of Erdos Problem #97.
 
 ## Outcome
 
-Outcome: `accepted_packet_soundness_T04`.
+Outcome: `accepted_packet_soundness_T08`.
 
-The T04/F13 local implication is sound under exactly the displayed hypotheses:
-natural cyclic order on labels `0,...,8` and the four-row core listed below.
+The T08/F02 local implication is sound under exactly the displayed hypotheses:
+natural cyclic order on labels `0,...,8` and the six-row core listed below.
 
 ```text
-T04/F13:
-0 -> {1,2,5,7}
-1 -> {2,3,6,8}
-3 -> {1,4,5,8}
-5 -> {1,3,6,7}
+T08/F02:
+0 -> {1,2,3,8}
+1 -> {0,3,4,7}
+2 -> {1,3,5,6}
+5 -> {2,4,6,7}
+6 -> {1,5,7,8}
+7 -> {0,1,4,6}
 ```
 
 This is an internal review of one local obstruction packet. It is not an
@@ -33,32 +35,34 @@ The packet has the selected-path self-edge proof shape: a selected-distance
 equality path identifies one row-circle outer chord with a proper subinterval
 chord, while vertex-circle monotonicity makes the outer chord strictly longer.
 
-Rows `5`, `3`, and `1` force
+Rows `1`, `7`, `6`, `5`, and `2` force
 
 ```text
-row 5: [1,5] = [3,5]
-row 3: [3,5] = [1,3]
-row 1: [1,3] = [1,2]
+row 1: [1,3] = [1,7]
+row 7: [1,7] = [6,7]
+row 6: [6,7] = [5,6]
+row 5: [5,6] = [2,5]
+row 2: [2,5] = [1,2]
 ```
 
 so
 
 ```text
-[1,5] = [3,5] = [1,3] = [1,2].
+[1,3] = [1,7] = [6,7] = [5,6] = [2,5] = [1,2].
 ```
 
 At vertex `0`, the selected witnesses occur in angular order
 
 ```text
-[1,2,5,7].
+[1,2,3,8].
 ```
 
-The chord `[1,5]` spans positions `0` to `2`, while `[1,2]` spans the proper
+The chord `[1,3]` spans positions `0` to `2`, while `[1,2]` spans the proper
 subinterval `0` to `1`. Strict convexity puts this inside an angle below `pi`,
 so row `0` gives
 
 ```text
-[1,5] > [1,2],
+[1,3] > [1,2],
 ```
 
 contradicting the equality chain.
@@ -72,25 +76,27 @@ can satisfy the displayed local core.
 The stored packet, self-edge source packet, template catalog, and mini-replay
 agree with the proof above:
 
-- template/family: `T04/F13`;
-- assignment ids: `A023` and `A174`;
-- assignment counts: `F13: 2`, total `2`;
-- core size: `4` selected rows;
-- equality path length: `3` selected-distance equality steps, and path length
-  `3` for both focused packet assignments;
-- strict edge: `F13` uses row `0` with outer pair `[1,5]` and inner pair
+- template/family: `T08/F02`;
+- assignment ids: `A002`, `A012`, `A043`, `A050`, `A067`, `A084`, `A085`,
+  `A086`, `A096`, `A106`, `A109`, `A122`, `A132`, `A134`, `A143`, `A149`,
+  `A150`, `A159`;
+- assignment counts: `F02: 18`, total `18`;
+- core size: `6` selected rows;
+- equality path length: `5` selected-distance equality steps, and path length
+  `5` for all `18` focused packet assignments;
+- strict edge: `F02` uses row `0` with outer pair `[1,3]` and inner pair
   `[1,2]`;
 - replay status: the family packet replays to `self_edge`;
-- strict edge count in the focused packet: `36`.
+- strict edge count in the focused packet: `54`.
 
 ## Commands Run
 
 ```bash
-python scripts/check_n9_vertex_circle_t04_self_edge_lemma_packet.py --check --assert-expected --json
-python scripts/check_n9_t04_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
-python -m pytest tests/test_n9_vertex_circle_t04_self_edge_lemma_packet.py tests/test_n9_t04_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+python -m pytest tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py tests/test_n9_t08_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
 ```
 
 All commands passed.
@@ -100,7 +106,7 @@ All commands passed.
 This review supports only the following narrow statement:
 
 ```text
-Any strictly convex configuration satisfying the T04/F13 local cyclic-order
+Any strictly convex configuration satisfying the T08/F02 local cyclic-order
 and selected-row core is impossible by a selected-distance quotient self-edge.
 ```
 

--- a/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
@@ -165,4 +165,4 @@ It does not support any of the following stronger statements:
 The follow-up T11/F07 and T12/F16 soundness reviews are now recorded, so the
 strict-cycle packet family has one internal soundness note for each of T10,
 T11, and T12. The remaining focused local-lemma packet soundness review
-targets are the self-edge packets T08-T09.
+target is the self-edge packet T09.

--- a/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
@@ -165,5 +165,5 @@ It does not support any of the following stronger statements:
 
 The strict-cycle packet family now has one internal soundness note for each of
 T10, T11, and T12. The remaining focused local-lemma packet soundness review
-targets are the self-edge packets T08-T09, while aggregate A10 review, `n=9`,
+target is the self-edge packet T09, while aggregate A10 review, `n=9`,
 and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
@@ -183,5 +183,5 @@ It does not support any of the following stronger statements:
 
 The follow-up T11/F07 soundness review is now recorded, so the strict-cycle
 packet family has one internal soundness note for each of T10, T11, and T12.
-The remaining focused local-lemma packet soundness review targets are the
-self-edge packets T08-T09.
+The remaining focused local-lemma packet soundness review target is the
+self-edge packet T09.


### PR DESCRIPTION
## Summary
- add an internal soundness review note for the T08/F02 local self-edge implication
- cross-link the T08 review from the packet docs and docs index
- update prior packet breadcrumbs so the remaining self-edge review target is T09

## Validation
- `python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py tests/test_n9_t08_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`