### PR TITLE
[codex] Add vertex-circle decision preflight

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -27,7 +27,9 @@ claim-neutral ledger for choosing bridge work. Prefer PRs that prove one of
 its named lemma contracts or reject one of its negative controls under explicit
 minimal/rich-class hypotheses.
 
-1. Use the 2026-06-09 internal A6/A7, A8, and A10 review notes as input for an
+1. Use the vertex-circle route decision preflight
+   `python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
+   to hand the 2026-06-09 internal A6/A7, A8, and A10 review notes into an
    explicit vertex-circle route gate decision, keeping any decision scoped as
    repo-local `n=9` review infrastructure rather than a general proof. The
    A6/A7 note records the source-frontier enumeration evidence bundle, the A8

--- a/docs/index.md
+++ b/docs/index.md
@@ -492,6 +492,9 @@ put detailed reconciliation in the canonical synthesis.
   soundness notes plus the A10 bookkeeping handoff under stored-frontier and
   strict-edge assumptions; not a source-of-truth A10, `n=9`, or global-status
   promotion.
+- [`n9-vertex-circle-route-decision-preflight.md`](n9-vertex-circle-route-decision-preflight.md):
+  checked handoff preflight joining the internal A6/A7, A8, and A10 review
+  notes to the still-open vertex-circle route decision-intake requirements.
 - [`n9-vertex-circle-certificate-chain.md`](n9-vertex-circle-certificate-chain.md):
   assignment-id bridge from the review-pending `n=9` frontier artifacts to the
   12 local quotient-obstruction templates.

--- a/docs/n9-review-decision-intake.md
+++ b/docs/n9-review-decision-intake.md
@@ -51,6 +51,17 @@ Render the Markdown worksheet to stdout:
 python scripts/check_n9_review_decision_intake.py --markdown
 ```
 
+Preflight the vertex-circle route handoff before filling a decision record:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+```
+
+The preflight checks that the internal A6/A7, A8, and A10 review notes are
+present and boundary-safe, that the relevant route gates remain open, and that
+`accepted_vertex_circle_route` still requires `independent_review`. It does not
+accept any gate or replace a written decision.
+
 ## Boundary
 
 Even a valid final decision record is only intake validation. An accepted

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -102,6 +102,13 @@ Print a fillable template with
 filled external decision with
 `python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json`.
 
+The vertex-circle route decision preflight is
+`docs/n9-vertex-circle-route-decision-preflight.md`, checked by
+`python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`.
+It verifies that the internal A6/A7, A8, and A10 review notes are present,
+that the route gates remain open, and that `accepted_vertex_circle_route`
+still requires written independent review. It is not a decision record.
+
 ## Review routes
 
 ### Route A: vertex-circle closure

--- a/docs/n9-vertex-circle-route-decision-preflight.md
+++ b/docs/n9-vertex-circle-route-decision-preflight.md
@@ -1,0 +1,56 @@
+# n=9 Vertex-circle Route Decision Preflight
+
+Status: `REVIEW_PREFLIGHT_ONLY`.
+
+Claim scope: reviewer handoff preflight for the review-pending `n=9`
+vertex-circle route. This note does not accept any review gate, does not prove
+`n=9`, does not prove Erdos Problem #97, does not claim a counterexample, and
+does not update the official/global status.
+
+## Purpose
+
+The internal A6/A7, A8, and A10 review notes now cover the current
+vertex-circle route evidence bundle:
+
+- A6/A7 source-frontier enumeration:
+  `docs/n9-vertex-circle-a6-a7-frontier-review-2026-06-09.md`;
+- A8 strict-edge geometry:
+  `docs/n9-vertex-circle-a8-strict-edge-review-2026-06-09.md`;
+- A10 quotient-obstruction packet chain:
+  `docs/n9-vertex-circle-a10-aggregate-review-2026-06-09.md`.
+
+Those notes are internal review evidence only. A source-of-truth route decision
+still needs a written independent review record validated by the decision
+intake.
+
+## Checked Preflight
+
+Run:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+```
+
+The preflight checks that:
+
+- the three internal review notes exist and retain their expected internal
+  outcomes and boundary language;
+- the ledger keeps `frontier_enumeration`, `vertex_circle_geometry`,
+  `quotient_obstruction_replay`, and `independent_review` open;
+- the `accepted_vertex_circle_route` decision-intake rule requires all four of
+  those accepted gates;
+- a schema-only draft shape for `accepted_vertex_circle_route` validates as a
+  decision record shape, without recording or implying a real decision.
+
+## Decision Boundary
+
+The next required external artifact remains a filled decision record checked by:
+
+```bash
+python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
+```
+
+Even a valid accepted route decision would only support a separate
+source-of-truth proposal for the repo-local `n=9` finite case. It would not
+prove Erdos Problem #97 for all larger polygons or change the official/global
+status.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -130,6 +130,10 @@ detection only and does not replace written independent review.
 The decision-intake aid `docs/n9-review-decision-intake.md` validates any
 external written-review record against the open gate ledger and allowed
 outcomes; it is still intake validation only.
