### PR TITLE
Document anti-activation bridge controls

### DIFF
--- a/docs/bootstrap-t12-anti-activation-negative-control.md
+++ b/docs/bootstrap-t12-anti-activation-negative-control.md
@@ -1,0 +1,89 @@
+# Bootstrap/T12 full-row anti-activation negative control
+
+Status: `EXACT_NEGATIVE_CONTROL` / `PROVENANCE`. No general proof of Erdos
+Problem #97 is claimed. No counterexample is claimed.
+
+This note isolates the full selected-row anti-activation control that is also
+summarized in `docs/closure-activation-negative-controls.md`. Its purpose is
+to block one overstrong bridge move:
+
+```text
+closure exposure of center 7 with witnesses 0,1,4
+    => selected row 7 -> {0,1,4,6} is forced.
+```
+
+The checked artifact is:
+
+```text
+data/certificates/bootstrap_t12_anti_activation_negative_control.json
+```
+
+Run the checker with:
+
+```bash
+python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json
+```
+
+Regenerate the artifact after an intentional source change with:
+
+```bash
+python scripts/check_bootstrap_t12_anti_activation_negative_control.py --write
+```
+
+## Control
+
+The control is a full abstract selected-row incidence system on cyclic order
+`0,1,2,3,4,5,6,7,8,9`.
+
+Starting from seed `{0,1,4}`, rich-triple closure adds center `7` and then
+stops:
+
+```text
+cl({0,1,4}) = {0,1,4,7}
+```
+
+The activated row at center `7` is:
+
+```text
+7 -> {0,1,3,4}
+```
+
+It contains the three core witnesses `{0,1,4}`, but its fourth witness is `3`,
+not the target private witness `6`. Thus the target row
+`7 -> {0,1,4,6}` is not active at the target center.
+
+## Checked Conditions
+
+The checker verifies:
+
+- every row has four distinct witnesses;
+- no row contains its own center;
+- every vertex appears in at least one selected row;
+- all row-pair intersections have size at most two;
+- every two-overlap pair satisfies the supplied cyclic crossing check;
+- adjacent selected rows intersect in at most one witness;
+- the closure and anti-activation row match the stored certificate.
+
+Current compact summary:
+
+| Quantity | Value |
+|---|---:|
+| closure result | `{0,1,4,7}` |
+| activated row at center `7` | `{0,1,3,4}` |
+| target row active at center `7` | `false` |
+| two-overlap row pairs | `18` |
+
+## Bridge Lesson
+
+This control shows that even a full selected-row incidence system can expose a
+center through the desired three core witnesses while switching the fourth
+witness. A future bootstrap/T12 bridge lemma therefore needs an additional
+condition that pins the fourth witness, such as activation provenance,
+critical-row uniqueness, radius ordering, or an all-fourth obstruction check.
+
+## Nonclaims
+
+This is not a Euclidean realization certificate, not a counterexample, not a
+proof that closure activation fails for genuine minimal counterexamples, and
+not a check against all vertex-circle, Kalmanson, row-Ptolemy, or algebraic
+obstruction templates.

