### PR TITLE
[codex] Record T09 self-edge soundness review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -568,6 +568,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-t09-self-edge-lemma.md`](n9-vertex-circle-t09-self-edge-lemma.md):
   focused review-pending T09/F03 self-edge local lemma packet for proof
   mining.
+- [`n9-vertex-circle-t09-soundness-review-2026-06-09.md`](n9-vertex-circle-t09-soundness-review-2026-06-09.md):
+  internal soundness review accepting only the T09/F03 local self-edge
+  implication under its displayed hypotheses; no A10 or `n=9` status
+  promotion.
 - [`n9-t09-self-edge-minireplay.md`](n9-t09-self-edge-minireplay.md):
   minimal input-data replay of the T09/F03 local self-edge family packet;
   proof-mining scaffolding only.

--- a/docs/n9-vertex-circle-local-lemma-review-packet.md
+++ b/docs/n9-vertex-circle-local-lemma-review-packet.md
@@ -59,6 +59,7 @@ auditable.
 - `docs/n9-vertex-circle-t08-self-edge-lemma.md`
 - `docs/n9-vertex-circle-t08-soundness-review-2026-06-09.md`
 - `docs/n9-vertex-circle-t09-self-edge-lemma.md`
+- `docs/n9-vertex-circle-t09-soundness-review-2026-06-09.md`
 - `docs/n9-vertex-circle-t10-strict-cycle-lemma.md`
 - `docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md`
 - `docs/n9-vertex-circle-t11-strict-cycle-lemma.md`
@@ -186,6 +187,10 @@ The 2026-06-09 T08 soundness review records
 `accepted_packet_soundness_T08` for the single T08/F02 self-edge implication
 under its displayed local hypotheses.
 
+The 2026-06-09 T09 soundness review records
+`accepted_packet_soundness_T09` for the single T09/F03 self-edge implication
+under its displayed local hypotheses.
+
 The 2026-06-08 T10 soundness review records
 `accepted_packet_soundness_T10` for the single T10/F12 strict-cycle implication
 under its displayed local hypotheses.
@@ -200,8 +205,9 @@ under its displayed local hypotheses. It is bridge-facing because current
 bootstrap/T12 diagnostics land on T12/F16, but it does not prove the missing
 row-forcing or rich-support forcing bridge step.
 
-Together, these notes check eight self-edge packets and all three strict-cycle
-packets. T09, aggregate A10 review, `n=9`, and global status remain
+Together, these notes check all nine self-edge packets and all three
+strict-cycle packets. Focused packet-soundness notes are now recorded for
+T01-T12, while aggregate A10 review, `n=9`, and global status remain
 review-pending.
 
 ## Aggregate bookkeeping obligations

--- a/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
+++ b/docs/n9-vertex-circle-t01-soundness-review-2026-06-07.md
@@ -112,5 +112,6 @@ It does not support any of the following stronger statements:
 ## Next Packet
 
 Follow-up soundness reviews are now recorded for T02, T03, T04, T05, T06, T07,
-T08, and for the strict-cycle packets T10, T11, and T12. The remaining focused
-local-lemma packet soundness review target is the self-edge packet T09.
+T08, T09, and for the strict-cycle packets T10, T11, and T12. Focused
+packet-soundness notes are now recorded for T01-T12, while aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t02-soundness-review-2026-06-08.md
@@ -205,7 +205,5 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review target is T09. After T08, the
-reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
-T10-T12, while aggregate A10 review, `n=9`, and global status all remain
-review-pending.
+Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t03-soundness-review-2026-06-08.md
@@ -156,7 +156,5 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review target is T09. After T08, the
-reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
-T10-T12, while aggregate A10 review, `n=9`, and global status all remain
-review-pending.
+Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t04-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t04-soundness-review-2026-06-08.md
@@ -116,7 +116,5 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review target is T09. After T08, the
-reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
-T10-T12, while aggregate A10 review, `n=9`, and global status all remain
-review-pending.
+Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t05-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t05-soundness-review-2026-06-09.md
@@ -118,7 +118,5 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review target is T09. After T08, the
-reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
-T10-T12, while aggregate A10 review, `n=9`, and global status all remain
-review-pending.
+Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t06-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t06-soundness-review-2026-06-09.md
@@ -120,7 +120,5 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review target is T09. After T08, the
-reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
-T10-T12, while aggregate A10 review, `n=9`, and global status all remain
-review-pending.
+Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t07-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t07-soundness-review-2026-06-09.md
@@ -120,7 +120,5 @@ It does not support any of the following stronger statements:
 
 ## Next Packet
 
-The remaining focused self-edge soundness review target is T09. After T08, the
-reviewed packet-soundness set is T01, T02, T03, T04, T05, T06, T07, T08, and
-T10-T12, while aggregate A10 review, `n=9`, and global status all remain
-review-pending.
+Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
+review, `n=9`, and global status all remain review-pending.

--- a/docs/n9-vertex-circle-t09-self-edge-lemma.md
+++ b/docs/n9-vertex-circle-t09-self-edge-lemma.md
@@ -16,6 +16,9 @@ derived from:
 - `data/certificates/n9_vertex_circle_self_edge_template_packet.json`
 - `data/certificates/n9_vertex_circle_template_lemma_catalog.json`
 
+An internal soundness review of this focused implication is recorded in
+`docs/n9-vertex-circle-t09-soundness-review-2026-06-09.md`.
+
 The template covers 18 assignment ids:
 
 ```text

