### PR TITLE
[codex] Add adjacent closest-pair nonagon barrier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_support_saturation_obstruction.py --check --json
 	$(PYTHON) scripts/check_n12_rich_support_determinant.py --check --json
 	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
+	$(PYTHON) scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected --json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -91,6 +91,22 @@ indegrees are all 4, adjacent row-pairs meet in exactly one selected witness,
 nonadjacent row-pairs meet in exactly two, and the common-witness map is a
 crossing permutation of the 20 octagon diagonals.
 
+### Lemma: adjacent closest-pair nonagon barrier
+
+Status: `LEMMA` / structural necessary condition.
+
+An endpoint of a globally closest pair cannot use the closest-pair distance as
+its four-rich radius. Combining this radius barrier with the adjacent-row
+crossing-bisector cap gives a conditional small nonagon obstruction: if an
+all-bad polygon has a globally closest pair that is a polygon side, then it
+has at least ten vertices.
+
+Equivalently, any hypothetical all-bad nonagon must have every globally closest
+pair realized by a diagonal rather than by a side. This is not an `n=9` proof:
+closest pairs in strictly convex polygons need not be adjacent. See
+`docs/closest-pair-radius-barrier.md` and
+`scripts/check_adjacent_closest_pair_nonagon_barrier.py`.
+
 ### Lemma: minimal-counterexample critical tie
 
 Status: proved.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2418,6 +2418,22 @@ Thus in any counterexample, every endpoint of a globally closest pair must use
 a four-rich distance class at radius strictly larger than the closest-pair
 distance. This is a structural constraint only, not a proof of Erdos #97.
 
+The same closest-pair exclusion combines with the crossing-bisector rule to
+give a conditional nonagon subcase: if an all-bad polygon has a globally
+closest pair that is a polygon side, then it has at least ten vertices. The
+borderline `n = 9` case would force the selected rows at the two neighboring
+endpoints to cover the other seven labels with one overlap; the rows at the
+next vertices on either side are then forced to share both closest-pair
+endpoints, contradicting the opposite-arc requirement for two common witnesses.
+Equivalently, any hypothetical all-bad nonagon must have every globally
+closest pair realized by a diagonal rather than a side. This is still only a
+conditional structural lemma: closest pairs in strictly convex polygons need
+not be adjacent, and the result does not prove `n = 9` or the full problem.
+The finite boundary check
+`scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json`
+enumerates the relevant rows at centers `0`, `1`, `2`, and `8` and finds zero
+complete assignments.
+
 ### Threefold pair-lift obstruction
 
 Status: `LEMMA` / `FAILED_SEARCH_MECHANISM`.

--- a/docs/closest-pair-radius-barrier.md
+++ b/docs/closest-pair-radius-barrier.md
@@ -2,7 +2,7 @@
 
 Status: `LEMMA` / structural necessary condition.
 
-This note records a small exact obstruction for the global closest-pair
+This note records small exact obstructions for the global closest-pair
 distance. It does not prove Erdos Problem #97 and does not produce a
 counterexample.
 
@@ -21,7 +21,13 @@ Consequently, in any counterexample, every endpoint of a globally closest pair
 must use only richer distance classes whose radii are strictly larger than
 `delta`.
 
-## Proof
+A conditional nonagon subcase also follows from the same closest-pair
+exclusion plus the two-overlap crossing-bisector rule: if an all-bad polygon
+has a globally closest pair that is a polygon side, then it has at least ten
+vertices. Equivalently, any hypothetical all-bad nonagon must have every
+globally closest pair realized by a diagonal, not by a side.
+
+## Radius Proof
 
 Let `p` be a closest-pair endpoint. Suppose, for contradiction, that four
 distinct vertices
@@ -58,9 +64,92 @@ contradicting the strict-convexity cone span.
 Thus no closest-pair endpoint can have four other vertices at the closest-pair
 distance.
 
