### PR TITLE
[codex] Add n9 preflight to review harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ verify-n9-candidate:
 	$(PYTHON) scripts/check_n9_review_dossier.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_run_bundle.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_decision_intake.py --check --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -94,6 +94,11 @@ minimal/rich-class hypotheses.
    `--template` to print a fillable draft and `--decision <path>` to validate a
    supplied record. It does not accept gates or update source-of-truth status
    files by itself.
+   The vertex-circle route decision preflight
+   `python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
+   is now part of the compact harness. It checks that the internal A6/A7, A8,
+   and A10 notes are present and that the route still requires written
+   independent review before any source-of-truth proposal.
    The focused mini-replay commands
    `python scripts/check_n9_t01_self_edge_minireplay.py --check --assert-expected --json`,
    `python scripts/check_n9_t02_self_edge_minireplay.py --check --assert-expected --json`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-review-decision-intake.md`](n9-review-decision-intake.md): guide to the
   checked reviewer-decision intake template and external decision-file
   validator for the compact `n=9` review harness.
+- [`n9-vertex-circle-route-decision-preflight.md`](n9-vertex-circle-route-decision-preflight.md):
+  checked preflight for handing the internal A6/A7, A8, and A10 vertex-circle
+  notes into the still-open written-review decision intake.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -113,6 +113,16 @@ The intake checker validates gate partitions and allowed outcomes only. It
 does not update source-of-truth status files and does not accept any gate by
 itself.
 
+The vertex-circle route decision preflight is checked by:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+```
+
+It verifies that the internal A6/A7, A8, and A10 notes are present, that the
+vertex-circle route gates remain open, and that a real route decision still
+requires written independent review. It is preflight infrastructure only.
+
 Run:
 
 ```bash
@@ -127,7 +137,8 @@ make verify-n9-candidate PYTHON=.venv/bin/python
 
 ## What It Checks
 