--- a/docs/n9-vertex-circle-t09-soundness-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-t09-soundness-review-2026-06-09.md
@@ -1,28 +1,28 @@
-# n=9 Vertex-circle T08 Soundness Review - 2026-06-09
+# n=9 Vertex-circle T09 Soundness Review - 2026-06-09
 
 Status: `INTERNAL_REVIEW_NOTE`.
 
-Claim scope: focused internal soundness review of the T08/F02 local self-edge
-implication in `docs/n9-vertex-circle-t08-self-edge-lemma.md`. This note does
+Claim scope: focused internal soundness review of the T09/F03 local self-edge
+implication in `docs/n9-vertex-circle-t09-self-edge-lemma.md`. This note does
 not prove `n=9`, does not claim a counterexample, does not review the
-exhaustive brancher, does not review all T01-T12 packets, and does not update
-the official/global status of Erdos Problem #97.
+exhaustive brancher, does not review all aggregate local-lemma obligations, and
+does not update the official/global status of Erdos Problem #97.
 
 ## Outcome
 
-Outcome: `accepted_packet_soundness_T08`.
+Outcome: `accepted_packet_soundness_T09`.
 
-The T08/F02 local implication is sound under exactly the displayed hypotheses:
+The T09/F03 local implication is sound under exactly the displayed hypotheses:
 natural cyclic order on labels `0,...,8` and the six-row core listed below.
 
 ```text
-T08/F02:
+T09/F03:
 0 -> {1,2,3,8}
-1 -> {0,3,4,7}
-2 -> {1,3,5,6}
-5 -> {2,4,6,7}
-6 -> {1,5,7,8}
-7 -> {0,1,4,6}
+1 -> {0,3,5,7}
+2 -> {1,3,4,6}
+3 -> {2,4,5,8}
+4 -> {0,3,6,8}
+8 -> {0,1,4,7}
 ```
 
 This is an internal review of one local obstruction packet. It is not an
@@ -35,20 +35,21 @@ The packet has the selected-path self-edge proof shape: a selected-distance
 equality path identifies one row-circle outer chord with a proper subinterval
 chord, while vertex-circle monotonicity makes the outer chord strictly longer.
 
-Rows `1`, `7`, `6`, `5`, and `2` force
+Rows `1`, `0`, `8`, `4`, `3`, and `2` force
 
 ```text
-row 1: [1,3] = [1,7]
-row 7: [1,7] = [6,7]
-row 6: [6,7] = [5,6]
-row 5: [5,6] = [2,5]
-row 2: [2,5] = [1,2]
+row 1: [1,3] = [0,1]
+row 0: [0,1] = [0,8]
+row 8: [0,8] = [4,8]
+row 4: [4,8] = [3,4]
+row 3: [3,4] = [2,3]
+row 2: [2,3] = [1,2]
 ```
 
 so
 
 ```text
-[1,3] = [1,7] = [6,7] = [5,6] = [2,5] = [1,2].
+[1,3] = [0,1] = [0,8] = [4,8] = [3,4] = [2,3] = [1,2].
 ```
 
 At vertex `0`, the selected witnesses occur in angular order
@@ -76,15 +77,15 @@ can satisfy the displayed local core.
 The stored packet, self-edge source packet, template catalog, and mini-replay
 agree with the proof above:
 
-- template/family: `T08/F02`;
-- assignment ids: `A002`, `A012`, `A043`, `A050`, `A067`, `A084`, `A085`,
-  `A086`, `A096`, `A106`, `A109`, `A122`, `A132`, `A134`, `A143`, `A149`,
-  `A150`, `A159`;
-- assignment counts: `F02: 18`, total `18`;
+- template/family: `T09/F03`;
+- assignment ids: `A003`, `A010`, `A017`, `A030`, `A033`, `A044`, `A049`,
+  `A073`, `A107`, `A108`, `A123`, `A130`, `A135`, `A142`, `A144`, `A160`,
+  `A161`, `A169`;
+- assignment counts: `F03: 18`, total `18`;
 - core size: `6` selected rows;
-- equality path length: `5` selected-distance equality steps, and path length
-  `5` for all `18` focused packet assignments;
-- strict edge: `F02` uses row `0` with outer pair `[1,3]` and inner pair
+- equality path length: `6` selected-distance equality steps, and path length
+  `6` for all `18` focused packet assignments;
+- strict edge: `F03` uses row `0` with outer pair `[1,3]` and inner pair
   `[1,2]`;
 - replay status: the family packet replays to `self_edge`;
 - strict edge count in the focused packet: `54`.
