### PR TITLE
[codex] Record A8 strict-edge geometry review

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -30,7 +30,10 @@ minimal/rich-class hypotheses.
 1. Use the 2026-06-09 internal aggregate A10 review note as input for an
    explicit source-of-truth A10 gate decision, keeping any decision scoped as
    proof-mining scaffolding under stored-frontier and strict-edge assumptions
-   rather than an `n=9` proof. Start from
+   rather than an `n=9` proof. The 2026-06-09 internal A8 review note now
+   records the local nested-chord strict-edge rule and checker-equivalence
+   contract as internally accepted, but it does not close the
+   `vertex_circle_geometry` gate without an explicit written decision. Start from
    `docs/n9-vertex-circle-local-lemma-review-packet.md`, which records the
    current five-layer audit path and review boundary. The aggregate note
    records the focused T01-T12 packet-soundness notes plus the A10 bookkeeping
@@ -129,8 +132,9 @@ minimal/rich-class hypotheses.
    The strict-edge geometry replay
    `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
    independently checks the proper-interval strict-edge generator for all
-   candidate selected rows; use `--json` when the full mismatch example block
-   is needed.
+   candidate selected rows; the 2026-06-09 internal A8 review note records the
+   corresponding local geometry review without closing the formal gate. Use
+   `--json` when the full mismatch example block is needed.
    The quotient-soundness replay
    `python scripts/check_n9_vertex_circle_quotient_soundness.py --check --assert-expected --summary-json`
    checks selected-distance quotient status agreement on the stored local-core

--- a/docs/index.md
+++ b/docs/index.md
@@ -467,6 +467,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-strict-edge-geometry-audit.md`](n9-vertex-circle-strict-edge-geometry-audit.md):
   local geometric audit of the vertex-circle proper-interval strict-edge rule
   used by the exhaustive `n=9` vertex-circle checker.
+- [`n9-vertex-circle-a8-strict-edge-review-2026-06-09.md`](n9-vertex-circle-a8-strict-edge-review-2026-06-09.md):
+  internal review note accepting the local A8 nested-chord strict-edge rule
+  and checker-equivalence contract while leaving the formal review gate,
+  A6/A7, quotient soundness, `n=9`, and global status open.
 - [`n9-vertex-circle-quotient-soundness-audit.md`](n9-vertex-circle-quotient-soundness-audit.md):
   quotient-graph soundness audit for selected-distance unioning, self-edge
   contradictions, directed strict-cycle contradictions, and the diagnostic

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -220,6 +220,11 @@ The strict-edge geometry audit should confirm:
 - strict-edge mismatches and quotient-replay strict-edge mismatches are both
   `0`.
 
+The 2026-06-09 internal A8 review note records acceptance of that local
+nested-chord rule and checker-equivalence contract only. It does not close the
+machine-readable `vertex_circle_geometry` gate without an explicit written
+review decision.
+
 The quotient/local-lemma audits should confirm:
 
 - the self-edge/strict-cycle split remains `158 + 26`;