--- a/docs/closure-activation-negative-controls.md
+++ b/docs/closure-activation-negative-controls.md
@@ -25,11 +25,17 @@ Run the full selected-row anti-activation checker with:
 python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json
 ```
 
+Focused note:
+`docs/bootstrap-t12-anti-activation-negative-control.md`.
+
 Run the closure-visibility replay checker with:
 
 ```bash
 python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json
 ```
+
+Focused note:
+`docs/closure-visibility-anti-activation-control.md`.
 
 Regenerate the checked JSON artifacts with:
 
@@ -179,6 +185,9 @@ keeps the abstract countermodels replayable.
 
 ## Full selected-row anti-activation control
 
+For the focused note, see
+`docs/bootstrap-t12-anti-activation-negative-control.md`.
+
 The checked artifact is
 `data/certificates/bootstrap_t12_anti_activation_negative_control.json`. It is
 a full abstract selected-row incidence system on cyclic order:
@@ -220,6 +229,9 @@ counterexample. It only rules out deriving the pinned fourth witness `6` from
 these abstract incidence and closure checks alone.
 
 ## Closure-visibility anti-activation control
+
+For the focused note, see
+`docs/closure-visibility-anti-activation-control.md`.
 
 The checked artifact is
 `data/certificates/closure_visibility_anti_activation_control.json`.

--- a/docs/closure-visibility-anti-activation-control.md
+++ b/docs/closure-visibility-anti-activation-control.md
@@ -1,0 +1,92 @@
+# Closure-visibility anti-activation control
+
+Status: `EXACT_NEGATIVE_CONTROL` / `PROVENANCE`. No general proof of Erdos
+Problem #97 is claimed. No counterexample is claimed.
+
+This note isolates the sparse closure-visibility control that is also
+summarized in `docs/closure-activation-negative-controls.md`. It blocks a
+different overstrong bridge move from the full-row anti-activation control:
+
+```text
+center c in cl(A) and target triple T subset cl(A)
+    => c has a selected or rich row containing T.
+```
+
+The checked artifact is:
+
+```text
+data/certificates/closure_visibility_anti_activation_control.json
+```
+
+Run the checker with:
+
+```bash
+python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json
+```
+
+Regenerate the artifact after an intentional source change with:
+
+```bash
+python scripts/check_closure_visibility_anti_activation_control.py --write
+```
+
+## Control
+
+The control uses cyclic order `0,1,2,3,4,5,6,7,8` and two sparse rich rows:
+
+```text
+3 -> {0,1,4,6}
+7 -> {0,3,4,8}
+```
+
+The target is a `151:7`-style closure-exposed row with center `7`, target
+witnesses `{0,1,4}`, private witness `6`, and target row `{0,1,4,6}`.
+
+Starting from seed `{0,1,4}`, closure proceeds as:
+
+```text
+{0,1,4}
+  -> add 3 via {0,1,4}
+  -> {0,1,3,4}
+  -> add 7 via {0,3,4}
+  -> {0,1,3,4,7}
+```
+
+At the end, the closure contains center `7` and all target witnesses
+`{0,1,4}`. However, center `7` entered through the different triple
+`{0,3,4}`, and its row contains neither the target triple nor the target row.
+
+## Checked Conditions
+
+The checker verifies:
+
+- four-uniformity and self-exclusion for the sparse rich rows;
+- row-pair intersections of size at most two;
+- the witness-pair cap;
+- the two-overlap crossing of source chord `{3,7}` with witness chord `{0,4}`;
+- the displayed closure steps;
+- absence of the target row at center `7`;
+- absence of target-triple activation for center `7`.
+
+Current compact summary:
+
+| Quantity | Value |
+|---|---:|
+| final closure | `{0,1,3,4,7}` |
+| target center in closure | `true` |
+| target witnesses in closure | `{0,1,4}` |
+| target row present at center `7` | `false` |
+| target center activated by target triple | `false` |
+
+## Bridge Lesson
+
+This control separates visibility from activation provenance. Seeing the target
+center and the target triple somewhere in the same deletion closure is weaker
+than knowing the target center was activated by that triple, and weaker still
+than knowing the specified fourth witness lies in the same rich class.
+
+## Nonclaims
+
+This is not a polygon, not a Euclidean realizability certificate, not a
+counterexample, and not a refutation of activation lemmas that require
+provenance, critical-row uniqueness, or all-fourth obstruction hypotheses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -357,6 +357,12 @@ put detailed reconciliation in the canonical synthesis.
   replayable wrong-fourth, full-row, and closure-visibility negative controls
   for overstrong closure-activation bridge claims; provenance and guardrail
   data only.
+- [`bootstrap-t12-anti-activation-negative-control.md`](bootstrap-t12-anti-activation-negative-control.md):
+  focused full selected-row anti-activation control showing closure exposure
+  of a center and three witnesses does not pin the target fourth witness.
+- [`closure-visibility-anti-activation-control.md`](closure-visibility-anti-activation-control.md):
+  focused sparse control separating target-label visibility in a closure from
+  activation by the target triple.
 - [`bootstrap-t12-81-3-repeated-support-catalogue-audit.md`](bootstrap-t12-81-3-repeated-support-catalogue-audit.md):
   one-layer repeated-support audit for the stored `81:3` chain-closure prefix
   survivors.

--- a/docs/lemma-driven-bridge-targets.md
+++ b/docs/lemma-driven-bridge-targets.md
@@ -97,12 +97,15 @@ Useful evidence:
 - `docs/bootstrap-t12-81-3-rich-triple-contract.md`
 - `docs/bootstrap-t12-81-3-chain-closure-csp.md`
 - `docs/bootstrap-t12-81-3-repeated-support-saturation-audit.md`
+- `docs/closure-visibility-anti-activation-control.md`
 
 Required guardrails:
 
 - Closure exposure of the fixed selected row is not rich-class forcing.
 - Full target-label visibility does not pin the fourth witness; see
   `docs/closure-activation-negative-controls.md`.
+- Target-label visibility in a deletion closure is not the same as activation
+  provenance by the target triple.
 - The repeated-support saturation packet closes only the stored-prefix,
   same-center-disjoint repeated-support model.
 
@@ -143,10 +146,13 @@ Useful evidence:
 - `docs/bootstrap-t12-hard-strict-endpoints.md`
 - `docs/bootstrap-t12-open-connector-pair.md`
 - `docs/bootstrap-t12-singleton-full-neighborhood-crosswalk.md`
+- `docs/bootstrap-t12-anti-activation-negative-control.md`
 
 Required guardrails:
 
 - Singleton support does not automatically supply both connector endpoints.
+- A full selected-row closure exposure can still switch the target fourth
+  witness.
 - Another selected-row neighborhood widening over the same packets is low
   leverage unless it proves support existence or a new necessary condition.
 


### PR DESCRIPTION
## Summary

- Add focused notes for the full selected-row bootstrap/T12 anti-activation negative control and the sparse closure-visibility anti-activation control.
- Cross-link the focused notes from the aggregate closure-activation guardrail doc, docs index, and lemma-driven bridge target guardrails.
- Preserve the controls as `EXACT_NEGATIVE_CONTROL` / `PROVENANCE` only: no proof of n=9, no proof of Erdos Problem #97, no counterexample, and no source-of-truth status update.

## Validation

- `python scripts/check_bootstrap_t12_anti_activation_negative_control.py --check --assert-expected --json`
- `python scripts/check_closure_visibility_anti_activation_control.py --check --assert-expected --json`
- `python scripts/check_closure_activation_negative_controls.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q tests/test_closure_activation_negative_controls.py`
- `python -m pytest -q` -> `1363 passed, 502 deselected`