@@ -92,11 +93,11 @@ agree with the proof above:
 ## Commands Run
 
 ```bash
-python scripts/check_n9_vertex_circle_t08_self_edge_lemma_packet.py --check --assert-expected --json
-python scripts/check_n9_t08_self_edge_minireplay.py --check --assert-expected --json
+python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json
+python scripts/check_n9_t09_self_edge_minireplay.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json
 python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json
-python -m pytest tests/test_n9_vertex_circle_t08_self_edge_lemma_packet.py tests/test_n9_t08_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
+python -m pytest tests/test_n9_vertex_circle_t09_self_edge_lemma_packet.py tests/test_n9_t09_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"
 ```
 
 All commands passed.
@@ -106,16 +107,16 @@ All commands passed.
 This review supports only the following narrow statement:
 
 ```text
-Any strictly convex configuration satisfying the T08/F02 local cyclic-order
+Any strictly convex configuration satisfying the T09/F03 local cyclic-order
 and selected-row core is impossible by a selected-distance quotient self-edge.
 ```
 
 It does not support any of the following stronger statements:
 
-- all T01-T12 packets have been mathematically reviewed;
 - the A10 local-lemma layer is fully reviewed;
 - the 184-assignment frontier is complete;
 - the vertex-circle strict-edge generator is fully reviewed;
+- the exhaustive brancher is sound;
 - no bad nonagon exists as a promoted source-of-truth claim;
 - Erdos Problem #97 is proved;
 - a counterexample is produced or certified.
@@ -123,4 +124,6 @@ It does not support any of the following stronger statements:
 ## Next Step
 
 Focused packet-soundness notes are now recorded for T01-T12. Aggregate A10
-review, `n=9`, and global status all remain review-pending.
+review, frontier coverage, `n=9`, and global status all remain review-pending.
+The next review layer is the aggregate local-lemma scan and its cross-artifact
+handoffs, not a proof or counterexample claim.

--- a/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t10-soundness-review-2026-06-08.md
@@ -164,5 +164,6 @@ It does not support any of the following stronger statements:
 
 The follow-up T11/F07 and T12/F16 soundness reviews are now recorded, so the
 strict-cycle packet family has one internal soundness note for each of T10,
-T11, and T12. The remaining focused local-lemma packet soundness review
-target is the self-edge packet T09.
+T11, and T12. Focused packet-soundness notes are now recorded for T01-T12,
+while aggregate A10 review, `n=9`, and global status all remain
+review-pending.

--- a/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t11-soundness-review-2026-06-08.md
@@ -164,6 +164,6 @@ It does not support any of the following stronger statements:
 ## Next Packet
 
 The strict-cycle packet family now has one internal soundness note for each of
-T10, T11, and T12. The remaining focused local-lemma packet soundness review
-target is the self-edge packet T09, while aggregate A10 review, `n=9`,
-and global status all remain review-pending.
+T10, T11, and T12. Focused packet-soundness notes are now recorded for
+T01-T12, while aggregate A10 review, `n=9`, and global status all remain
+review-pending.

--- a/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
+++ b/docs/n9-vertex-circle-t12-soundness-review-2026-06-08.md
@@ -183,5 +183,5 @@ It does not support any of the following stronger statements:
 
 The follow-up T11/F07 soundness review is now recorded, so the strict-cycle
 packet family has one internal soundness note for each of T10, T11, and T12.
-The remaining focused local-lemma packet soundness review target is the
-self-edge packet T09.
+Focused packet-soundness notes are now recorded for T01-T12, while aggregate
+A10 review, `n=9`, and global status all remain review-pending.


### PR DESCRIPTION
## Summary
- add an internal soundness review note for the T09/F03 local self-edge implication
- cross-link the T09 review from the packet docs and docs index
- update prior packet breadcrumbs to record that focused packet-soundness notes now exist for T01-T12 while aggregate A10 review remains pending

## Validation
- `python scripts/check_n9_vertex_circle_t09_self_edge_lemma_packet.py --check --assert-expected --json`
- `python scripts/check_n9_t09_self_edge_minireplay.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_self_edge_template_packet.py --check --assert-expected --json`
- `python scripts/check_n9_vertex_circle_template_lemma_catalog.py --check --assert-expected --json`
- `python -m pytest tests/test_n9_vertex_circle_t09_self_edge_lemma_packet.py tests/test_n9_t09_self_edge_minireplay.py tests/test_n9_vertex_circle_self_edge_template_packet.py tests/test_n9_vertex_circle_template_lemma_catalog.py -q -m "artifact"`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `git diff --cached --check`
- `python -m ruff check .`
- `python -m pytest -q`