-The target first runs the Lean pilot guardrails:
+The target first runs the review-infrastructure checks and Lean pilot
+guardrails:
 
 ```bash
 python scripts/check_n9_candidate_review_manifest.py --check --summary-json
@@ -136,13 +147,14 @@ python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 python scripts/check_n9_review_dossier.py --check --summary-json
 python scripts/check_n9_review_run_bundle.py --check --summary-json
 python scripts/check_n9_review_decision_intake.py --check --summary-json
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
-The manifest, gate-ledger, evidence-matrix, dossier, run-bundle, and
-decision-intake checkers run before the Lean pilot guardrails. The Lean layer
-includes
+The manifest, gate-ledger, evidence-matrix, dossier, run-bundle,
+decision-intake, and vertex-circle preflight checkers run before the Lean pilot
+guardrails. The Lean layer includes
 `lean/Erdos97/TurnPacking.lean`, a dependency-free formal contract for the
 turn-packing route. It pins the forward/reverse interval support convention
 and proves the small arithmetic kernel behind the stored dual certificates: a

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -124,6 +124,12 @@ by `python scripts/check_n9_review_decision_intake.py --check --summary-json`,
 validates external written-review records against the same gates and allowed
 outcomes.
 
+The vertex-circle route decision preflight
+`scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
+checks that the internal A6/A7, A8, and A10 notes are ready for that intake
+while the route gates and independent-review gate remain open. It is not a
+review decision.
+
 The most important global gap is separate:
 
 ```text

--- a/docs/n9-review-dossier.md
+++ b/docs/n9-review-dossier.md
@@ -24,6 +24,8 @@ The separate run-bundle checker records digest-level provenance for one actual
 execution of the same compact command surface.
 The reviewer-decision intake checker validates how an external written review
 records accepted gates, rejected gates, exact gaps, and allowed outcomes.
+The vertex-circle route decision preflight appears in the same command surface
+as a non-decisive guard before any written review record is validated.
 
 ## Commands
 

--- a/docs/n9-review-evidence-matrix.md
+++ b/docs/n9-review-evidence-matrix.md
@@ -68,6 +68,7 @@ The matrix covers all commands in `make verify-n9-candidate`:
 - the reviewer dossier checker;
 - the reviewer run-bundle checker in contract-only mode;
 - the reviewer decision-intake checker in contract-only mode;
+- the vertex-circle route decision preflight in preflight-only mode;
 - Lean sketch and optional Lean compilation guardrails;
 - the compact vertex-circle route commands;
 - the compact turn-packing route commands;

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -167,6 +167,9 @@ python scripts/check_n9_review_evidence_matrix.py --check --summary-json
 python scripts/check_n9_review_dossier.py --check --summary-json
 python scripts/check_n9_review_run_bundle.py --check --summary-json
 python scripts/check_n9_review_decision_intake.py --check --summary-json
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+python scripts/check_lean_sketch_integrity.py
+python scripts/check_lean_files.py
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json
 python scripts/check_n9_vertex_circle_input_audit.py --check --assert-expected --summary-json
 python scripts/check_n9_vertex_circle_incidence_filters.py --check --assert-expected --summary-json

--- a/docs/n9-review-run-bundle.md
+++ b/docs/n9-review-run-bundle.md
@@ -27,6 +27,9 @@ The digest capture is useful for comparing review runs without placing large
 command outputs in docs or metadata.
 After a reviewer has a run digest and written notes, the decision-intake
 checker validates any external decision record against the current gate ledger.
+The vertex-circle route decision preflight is included as a compact
+pre-decision guard: it checks that the internal A6/A7, A8, and A10 notes are
+ready for intake while the relevant gates remain open.
 
 ## Commands
 

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -120,6 +120,8 @@ routes:
         command: python scripts/check_n9_review_run_bundle.py --check --summary-json
       - id: n9_review_decision_intake
         command: python scripts/check_n9_review_decision_intake.py --check --summary-json
+      - id: n9_vertex_circle_route_decision_preflight
+        command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
 
   - id: lean_guardrails
     title: Lean pilot guardrails

--- a/metadata/n9_review_dossier.yaml
+++ b/metadata/n9_review_dossier.yaml
@@ -77,6 +77,7 @@ sections:
       - n9_review_dossier
       - n9_review_run_bundle
       - n9_review_decision_intake
+      - n9_vertex_circle_route_decision_preflight
       - lean_sketch_integrity
       - lean_files
       - n9_vertex_circle_exhaustive

--- a/metadata/n9_review_evidence_matrix.yaml
+++ b/metadata/n9_review_evidence_matrix.yaml
@@ -31,7 +31,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: command_count
-        equals: 19
+        equals: 20
       - path: review_gate_count
         equals: 8
       - path: review_gate_ledger
@@ -63,7 +63,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: evidence_record_count
-        equals: 19
+        equals: 20
       - path: live_replay_enabled
         equals: false
 
@@ -80,7 +80,7 @@ evidence_records:
       - path: review_gate_count
         equals: 6
       - path: evidence_record_count
-        equals: 19
+        equals: 20
       - path: review_question_count
         equals: 6
 
@@ -95,9 +95,9 @@ evidence_records:
       - path: route_count
         equals: 5
       - path: command_count
-        equals: 19
+        equals: 20
       - path: evidence_record_count
-        equals: 19
+        equals: 20
       - path: run_capture_enabled
         equals: false
 
@@ -116,6 +116,27 @@ evidence_records:
       - path: outcome_rule_count
         equals: 4
       - path: decision_loaded
+        equals: false
+
+  - id: n9_vertex_circle_route_decision_preflight
+    route_id: manifest_contract
+    command_id: n9_vertex_circle_route_decision_preflight
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: status
+        equals: REVIEW_PREFLIGHT_ONLY
+      - path: route_outcome
+        equals: accepted_vertex_circle_route
+      - path: all_required_gates_still_open
+        equals: true
+      - path: internal_review_note_count
+        equals: 3
+      - path: draft_vertex_circle_decision_shape_validation_status
+        equals: passed
+      - path: source_of_truth_update_allowed
         equals: false
 
   - id: lean_sketch_integrity

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -49,6 +49,7 @@ SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
     "python scripts/check_n9_review_dossier.py",
     "python scripts/check_n9_review_run_bundle.py",
     "python scripts/check_n9_review_decision_intake.py",
+    "python scripts/check_n9_vertex_circle_route_decision_preflight.py",
     "python scripts/check_n9_vertex_circle_input_audit.py",
     "python scripts/check_n9_vertex_circle_incidence_filters.py",
     "python scripts/check_n9_vertex_circle_mro_branching_replay.py",

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -28,6 +28,10 @@ def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
         "python scripts/check_n9_review_dossier.py --check --summary-json",
         "python scripts/check_n9_review_run_bundle.py --check --summary-json",
         "python scripts/check_n9_review_decision_intake.py --check --summary-json",
+        (
+            "python scripts/check_n9_vertex_circle_route_decision_preflight.py "
+            "--check --summary-json"
+        ),
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_review_dossier.py
+++ b/tests/test_n9_review_dossier.py
@@ -31,7 +31,7 @@ def test_n9_review_dossier_payload_contains_expected_layers() -> None:
     assert len(dossier["routes"]) == 5
     assert len(dossier["review_gates"]) == 6
     assert len(dossier["infrastructure_gates"]) == 2
-    assert len(dossier["evidence_records"]) == 19
+    assert len(dossier["evidence_records"]) == 20
 
 
 def test_n9_review_dossier_rejects_missing_section_id() -> None:

--- a/tests/test_n9_review_evidence_matrix.py
+++ b/tests/test_n9_review_evidence_matrix.py
@@ -43,7 +43,7 @@ def test_n9_review_evidence_matrix_covers_manifest_commands() -> None:
     }
 
     assert record_command_ids == _manifest_command_ids()
-    assert len(record_command_ids) == 19
+    assert len(record_command_ids) == 20
 
 
 def test_n9_review_evidence_matrix_rejects_missing_manifest_command() -> None:

--- a/tests/test_n9_review_run_bundle.py
+++ b/tests/test_n9_review_run_bundle.py
@@ -31,10 +31,10 @@ def test_n9_review_run_bundle_payload_contains_expected_layers() -> None:
     bundle = build_bundle_payload(payload)
 
     assert len(bundle["routes"]) == 5
-    assert len(bundle["command_records"]) == 19
+    assert len(bundle["command_records"]) == 20
     assert len(bundle["review_gates"]) == 6
     assert len(bundle["infrastructure_gates"]) == 2
-    assert len(bundle["evidence_records"]) == 19
+    assert len(bundle["evidence_records"]) == 20
 
 
 def test_n9_review_run_bundle_rejects_missing_capture_field() -> None:
@@ -70,8 +70,8 @@ def test_n9_review_run_bundle_summary_is_static_by_default() -> None:
 
     summary = summary_payload(payload, [], run_capture_enabled=False)
 
-    assert summary["command_count"] == 19
-    assert summary["evidence_record_count"] == 19
+    assert summary["command_count"] == 20
+    assert summary["evidence_record_count"] == 20
     assert summary["run_capture_enabled"] is False
     assert summary["run_record_count"] == 0
 


### PR DESCRIPTION
## Summary

- Add the vertex-circle route decision preflight to `verify-n9-candidate` and the machine-readable route manifest.
- Add an evidence-matrix record for the preflight, keeping it explicitly preflight-only with `source_of_truth_update_allowed: false`.
- Update review harness docs and tests for the 20-command compact review surface.

## Boundary

This is review infrastructure only. It does not accept any review gate, prove `n=9`, prove Erdos Problem #97, claim a counterexample, complete independent review, or update official/global status.

## Validation

- `python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `python scripts/check_n9_review_evidence_matrix.py --check --summary-json`
- `python scripts/check_n9_review_dossier.py --check --summary-json`
- `python scripts/check_n9_review_run_bundle.py --check --summary-json`
- `python scripts/check_n9_review_decision_intake.py --check --summary-json`
- `python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
- `python -m pytest tests/test_makefile_targets.py tests/test_n9_candidate_review_manifest.py tests/test_n9_review_evidence_matrix.py tests/test_n9_review_dossier.py tests/test_n9_review_run_bundle.py tests/test_n9_vertex_circle_route_decision_preflight.py -q`
- `python scripts/check_n9_review_evidence_matrix.py --check --run --summary-json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`

Note: `make verify-n9-candidate` could not be invoked directly in PowerShell because `make` is not installed there; the manifest checker plus live evidence-matrix replay verified the same compact target surface.