### PR TITLE
[codex] Clarify adjacent closest-pair checker scope

### DIFF
--- a/scripts/check_adjacent_closest_pair_nonagon_barrier.py
+++ b/scripts/check_adjacent_closest_pair_nonagon_barrier.py
@@ -25,7 +25,7 @@ CLAIM_SCOPE = (
     "Finite combinatorial audit of the adjacent closest-pair n=9 boundary. "
     "It enumerates selected witness rows at centers 0, 1, 2, and 8 under the "
     "closest-pair endpoint exclusions, two-circle row-pair cap, and "
-    "two-overlap crossing-bisector rule. It proves only the conditional "
+    "two-overlap crossing-bisector rule. It checks only the conditional "
     "subcase where a globally closest pair is a polygon side; it does not "
     "prove n=9, does not prove Erdos Problem #97, does not claim a "
     "counterexample, and does not update the official/global status."


### PR DESCRIPTION
## Summary

- Softens the adjacent closest-pair checker claim-scope wording from `proves only` to `checks only`.
- Keeps the recently merged structural lemma intact while making the executable audit description more precise and less theorem-like.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json`
- `python -m pytest -q` (`1363 passed, 502 deselected`)

## Scope

This is wording-only. It does not change the computed audit, does not prove `n = 9`, does not claim a counterexample, and does not update the official/global status.