+## Adjacent Closest Pair
+
+Suppose now that a counterexample has a globally closest pair `v0,v1` that is
+a side of the polygon, with vertices labelled in cyclic order
+
+```text
+v0, v1, ..., v(n-1).
+```
+
+For each bad vertex `x`, choose a same-radius witness set `S(x)` of size four.
+By the closest-pair radius barrier, `v1 notin S(v0)` and `v0 notin S(v1)`.
+Because `v0v1` is a side, the crossing-bisector rule gives
+
+```text
+|S(v0) cap S(v1)| <= 1.
+```
+
+Hence
+
+```text
+|S(v0) union S(v1)| >= 4 + 4 - 1 = 7.
+```
+
+This union is contained in the `n - 2` vertices other than `v0,v1`, so
+`n >= 9`.
+
+It remains to exclude the borderline `n = 9` case under the same adjacent
+closest-pair hypothesis. If `n = 9`, then the preceding inequalities saturate:
+
+```text
+S(v0) union S(v1) = {v2, v3, ..., v8},
+|S(v0) cap S(v1)| = 1.
+```
+
+Consider `v2`. If `S(v0) cap S(v2)` contained two vertices, the
+crossing-bisector rule would force those two common witnesses to lie on
+opposite open cyclic arcs between `v0` and `v2`. One of those arcs contains
+only `v1`, but `v1 notin S(v0)`. Therefore
+
+```text
+|S(v0) cap S(v2)| <= 1.
+```
+
+Also `v1` and `v2` are adjacent, so
+
+```text
+|S(v1) cap S(v2)| <= 1.
+```
+
+Every vertex among `v3,...,v8` lies in `S(v0) union S(v1)`, and these two
+intersection caps allow `S(v2)` to contain at most two vertices from that
+union. Since `S(v2)` has size four and cannot contain `v2`, it must contain
+both `v0` and `v1`.
+
+The same endpoint argument at `v8` shows that `S(v8)` must also contain both
+`v0` and `v1`: use adjacency of `v8,v0`, and for the pair `v1,v8` note that
+the open arc from `v8` to `v1` through `v0` contains only `v0`, while
+`v0 notin S(v1)`.
+
+Thus `S(v2) cap S(v8)` contains both `v0` and `v1`. But `v0` and `v1` lie on
+the same open cyclic arc between `v2` and `v8`, contradicting the
+crossing-bisector rule for two common witnesses. Therefore the `n = 9`
+borderline is impossible, and any counterexample with an adjacent closest pair
+has `n >= 10`.
+
+The finite row-level boundary can also be replayed by:
+
+```bash
+python scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json
+```
+
+This checker enumerates the possible selected rows at centers `0`, `1`, `2`,
+and `8` under the closest-pair endpoint exclusions, the two-circle row-pair
+cap, and the two-overlap crossing rule. It verifies that all `5,760` partial
+boundary assignments are rejected by the final `S(v2),S(v8)` row-pair check.
+It is a combinatorial audit of this conditional subcase only.
+
 ## Scope
 
-This is weaker than a global contradiction. It only says that closest-pair
-endpoints cannot witness badness at the minimum intervertex distance. In a
-counterexample, such vertices would need a separate four-rich distance class at
-a larger radius.
+These are weaker than a global contradiction. The radius barrier only says that
+closest-pair endpoints cannot witness badness at the minimum intervertex
+distance. In a counterexample, such vertices would need a separate four-rich
+distance class at a larger radius.
+
+The adjacent-pair consequence is conditional: a closest pair in a strictly
+convex polygon need not be a polygon side. It rules out only all-bad nonagons
+whose global closest-pair distance is attained by an adjacent pair. It does not
+prove `n = 9`, does not promote the review-pending finite-case artifacts, and
+does not prove Erdos Problem #97.

--- a/docs/index.md
+++ b/docs/index.md
@@ -202,7 +202,9 @@ put detailed reconciliation in the canonical synthesis.
   by itself.
 - [`closest-pair-radius-barrier.md`](closest-pair-radius-barrier.md): exact
   closest-pair obstruction showing that endpoints of a global closest pair
