### PR TITLE
[codex] Add n9 decision request to compact harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ verify-n9-candidate:
 	$(PYTHON) scripts/check_n9_review_run_bundle.py --check --summary-json
 	$(PYTHON) scripts/check_n9_review_decision_intake.py --check --summary-json
 	$(PYTHON) scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+	$(PYTHON) scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
 	$(PYTHON) scripts/check_lean_sketch_integrity.py
 	$(PYTHON) scripts/check_lean_files.py
 	$(PYTHON) scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-route-decision-preflight.md`](n9-vertex-circle-route-decision-preflight.md):
   checked preflight for handing the internal A6/A7, A8, and A10 vertex-circle
   notes into the still-open written-review decision intake.
+- [`n9-vertex-circle-route-decision-request.md`](n9-vertex-circle-route-decision-request.md):
+  checked request packet spelling out the vertex-circle route gate partition
+  and reviewer commands without accepting any gate.
 - [`gpt55-solver-brief.md`](gpt55-solver-brief.md): front-loaded LLM
   solver-steering brief with anti-loop guardrails, hard status boundaries, and
   live frontier output contracts; prompt context only, not mathematical
@@ -500,6 +503,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`n9-vertex-circle-route-decision-preflight.md`](n9-vertex-circle-route-decision-preflight.md):
   checked handoff preflight joining the internal A6/A7, A8, and A10 review
   notes to the still-open vertex-circle route decision-intake requirements.
+- [`n9-vertex-circle-route-decision-request.md`](n9-vertex-circle-route-decision-request.md):
+  checked reviewer request packet for the same vertex-circle route decision;
+  request-only, not a gate acceptance or `n=9` status promotion.
 - [`n9-vertex-circle-certificate-chain.md`](n9-vertex-circle-certificate-chain.md):
   assignment-id bridge from the review-pending `n=9` frontier artifacts to the
   12 local quotient-obstruction templates.

--- a/docs/n9-candidate-promotion-harness.md
+++ b/docs/n9-candidate-promotion-harness.md
@@ -123,6 +123,16 @@ It verifies that the internal A6/A7, A8, and A10 notes are present, that the
 vertex-circle route gates remain open, and that a real route decision still
 requires written independent review. It is preflight infrastructure only.
 
+The explicit vertex-circle decision-request packet is checked by:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
+```
+
+It records the requested gate partition and reviewer workflow for a future
+written route decision. It is request infrastructure only: it does not accept
+any gate and does not update source-of-truth status files.
+
 Run:
 
 ```bash
@@ -148,13 +158,14 @@ python scripts/check_n9_review_dossier.py --check --summary-json
 python scripts/check_n9_review_run_bundle.py --check --summary-json
 python scripts/check_n9_review_decision_intake.py --check --summary-json
 python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 ```
 
 The manifest, gate-ledger, evidence-matrix, dossier, run-bundle,
-decision-intake, and vertex-circle preflight checkers run before the Lean pilot
-guardrails. The Lean layer includes
+decision-intake, vertex-circle preflight, and decision-request checkers run
+before the Lean pilot guardrails. The Lean layer includes
 `lean/Erdos97/TurnPacking.lean`, a dependency-free formal contract for the
 turn-packing route. It pins the forward/reverse interval support convention
 and proves the small arithmetic kernel behind the stored dual certificates: a

--- a/docs/n9-review-dossier.md
+++ b/docs/n9-review-dossier.md
@@ -25,7 +25,9 @@ execution of the same compact command surface.
 The reviewer-decision intake checker validates how an external written review
 records accepted gates, rejected gates, exact gaps, and allowed outcomes.
 The vertex-circle route decision preflight appears in the same command surface
-as a non-decisive guard before any written review record is validated.
+as a non-decisive guard before any written review record is validated. The
+vertex-circle route decision request appears alongside it as the checked
+request packet for that future written review.
 
 ## Commands
 

--- a/docs/n9-review-evidence-matrix.md
+++ b/docs/n9-review-evidence-matrix.md
@@ -69,6 +69,7 @@ The matrix covers all commands in `make verify-n9-candidate`:
 - the reviewer run-bundle checker in contract-only mode;
 - the reviewer decision-intake checker in contract-only mode;
 - the vertex-circle route decision preflight in preflight-only mode;
+- the vertex-circle route decision request in request-only mode;
 - Lean sketch and optional Lean compilation guardrails;
 - the compact vertex-circle route commands;
 - the compact turn-packing route commands;

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -109,6 +109,12 @@ It verifies that the internal A6/A7, A8, and A10 review notes are present,
 that the route gates remain open, and that `accepted_vertex_circle_route`
 still requires written independent review. It is not a decision record.
 
+The explicit vertex-circle route decision request is
+`docs/n9-vertex-circle-route-decision-request.md`, checked by
+`python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json`.
+It records the requested `accepted_vertex_circle_route` gate partition and
+reviewer commands. It is still only a request packet, not a written decision.
+
 ## Review routes
 
 ### Route A: vertex-circle closure