--- a/docs/n9-vertex-circle-a8-strict-edge-review-2026-06-09.md
+++ b/docs/n9-vertex-circle-a8-strict-edge-review-2026-06-09.md
@@ -1,0 +1,134 @@
+# n=9 Vertex-circle A8 Strict-edge Review - 2026-06-09
+
+Status: `INTERNAL_REVIEW_NOTE`.
+
+Claim scope: internal review of the A8 vertex-circle strict-edge geometry rule
+used by the review-pending `n=9` vertex-circle checker. This note reviews the
+local nested-chord implication and its implementation as a proper-interval
+strict-edge generator. It does not review row coverage, brancher coverage,
+A6/A7 source-frontier enumeration, selected-distance quotient soundness, A10
+local-lemma completeness, the exhaustive `n=9` brancher, `n=9`, a
+counterexample, or the official/global status of Erdos Problem #97.
+
+## Outcome
+
+Outcome: `accepted_A8_strict_edge_geometry_internal`.
+
+The internal review accepts the local statement that, for a selected row
+whose witnesses lie on one circle centered at the row center, proper interval
+containment in the cyclic witness order forces a strict ordinary-distance
+inequality between the corresponding witness chords. It also accepts that the
+repo-native checker and reusable quotient replay enumerate exactly that
+proper-containment rule for the current `n=9` selected-row universe.
+
+This is not an external review-decision record. The machine-readable
+`vertex_circle_geometry` gate in `metadata/n9_review_gate_ledger.yaml` remains
+open until an explicit written decision is validated through the review-decision
+intake or an equivalent source-of-truth review process.
+
+## Geometry Reviewed
+
+For a strictly convex polygon, fix a vertex `c` and four selected witnesses
+`w0,w1,w2,w3` that lie on a circle centered at `p_c`. The other vertices have
+distinct angular coordinates around `p_c` in an interval of length less than
+`pi`, ordered by the polygon cyclic order up to reversal.
+
+For two selected witnesses with angular separation `theta`, their chord length
+on the selected circle is:
+
+```text
+2R sin(theta / 2).
+```
+
+On `0 < theta < pi`, this is strictly increasing. Therefore if witness
+interval `[r,s]` properly contains `[u,v]` in the selected-witness order, the
+ordinary chord distance for `{w_r,w_s}` is strictly larger than the ordinary
+chord distance for `{w_u,w_v}`.
+
+The rule is invariant under reversing the witness order, so sorting witnesses
+by cyclic position relative to `c` is enough to choose one of the two equivalent
+orientations.
+
+## Implementation Reviewed
+
+The reviewed implementation contract is:
+
+```text
+outer_start <= inner_start
+and inner_end <= outer_end
+and (outer_start < inner_start or inner_end < outer_end)
+```
+
+The exhaustive checker builds `STRICT_EDGES` by sorting each row's witnesses
+relative to the center and adding exactly the outer/inner pair distances that
+satisfy this condition. The quotient replay helper uses the same condition
+after sorting witnesses in the supplied cyclic order.
+
+For four witnesses, the six witness intervals yield nine strict comparisons
+per selected row:
+
+```text
+outer span 2, inner span 1: 4
+outer span 3, inner span 1: 3
+outer span 3, inner span 2: 2
+```
+
+No non-contained interval comparison is accepted by this review; such a
+comparison is not forced by cyclic order alone.
+
+## Commands Run
+
+```bash
+python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json
+python scripts/check_n9_review_gate_ledger.py --check --summary-json
+python scripts/check_n9_candidate_review_manifest.py --check --summary-json
+python scripts/check_n9_review_decision_intake.py --check --summary-json
+```
+
+## Stable Invariants Observed
+
+- Strict-edge geometry audit validation status: `passed`.
+- Selected rows checked: `630`.
+- Strict edges per selected row: `{9: 630}`.
+- Total direct strict edges checked: `5670`.
+- Strict-edge table mismatches: `0`.
+- One-row quotient replay strict-edge count mismatches: `0`.
+- Interval-span histogram:
+  - `2->1: 2520`;
+  - `3->1: 1890`;
+  - `3->2: 1260`.
+- Review-gate ledger validation status: `passed`.
+- Candidate review manifest validation status: `passed`.
+- Review-decision intake validation status: `passed`.
+
+## Narrow Statement Supported
+
+This pass supports the following narrow internal-review statement:
+
+```text
+For the current n=9 selected-row universe, the vertex-circle proper-interval
+strict-edge rule is geometrically sound, and the exhaustive checker plus
+quotient replay helper enumerate that local rule without strict-edge table or
+one-row replay-count drift.
+```
+
+## Review Boundary
+
+This pass does not support any of the following stronger statements:
+
+- the A6/A7 source-frontier enumeration is reviewed;
+- the selected-distance quotient implementation is reviewed;
+- the A10 local-lemma packet chain is promoted as a source-of-truth gate;
+- the full vertex-circle route is accepted;
+- the turn-packing route is accepted;
+- no bad nonagon exists as a promoted source-of-truth claim;
+- Erdos Problem #97 is proved;
+- any counterexample is produced or certified;
+- the official/global status changes.
+
+## Next Review Step
+
+The next source-of-truth step is either an explicit `vertex_circle_geometry`
+gate decision using the review-decision intake, or upstream review of the
+A6/A7 source-frontier enumeration so the internally reviewed A8 and A10 layers
+can be placed in the full vertex-circle route.

--- a/docs/n9-vertex-circle-strict-edge-geometry-audit.md
+++ b/docs/n9-vertex-circle-strict-edge-geometry-audit.md
@@ -138,6 +138,11 @@ This audit checks implementation agreement with the strict-edge lemma. It
 does not audit the later selected-distance quotient graph, self-edge
 criterion, strict-cycle criterion, or exhaustive assignment coverage.
 
+A 2026-06-09 internal review note records
+`accepted_A8_strict_edge_geometry_internal` for this local strict-edge rule
+and checker-equivalence contract. The machine-readable `vertex_circle_geometry`
+gate remains open until an explicit written review decision is supplied.
+
 ## Scope
 
 This audit covers only the local vertex-circle strict-edge generation rule:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -325,6 +325,11 @@ review selected-distance quotient soundness, branch coverage, the crossing
 filters, prove `n=9`, or complete review. Use `--json` instead when the full
 mismatch example block is needed.
 
+The 2026-06-09 internal A8 review note records
+`accepted_A8_strict_edge_geometry_internal` for the local nested-chord rule
+and checker-equivalence contract. Treat it as input to a formal
+review-decision record, not as a source-of-truth gate closure.
+
 Current quotient-soundness audit:
 
 ```bash


### PR DESCRIPTION
## Summary
- add an internal A8 strict-edge geometry review note for the vertex-circle nested-chord rule
- cross-link the note from the strict-edge audit, review packet, docs index, review priorities, and backlog
- keep the `vertex_circle_geometry` gate explicitly open pending written review-decision intake

## Validation
- `python scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --summary-json`
- `python scripts/check_n9_review_gate_ledger.py --check --summary-json`
- `python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `python scripts/check_n9_review_decision_intake.py --check --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_strict_edge_geometry.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `git diff --cached --check`
- `python -m ruff check .`
- `python -m pytest -q`