+The vertex-circle route preflight
+`docs/n9-vertex-circle-route-decision-preflight.md` checks that the internal
+A6/A7, A8, and A10 notes are ready to hand to the decision intake while the
+route gates remain open and independent written review remains required.
 
 The 2026-05-03 archive bundle has been refactored into a repo-native checker
 that leaves 0 full `n=9` selected-witness assignments after exact

--- a/scripts/check_n9_vertex_circle_route_decision_preflight.py
+++ b/scripts/check_n9_vertex_circle_route_decision_preflight.py
@@ -155,6 +155,26 @@ def _outcome_rule(intake: dict[str, Any], outcome_id: str) -> dict[str, Any]:
     return {}
 
 
+def _gate_list(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    label: str,
+    errors: list[str],
+) -> tuple[str, ...]:
+    values = payload.get(key)
+    if not isinstance(values, list):
+        errors.append(f"{label}.{key} must be a list")
+        return ()
+    strings: list[str] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            errors.append(f"{label}.{key}[{index}] must be a string")
+            continue
+        strings.append(value)
+    return tuple(strings)
+
+
 def _decision_template_gate_ids(intake: dict[str, Any]) -> set[str]:
     template = intake.get("decision_template", {})
     if not isinstance(template, dict):
@@ -261,7 +281,12 @@ def validate_preflight(
             errors.append(f"gate {gate_id!r} must remain open before review intake")
 
     ledger_outcome = _review_outcome(ledger, ACCEPTED_VERTEX_CIRCLE_ROUTE)
-    ledger_required = tuple(ledger_outcome.get("required_gates", []))
+    ledger_required = _gate_list(
+        ledger_outcome,
+        "required_gates",
+        label="ledger accepted_vertex_circle_route",
+        errors=errors,
+    )
     if set(ledger_required) != set(VERTEX_CIRCLE_ROUTE_GATES):
         errors.append(
             "ledger accepted_vertex_circle_route must require exactly "
@@ -269,8 +294,18 @@ def validate_preflight(
         )
 
     intake_rule = _outcome_rule(intake, ACCEPTED_VERTEX_CIRCLE_ROUTE)
-    intake_required = tuple(intake_rule.get("required_accepted_gates", []))
-    intake_blocking = tuple(intake_rule.get("blocks_if_rejected_or_unreviewed", []))
+    intake_required = _gate_list(
+        intake_rule,
+        "required_accepted_gates",
+        label="intake accepted_vertex_circle_route",
+        errors=errors,
+    )
+    intake_blocking = _gate_list(
+        intake_rule,
+        "blocks_if_rejected_or_unreviewed",
+        label="intake accepted_vertex_circle_route",
+        errors=errors,
+    )
     if set(intake_required) != set(DECISION_REQUIRED_ACCEPTED_GATES):
         errors.append(
             "intake accepted_vertex_circle_route must require exactly "
@@ -286,7 +321,17 @@ def validate_preflight(
     errors.extend(note_errors)
 
     draft_decision = _draft_vertex_circle_decision_record(intake)
-    draft_errors = validate_decision_record(draft_decision, intake, gate_ledger=ledger)
+    try:
+        draft_errors = validate_decision_record(
+            draft_decision,
+            intake,
+            gate_ledger=ledger,
+        )
+    except TypeError as exc:
+        draft_errors = [
+            "decision-intake draft shape validation could not run cleanly: "
+            f"{exc}"
+        ]
     errors.extend(
         f"draft vertex-circle decision shape: {error}" for error in draft_errors
     )

--- a/scripts/check_n9_vertex_circle_route_decision_preflight.py
+++ b/scripts/check_n9_vertex_circle_route_decision_preflight.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Preflight the n=9 vertex-circle route decision handoff."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.check_n9_review_decision_intake import (  # noqa: E402
+    load_intake,
+    validate_decision_record,
+    validate_intake,
+)
+from scripts.check_n9_review_gate_ledger import (  # noqa: E402
+    load_ledger,
+    validate_ledger,
+)
+
+
+SCHEMA = "erdos97.n9_vertex_circle_route_decision_preflight.v1"
+STATUS = "REVIEW_PREFLIGHT_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CANONICAL_COMMAND = (
+    "python scripts/check_n9_vertex_circle_route_decision_preflight.py "
+    "--check --summary-json"
+)
+ACCEPTED_VERTEX_CIRCLE_ROUTE = "accepted_vertex_circle_route"
+VERTEX_CIRCLE_ROUTE_GATES = (
+    "frontier_enumeration",
+    "vertex_circle_geometry",
+    "quotient_obstruction_replay",
+)
+DECISION_REQUIRED_ACCEPTED_GATES = (
+    "frontier_enumeration",
+    "vertex_circle_geometry",
+    "quotient_obstruction_replay",
+    "independent_review",
+)
+SOURCE_OF_TRUTH_UPDATE_ALLOWED = False
+
+
+INTERNAL_REVIEW_NOTES: tuple[dict[str, Any], ...] = (
+    {
+        "id": "a6_a7_source_frontier",
+        "gate_id": "frontier_enumeration",
+        "path": "docs/n9-vertex-circle-a6-a7-frontier-review-2026-06-09.md",
+        "outcomes": ("accepted_A6_A7_source_frontier_internal",),
+        "required_phrases": (
+            "not an external review-decision record",
+            "`frontier_enumeration` gate",
+            "open until",
+            "does not support any of the following stronger statements",
+            "Erdos Problem #97 is proved",
+            "any counterexample is produced or certified",
+            "the official/global status changes",
+        ),
+    },
+    {
+        "id": "a8_strict_edge_geometry",
+        "gate_id": "vertex_circle_geometry",
+        "path": "docs/n9-vertex-circle-a8-strict-edge-review-2026-06-09.md",
+        "outcomes": ("accepted_A8_strict_edge_geometry_internal",),
+        "required_phrases": (
+            "not an external review-decision record",
+            "`vertex_circle_geometry` gate",
+            "open until",
+            "does not support any of the following stronger statements",
+            "Erdos Problem #97 is proved",
+            "any counterexample is produced or certified",
+            "the official/global status changes",
+        ),
+    },
+    {
+        "id": "a10_quotient_obstruction",
+        "gate_id": "quotient_obstruction_replay",
+        "path": "docs/n9-vertex-circle-a10-aggregate-review-2026-06-09.md",
+        "outcomes": (
+            "accepted_packet_soundness_T01_T12",
+            "accepted_A10_bookkeeping_after_packet_soundness",
+        ),
+        "required_phrases": (
+            "internal review-note outcome",
+            "source-of-truth gate",
+            "review-decision intake",
+            "does not support any of the following stronger statements",
+            "Erdos Problem #97 is proved",
+            "any counterexample is produced or certified",
+        ),
+    },
+)
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            f"PyYAML is required to parse {label}; install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} top level must be a mapping")
+    return payload
+
+
+def _all_gate_records(ledger: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    records: dict[str, dict[str, Any]] = {}
+    for key in ("review_gates", "infrastructure_gates"):
+        gates = ledger.get(key, [])
+        if not isinstance(gates, list):
+            continue
+        for gate in gates:
+            if isinstance(gate, dict) and isinstance(gate.get("id"), str):
+                records[gate["id"]] = gate
+    return records
+
+
+def _review_outcome(ledger: dict[str, Any], outcome_id: str) -> dict[str, Any]:
+    outcomes = ledger.get("review_outcomes", [])
+    if not isinstance(outcomes, list):
+        return {}
+    for outcome in outcomes:
+        if isinstance(outcome, dict) and outcome.get("id") == outcome_id:
+            return outcome
+    return {}
+
+
+def _outcome_rule(intake: dict[str, Any], outcome_id: str) -> dict[str, Any]:
+    rules = intake.get("outcome_rules", [])
+    if not isinstance(rules, list):
+        return {}
+    for rule in rules:
+        if isinstance(rule, dict) and rule.get("id") == outcome_id:
+            return rule
+    return {}
+
+
+def _decision_template_gate_ids(intake: dict[str, Any]) -> set[str]:
+    template = intake.get("decision_template", {})
+    if not isinstance(template, dict):
+        return set()
+    gates = template.get("not_reviewed_gates", [])
+    if not isinstance(gates, list):
+        return set()
+    return {gate for gate in gates if isinstance(gate, str)}
+
+
+def _draft_vertex_circle_decision_record(
+    intake: dict[str, Any],
+) -> dict[str, Any]:
+    accepted = set(DECISION_REQUIRED_ACCEPTED_GATES)
+    all_gates = _decision_template_gate_ids(intake)
+    return {
+        "schema": intake.get("decision_record_schema"),
+        "decision_status": "draft",
+        "reviewer_name": "",
+        "review_date": "",
+        "reviewed_git_head": "",
+        "run_bundle_digest": "",
+        "recommended_outcome": ACCEPTED_VERTEX_CIRCLE_ROUTE,
+        "accepted_gates": sorted(accepted),
+        "rejected_gates": [],
+        "not_reviewed_gates": sorted(all_gates - accepted),
+        "precise_gaps": [],
+        "acknowledgements": {
+            "no_general_proof_claimed": True,
+            "no_counterexample_claimed": True,
+            "official_status_unchanged": True,
+            "source_of_truth_pr_required": True,
+        },
+        "notes": (
+            "Schema preflight only. This draft shape is not a written review "
+            "decision and does not accept any gate."
+        ),
+    }
+
+
+def _validate_internal_notes() -> tuple[list[dict[str, Any]], list[str]]:
+    summaries: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for note in INTERNAL_REVIEW_NOTES:
+        path = repo_path(str(note["path"]))
+        summary: dict[str, Any] = {
+            "id": note["id"],
+            "gate_id": note["gate_id"],
+            "path": note["path"],
+            "path_exists": path.exists(),
+            "expected_outcomes": list(note["outcomes"]),
+            "missing_outcomes": [],
+            "missing_required_phrases": [],
+        }
+        if not path.exists():
+            errors.append(f"{note['id']} note is missing: {note['path']}")
+            summaries.append(summary)
+            continue
+        text = path.read_text(encoding="utf-8")
+        missing_outcomes = [
+            outcome for outcome in note["outcomes"] if outcome not in text
+        ]
+        missing_phrases = [
+            phrase for phrase in note["required_phrases"] if phrase not in text
+        ]
+        summary["missing_outcomes"] = missing_outcomes
+        summary["missing_required_phrases"] = missing_phrases
+        if missing_outcomes:
+            errors.append(
+                f"{note['id']} note missing outcomes: "
+                + ", ".join(missing_outcomes)
+            )
+        if missing_phrases:
+            errors.append(
+                f"{note['id']} note missing required phrases: "
+                + ", ".join(missing_phrases)
+            )
+        summaries.append(summary)
+    return summaries, errors
+
+
+def validate_preflight(
+    *,
+    ledger: dict[str, Any] | None = None,
+    intake: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    if ledger is None:
+        ledger = load_ledger(REPO_ROOT / "metadata" / "n9_review_gate_ledger.yaml")
+    if intake is None:
+        intake = load_intake(REPO_ROOT / "metadata" / "n9_review_decision_intake.yaml")
+
+    errors.extend(f"review_gate_ledger: {error}" for error in validate_ledger(ledger))
+    errors.extend(f"review_decision_intake: {error}" for error in validate_intake(intake))
+
+    gate_records = _all_gate_records(ledger)
+    gate_open_status: dict[str, bool | None] = {}
+    for gate_id in (*VERTEX_CIRCLE_ROUTE_GATES, "independent_review"):
+        record = gate_records.get(gate_id)
+        gate_open_status[gate_id] = record.get("still_open") if record else None
+        if record is None:
+            errors.append(f"gate {gate_id!r} is missing from the ledger")
+        elif record.get("still_open") is not True:
+            errors.append(f"gate {gate_id!r} must remain open before review intake")
+
+    ledger_outcome = _review_outcome(ledger, ACCEPTED_VERTEX_CIRCLE_ROUTE)
+    ledger_required = tuple(ledger_outcome.get("required_gates", []))
+    if set(ledger_required) != set(VERTEX_CIRCLE_ROUTE_GATES):
+        errors.append(
+            "ledger accepted_vertex_circle_route must require exactly "
+            + ", ".join(VERTEX_CIRCLE_ROUTE_GATES)
+        )
+
+    intake_rule = _outcome_rule(intake, ACCEPTED_VERTEX_CIRCLE_ROUTE)
+    intake_required = tuple(intake_rule.get("required_accepted_gates", []))
+    intake_blocking = tuple(intake_rule.get("blocks_if_rejected_or_unreviewed", []))
+    if set(intake_required) != set(DECISION_REQUIRED_ACCEPTED_GATES):
+        errors.append(
+            "intake accepted_vertex_circle_route must require exactly "
+            + ", ".join(DECISION_REQUIRED_ACCEPTED_GATES)
+        )
+    if set(intake_blocking) != set(DECISION_REQUIRED_ACCEPTED_GATES):
+        errors.append(
+            "intake accepted_vertex_circle_route must be blocked by exactly "
+            + ", ".join(DECISION_REQUIRED_ACCEPTED_GATES)
+        )
+
+    note_summaries, note_errors = _validate_internal_notes()
+    errors.extend(note_errors)
+
+    draft_decision = _draft_vertex_circle_decision_record(intake)
+    draft_errors = validate_decision_record(draft_decision, intake, gate_ledger=ledger)
+    errors.extend(
+        f"draft vertex-circle decision shape: {error}" for error in draft_errors
+    )
+
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "canonical_command": CANONICAL_COMMAND,
+        "route_outcome": ACCEPTED_VERTEX_CIRCLE_ROUTE,
+        "route_gate_ids": list(VERTEX_CIRCLE_ROUTE_GATES),
+        "decision_required_accepted_gates": list(DECISION_REQUIRED_ACCEPTED_GATES),
+        "gate_open_status": gate_open_status,
+        "all_required_gates_still_open": all(
+            gate_open_status.get(gate_id) is True
+            for gate_id in (*VERTEX_CIRCLE_ROUTE_GATES, "independent_review")
+        ),
+        "internal_review_notes": note_summaries,
+        "draft_vertex_circle_decision_shape": {
+            "decision_status": draft_decision["decision_status"],
+            "recommended_outcome": draft_decision["recommended_outcome"],
+            "accepted_gates": draft_decision["accepted_gates"],
+            "not_reviewed_gates": draft_decision["not_reviewed_gates"],
+            "validation_status": "passed" if not draft_errors else "failed",
+            "validation_error_count": len(draft_errors),
+            "first_validation_errors": draft_errors[:5],
+            "boundary": draft_decision["notes"],
+        },
+        "source_of_truth_update_allowed": SOURCE_OF_TRUTH_UPDATE_ALLOWED,
+        "next_required_external_artifact": (
+            "A written independent review decision record validated by "
+            "python scripts/check_n9_review_decision_intake.py --decision "
+            "<path> --check --summary-json."
+        ),
+    }
+    return payload, errors
+
+
+def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str, Any]:
+    note_summaries = payload.get("internal_review_notes", [])
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "route_outcome": payload.get("route_outcome"),
+        "route_gate_ids": payload.get("route_gate_ids"),
+        "decision_required_accepted_gates": payload.get(
+            "decision_required_accepted_gates"
+        ),
+        "all_required_gates_still_open": payload.get(
+            "all_required_gates_still_open"
+        ),
+        "internal_review_note_count": len(note_summaries)
+        if isinstance(note_summaries, list)
+        else 0,
+        "draft_vertex_circle_decision_shape_validation_status": payload.get(
+            "draft_vertex_circle_decision_shape", {}
+        ).get("validation_status"),
+        "source_of_truth_update_allowed": payload.get(
+            "source_of_truth_update_allowed"
+        ),
+        "next_required_external_artifact": payload.get(
+            "next_required_external_artifact"
+        ),
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+    }
+
+
+def render_markdown(payload: dict[str, Any], errors: Sequence[str]) -> str:
+    status = "passed" if not errors else "failed"
+    lines: list[str] = [
+        "# n=9 Vertex-circle Route Decision Preflight",
+        "",
+        "Status: `REVIEW_PREFLIGHT_ONLY`.",
+        "",
+        "This preflight checks that the internal A6/A7, A8, and A10 review "
+        "notes are present, that the vertex-circle route gates remain open, "
+        "and that the decision-intake schema still requires written "
+        "independent review before `accepted_vertex_circle_route` can be "
+        "recorded.",
+        "",
+        "## Result",
+        "",
+        f"- Validation status: `{status}`",
+        f"- Route outcome: `{payload.get('route_outcome')}`",
+        "- Required accepted gates: "
+        + ", ".join(
+            f"`{gate}`"
+            for gate in payload.get("decision_required_accepted_gates", [])
+        ),
+        f"- Source-of-truth update allowed: "
+        f"`{payload.get('source_of_truth_update_allowed')}`",
+        "",
+        "## Internal Notes",
+        "",
+    ]
+    for note in payload.get("internal_review_notes", []):
+        lines.append(
+            f"- `{note.get('id')}` -> `{note.get('gate_id')}`: "
+            f"`{note.get('path')}`"
+        )
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            "This is not a review decision and does not accept any gate. The "
+            "next external artifact remains a written decision record "
+            "validated by the decision-intake checker.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail on validation errors")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    output_group.add_argument("--markdown", action="store_true", help="print Markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        payload, errors = validate_preflight()
+    except (OSError, ValueError, YAMLError) as exc:
+        payload = {"schema": SCHEMA, "status": "LOAD_FAILED", "trust": TRUST}
+        errors = [str(exc)]
+
+    if args.markdown:
+        print(render_markdown(payload, errors))
+    elif args.summary_json:
+        print(json.dumps(summary_payload(payload, errors), indent=2, sort_keys=True))
+    elif args.json:
+        full_payload = dict(payload)
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        full_payload["validation_errors"] = errors
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 vertex-circle route decision preflight")
+        print(f"status: {payload.get('status')}")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if args.check and errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_n9_vertex_circle_route_decision_preflight.py
+++ b/tests/test_n9_vertex_circle_route_decision_preflight.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_review_decision_intake import load_intake
+from scripts.check_n9_review_gate_ledger import load_ledger
+from scripts.check_n9_vertex_circle_route_decision_preflight import (
+    DECISION_REQUIRED_ACCEPTED_GATES,
+    INTERNAL_REVIEW_NOTES,
+    VERTEX_CIRCLE_ROUTE_GATES,
+    validate_preflight,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEDGER = ROOT / "metadata" / "n9_review_gate_ledger.yaml"
+INTAKE = ROOT / "metadata" / "n9_review_decision_intake.yaml"
+
+
+def _set_gate_open(payload: dict[str, object], gate_id: str, value: bool) -> None:
+    for key in ("review_gates", "infrastructure_gates"):
+        gates = payload.get(key)
+        if not isinstance(gates, list):
+            continue
+        for gate in gates:
+            if isinstance(gate, dict) and gate.get("id") == gate_id:
+                gate["still_open"] = value
+                return
+    raise AssertionError(f"gate not found: {gate_id}")
+
+
+def _remove_rule_gate(payload: dict[str, object], gate_id: str) -> None:
+    rules = payload.get("outcome_rules")
+    assert isinstance(rules, list)
+    for rule in rules:
+        if isinstance(rule, dict) and rule.get("id") == "accepted_vertex_circle_route":
+            for field in ("required_accepted_gates", "blocks_if_rejected_or_unreviewed"):
+                values = rule.get(field)
+                assert isinstance(values, list)
+                rule[field] = [value for value in values if value != gate_id]
+            return
+    raise AssertionError("accepted_vertex_circle_route rule not found")
+
+
+def test_n9_vertex_circle_route_decision_preflight_is_valid() -> None:
+    payload, errors = validate_preflight()
+
+    assert errors == []
+    assert payload["route_gate_ids"] == list(VERTEX_CIRCLE_ROUTE_GATES)
+    assert payload["decision_required_accepted_gates"] == list(
+        DECISION_REQUIRED_ACCEPTED_GATES
+    )
+    assert payload["all_required_gates_still_open"] is True
+    assert payload["source_of_truth_update_allowed"] is False
+    assert len(payload["internal_review_notes"]) == len(INTERNAL_REVIEW_NOTES)
+    assert (
+        payload["draft_vertex_circle_decision_shape"]["validation_status"]
+        == "passed"
+    )
+
+
+def test_n9_vertex_circle_route_preflight_rejects_closed_route_gate() -> None:
+    ledger = deepcopy(load_ledger(LEDGER))
+    intake = load_intake(INTAKE)
+    _set_gate_open(ledger, "frontier_enumeration", False)
+
+    _, errors = validate_preflight(ledger=ledger, intake=intake)
+
+    assert "gate 'frontier_enumeration' must remain open before review intake" in errors
+
+
+def test_n9_vertex_circle_route_preflight_requires_independent_review() -> None:
+    ledger = load_ledger(LEDGER)
+    intake = deepcopy(load_intake(INTAKE))
+    _remove_rule_gate(intake, "independent_review")
+
+    _, errors = validate_preflight(ledger=ledger, intake=intake)
+
+    assert any(
+        error.startswith(
+            "intake accepted_vertex_circle_route must require exactly"
+        )
+        for error in errors
+    )
+    assert any(
+        error.startswith(
+            "intake accepted_vertex_circle_route must be blocked by exactly"
+        )
+        for error in errors
+    )

--- a/tests/test_n9_vertex_circle_route_decision_preflight.py
+++ b/tests/test_n9_vertex_circle_route_decision_preflight.py
@@ -89,3 +89,23 @@ def test_n9_vertex_circle_route_preflight_requires_independent_review() -> None:
         )
         for error in errors
     )