@@ -168,6 +174,7 @@ python scripts/check_n9_review_dossier.py --check --summary-json
 python scripts/check_n9_review_run_bundle.py --check --summary-json
 python scripts/check_n9_review_decision_intake.py --check --summary-json
 python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
 python scripts/check_lean_sketch_integrity.py
 python scripts/check_lean_files.py
 python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json

--- a/docs/n9-review-run-bundle.md
+++ b/docs/n9-review-run-bundle.md
@@ -29,7 +29,9 @@ After a reviewer has a run digest and written notes, the decision-intake
 checker validates any external decision record against the current gate ledger.
 The vertex-circle route decision preflight is included as a compact
 pre-decision guard: it checks that the internal A6/A7, A8, and A10 notes are
-ready for intake while the relevant gates remain open.
+ready for intake while the relevant gates remain open. The route decision
+request checker is included too, so the captured command surface also verifies
+the requested gate partition and reviewer workflow without accepting any gate.
 
 ## Commands
 

--- a/metadata/n9_candidate_review.yaml
+++ b/metadata/n9_candidate_review.yaml
@@ -44,6 +44,7 @@ harness_documents:
   - docs/n9-review-dossier.md
   - docs/n9-review-run-bundle.md
   - docs/n9-review-decision-intake.md
+  - docs/n9-vertex-circle-route-decision-request.md
   - docs/n9-reduction-chain.md
   - docs/n9-review-packet.md
   - docs/turn-inequality-lemma.md
@@ -122,6 +123,8 @@ routes:
         command: python scripts/check_n9_review_decision_intake.py --check --summary-json
       - id: n9_vertex_circle_route_decision_preflight
         command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
+      - id: n9_vertex_circle_route_decision_request
+        command: python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json
 
   - id: lean_guardrails
     title: Lean pilot guardrails

--- a/metadata/n9_review_dossier.yaml
+++ b/metadata/n9_review_dossier.yaml
@@ -30,6 +30,7 @@ required_documents:
   - docs/n9-review-dossier.md
   - docs/n9-review-run-bundle.md
   - docs/n9-review-decision-intake.md
+  - docs/n9-vertex-circle-route-decision-request.md
   - docs/n9-reduction-chain.md
 
 sections:
@@ -78,6 +79,7 @@ sections:
       - n9_review_run_bundle
       - n9_review_decision_intake
       - n9_vertex_circle_route_decision_preflight
+      - n9_vertex_circle_route_decision_request
       - lean_sketch_integrity
       - lean_files
       - n9_vertex_circle_exhaustive

--- a/metadata/n9_review_evidence_matrix.yaml
+++ b/metadata/n9_review_evidence_matrix.yaml
@@ -31,7 +31,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: command_count
-        equals: 20
+        equals: 21
       - path: review_gate_count
         equals: 8
       - path: review_gate_ledger
@@ -63,7 +63,7 @@ evidence_records:
       - path: validation_status
         equals: passed
       - path: evidence_record_count
-        equals: 20
+        equals: 21
       - path: live_replay_enabled
         equals: false
 
@@ -80,7 +80,7 @@ evidence_records:
       - path: review_gate_count
         equals: 6
       - path: evidence_record_count
-        equals: 20
+        equals: 21
       - path: review_question_count
         equals: 6
 
@@ -95,9 +95,9 @@ evidence_records:
       - path: route_count
         equals: 5
       - path: command_count
-        equals: 20
+        equals: 21
       - path: evidence_record_count
-        equals: 20
+        equals: 21
       - path: run_capture_enabled
         equals: false
 
@@ -136,6 +136,33 @@ evidence_records:
         equals: 3
       - path: draft_vertex_circle_decision_shape_validation_status
         equals: passed
+      - path: source_of_truth_update_allowed
+        equals: false
+
+  - id: n9_vertex_circle_route_decision_request
+    route_id: manifest_contract
+    command_id: n9_vertex_circle_route_decision_request
+    output_format: json
+    ledger_gate_ids: []
+    expectations:
+      - path: validation_status
+        equals: passed
+      - path: status
+        equals: REVIEW_DECISION_REQUEST_ONLY
+      - path: requested_outcome
+        equals: accepted_vertex_circle_route
+      - path: requested_accepted_gate_count
+        equals: 4
+      - path: requested_not_reviewed_gate_count
+        equals: 4
+      - path: internal_review_note_count
+        equals: 3
+      - path: preflight_validation_status
+        equals: passed
+      - path: requested_decision_shape_validation_status
+        equals: passed
+      - path: external_reviewer_required
+        equals: true
       - path: source_of_truth_update_allowed
         equals: false
 

--- a/metadata/n9_review_run_bundle.yaml
+++ b/metadata/n9_review_run_bundle.yaml
@@ -33,6 +33,7 @@ required_documents:
   - docs/n9-review-dossier.md
   - docs/n9-review-run-bundle.md
   - docs/n9-review-decision-intake.md
+  - docs/n9-vertex-circle-route-decision-request.md
   - docs/n9-reduction-chain.md
 
 expected_route_ids:

--- a/scripts/check_n9_candidate_review_manifest.py
+++ b/scripts/check_n9_candidate_review_manifest.py
@@ -50,6 +50,7 @@ SUMMARY_JSON_REVIEW_COMMAND_PREFIXES = (
     "python scripts/check_n9_review_run_bundle.py",
     "python scripts/check_n9_review_decision_intake.py",
     "python scripts/check_n9_vertex_circle_route_decision_preflight.py",
+    "python scripts/check_n9_vertex_circle_route_decision_request.py",
     "python scripts/check_n9_vertex_circle_input_audit.py",
     "python scripts/check_n9_vertex_circle_incidence_filters.py",
     "python scripts/check_n9_vertex_circle_mro_branching_replay.py",

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -32,6 +32,10 @@ def test_verify_n9_candidate_is_compact_promotion_review_harness() -> None:
             "python scripts/check_n9_vertex_circle_route_decision_preflight.py "
             "--check --summary-json"
         ),
+        (
+            "python scripts/check_n9_vertex_circle_route_decision_request.py "
+            "--check --summary-json"
+        ),
         "python scripts/check_lean_sketch_integrity.py",
         "python scripts/check_lean_files.py",
         "python scripts/check_n9_vertex_circle_exhaustive.py --assert-expected --json",

--- a/tests/test_n9_review_dossier.py
+++ b/tests/test_n9_review_dossier.py
@@ -31,7 +31,7 @@ def test_n9_review_dossier_payload_contains_expected_layers() -> None:
     assert len(dossier["routes"]) == 5
     assert len(dossier["review_gates"]) == 6
     assert len(dossier["infrastructure_gates"]) == 2
-    assert len(dossier["evidence_records"]) == 20
+    assert len(dossier["evidence_records"]) == 21
 
 
 def test_n9_review_dossier_rejects_missing_section_id() -> None:

--- a/tests/test_n9_review_evidence_matrix.py
+++ b/tests/test_n9_review_evidence_matrix.py
@@ -43,7 +43,7 @@ def test_n9_review_evidence_matrix_covers_manifest_commands() -> None:
     }
 
     assert record_command_ids == _manifest_command_ids()
-    assert len(record_command_ids) == 20
+    assert len(record_command_ids) == 21
 
 
 def test_n9_review_evidence_matrix_rejects_missing_manifest_command() -> None:

--- a/tests/test_n9_review_run_bundle.py
+++ b/tests/test_n9_review_run_bundle.py
@@ -31,10 +31,10 @@ def test_n9_review_run_bundle_payload_contains_expected_layers() -> None:
     bundle = build_bundle_payload(payload)
 
     assert len(bundle["routes"]) == 5
-    assert len(bundle["command_records"]) == 20
+    assert len(bundle["command_records"]) == 21
     assert len(bundle["review_gates"]) == 6
     assert len(bundle["infrastructure_gates"]) == 2
-    assert len(bundle["evidence_records"]) == 20
+    assert len(bundle["evidence_records"]) == 21
 
 
 def test_n9_review_run_bundle_rejects_missing_capture_field() -> None:
@@ -70,8 +70,8 @@ def test_n9_review_run_bundle_summary_is_static_by_default() -> None:
 
     summary = summary_payload(payload, [], run_capture_enabled=False)
 
-    assert summary["command_count"] == 20
-    assert summary["evidence_record_count"] == 20
+    assert summary["command_count"] == 21
+    assert summary["evidence_record_count"] == 21
     assert summary["run_capture_enabled"] is False
     assert summary["run_record_count"] == 0
 


### PR DESCRIPTION
## Summary

- Adds `check_n9_vertex_circle_route_decision_request.py` to the compact `verify-n9-candidate` harness.
- Extends the n=9 review manifest, evidence matrix, dossier, and run-bundle contracts from 20 to 21 commands.
- Updates reviewer-facing docs/tests so the explicit vertex-circle decision request is captured alongside the preflight without accepting any gate.

## Validation

- `python scripts/check_n9_candidate_review_manifest.py --check --summary-json`
- `python scripts/check_n9_review_evidence_matrix.py --check --summary-json`
- `python scripts/check_n9_review_dossier.py --check --summary-json`
- `python scripts/check_n9_review_run_bundle.py --check --summary-json`
- `python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json`
- `python -m pytest tests/test_n9_candidate_review_manifest.py tests/test_n9_review_evidence_matrix.py tests/test_n9_review_dossier.py tests/test_n9_review_run_bundle.py tests/test_n9_vertex_circle_route_decision_request.py tests/test_makefile_targets.py -q` (`43 passed`)
- `python scripts/check_n9_review_run_bundle.py --check --run --summary-json` on head `15f83bc52aa66142fb49ee60b5e88dba80b5bf6e` (`21` records, digest `28e6b25b4c6c363233c837424d6e4ec16737fe728975f67357485e00eecdf129`, `git_tracked_dirty_count: 0`)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1363 passed, 502 deselected`)

## Scope

This is review-harness plumbing only. It does not accept any review gate, does not complete independent review, does not prove `n = 9`, does not claim a counterexample, and does not update the official/global status.