### PR TITLE
[codex] Add n9 vertex-circle decision request packet

### DIFF
--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -41,7 +41,12 @@ minimal/rich-class hypotheses.
    current five-layer audit path and review boundary. The aggregate note
    records the focused T01-T12 packet-soundness notes plus the A10 bookkeeping
    handoff; source-of-truth A10 promotion, `n=9`, and global status remain
-   review-pending until an explicit decision record is supplied. The focused
+   review-pending until an explicit decision record is supplied. The checked
+   decision-request packet
+   `python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json`
+   records the exact requested vertex-circle gate partition and reviewer
+   commands without accepting any gate or updating source-of-truth status. The
+   focused
    packet catalog audit command
    `python scripts/check_n9_vertex_circle_focused_packet_catalog_audit.py --check --assert-expected --summary-json`
    now checks that the focused packet coverage, source template records,

--- a/docs/n9-review-decision-intake.md
+++ b/docs/n9-review-decision-intake.md
@@ -62,6 +62,16 @@ present and boundary-safe, that the relevant route gates remain open, and that
 `accepted_vertex_circle_route` still requires `independent_review`. It does not
 accept any gate or replace a written decision.
 
+Validate the explicit vertex-circle decision-request packet:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
+```
+
+The request packet records the exact requested gate partition and reviewer
+commands for the vertex-circle route. It is still a request only, not a
+decision record and not a status update.
+
 ## Boundary
 
 Even a valid final decision record is only intake validation. An accepted

--- a/docs/n9-vertex-circle-route-decision-preflight.md
+++ b/docs/n9-vertex-circle-route-decision-preflight.md
@@ -50,6 +50,13 @@ The next required external artifact remains a filled decision record checked by:
 python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
 ```
 