-  cannot be four-rich at the closest-pair radius.
+  cannot be four-rich at the closest-pair radius, plus the conditional
+  adjacent closest-pair barrier for all-bad nonagons and its finite row-level
+  boundary checker.
 - [`minimal-fragile-cover-bridge.md`](minimal-fragile-cover-bridge.md):
   partial bridge theorem showing that every minimal counterexample admits a
   fragile-cover witness system; also records why this is not sufficient,

--- a/scripts/check_adjacent_closest_pair_nonagon_barrier.py
+++ b/scripts/check_adjacent_closest_pair_nonagon_barrier.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Check the adjacent closest-pair nonagon barrier.
+
+This is a finite combinatorial audit for one structural subcase. It does not
+prove n=9, does not prove Erdos Problem #97, and does not produce a
+counterexample.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from itertools import combinations
+from typing import Any, Sequence
+
+SCHEMA = "erdos97.adjacent_closest_pair_nonagon_barrier.v1"
+STATUS = "LEMMA_COMBINATORIAL_AUDIT_ONLY"
+TRUST = "LEMMA"
+N = 9
+ROW_SIZE = 4
+ORDER = tuple(range(N))
+ADJACENT_CLOSEST_PAIR = (0, 1)
+BOUNDARY_CENTERS = (0, 1, 2, 8)
+CLAIM_SCOPE = (
+    "Finite combinatorial audit of the adjacent closest-pair n=9 boundary. "
+    "It enumerates selected witness rows at centers 0, 1, 2, and 8 under the "
+    "closest-pair endpoint exclusions, two-circle row-pair cap, and "
+    "two-overlap crossing-bisector rule. It proves only the conditional "
+    "subcase where a globally closest pair is a polygon side; it does not "
+    "prove n=9, does not prove Erdos Problem #97, does not claim a "
+    "counterexample, and does not update the official/global status."
+)
+
+EXPECTED_SUMMARY = {
+    "n": 9,
+    "row_size": 4,
+    "adjacent_closest_pair": [0, 1],
+    "endpoint_pair_count": 140,
+    "endpoint_pair_union_saturation_count": 140,
+    "endpoint_pair_intersection_histogram": {"1": 140},
+    "v2_candidate_count": 900,
+    "v2_forced_closest_pair_endpoint_count": 900,
+    "v2_option_count_distribution": {"6": 120, "9": 20},
+    "v8_candidate_count": 900,
+    "v8_forced_closest_pair_endpoint_count": 900,
+    "v8_option_count_distribution": {"6": 120, "9": 20},
+    "partial_frontier_count_before_final_pair": 5760,
+    "final_pair_rejection_counts": {
+        "row_pair_cap": 3120,
+        "two_overlap_crossing": 2640,
+    },
+    "final_pair_overlap_histogram": {"2": 2640, "3": 2520, "4": 600},
+    "complete_assignment_count": 0,
+}
+
+Row = tuple[int, ...]
+Pair = tuple[int, int]
+
+
+def normalize_pair(left: int, right: int) -> Pair:
+    """Return an unordered non-loop pair."""
+
+    if left == right:
+        raise ValueError(f"loop pair is not allowed: {left}")
+    return (left, right) if left < right else (right, left)
+
+
+def chords_cross_in_natural_order(left: Pair, right: Pair) -> bool:
+    """Return whether two disjoint chords cross in cyclic order 0,...,8."""
+
+    if set(left) & set(right):
+        return False
+    a, b = sorted(left)
+    c, d = sorted(right)
+    return (a < c < b < d) or (c < a < d < b)
+
+
+def row_pair_rejection(
+    left_center: int,
+    left_row: Sequence[int],
+    right_center: int,
+    right_row: Sequence[int],
+) -> str | None:
+    """Return the exact row-pair reason rejecting two selected rows."""
+
+    overlap = sorted(set(left_row) & set(right_row))
+    if len(overlap) > 2:
+        return "row_pair_cap"
+    if len(overlap) == 2:
+        source = normalize_pair(left_center, right_center)
+        witness = normalize_pair(overlap[0], overlap[1])
+        if not chords_cross_in_natural_order(source, witness):
+            return "two_overlap_crossing"
+    return None
+
+
+def row_pair_is_compatible(
+    left_center: int,
+    left_row: Sequence[int],
+    right_center: int,
+    right_row: Sequence[int],
+) -> bool:
+    """Return whether the row pair passes the cap and crossing filters."""
+
+    return row_pair_rejection(left_center, left_row, right_center, right_row) is None
+
+
+def row_options(center: int, *, n: int = N, row_size: int = ROW_SIZE) -> tuple[Row, ...]:
+    """Return all selected witness rows of size ``row_size`` for ``center``."""
+
+    if center < 0 or center >= n:
+        raise ValueError(f"center out of range: {center}")
+    return tuple(
+        tuple(row)
+        for row in combinations((label for label in range(n) if label != center), row_size)
+    )
+
+
+def endpoint_pair_is_compatible(row0: Row, row1: Row) -> bool:
+    """Check the closest-pair endpoint exclusions and row-pair filter."""
+
+    return (
+        1 not in row0
+        and 0 not in row1
+        and row_pair_is_compatible(0, row0, 1, row1)
+    )
+
+
+def compatible_boundary_rows(center: int, row0: Row, row1: Row) -> list[Row]:
+    """Return rows at ``center`` compatible with the two closest-pair endpoints."""
+
+    return [
+        row
+        for row in row_options(center)
+        if row_pair_is_compatible(0, row0, center, row)
+        and row_pair_is_compatible(1, row1, center, row)
+    ]
+
+
+def _counter_json(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter, key=str)}
+
+
+def _row_json(row: Sequence[int]) -> list[int]:
+    return [int(label) for label in row]
+
+
+def build_payload() -> dict[str, Any]:
+    """Build the finite audit payload."""
+
+    rows0 = row_options(0)
+    rows1 = row_options(1)
+    endpoint_pairs: list[tuple[Row, Row]] = []
+    endpoint_pair_intersections: Counter[int] = Counter()
+    endpoint_pair_union_saturation_count = 0
+    v2_count_distribution: Counter[int] = Counter()
+    v8_count_distribution: Counter[int] = Counter()
+    final_pair_rejections: Counter[str] = Counter()
+    final_pair_overlap_histogram: Counter[int] = Counter()
+    v2_candidate_count = 0
+    v2_forced_closest_pair_endpoint_count = 0
+    v8_candidate_count = 0
+    v8_forced_closest_pair_endpoint_count = 0
+    partial_frontier_count = 0
+    complete_assignment_count = 0
+    first_partial_record: dict[str, Any] | None = None
+    first_final_rejection_examples: dict[str, dict[str, Any]] = {}
+
+    other_endpoint_labels = set(range(2, N))
+    closest_pair_endpoints = set(ADJACENT_CLOSEST_PAIR)
+
+    for row0 in rows0:
+        for row1 in rows1:
+            if not endpoint_pair_is_compatible(row0, row1):
+                continue
+            endpoint_pairs.append((row0, row1))
+            endpoint_intersection = len(set(row0) & set(row1))
+            endpoint_pair_intersections[endpoint_intersection] += 1
+            if set(row0) | set(row1) == other_endpoint_labels:
+                endpoint_pair_union_saturation_count += 1
+
+            v2_options = compatible_boundary_rows(2, row0, row1)
+            v8_options = compatible_boundary_rows(8, row0, row1)
+            v2_count_distribution[len(v2_options)] += 1
+            v8_count_distribution[len(v8_options)] += 1
+
+            for row2 in v2_options:
+                v2_candidate_count += 1
+                if closest_pair_endpoints <= set(row2):
+                    v2_forced_closest_pair_endpoint_count += 1
+            for row8 in v8_options:
+                v8_candidate_count += 1
+                if closest_pair_endpoints <= set(row8):
+                    v8_forced_closest_pair_endpoint_count += 1
+
+            for row2 in v2_options:
+                for row8 in v8_options:
+                    partial_frontier_count += 1
+                    rejection = row_pair_rejection(2, row2, 8, row8)
+                    overlap = sorted(set(row2) & set(row8))
+                    final_pair_overlap_histogram[len(overlap)] += 1
+                    if first_partial_record is None:
+                        first_partial_record = {
+                            "S0": _row_json(row0),
+                            "S1": _row_json(row1),
+                            "S2": _row_json(row2),
+                            "S8": _row_json(row8),
+                            "S2_cap_S8": _row_json(overlap),
+                        }
+                    if rejection is None:
+                        complete_assignment_count += 1
+                    else:
+                        final_pair_rejections[rejection] += 1
+                        first_final_rejection_examples.setdefault(
+                            rejection,
+                            {
+                                "S0": _row_json(row0),
+                                "S1": _row_json(row1),
+                                "S2": _row_json(row2),
+                                "S8": _row_json(row8),
+                                "S2_cap_S8": _row_json(overlap),
+                                "rejection": rejection,
+                            },
+                        )
+
+    summary = {
+        "n": N,
+        "row_size": ROW_SIZE,
+        "cyclic_order": list(ORDER),
+        "adjacent_closest_pair": list(ADJACENT_CLOSEST_PAIR),
+        "boundary_centers": list(BOUNDARY_CENTERS),
+        "endpoint_pair_count": len(endpoint_pairs),
+        "endpoint_pair_union_saturation_count": endpoint_pair_union_saturation_count,
+        "endpoint_pair_intersection_histogram": _counter_json(
+            endpoint_pair_intersections
+        ),
+        "v2_candidate_count": v2_candidate_count,
+        "v2_forced_closest_pair_endpoint_count": (
+            v2_forced_closest_pair_endpoint_count
+        ),
+        "v2_option_count_distribution": _counter_json(v2_count_distribution),
+        "v8_candidate_count": v8_candidate_count,
+        "v8_forced_closest_pair_endpoint_count": (
+            v8_forced_closest_pair_endpoint_count
+        ),
+        "v8_option_count_distribution": _counter_json(v8_count_distribution),
+        "partial_frontier_count_before_final_pair": partial_frontier_count,
+        "final_pair_rejection_counts": _counter_json(final_pair_rejections),
+        "final_pair_overlap_histogram": _counter_json(final_pair_overlap_histogram),
+        "complete_assignment_count": complete_assignment_count,
+    }
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "summary": summary,
+        "first_partial_record": first_partial_record,
+        "first_final_rejection_examples": first_final_rejection_examples,
+        "interpretation": (
+            "Every compatible endpoint pair saturates the seven non-endpoint "
+            "labels; every compatible row at v2 and v8 contains both closest "
+            "pair endpoints 0 and 1; the final row pair S2,S8 is always "
+            "rejected by either the row-pair cap or the two-overlap crossing "
+            "rule. Thus the adjacent closest-pair n=9 boundary has no "
+            "selected-witness realization under these necessary conditions."
+        ),
+    }
+
+
+def validate_payload(payload: dict[str, Any]) -> list[str]:
+    """Return validation errors for the computed audit payload."""
+
+    errors: list[str] = []
+    if payload.get("schema") != SCHEMA:
+        errors.append(f"schema is {payload.get('schema')!r}, expected {SCHEMA!r}")
+    if payload.get("status") != STATUS:
+        errors.append(f"status is {payload.get('status')!r}, expected {STATUS!r}")
+    if payload.get("trust") != TRUST:
+        errors.append(f"trust is {payload.get('trust')!r}, expected {TRUST!r}")
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str):
+        errors.append("claim_scope must be a string")
+    else:
+        for phrase in (
+            "does not prove n=9",
+            "does not prove Erdos Problem #97",
+            "does not claim a counterexample",
+            "does not update the official/global status",
+        ):
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must include {phrase!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        errors.append("summary must be a mapping")
+        return errors
+    for key, expected in EXPECTED_SUMMARY.items():
+        observed = summary.get(key)
+        if observed != expected:
+            errors.append(f"summary.{key} is {observed!r}, expected {expected!r}")
+    if summary.get("complete_assignment_count") != 0:
+        errors.append("complete_assignment_count must be 0")
+    return errors
+
+
+def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str, Any]:
+    """Return compact JSON for docs and CI output."""
+
+    summary = payload.get("summary", {})
+    return {
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "n": summary.get("n"),
+        "adjacent_closest_pair": summary.get("adjacent_closest_pair"),
+        "endpoint_pair_count": summary.get("endpoint_pair_count"),
+        "endpoint_pair_union_saturation_count": summary.get(
+            "endpoint_pair_union_saturation_count"
+        ),
+        "v2_forced_closest_pair_endpoint_count": summary.get(
+            "v2_forced_closest_pair_endpoint_count"
+        ),
+        "v8_forced_closest_pair_endpoint_count": summary.get(
+            "v8_forced_closest_pair_endpoint_count"
+        ),
+        "partial_frontier_count_before_final_pair": summary.get(
+            "partial_frontier_count_before_final_pair"
+        ),
+        "final_pair_rejection_counts": summary.get("final_pair_rejection_counts"),
+        "complete_assignment_count": summary.get("complete_assignment_count"),
+        "validation_status": "passed" if not errors else "failed",
+        "validation_error_count": len(errors),
+        "first_validation_errors": list(errors[:5]),
+    }
+
+
+def render_markdown(payload: dict[str, Any], errors: Sequence[str]) -> str:
+    """Render a small reviewer-facing note."""
+
+    summary = payload.get("summary", {})
+    status = "passed" if not errors else "failed"
+    lines = [
+        "# Adjacent Closest-Pair Nonagon Barrier Check",
+        "",
+        f"Status: `{payload.get('status')}`.",
+        "",
+        str(payload.get("claim_scope", "")).strip(),
+        "",
+        "## Result",
+        "",
+        f"- Validation status: `{status}`",
+        f"- Endpoint row pairs: `{summary.get('endpoint_pair_count')}`",
+        "- Partial boundary assignments before the final row-pair check: "
+        f"`{summary.get('partial_frontier_count_before_final_pair')}`",
+        f"- Complete assignments: `{summary.get('complete_assignment_count')}`",
+        "",
+        "## Boundary",
+        "",
+        "This checks only the adjacent closest-pair nonagon subcase. A "
+        "hypothetical nonagon whose globally closest pairs are all diagonals "
+        "is outside this checker.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail on validation errors")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact JSON",
+    )
+    output_group.add_argument("--markdown", action="store_true", help="print Markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload()
+    errors = validate_payload(payload)
+
+    if args.markdown:
+        print(render_markdown(payload, errors))
+    elif args.summary_json:
+        print(json.dumps(summary_payload(payload, errors), indent=2, sort_keys=True))
+    elif args.json:
+        full_payload = dict(payload)
+        full_payload["validation_status"] = "passed" if not errors else "failed"
+        full_payload["validation_errors"] = errors
+        print(json.dumps(full_payload, indent=2, sort_keys=True))
+    else:
+        print("adjacent closest-pair nonagon barrier")
+        print(f"validation_status: {'passed' if not errors else 'failed'}")
+
+    if args.check and errors:
+        for error in errors:
+            print(error)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adjacent_closest_pair_nonagon_barrier.py
+++ b/tests/test_adjacent_closest_pair_nonagon_barrier.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from scripts.check_adjacent_closest_pair_nonagon_barrier import (
+    EXPECTED_SUMMARY,
+    build_payload,
+    render_markdown,
+    row_pair_rejection,
+    summary_payload,
+    validate_payload,
+)
+
+
+def test_adjacent_closest_pair_nonagon_barrier_matches_expected() -> None:
+    payload = build_payload()
+
+    errors = validate_payload(payload)
+
+    assert errors == []
+    assert payload["summary"]["complete_assignment_count"] == 0
+    assert payload["summary"]["final_pair_rejection_counts"] == {
+        "row_pair_cap": 3120,
+        "two_overlap_crossing": 2640,
+    }
+
+
+def test_adjacent_closest_pair_nonagon_barrier_forces_boundary_rows() -> None:
+    payload = build_payload()
+    summary = payload["summary"]
+
+    assert summary["endpoint_pair_count"] == EXPECTED_SUMMARY["endpoint_pair_count"]
+    assert (
+        summary["endpoint_pair_union_saturation_count"]
+        == summary["endpoint_pair_count"]
+    )
+    assert (
+        summary["v2_candidate_count"]
+        == summary["v2_forced_closest_pair_endpoint_count"]
+    )
+    assert (
+        summary["v8_candidate_count"]
+        == summary["v8_forced_closest_pair_endpoint_count"]
+    )
+
+
+def test_adjacent_closest_pair_nonagon_barrier_summary_payload() -> None:
+    payload = build_payload()
+    summary = summary_payload(payload, [])
+
+    assert summary["validation_status"] == "passed"
+    assert summary["endpoint_pair_count"] == 140
+    assert summary["partial_frontier_count_before_final_pair"] == 5760
+    assert summary["complete_assignment_count"] == 0
+
+
+def test_adjacent_closest_pair_nonagon_barrier_rejects_final_pair_examples() -> None:
+    payload = build_payload()
+    examples = payload["first_final_rejection_examples"]
+
+    cap_example = examples["row_pair_cap"]
+    crossing_example = examples["two_overlap_crossing"]
+
+    assert row_pair_rejection(2, cap_example["S2"], 8, cap_example["S8"]) == (
+        "row_pair_cap"
+    )
+    assert row_pair_rejection(
+        2,
+        crossing_example["S2"],
+        8,
+        crossing_example["S8"],
+    ) == "two_overlap_crossing"
+    assert crossing_example["S2_cap_S8"] == [0, 1]
+
+
+def test_adjacent_closest_pair_nonagon_barrier_markdown_keeps_scope() -> None:
+    payload = build_payload()
+    markdown = render_markdown(payload, [])
+
+    assert "# Adjacent Closest-Pair Nonagon Barrier Check" in markdown
+    assert "Complete assignments: `0`" in markdown
+    assert "only the adjacent closest-pair nonagon subcase" in markdown

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -210,6 +210,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
         "python scripts/check_n12_rich_support_determinant.py --check --json",
         "python scripts/check_localized_rich_support_counting.py --check --json",
         (
+            "python scripts/check_adjacent_closest_pair_nonagon_barrier.py "
+            "--check --summary-json"
+        ),
+        (
             "python scripts/check_bootstrap_core_crosswalk.py "
             "--check --assert-expected --json"
         ),


### PR DESCRIPTION
## Summary

- Adds a scoped proof note for the adjacent closest-pair nonagon barrier: an all-bad polygon whose global closest pair is a side must have at least ten vertices.
- Adds a finite row-level audit script and pytest coverage for the `n = 9` boundary case.
- Hooks the checker into `verify-bridge-frontier` and updates the claims ledger, results ledger, and documentation index while preserving the open/global status boundaries.

## Validation

- `python scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json`
- `python -m pytest tests/test_adjacent_closest_pair_nonagon_barrier.py tests/test_makefile_targets.py -q` (`9 passed`)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1363 passed, 502 deselected`)

## Scope

This is a conditional structural lemma only. It does not prove `n = 9`, does not promote review-pending finite-case artifacts, does not claim a counterexample, and does not prove Erdos Problem #97.