+
+
+def test_n9_vertex_circle_route_preflight_rejects_malformed_gate_lists() -> None:
+    ledger = load_ledger(LEDGER)
+    intake = deepcopy(load_intake(INTAKE))
+    rules = intake.get("outcome_rules")
+    assert isinstance(rules, list)
+    for rule in rules:
+        if isinstance(rule, dict) and rule.get("id") == "accepted_vertex_circle_route":
+            rule["required_accepted_gates"] = None
+            break
+    else:
+        raise AssertionError("accepted_vertex_circle_route rule not found")
+
+    _, errors = validate_preflight(ledger=ledger, intake=intake)
+
+    assert (
+        "intake accepted_vertex_circle_route.required_accepted_gates must be a list"
+        in errors
+    )


### PR DESCRIPTION
## Summary
- Add `check_n9_vertex_circle_route_decision_preflight.py`, a checked handoff preflight for the vertex-circle route decision path.
- Verify that the internal A6/A7, A8, and A10 review notes retain their expected outcomes and boundary language, that the vertex-circle route gates plus `independent_review` remain open, and that `accepted_vertex_circle_route` still requires written independent review.
- Add focused tests and link the preflight from the review packet, decision-intake doc, index, review priorities, and backlog.
- Harden malformed decision-intake gate-list handling so preflight drift failures return validation errors instead of tracebacks.

## Boundary
- This is `REVIEW_PREFLIGHT_ONLY`; it does not accept any gate, close the formal decision intake, prove `n=9`, prove Erdos Problem #97, claim a counterexample, or update official/global status.

## Validation
- `python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_route_decision_preflight.py -q`
- `python scripts/check_n9_review_decision_intake.py --check --summary-json`
- `python scripts/check_n9_review_gate_ledger.py --check --summary-json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `git diff --cached --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1350 passed, 502 deselected`)