+For a checked request packet that spells out the requested vertex-circle gate
+partition and reviewer commands, run:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
+```
+
 Even a valid accepted route decision would only support a separate
 source-of-truth proposal for the repo-local `n=9` finite case. It would not
 prove Erdos Problem #97 for all larger polygons or change the official/global

--- a/docs/n9-vertex-circle-route-decision-request.md
+++ b/docs/n9-vertex-circle-route-decision-request.md
@@ -1,0 +1,74 @@
+# n=9 Vertex-circle Route Decision Request
+
+Status: `REVIEW_DECISION_REQUEST_ONLY`.
+
+Claim scope: reviewer request packet for the review-pending `n=9`
+vertex-circle route. This note does not accept any review gate, does not prove
+`n=9`, does not prove Erdos Problem #97, does not claim a counterexample,
+does not complete independent review, and does not update the official/global
+status.
+
+## Purpose
+
+The route preflight says the internal A6/A7, A8, and A10 notes are ready to
+hand to decision intake. This request packet turns that into an explicit ask:
+review the vertex-circle route and, only if the written review supports it,
+record an `accepted_vertex_circle_route` decision that accepts exactly:
+
+- `frontier_enumeration`;
+- `vertex_circle_geometry`;
+- `quotient_obstruction_replay`;
+- `independent_review`.
+
+The turn-packing, Kalmanson corroboration, and Lean compilation gates remain
+outside this request.
+
+## Checked Request
+
+Run:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
+```
+
+The checker validates:
+
+- the request metadata and linked documents;
+- the existing vertex-circle route preflight;
+- the internal A6/A7, A8, and A10 review-note references;
+- the requested gate partition against the decision-intake schema;
+- the required boundary acknowledgements.
+
+## Reviewer Workflow
+
+Preflight the route:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+```
+
+Capture a live run digest for the checkout under review:
+
+```bash
+python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+```
+
+Print the decision template:
+
+```bash
+python scripts/check_n9_review_decision_intake.py --template
+```
+
+Validate a filled written decision:
+
+```bash
+python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
+```
+
+## Boundary
+
+This request packet is not the written decision. Even a valid accepted route
+decision would only support a separate source-of-truth proposal for the
+repo-local `n=9` finite case. It would not prove Erdos Problem #97 for all
+larger polygons, produce a counterexample, or change the official/global
+status.

--- a/metadata/n9_vertex_circle_route_decision_request.yaml
+++ b/metadata/n9_vertex_circle_route_decision_request.yaml
@@ -1,0 +1,104 @@
+schema: erdos97.n9_vertex_circle_route_decision_request.v1
+status: REVIEW_DECISION_REQUEST_ONLY
+trust: REVIEW_PENDING_DIAGNOSTIC
+candidate_manifest: metadata/n9_candidate_review.yaml
+review_gate_ledger: metadata/n9_review_gate_ledger.yaml
+review_evidence_matrix: metadata/n9_review_evidence_matrix.yaml
+review_dossier: metadata/n9_review_dossier.yaml
+review_run_bundle: metadata/n9_review_run_bundle.yaml
+review_decision_intake: metadata/n9_review_decision_intake.yaml
+route_preflight: docs/n9-vertex-circle-route-decision-preflight.md
+canonical_command: python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
+markdown_command: python scripts/check_n9_vertex_circle_route_decision_request.py --markdown
+preflight_command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+run_capture_command: python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+decision_template_command: python scripts/check_n9_review_decision_intake.py --template
+decision_validation_command: python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
+claim_scope: >
+  Machine-readable request packet for asking an external reviewer to decide
+  the still-open vertex-circle route gates for the compact review-pending n=9
+  selected-witness harness. It records the requested gate partition, exact
+  commands, internal-note inputs, and boundary acknowledgements. It does not
+  prove n=9, does not prove Erdos Problem #97, does not claim a counterexample,
+  does not complete independent review, does not accept any review gate, and
+  does not update the official/global status.
+
+forbidden_promotions:
+  - "general proof of Erdos Problem #97"
+  - proof of n=9
+  - "counterexample to Erdos Problem #97"
+  - official/global status update
+  - completed independent review
+  - accepted review gate
+  - formal proof of the Euclidean turn lemma
+
+request_documents:
+  - docs/n9-vertex-circle-route-decision-preflight.md
+  - docs/n9-review-decision-intake.md
+  - docs/n9-review-run-bundle.md
+  - docs/n9-review-packet.md
+  - docs/n9-vertex-circle-local-lemma-review-packet.md
+  - docs/n9-vertex-circle-a6-a7-frontier-review-2026-06-09.md
+  - docs/n9-vertex-circle-a8-strict-edge-review-2026-06-09.md
+  - docs/n9-vertex-circle-a10-aggregate-review-2026-06-09.md
+
+internal_review_notes:
+  - id: a6_a7_source_frontier
+    gate_id: frontier_enumeration
+    path: docs/n9-vertex-circle-a6-a7-frontier-review-2026-06-09.md
+    expected_outcomes:
+      - accepted_A6_A7_source_frontier_internal
+  - id: a8_strict_edge_geometry
+    gate_id: vertex_circle_geometry
+    path: docs/n9-vertex-circle-a8-strict-edge-review-2026-06-09.md
+    expected_outcomes:
+      - accepted_A8_strict_edge_geometry_internal
+  - id: a10_quotient_obstruction
+    gate_id: quotient_obstruction_replay
+    path: docs/n9-vertex-circle-a10-aggregate-review-2026-06-09.md
+    expected_outcomes:
+      - accepted_packet_soundness_T01_T12
+      - accepted_A10_bookkeeping_after_packet_soundness
+
+requested_outcome: accepted_vertex_circle_route
+requested_accepted_gates:
+  - frontier_enumeration
+  - vertex_circle_geometry
+  - quotient_obstruction_replay
+  - independent_review
+requested_rejected_gates: []
+requested_not_reviewed_gates:
+  - turn_geometry
+  - turn_arithmetic_replay
+  - kalmanson_corroboration
+  - lean_compilation
+
+external_reviewer_required: true
+source_of_truth_update_allowed: false
+decision_record_status: draft_request_only
+required_acknowledgements:
+  no_general_proof_claimed: true
+  no_counterexample_claimed: true
+  official_status_unchanged: true
+  source_of_truth_pr_required: true
+
+reviewer_steps:
+  - id: preflight
+    command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+    purpose: >
+      Confirm that the internal vertex-circle route notes are present and that
+      the route gates remain open before written review intake.
+  - id: live_run_capture
+    command: python scripts/check_n9_review_run_bundle.py --check --run --summary-json
+    purpose: >
+      Capture command-output digests for the checkout being reviewed. This is
+      execution provenance only.
+  - id: template
+    command: python scripts/check_n9_review_decision_intake.py --template
+    purpose: >
+      Print the fillable decision record schema.
+  - id: filled_decision_validation
+    command: python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
+    purpose: >
+      Validate the written decision record against the current gate ledger and
+      allowed outcomes.

--- a/scripts/check_n9_vertex_circle_route_decision_request.py
+++ b/scripts/check_n9_vertex_circle_route_decision_request.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Validate the n=9 vertex-circle route decision-request packet."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only without dependencies.
+    yaml = None
+    YAMLError = ValueError
+else:
+    YAMLError = yaml.YAMLError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.check_n9_review_decision_intake import (  # noqa: E402
+    load_intake,
+    validate_decision_record,
+    validate_intake,
+)
+from scripts.check_n9_review_gate_ledger import (  # noqa: E402
+    load_ledger,
+    validate_ledger,
+)
+from scripts.check_n9_vertex_circle_route_decision_preflight import (  # noqa: E402
+    DECISION_REQUIRED_ACCEPTED_GATES,
+    INTERNAL_REVIEW_NOTES,
+    validate_preflight,
+)
+
+
+DEFAULT_REQUEST = (
+    REPO_ROOT / "metadata" / "n9_vertex_circle_route_decision_request.yaml"
+)
+SCHEMA = "erdos97.n9_vertex_circle_route_decision_request.v1"
+STATUS = "REVIEW_DECISION_REQUEST_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+ACCEPTED_VERTEX_CIRCLE_ROUTE = "accepted_vertex_circle_route"
+SOURCE_OF_TRUTH_UPDATE_ALLOWED = False
+EXTERNAL_REVIEWER_REQUIRED = True
+CANONICAL_COMMAND = (
+    "python scripts/check_n9_vertex_circle_route_decision_request.py "
+    "--check --summary-json"
+)
+MARKDOWN_COMMAND = (
+    "python scripts/check_n9_vertex_circle_route_decision_request.py --markdown"
+)
+PREFLIGHT_COMMAND = (
+    "python scripts/check_n9_vertex_circle_route_decision_preflight.py "
+    "--check --summary-json"
+)
+RUN_CAPTURE_COMMAND = (
+    "python scripts/check_n9_review_run_bundle.py --check --run --summary-json"
+)
+DECISION_TEMPLATE_COMMAND = (
+    "python scripts/check_n9_review_decision_intake.py --template"
+)
+DECISION_VALIDATION_COMMAND = (
+    "python scripts/check_n9_review_decision_intake.py --decision "
+    "path/to/decision.yaml --check --summary-json"
+)
+REVIEWER_STEP_COMMANDS = {
+    "preflight": PREFLIGHT_COMMAND,
+    "live_run_capture": RUN_CAPTURE_COMMAND,
+    "template": DECISION_TEMPLATE_COMMAND,
+    "filled_decision_validation": DECISION_VALIDATION_COMMAND,
+}
+LINKED_FILES = {
+    "candidate_manifest": "metadata/n9_candidate_review.yaml",
+    "review_gate_ledger": "metadata/n9_review_gate_ledger.yaml",
+    "review_evidence_matrix": "metadata/n9_review_evidence_matrix.yaml",
+    "review_dossier": "metadata/n9_review_dossier.yaml",
+    "review_run_bundle": "metadata/n9_review_run_bundle.yaml",
+    "review_decision_intake": "metadata/n9_review_decision_intake.yaml",
+    "route_preflight": "docs/n9-vertex-circle-route-decision-preflight.md",
+}
+REQUIRED_FORBIDDEN_PROMOTIONS = {
+    "general proof of Erdos Problem #97",
+    "proof of n=9",
+    "counterexample to Erdos Problem #97",
+    "official/global status update",
+    "completed independent review",
+    "accepted review gate",
+    "formal proof of the Euclidean turn lemma",
+}
+REQUIRED_CLAIM_SCOPE_PHRASES = (
+    "does not prove n=9",
+    "does not prove Erdos Problem #97",
+    "does not claim a counterexample",
+    "does not complete independent review",
+    "does not accept any review gate",
+    "does not update the official/global status",
+)
+
+
+def repo_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    if yaml is None:
+        raise ValueError(
+            f"PyYAML is required to parse {label}; install with `pip install -e .`"
+        )
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} top level must be a mapping")
+    return payload
+
+
+def load_request(path: Path = DEFAULT_REQUEST) -> dict[str, Any]:
+    return load_yaml_mapping(
+        path,
+        label="metadata/n9_vertex_circle_route_decision_request.yaml",
+    )
+
+
+def _decision_gate_ids(intake: dict[str, Any]) -> set[str]:
+    template = intake.get("decision_template", {})
+    if not isinstance(template, dict):
+        return set()
+    gates = template.get("not_reviewed_gates", [])
+    if not isinstance(gates, list):
+        return set()
+    return {gate for gate in gates if isinstance(gate, str)}
+
+
+def _string_list(value: Any, *, label: str) -> tuple[list[str], list[str]]:
+    if not isinstance(value, list):
+        return [], [f"{label} must be a list"]
+    strings: list[str] = []
+    errors: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{label}[{index}] must be a nonempty string")
+        else:
+            strings.append(item)
+    return strings, errors
+
+
+def _validate_paths(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for key, expected in LINKED_FILES.items():
+        if payload.get(key) != expected:
+            errors.append(f"{key} must be {expected!r}")
+            continue
+        if not repo_path(expected).exists():
+            errors.append(f"{key} does not exist: {expected}")
+
+    docs, doc_errors = _string_list(
+        payload.get("request_documents"),
+        label="request_documents",
+    )
+    errors.extend(doc_errors)
+    for index, doc in enumerate(docs):
+        if not repo_path(doc).exists():
+            errors.append(f"request_documents[{index}] does not exist: {doc}")
+    return errors
+
+
+def _validate_claim_scope(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str) or not claim_scope.strip():
+        errors.append("claim_scope must be a nonempty string")
+    else:
+        for phrase in REQUIRED_CLAIM_SCOPE_PHRASES:
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    forbidden = payload.get("forbidden_promotions")
+    if not isinstance(forbidden, list) or not forbidden:
+        errors.append("forbidden_promotions must be a nonempty list")
+    else:
+        missing = REQUIRED_FORBIDDEN_PROMOTIONS - set(forbidden)
+        for phrase in sorted(missing):
+            errors.append(f"forbidden_promotions missing {phrase!r}")
+    return errors
+
+
+def _validate_commands(payload: dict[str, Any]) -> list[str]:
+    expected = {
+        "canonical_command": CANONICAL_COMMAND,
+        "markdown_command": MARKDOWN_COMMAND,
+        "preflight_command": PREFLIGHT_COMMAND,
+        "run_capture_command": RUN_CAPTURE_COMMAND,
+        "decision_template_command": DECISION_TEMPLATE_COMMAND,
+        "decision_validation_command": DECISION_VALIDATION_COMMAND,
+    }
+    errors = [
+        f"{key} must be {command!r}"
+        for key, command in expected.items()
+        if payload.get(key) != command
+    ]
+    steps = payload.get("reviewer_steps")
+    if not isinstance(steps, list):
+        errors.append("reviewer_steps must be a list")
+        return errors
+    seen: set[str] = set()
+    for index, step in enumerate(steps):
+        label = f"reviewer_steps[{index}]"
+        if not isinstance(step, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        step_id = step.get("id")
+        if not isinstance(step_id, str) or step_id not in REVIEWER_STEP_COMMANDS:
+            errors.append(f"{label}.id is not an expected reviewer step")
+            continue
+        seen.add(step_id)
+        expected_command = REVIEWER_STEP_COMMANDS[step_id]
+        if step.get("command") != expected_command:
+            errors.append(f"{label}.command must be {expected_command!r}")
+        purpose = step.get("purpose")
+        if not isinstance(purpose, str) or not purpose.strip():
+            errors.append(f"{label}.purpose must be a nonempty string")
+    for step_id in sorted(set(REVIEWER_STEP_COMMANDS) - seen):
+        errors.append(f"reviewer_steps missing {step_id!r}")
+    return errors
+
+
+def _validate_internal_review_notes(payload: dict[str, Any]) -> list[str]:
+    notes = payload.get("internal_review_notes")
+    if not isinstance(notes, list):
+        return ["internal_review_notes must be a list"]
+
+    errors: list[str] = []
+    expected_notes = {
+        str(note["id"]): note
+        for note in INTERNAL_REVIEW_NOTES
+        if isinstance(note.get("id"), str)
+    }
+    observed_ids: set[str] = set()
+    for index, note in enumerate(notes):
+        label = f"internal_review_notes[{index}]"
+        if not isinstance(note, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        note_id = note.get("id")
+        if not isinstance(note_id, str) or note_id not in expected_notes:
+            errors.append(f"{label}.id is not an expected internal note")
+            continue
+        observed_ids.add(note_id)
+        expected = expected_notes[note_id]
+        if note.get("gate_id") != expected["gate_id"]:
+            errors.append(f"{label}.gate_id must be {expected['gate_id']!r}")
+        if note.get("path") != expected["path"]:
+            errors.append(f"{label}.path must be {expected['path']!r}")
+        outcomes, outcome_errors = _string_list(
+            note.get("expected_outcomes"),
+            label=f"{label}.expected_outcomes",
+        )
+        errors.extend(outcome_errors)
+        if set(outcomes) != set(expected["outcomes"]):
+            errors.append(f"{label}.expected_outcomes does not match preflight")
+    for note_id in sorted(set(expected_notes) - observed_ids):
+        errors.append(f"internal_review_notes missing {note_id!r}")
+    return errors
+
+
+def _validate_required_acknowledgements(payload: dict[str, Any]) -> list[str]:
+    acknowledgements = payload.get("required_acknowledgements")
+    if not isinstance(acknowledgements, dict):
+        return ["required_acknowledgements must be a mapping"]
+    errors: list[str] = []
+    for key in (
+        "no_general_proof_claimed",
+        "no_counterexample_claimed",
+        "official_status_unchanged",
+        "source_of_truth_pr_required",
+    ):
+        if acknowledgements.get(key) is not True:
+            errors.append(f"required_acknowledgements.{key} must be true")
+    return errors
+
+
+def _draft_requested_decision(
+    payload: dict[str, Any],
+    intake: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema": intake.get("decision_record_schema"),
+        "decision_status": "draft",
+        "reviewer_name": "",
+        "review_date": "",
+        "reviewed_git_head": "",
+        "run_bundle_digest": "",
+        "recommended_outcome": payload.get("requested_outcome"),
+        "accepted_gates": payload.get("requested_accepted_gates", []),
+        "rejected_gates": payload.get("requested_rejected_gates", []),
+        "not_reviewed_gates": payload.get("requested_not_reviewed_gates", []),
+        "precise_gaps": [],
+        "acknowledgements": payload.get("required_acknowledgements", {}),
+        "notes": (
+            "Decision-request shape only. This record is not a written "
+            "independent review and does not accept any gate."
+        ),
+    }
+
+
+def validate_request(
+    payload: dict[str, Any],
+    *,
+    ledger: dict[str, Any] | None = None,
+    intake: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+
+    errors.extend(_validate_paths(payload))
+    errors.extend(_validate_claim_scope(payload))
+    errors.extend(_validate_commands(payload))
+    errors.extend(_validate_internal_review_notes(payload))
+    errors.extend(_validate_required_acknowledgements(payload))
+
+    if ledger is None:
+        ledger = load_ledger(repo_path(LINKED_FILES["review_gate_ledger"]))
+    if intake is None:
+        intake = load_intake(repo_path(LINKED_FILES["review_decision_intake"]))
+
+    errors.extend(f"review_gate_ledger: {error}" for error in validate_ledger(ledger))
+    errors.extend(f"review_decision_intake: {error}" for error in validate_intake(intake))
+
+    preflight_payload, preflight_errors = validate_preflight(
+        ledger=ledger,
+        intake=intake,
+    )
+    errors.extend(f"route_preflight: {error}" for error in preflight_errors)
+
+    all_gate_ids = _decision_gate_ids(intake)
+    accepted_values, accepted_errors = _string_list(
+        payload.get("requested_accepted_gates"),
+        label="requested_accepted_gates",
+    )
+    rejected_values, rejected_errors = _string_list(
+        payload.get("requested_rejected_gates"),
+        label="requested_rejected_gates",
+    )
+    not_reviewed_values, not_reviewed_errors = _string_list(
+        payload.get("requested_not_reviewed_gates"),
+        label="requested_not_reviewed_gates",
+    )
+    errors.extend(accepted_errors)
+    errors.extend(rejected_errors)
+    errors.extend(not_reviewed_errors)
+    accepted = tuple(accepted_values)
+    rejected = tuple(rejected_values)
+    not_reviewed = tuple(not_reviewed_values)
+    expected_not_reviewed = all_gate_ids - set(DECISION_REQUIRED_ACCEPTED_GATES)
+
+    if payload.get("requested_outcome") != ACCEPTED_VERTEX_CIRCLE_ROUTE:
+        errors.append(
+            f"requested_outcome must be {ACCEPTED_VERTEX_CIRCLE_ROUTE!r}"
+        )
+    if tuple(accepted) != DECISION_REQUIRED_ACCEPTED_GATES:
+        errors.append(
+            "requested_accepted_gates must match the vertex-circle "
+            "decision-intake gate order"
+        )
+    if list(rejected) != []:
+        errors.append("requested_rejected_gates must be empty for this request")
+    if set(not_reviewed) != expected_not_reviewed:
+        errors.append(
+            "requested_not_reviewed_gates must be the non-vertex-circle "
+            "decision gates"
+        )
+    if payload.get("source_of_truth_update_allowed") is not SOURCE_OF_TRUTH_UPDATE_ALLOWED:
+        errors.append("source_of_truth_update_allowed must be false")
+    if payload.get("external_reviewer_required") is not EXTERNAL_REVIEWER_REQUIRED:
+        errors.append("external_reviewer_required must be true")
+    if payload.get("decision_record_status") != "draft_request_only":
+        errors.append("decision_record_status must be 'draft_request_only'")
+
+    draft_decision = _draft_requested_decision(payload, intake)
+    decision_errors = validate_decision_record(
+        draft_decision,
+        intake,
+        gate_ledger=ledger,
+    )
+    errors.extend(f"requested decision shape: {error}" for error in decision_errors)
+
+    request_payload = build_request_payload(
+        payload,
+        preflight_errors=preflight_errors,
+        decision_errors=decision_errors,
+    )
+    return request_payload, errors
+
+
+def build_request_payload(
+    payload: dict[str, Any],
+    *,
+    preflight_errors: Sequence[str] | None = None,
+    decision_errors: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    preflight_errors = list(preflight_errors or [])
+    decision_errors = list(decision_errors or [])
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "claim_scope": payload.get("claim_scope"),
+        "requested_outcome": payload.get("requested_outcome"),
+        "requested_accepted_gates": payload.get("requested_accepted_gates", []),
+        "requested_rejected_gates": payload.get("requested_rejected_gates", []),
+        "requested_not_reviewed_gates": payload.get("requested_not_reviewed_gates", []),
+        "request_documents": payload.get("request_documents", []),
+        "internal_review_notes": payload.get("internal_review_notes", []),
+        "preflight_command": payload.get("preflight_command"),
+        "run_capture_command": payload.get("run_capture_command"),
+        "decision_template_command": payload.get("decision_template_command"),
+        "decision_validation_command": payload.get("decision_validation_command"),
+        "preflight_validation_status": (
+            "passed" if not preflight_errors else "failed"
+        ),
+        "preflight_validation_error_count": len(preflight_errors),
+        "first_preflight_validation_errors": preflight_errors[:5],
+        "requested_decision_shape_validation_status": (
+            "passed" if not decision_errors else "failed"
+        ),
+        "requested_decision_shape_validation_error_count": len(decision_errors),
+        "first_requested_decision_shape_errors": decision_errors[:5],
+        "external_reviewer_required": payload.get("external_reviewer_required"),
+        "source_of_truth_update_allowed": payload.get(
+            "source_of_truth_update_allowed"
+        ),
+    }
+
+
+def summary_payload(
+    request_payload: dict[str, Any],
+    errors: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "schema": request_payload.get("schema"),
+        "status": request_payload.get("status"),
+        "trust": request_payload.get("trust"),
+        "requested_outcome": request_payload.get("requested_outcome"),
+        "requested_accepted_gate_count": len(
+            request_payload.get("requested_accepted_gates", [])
+        ),
+        "requested_not_reviewed_gate_count": len(
+            request_payload.get("requested_not_reviewed_gates", [])
+        ),
+        "internal_review_note_count": len(
+            request_payload.get("internal_review_notes", [])
+        ),
+        "request_document_count": len(request_payload.get("request_documents", [])),
+        "preflight_validation_status": request_payload.get(
+            "preflight_validation_status"
+        ),
+        "requested_decision_shape_validation_status": request_payload.get(
+            "requested_decision_shape_validation_status"
+        ),
+        "external_reviewer_required": request_payload.get(
+            "external_reviewer_required"
+        ),
+        "source_of_truth_update_allowed": request_payload.get(
+            "source_of_truth_update_allowed"
+        ),
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+    }
+
+
+def render_markdown(
+    request_payload: dict[str, Any],
+    errors: Sequence[str],
+) -> str:
+    status = "passed" if not errors else "failed"
+    lines: list[str] = [
+        "# n=9 Vertex-circle Route Decision Request",
+        "",
+        "Status: `REVIEW_DECISION_REQUEST_ONLY`.",
+        "",
+        str(request_payload.get("claim_scope", "")).strip(),
+        "",
+        "## Request",
+        "",
+        f"- Validation status: `{status}`",
+        f"- Requested outcome: `{request_payload.get('requested_outcome')}`",
+        "- Requested accepted gates: "
+        + ", ".join(
+            f"`{gate}`"
+            for gate in request_payload.get("requested_accepted_gates", [])
+        ),
+        "- Requested not-reviewed gates: "
+        + ", ".join(
+            f"`{gate}`"
+            for gate in request_payload.get("requested_not_reviewed_gates", [])
+        ),
+        f"- Source-of-truth update allowed: "
+        f"`{request_payload.get('source_of_truth_update_allowed')}`",
+        "",
+        "## Reviewer Commands",
+        "",
+        f"- Preflight: `{request_payload.get('preflight_command')}`",
+        f"- Live run capture: `{request_payload.get('run_capture_command')}`",
+        f"- Decision template: `{request_payload.get('decision_template_command')}`",
+        f"- Validate filled decision: "
+        f"`{request_payload.get('decision_validation_command')}`",
+        "",
+        "## Boundary",
+        "",
+        "This request packet is not a written independent review, does not "
+        "accept any gate, and does not update any source-of-truth status file.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--request", type=Path, default=DEFAULT_REQUEST)
+    parser.add_argument("--check", action="store_true", help="fail on errors")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact reviewer-facing JSON",
+    )
+    output_group.add_argument("--markdown", action="store_true", help="print Markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    request_path = args.request
+    if not request_path.is_absolute():
+        request_path = REPO_ROOT / request_path
+
+    try:
+        payload = load_request(request_path)
+        request_payload, errors = validate_request(payload)
+    except (OSError, ValueError, YAMLError) as exc:
+        request_payload = {"schema": SCHEMA, "status": "LOAD_FAILED", "trust": TRUST}
+        errors = [str(exc)]
+
+    if args.markdown:
+        print(render_markdown(request_payload, errors))
+    elif args.summary_json:
+        print(json.dumps(summary_payload(request_payload, errors), indent=2))
+    elif args.json:
+        full_payload = dict(request_payload)
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        full_payload["validation_errors"] = errors
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("n=9 vertex-circle route decision request")
+        print(f"status: {request_payload.get('status')}")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if args.check and errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_n9_vertex_circle_route_decision_request.py
+++ b/tests/test_n9_vertex_circle_route_decision_request.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from scripts.check_n9_vertex_circle_route_decision_request import (
+    ACCEPTED_VERTEX_CIRCLE_ROUTE,
+    DECISION_REQUIRED_ACCEPTED_GATES,
+    DEFAULT_REQUEST,
+    build_request_payload,
+    load_request,
+    render_markdown,
+    summary_payload,
+    validate_request,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_n9_vertex_circle_route_decision_request_is_valid() -> None:
+    payload = load_request(DEFAULT_REQUEST)
+
+    request_payload, errors = validate_request(payload)
+
+    assert errors == []
+    assert request_payload["requested_outcome"] == ACCEPTED_VERTEX_CIRCLE_ROUTE
+    assert request_payload["requested_accepted_gates"] == list(
+        DECISION_REQUIRED_ACCEPTED_GATES
+    )
+    assert request_payload["requested_rejected_gates"] == []
+    assert request_payload["external_reviewer_required"] is True
+    assert request_payload["source_of_truth_update_allowed"] is False
+
+
+def test_n9_vertex_circle_route_decision_request_summary() -> None:
+    payload = load_request(DEFAULT_REQUEST)
+    request_payload, errors = validate_request(payload)
+
+    summary = summary_payload(request_payload, errors)
+
+    assert summary["validation_status"] == "passed"
+    assert summary["requested_outcome"] == ACCEPTED_VERTEX_CIRCLE_ROUTE
+    assert summary["requested_accepted_gate_count"] == 4
+    assert summary["requested_not_reviewed_gate_count"] == 4
+    assert summary["internal_review_note_count"] == 3
+
+
+def test_n9_vertex_circle_route_decision_request_rejects_gate_acceptance() -> None:
+    payload = deepcopy(load_request(DEFAULT_REQUEST))
+    payload["source_of_truth_update_allowed"] = True
+
+    _, errors = validate_request(payload)
+
+    assert "source_of_truth_update_allowed must be false" in errors
+
+
+def test_n9_vertex_circle_route_decision_request_requires_independent_review() -> None:
+    payload = deepcopy(load_request(DEFAULT_REQUEST))
+    payload["requested_accepted_gates"] = [
+        gate
+        for gate in payload["requested_accepted_gates"]
+        if gate != "independent_review"
+    ]
+    payload["requested_not_reviewed_gates"].append("independent_review")
+
+    _, errors = validate_request(payload)
+
+    assert (
+        "requested_accepted_gates must match the vertex-circle "
+        "decision-intake gate order"
+    ) in errors
+    assert any(error.startswith("requested decision shape:") for error in errors)
+
+
+def test_n9_vertex_circle_route_decision_request_rejects_note_drift() -> None:
+    payload = deepcopy(load_request(DEFAULT_REQUEST))
+    payload["internal_review_notes"][0]["expected_outcomes"] = ["wrong"]
+
+    _, errors = validate_request(payload)
+
+    assert (
+        "internal_review_notes[0].expected_outcomes does not match preflight"
+        in errors
+    )
+
+
+def test_n9_vertex_circle_route_decision_request_rejects_malformed_gate_list() -> None:
+    payload = deepcopy(load_request(DEFAULT_REQUEST))
+    payload["requested_not_reviewed_gates"] = None
+
+    _, errors = validate_request(payload)
+
+    assert "requested_not_reviewed_gates must be a list" in errors
+
+
+def test_n9_vertex_circle_route_decision_request_rejects_step_drift() -> None:
+    payload = deepcopy(load_request(DEFAULT_REQUEST))
+    payload["reviewer_steps"][0]["command"] = "python wrong.py"
+
+    _, errors = validate_request(payload)
+
+    assert any(
+        error.startswith("reviewer_steps[0].command must be")
+        for error in errors
+    )
+
+
+def test_n9_vertex_circle_route_decision_request_renders_markdown() -> None:
+    payload = load_request(DEFAULT_REQUEST)
+    request_payload = build_request_payload(payload)
+
+    markdown = render_markdown(request_payload, [])
+
+    assert "# n=9 Vertex-circle Route Decision Request" in markdown
+    assert "`accepted_vertex_circle_route`" in markdown
+    assert "does not accept any gate" in markdown
+    assert str(ROOT) not in markdown


### PR DESCRIPTION
## Summary

- add a checked metadata packet for requesting an external vertex-circle route decision
- add a validator, Markdown renderer, and focused tests for the request contract
- link the request from the decision-intake, route-preflight, and backlog docs while preserving the no-promotion boundary

## Validation

- `python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json`
- `python -m pytest tests/test_n9_vertex_circle_route_decision_request.py -q` (`8 passed`)
- `python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
- `python scripts/check_n9_review_decision_intake.py --check --summary-json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1358 passed, 502 deselected`)

## Boundaries

This PR adds review infrastructure only. It does not accept any n=9 review gate, prove n=9, prove Erdos Problem #97, claim a counterexample, complete independent review, or update the official/global status.