### PR TITLE
[codex] Add 151:6 outside-pair escape partition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_full_neighborhood_vertex_circle.py --check --assert-expected --json

--- a/data/certificates/bootstrap_t12_151_6_outside_pair_escape_partition.json
+++ b/data/certificates/bootstrap_t12_151_6_outside_pair_escape_partition.json
@@ -1,0 +1,549 @@
+{
+  "claim_scope": "Proof-mining diagnostic partitioning the source-151 row-6 outside-pair full-neighborhood target rows by support-pair role. It shows that the private-halo-only connector-avoiding row family has 12 basic-filter complete assignments, while endpoint-8 connector-available row families have 16 basic-filter complete assignments, and that exact vertex-circle quotient replay kills all 28. This does not prove outside-pair support existence, does not prove row forcing, does not prove the private-halo-only pair is impossible, does not prove n=9, does not prove the bridge, is not a counterexample, and is not a global status update.",
+  "interpretation": [
+    "The connector-avoiding private-halo-only target rows are not eliminated by the basic incidence/crossing filters.",
+    "All currently recorded private-halo-only and endpoint-8 basic-filter survivors are eliminated by exact vertex-circle quotient replay.",
+    "The remaining bridge gap is genuine outside-pair support existence and row/rich-class forcing, not another selected-row neighborhood replay for this packet.",
+    "The artifact does not prove that pair [3,5] is impossible; it only records where that escape dies inside this diagnostic."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py"
+  },
+  "schema": "erdos97.bootstrap_t12_151_6_outside_pair_escape_partition.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.json",
+      "role": "source 151:6 full-neighborhood vertex-circle packet",
+      "schema": "erdos97.bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.v1",
+      "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_151_6_outside_pair_connector_contract.json",
+      "role": "source 151:6 outside-pair connector contract",
+      "schema": "erdos97.bootstrap_t12_151_6_outside_pair_connector_contract.v1",
+      "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_CONNECTOR_CONTRACT_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_ESCAPE_PARTITION_DIAGNOSTIC_ONLY",
+  "summary": {
+    "basic_filter_complete_assignment_count": 28,
+    "basic_filter_complete_assignment_count_by_partition": {
+      "endpoint8_connector_available": 9,
+      "mixed_private_and_endpoint8": 7,
+      "private_halo_only_connector_avoiding": 12
+    },
+    "basic_filter_non_original_row6_assignment_count": 21,
+    "bootstrap_core_witnesses": [
+      0
+    ],
+    "connector_available_basic_survivor_count": 16,
+    "connector_available_target_row_count": 9,
+    "connector_available_vertex_circle_survivor_count": 0,
+    "connector_avoiding_basic_survivor_count": 12,
+    "connector_avoiding_support_pairs": [
+      [
+        3,
+        5
+      ]
+    ],
+    "connector_avoiding_target_row_count": 4,
+    "connector_avoiding_vertex_circle_survivor_count": 0,
+    "connector_forcing_support_pairs": [
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "cyclic_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8
+    ],
+    "empty_domain_count": 7097,
+    "original_target_center_class": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "outside_support_pairs": [
+      [
+        3,
+        5
+      ],
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "remaining_gap": "The private-halo-only connector-avoiding family survives basic filters, so the remaining proof-facing task is support existence and row/rich-class forcing. This artifact does not prove pair [3,5] impossible, does not prove an endpoint-8 support is forced, and does not promote the review-pending n=9 checker.",
+    "scan_status": "PRIVATE_HALO_ONLY_AND_ENDPOINT8_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED",
+    "search_node_count": 13439,
+    "source_record_ids": [
+      151
+    ],
+    "target_center": 6,
+    "target_center_candidate_count": 13,
+    "target_row_count_by_partition": {
+      "endpoint8_connector_available": 8,
+      "mixed_private_and_endpoint8": 1,
+      "private_halo_only_connector_avoiding": 4
+    },
+    "target_row_key": "151:6",
+    "target_row_keys_by_partition": {
+      "endpoint8_connector_available": [
+        "0,1,3,8",
+        "0,1,5,8",
+        "0,2,3,8",
+        "0,2,5,8",
+        "0,3,4,8",
+        "0,3,7,8",
+        "0,4,5,8",
+        "0,5,7,8"
+      ],
+      "mixed_private_and_endpoint8": [
+        "0,3,5,8"
+      ],
+      "private_halo_only_connector_avoiding": [
+        "0,1,3,5",
+        "0,2,3,5",
+        "0,3,4,5",
+        "0,3,5,7"
+      ]
+    },
+    "vertex_circle_status_counts": {
+      "self_edge": 20,
+      "strict_cycle": 8
+    },
+    "vertex_circle_status_counts_by_partition": {
+      "endpoint8_connector_available": {
+        "self_edge": 7,
+        "strict_cycle": 2
+      },
+      "mixed_private_and_endpoint8": {
+        "self_edge": 3,
+        "strict_cycle": 4
+      },
+      "private_halo_only_connector_avoiding": {
+        "self_edge": 10,
+        "strict_cycle": 2
+      }
+    },
+    "vertex_circle_surviving_assignment_count": 0,
+    "vertex_circle_surviving_assignment_count_by_partition": {
+      "endpoint8_connector_available": 0,
+      "mixed_private_and_endpoint8": 0,
+      "private_halo_only_connector_avoiding": 0
+    }
+  },
+  "target_row_partition": [
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": false,
+      "contains_private_halo_pair": true,
+      "empty_domain_count": 198,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "private_halo_only_connector_avoiding",
+      "search_node_count": 364,
+      "support_pair_roles_present": [
+        "connector_avoiding_escape_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          5
+        ]
+      ],
+      "target_center_class": [
+        0,
+        1,
+        3,
+        5
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,1,3,5",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 160,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 315,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        1,
+        3,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,1,3,8",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 269,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 451,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          5,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        1,
+        5,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,1,5,8",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": false,
+      "contains_private_halo_pair": true,
+      "empty_domain_count": 206,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "private_halo_only_connector_avoiding",
+      "search_node_count": 391,
+      "support_pair_roles_present": [
+        "connector_avoiding_escape_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          5
+        ]
+      ],
+      "target_center_class": [
+        0,
+        2,
+        3,
+        5
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,2,3,5",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 153,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 272,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        2,
+        3,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,2,3,8",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 3,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 418,
+      "non_original_target_basic_assignment_count": 3,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 786,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          5,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        2,
+        5,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,2,5,8",
+      "vertex_circle_status_counts": {
+        "self_edge": 2,
+        "strict_cycle": 1
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": false,
+      "contains_private_halo_pair": true,
+      "empty_domain_count": 231,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "private_halo_only_connector_avoiding",
+      "search_node_count": 477,
+      "support_pair_roles_present": [
+        "connector_avoiding_escape_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          5
+        ]
+      ],
+      "target_center_class": [
+        0,
+        3,
+        4,
+        5
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,3,4,5",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 315,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 586,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        3,
+        4,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,3,4,8",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 12,
+      "contains_endpoint8": false,
+      "contains_private_halo_pair": true,
+      "empty_domain_count": 2729,
+      "non_original_target_basic_assignment_count": 12,
+      "partition": "private_halo_only_connector_avoiding",
+      "search_node_count": 5150,
+      "support_pair_roles_present": [
+        "connector_avoiding_escape_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          5
+        ]
+      ],
+      "target_center_class": [
+        0,
+        3,
+        5,
+        7
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,3,5,7",
+      "vertex_circle_status_counts": {
+        "self_edge": 10,
+        "strict_cycle": 2
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 7,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": true,
+      "empty_domain_count": 452,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "mixed_private_and_endpoint8",
+      "search_node_count": 894,
+      "support_pair_roles_present": [
+        "connector_avoiding_escape_support",
+        "endpoint8_connector_support",
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          5
+        ],
+        [
+          3,
+          8
+        ],
+        [
+          5,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        3,
+        5,
+        8
+      ],
+      "target_center_class_is_original": true,
+      "target_center_class_key": "0,3,5,8",
+      "vertex_circle_status_counts": {
+        "self_edge": 3,
+        "strict_cycle": 4
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 0,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 228,
+      "non_original_target_basic_assignment_count": 0,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 484,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          3,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        3,
+        7,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,3,7,8",
+      "vertex_circle_status_counts": {},
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 3,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 448,
+      "non_original_target_basic_assignment_count": 3,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 915,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          5,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        4,
+        5,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,4,5,8",
+      "vertex_circle_status_counts": {
+        "self_edge": 2,
+        "strict_cycle": 1
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    },
+    {
+      "basic_filter_complete_assignment_count": 3,
+      "contains_endpoint8": true,
+      "contains_private_halo_pair": false,
+      "empty_domain_count": 1290,
+      "non_original_target_basic_assignment_count": 3,
+      "partition": "endpoint8_connector_available",
+      "search_node_count": 2354,
+      "support_pair_roles_present": [
+        "endpoint8_connector_support"
+      ],
+      "support_pairs_present": [
+        [
+          5,
+          8
+        ]
+      ],
+      "target_center_class": [
+        0,
+        5,
+        7,
+        8
+      ],
+      "target_center_class_is_original": false,
+      "target_center_class_key": "0,5,7,8",
+      "vertex_circle_status_counts": {
+        "self_edge": 3
+      },
+      "vertex_circle_surviving_assignment_count": 0
+    }
+  ],
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": [],
+  "validation_status": "passed"
+}

--- a/docs/bootstrap-t12-151-6-outside-pair-connector-contract.md
+++ b/docs/bootstrap-t12-151-6-outside-pair-connector-contract.md
@@ -88,6 +88,12 @@ Can genuine outside-pair/rich-class geometry force one of [3,8] or [5,8],
 or can the private-halo-only pair [3,5] realize the connector-avoiding escape?
 ```
 
+The companion partition
+`docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` locates this escape
+inside the full-neighborhood packet: private-halo-only rows leave `12`
+basic-filter survivors, while endpoint-`8` connector-available rows leave
+`16`; exact vertex-circle replay kills all `28`.
+
 Either outcome would reduce the bridge gap. Forcing an endpoint-`8` support
 gives the needed connector without proving the full fixed row. Explaining the
 `[3,5]` escape would isolate the exact geometric route that keeps the connector

--- a/docs/bootstrap-t12-151-6-outside-pair-escape-partition.md
+++ b/docs/bootstrap-t12-151-6-outside-pair-escape-partition.md
@@ -1,0 +1,88 @@
+# Bootstrap T12 151:6 Outside-Pair Escape Partition
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note partitions the source-`151` row-`6` outside-pair full-neighborhood
+vertex-circle packet by the connector role of the row-`6` support pair. It is a
+derivative crosswalk over two existing checked packets:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --write --assert-expected
+```
+
+to `data/certificates/bootstrap_t12_151_6_outside_pair_escape_partition.json`.
+
+## Scope
+
+The source packets are:
+
+- `data/certificates/bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.json`;
+- `data/certificates/bootstrap_t12_151_6_outside_pair_connector_contract.json`.
+
+The partition keeps the `151:6` target fixed to the thirteen candidate
+bootstrap-core-plus-outside-pair rows from the full-neighborhood packet and
+classifies each candidate row as:
+
+- `private_halo_only_connector_avoiding`: contains pair `[3,5]` and avoids
+  endpoint `8`;
+- `endpoint8_connector_available`: contains `[3,8]` or `[5,8]` and does not
+  also contain `[3,5]`;
+- `mixed_private_and_endpoint8`: the original row `[0,3,5,8]`, which contains
+  both the private pair and endpoint-`8` connector supports.
+
+## Partition Result
+
+| Partition | Candidate rows | Basic survivors | Vertex-circle statuses | Vertex-circle survivors |
+| --- | ---: | ---: | --- | ---: |
+| `private_halo_only_connector_avoiding` | 4 | 12 | `self_edge: 10`, `strict_cycle: 2` | 0 |
+| `endpoint8_connector_available` | 8 | 9 | `self_edge: 7`, `strict_cycle: 2` | 0 |
+| `mixed_private_and_endpoint8` | 1 | 7 | `self_edge: 3`, `strict_cycle: 4` | 0 |
+
+Combined:
+
+```text
+connector-avoiding basic survivors:   12
+connector-available basic survivors:  16
+total basic survivors:                28
+vertex-circle survivors:               0
+```
+
+The named connector-avoiding lane is therefore not killed by the basic
+incidence/crossing filters. It is killed only when the stored exact
+vertex-circle quotient replay is applied.
+
+## Interpretation
+
+The connector contract already says that endpoint-`8` outside supports
+`[3,8]` and `[5,8]` would supply the needed equality connector at center `6`,
+while private-halo-only `[3,5]` is the unique connector-avoiding support pair
+in the current ledger.
+
+This partition shows where that escape sits inside the full-neighborhood
+packet: private-halo-only `[3,5]` rows leave `12` complete basic-filter
+assignments, all in the non-original row `[0,3,5,7]`, and all are then
+obstructed by vertex-circle replay.
+
+## Remaining Gap
+
+This artifact does not prove outside-pair support existence, does not prove
+row forcing, and does not prove that pair `[3,5]` is impossible. The next
+proof-facing target is still:
+
+```text
+Force an endpoint-8 outside support, or prove that the private-halo-only
+[3,5] escape cannot occur under genuine minimal/rich-class hypotheses.
+```
+
+## What This Does Not Prove
+
+This artifact does not prove `n=9`, the bootstrap bridge, Erdos Problem #97, or
+a counterexample. It is a finite diagnostic crosswalk for one
+relation-sufficient outside-pair row target.

--- a/docs/bootstrap-t12-151-6-outside-pair-full-neighborhood-vertex-circle.md
+++ b/docs/bootstrap-t12-151-6-outside-pair-full-neighborhood-vertex-circle.md
@@ -71,6 +71,16 @@ self-edge:     20
 strict-cycle:   8
 ```
 
+The derivative partition
+`docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` splits these
+survivors by support role:
+
+```text
+private-halo-only connector-avoiding basic survivors: 12
+endpoint-8 connector-available basic survivors:       16
+vertex-circle survivors in both groups:                0
+```
+
 The checked scan status is:
 
 ```text

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -491,7 +491,13 @@ minimal/rich-class hypotheses.
    `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` narrows that
    support question: endpoint-`8` pairs `[3,8]` and `[5,8]` would supply the
    needed connector, while private-halo-only `[3,5]` is the unique
-   connector-avoiding outside-pair escape. The
+   connector-avoiding outside-pair escape. The escape partition in
+   `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` now shows this
+   private-halo-only lane has `12` basic-filter survivors, while the
+   endpoint-`8` connector-available lanes have `16`; vertex-circle replay kills
+   all `28`. This is a diagnostic split only, so the next useful PR should
+   attack support existence or forcing for endpoint-`8` versus `[3,5]`, not
+   another selected-row neighborhood widening around `151:6`. The
    source-`151` singleton-support audit in
    `docs/bootstrap-t12-151-singleton-support-audit.md` applies the same local
    audit shape to rows `151:5` and `151:8`; it also leaves the genuine

--- a/docs/index.md
+++ b/docs/index.md
@@ -393,6 +393,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-151-6-outside-pair-connector-contract.md`](bootstrap-t12-151-6-outside-pair-connector-contract.md):
   connector contract splitting the source-`151` row-`6` endpoint-`8` outside
   supports from the private-halo-only connector escape.
+- [`bootstrap-t12-151-6-outside-pair-escape-partition.md`](bootstrap-t12-151-6-outside-pair-escape-partition.md):
+  crosswalk partitioning the source-`151` row-`6` full-neighborhood survivors
+  by private-halo-only versus endpoint-`8` support role.
 - [`bootstrap-t12-151-singleton-support-audit.md`](bootstrap-t12-151-singleton-support-audit.md):
   source-`151` singleton-support audit covering rows `151:5` and `151:8`.
 - [`bootstrap-t12-151-singleton-two-row-drop.md`](bootstrap-t12-151-singleton-two-row-drop.md):

--- a/docs/lemma-driven-bridge-targets.md
+++ b/docs/lemma-driven-bridge-targets.md
@@ -53,7 +53,7 @@ force one of the stored local templates by themselves.
 | `T01`--`T12` local templates | `docs/n9-vertex-circle-local-lemma-review-packet.md` packages 12 templates, 16 families, and 184 stored assignments | A proof that a minimal/rich-support counterexample must contain one of these local cores, without enumerating the whole frontier |
 | non-ear frontier rows `81` and `151` | `docs/bridge-lemma-frontier.md` and `docs/bootstrap-vertex-circle-overlay.md` isolate the two tight `n=9` non-ear rows and their `T12/F16` strict-cycle landing | A bootstrap/rich-class lemma that makes the needed T12 row relations genuinely available |
 | source `81`, row `3` | `docs/bootstrap-t12-81-3-closure-target.md` and `docs/bootstrap-t12-81-3-rich-triple-contract.md` reduce the target to the connector pair `[0,1]` | Force a genuine center-`3` rich class containing `[0,1]`, or classify the label-`6` connector-avoiding escape |
-| source `151`, row `6` | `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` splits endpoint-`8` supports from private-halo-only pair `[3,5]` | Force an endpoint-`8` outside-pair support, or prove the `[3,5]` private-halo-only escape is geometrically impossible |
+| source `151`, row `6` | `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` splits endpoint-`8` supports from private-halo-only pair `[3,5]`; `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` shows the private-halo-only lane has `12` basic survivors before vertex-circle replay | Force an endpoint-`8` outside-pair support, or prove the `[3,5]` private-halo-only escape is geometrically impossible |
 | source `151`, rows `7` and `8` | `docs/bootstrap-t12-hard-strict-endpoints.md` isolates missing strict-edge endpoint sets | Supply the hard endpoint labels from genuine closure/support geometry, not fixed-row bookkeeping |
 | block-6 fragile family | `docs/block6-fragile-vertex-circle-extension-audit.md` and `docs/bridge-negative-controls.md` record exact negative controls | A minimal/rich-class condition that rejects the family beyond fixed natural/block-preserving order slices |
 
@@ -122,12 +122,15 @@ Useful evidence:
 
 - `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md`
 - `docs/bootstrap-t12-151-6-outside-pair-full-neighborhood-vertex-circle.md`
+- `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md`
 - `docs/bootstrap-t12-relation-sufficient-rows.md`
 
 Required guardrails:
 
 - The fixed full-neighborhood vertex-circle packet kills selected-row
   neighborhoods, not support existence.
+- The private-halo-only lane has basic-filter survivors, so it cannot be
+  dismissed by incidence/crossing filters alone.
 - The private-halo-only pair `[3,5]` is the named escape and must be excluded
   or explicitly realized as an escape mechanism.
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -7435,6 +7435,73 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_151_6_outside_pair_escape_partition
+    path: data/certificates/bootstrap_t12_151_6_outside_pair_escape_partition.json
+    sha256: 4f139bf40ca66a2e195719b042eb6ff5d4a09a7c9f2f64ca235502a9d50c7073
+    size_bytes: 16047
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py
+    command: python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py
+    check_command: python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-151 row-6 outside-pair escape-partition crosswalk; private-halo-only connector-avoiding rows have 12 basic-filter survivors and endpoint-8 connector-available rows have 16, but all 28 are vertex-circle obstructed. This is not outside-pair support existence, not row forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_151_6_outside_pair_escape_partition.v1
+      status: BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_ESCAPE_PARTITION_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "151:6"
+      summary.source_record_ids:
+        - 151
+      summary.target_center: 6
+      summary.target_center_candidate_count: 13
+      summary.target_row_count_by_partition.private_halo_only_connector_avoiding: 4
+      summary.target_row_count_by_partition.endpoint8_connector_available: 8
+      summary.target_row_count_by_partition.mixed_private_and_endpoint8: 1
+      summary.basic_filter_complete_assignment_count_by_partition.private_halo_only_connector_avoiding: 12
+      summary.basic_filter_complete_assignment_count_by_partition.endpoint8_connector_available: 9
+      summary.basic_filter_complete_assignment_count_by_partition.mixed_private_and_endpoint8: 7
+      summary.connector_avoiding_basic_survivor_count: 12
+      summary.connector_available_basic_survivor_count: 16
+      summary.vertex_circle_status_counts_by_partition.private_halo_only_connector_avoiding.self_edge: 10
+      summary.vertex_circle_status_counts_by_partition.private_halo_only_connector_avoiding.strict_cycle: 2
+      summary.vertex_circle_status_counts_by_partition.endpoint8_connector_available.self_edge: 7
+      summary.vertex_circle_status_counts_by_partition.endpoint8_connector_available.strict_cycle: 2
+      summary.vertex_circle_status_counts_by_partition.mixed_private_and_endpoint8.self_edge: 3
+      summary.vertex_circle_status_counts_by_partition.mixed_private_and_endpoint8.strict_cycle: 4
+      summary.connector_avoiding_vertex_circle_survivor_count: 0
+      summary.connector_available_vertex_circle_survivor_count: 0
+      summary.basic_filter_complete_assignment_count: 28
+      summary.basic_filter_non_original_row6_assignment_count: 21
+      summary.vertex_circle_status_counts.self_edge: 20
+      summary.vertex_circle_status_counts.strict_cycle: 8
+      summary.vertex_circle_surviving_assignment_count: 0
+      summary.search_node_count: 13439
+      summary.empty_domain_count: 7097
+      summary.scan_status: PRIVATE_HALO_ONLY_AND_ENDPOINT8_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED
+      provenance.generator: scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py
+      provenance.command: python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - outside pair support proves row-center forcing
+      - the 151:6 row is forced
+      - the 151:6 outside support exists
+      - the 151:6 escape partition proves the bridge
+      - the private-halo-only pair 3,5 is impossible
+      - endpoint-8 support is forced
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_151_singleton_support_audit
     path: data/certificates/bootstrap_t12_151_singleton_support_audit.json
     sha256: 9647c2062ffdc1363dab531a70aa3e2e97e4bb4330b337516f286591eb1dfc5e

--- a/scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py
+++ b/scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py
@@ -1,0 +1,864 @@
+#!/usr/bin/env python3
+"""Generate or check the bootstrap/T12 151:6 outside-pair escape partition."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.path_display import display_path  # noqa: E402
+
+SCHEMA = "erdos97.bootstrap_t12_151_6_outside_pair_escape_partition.v1"
+STATUS = "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_ESCAPE_PARTITION_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+SCAN_STATUS = "PRIVATE_HALO_ONLY_AND_ENDPOINT8_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED"
+CLAIM_SCOPE = (
+    "Proof-mining diagnostic partitioning the source-151 row-6 outside-pair "
+    "full-neighborhood target rows by support-pair role. It shows that the "
+    "private-halo-only connector-avoiding row family has 12 basic-filter "
+    "complete assignments, while endpoint-8 connector-available row families "
+    "have 16 basic-filter complete assignments, and that exact vertex-circle "
+    "quotient replay kills all 28. This does not prove outside-pair support "
+    "existence, does not prove row forcing, does not prove the private-halo-only "
+    "pair is impossible, does not prove n=9, does not prove the bridge, is not "
+    "a counterexample, and is not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py",
+    "command": (
+        "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py "
+        "--write --assert-expected"
+    ),
+}
+
+DEFAULT_SOURCE_FULL_NEIGHBORHOOD = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.json"
+)
+DEFAULT_SOURCE_CONNECTOR_CONTRACT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_outside_pair_connector_contract.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_outside_pair_escape_partition.json"
+)
+
+SOURCE_FULL_NEIGHBORHOOD_SCHEMA = (
+    "erdos97.bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.v1"
+)
+SOURCE_FULL_NEIGHBORHOOD_STATUS = (
+    "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_"
+    "DIAGNOSTIC_ONLY"
+)
+SOURCE_CONNECTOR_CONTRACT_SCHEMA = (
+    "erdos97.bootstrap_t12_151_6_outside_pair_connector_contract.v1"
+)
+SOURCE_CONNECTOR_CONTRACT_STATUS = (
+    "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_CONNECTOR_CONTRACT_DIAGNOSTIC_ONLY"
+)
+SOURCE_SCAN_STATUS = "FULL_NEIGHBORHOOD_BASIC_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED"
+
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "interpretation",
+    "provenance",
+    "schema",
+    "source_artifacts",
+    "status",
+    "summary",
+    "target_row_partition",
+    "trust",
+    "validation_errors",
+    "validation_status",
+}
+EXPECTED_TARGET_RECORD_KEYS = {
+    "basic_filter_complete_assignment_count",
+    "contains_endpoint8",
+    "contains_private_halo_pair",
+    "empty_domain_count",
+    "non_original_target_basic_assignment_count",
+    "partition",
+    "search_node_count",
+    "support_pair_roles_present",
+    "support_pairs_present",
+    "target_center_class",
+    "target_center_class_is_original",
+    "target_center_class_key",
+    "vertex_circle_status_counts",
+    "vertex_circle_surviving_assignment_count",
+}
+PARTITION_ORDER = [
+    "private_halo_only_connector_avoiding",
+    "endpoint8_connector_available",
+    "mixed_private_and_endpoint8",
+]
+EXPECTED_TARGET_ROW_KEYS_BY_PARTITION = {
+    "private_halo_only_connector_avoiding": [
+        "0,1,3,5",
+        "0,2,3,5",
+        "0,3,4,5",
+        "0,3,5,7",
+    ],
+    "endpoint8_connector_available": [
+        "0,1,3,8",
+        "0,1,5,8",
+        "0,2,3,8",
+        "0,2,5,8",
+        "0,3,4,8",
+        "0,3,7,8",
+        "0,4,5,8",
+        "0,5,7,8",
+    ],
+    "mixed_private_and_endpoint8": ["0,3,5,8"],
+}
+EXPECTED_PARTITION_COUNTS = {
+    "private_halo_only_connector_avoiding": 4,
+    "endpoint8_connector_available": 8,
+    "mixed_private_and_endpoint8": 1,
+}
+EXPECTED_BASIC_BY_PARTITION = {
+    "private_halo_only_connector_avoiding": 12,
+    "endpoint8_connector_available": 9,
+    "mixed_private_and_endpoint8": 7,
+}
+EXPECTED_STATUS_BY_PARTITION = {
+    "private_halo_only_connector_avoiding": {"self_edge": 10, "strict_cycle": 2},
+    "endpoint8_connector_available": {"self_edge": 7, "strict_cycle": 2},
+    "mixed_private_and_endpoint8": {"self_edge": 3, "strict_cycle": 4},
+}
+EXPECTED_ZERO_SURVIVORS_BY_PARTITION = {
+    "private_halo_only_connector_avoiding": 0,
+    "endpoint8_connector_available": 0,
+    "mixed_private_and_endpoint8": 0,
+}
+EXPECTED_CYCLIC_ORDER = list(range(9))
+EXPECTED_OUTSIDE_SUPPORT_PAIRS = [[3, 5], [3, 8], [5, 8]]
+PRIVATE_HALO_ONLY_PAIR = [3, 5]
+ENDPOINT8_SUPPORT_PAIRS = [[3, 8], [5, 8]]
+ORIGINAL_TARGET_CLASS = [0, 3, 5, 8]
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def build_escape_partition_payload(
+    full_neighborhood: Mapping[str, Any],
+    connector_contract: Mapping[str, Any],
+    *,
+    full_neighborhood_path: Path = DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    connector_contract_path: Path = DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+) -> dict[str, Any]:
+    """Return the deterministic 151:6 outside-pair escape-partition payload."""
+
+    errors: list[str] = []
+    _validate_source_full_neighborhood(full_neighborhood, errors)
+    _validate_source_connector_contract(connector_contract, errors)
+    _validate_source_alignment(full_neighborhood, connector_contract, errors)
+
+    records = _target_row_records(full_neighborhood, errors)
+    summary = _summary(records)
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "summary": summary,
+        "target_row_partition": records,
+        "source_artifacts": [
+            _source_summary(
+                full_neighborhood_path,
+                "source 151:6 full-neighborhood vertex-circle packet",
+                full_neighborhood,
+            ),
+            _source_summary(
+                connector_contract_path,
+                "source 151:6 outside-pair connector contract",
+                connector_contract,
+            ),
+        ],
+        "interpretation": [
+            (
+                "The connector-avoiding private-halo-only target rows are not "
+                "eliminated by the basic incidence/crossing filters."
+            ),
+            (
+                "All currently recorded private-halo-only and endpoint-8 "
+                "basic-filter survivors are eliminated by exact vertex-circle "
+                "quotient replay."
+            ),
+            (
+                "The remaining bridge gap is genuine outside-pair support "
+                "existence and row/rich-class forcing, not another selected-row "
+                "neighborhood replay for this packet."
+            ),
+            (
+                "The artifact does not prove that pair [3,5] is impossible; "
+                "it only records where that escape dies inside this diagnostic."
+            ),
+        ],
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "provenance": PROVENANCE,
+    }
+    assert_expected_escape_partition(payload)
+    return payload
+
+
+def assert_expected_escape_partition(payload: Mapping[str, Any]) -> None:
+    """Assert the pinned 151:6 outside-pair escape partition."""
+
+    errors = validate_payload(payload, recompute=False)
+    if errors:
+        raise AssertionError("; ".join(errors))
+
+
+def validate_payload(
+    payload: Mapping[str, Any],
+    *,
+    recompute: bool = True,
+    full_neighborhood_path: Path = DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    connector_contract_path: Path = DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+) -> list[str]:
+    """Return validation errors for an escape-partition payload."""
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+        return errors
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "validation_status": "passed",
+        "validation_errors": [],
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        if payload.get(key) != expected:
+            errors.append(
+                f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}"
+            )
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str):
+        errors.append("claim_scope must be a string")
+    else:
+        for phrase in (
+            "does not prove outside-pair support existence",
+            "does not prove row forcing",
+            "does not prove the private-halo-only pair is impossible",
+            "does not prove n=9",
+            "does not prove the bridge",
+            "not a counterexample",
+            "not a global status update",
+        ):
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must contain {phrase!r}")
+
+    records = payload.get("target_row_partition")
+    if not isinstance(records, list):
+        errors.append("target_row_partition must be a list")
+        return errors
+    for record in records:
+        if not isinstance(record, Mapping):
+            errors.append("target_row_partition entries must be objects")
+            continue
+        _validate_target_record(record, errors)
+    _validate_summary(payload.get("summary"), records, errors)
+
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list):
+        errors.append("interpretation must be a list")
+    elif not any("does not prove that pair [3,5] is impossible" in item for item in interpretation):
+        errors.append("interpretation must preserve the [3,5] nonclaim")
+
+    if recompute and not errors:
+        generated = build_escape_partition_payload(
+            load_artifact(full_neighborhood_path),
+            load_artifact(connector_contract_path),
+            full_neighborhood_path=full_neighborhood_path,
+            connector_contract_path=connector_contract_path,
+        )
+        if dict(payload) != generated:
+            errors.append("stored artifact is stale relative to source packets")
+    return errors
+
+
+def summary_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    errors: Sequence[str],
+) -> dict[str, Any]:
+    """Return a compact CLI summary."""
+
+    summary = payload.get("summary", {})
+    if not isinstance(summary, Mapping):
+        summary = {}
+    return {
+        "artifact": display_path(path, ROOT),
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "ok": not errors,
+        "target_row_key": summary.get("target_row_key"),
+        "target_center_candidate_count": summary.get("target_center_candidate_count"),
+        "target_row_count_by_partition": summary.get("target_row_count_by_partition"),
+        "basic_filter_complete_assignment_count_by_partition": summary.get(
+            "basic_filter_complete_assignment_count_by_partition"
+        ),
+        "vertex_circle_status_counts_by_partition": summary.get(
+            "vertex_circle_status_counts_by_partition"
+        ),
+        "connector_avoiding_basic_survivor_count": summary.get(
+            "connector_avoiding_basic_survivor_count"
+        ),
+        "connector_available_basic_survivor_count": summary.get(
+            "connector_available_basic_survivor_count"
+        ),
+        "vertex_circle_surviving_assignment_count": summary.get(
+            "vertex_circle_surviving_assignment_count"
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def _target_row_records(
+    full_neighborhood: Mapping[str, Any],
+    errors: list[str],
+) -> list[dict[str, Any]]:
+    source_records = full_neighborhood.get("per_target_center_class")
+    if not isinstance(source_records, list):
+        errors.append("source per_target_center_class must be a list")
+        return []
+
+    records = []
+    for source_record in source_records:
+        if not isinstance(source_record, Mapping):
+            errors.append("source target-center records must be objects")
+            continue
+        target_class = _int_list(
+            _sequence(source_record.get("target_center_class"), "target_center_class")
+        )
+        support_pairs_present = _support_pairs_present(target_class)
+        records.append(
+            {
+                "target_center_class_key": _row_key(target_class),
+                "target_center_class": target_class,
+                "target_center_class_is_original": target_class
+                == ORIGINAL_TARGET_CLASS,
+                "partition": _target_partition(target_class),
+                "support_pairs_present": support_pairs_present,
+                "support_pair_roles_present": _support_pair_roles_present(
+                    support_pairs_present
+                ),
+                "contains_private_halo_pair": _contains_pair(
+                    target_class, PRIVATE_HALO_ONLY_PAIR
+                ),
+                "contains_endpoint8": 8 in set(target_class),
+                "search_node_count": _int(source_record.get("search_node_count")),
+                "empty_domain_count": _int(source_record.get("empty_domain_count")),
+                "basic_filter_complete_assignment_count": _int(
+                    source_record.get("basic_filter_complete_assignment_count")
+                ),
+                "non_original_target_basic_assignment_count": _int(
+                    source_record.get("non_original_target_basic_assignment_count")
+                ),
+                "vertex_circle_status_counts": _status_counts(
+                    source_record.get("vertex_circle_status_counts")
+                ),
+                "vertex_circle_surviving_assignment_count": _int(
+                    source_record.get("vertex_circle_surviving_assignment_count")
+                ),
+            }
+        )
+    return sorted(records, key=lambda record: str(record["target_center_class_key"]))
+
+
+def _summary(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    rows_by_partition: dict[str, list[str]] = {partition: [] for partition in PARTITION_ORDER}
+    row_counts: Counter[str] = Counter()
+    basic_counts: Counter[str] = Counter()
+    vertex_survivor_counts: Counter[str] = Counter()
+    status_counts_by_partition: dict[str, Counter[str]] = {
+        partition: Counter() for partition in PARTITION_ORDER
+    }
+    status_counts_total: Counter[str] = Counter()
+    search_nodes = 0
+    empty_domains = 0
+    non_original_basic = 0
+    for record in records:
+        partition = str(record["partition"])
+        row_key = str(record["target_center_class_key"])
+        rows_by_partition[partition].append(row_key)
+        row_counts[partition] += 1
+        basic_counts[partition] += int(record["basic_filter_complete_assignment_count"])
+        vertex_survivor_counts[partition] += int(
+            record["vertex_circle_surviving_assignment_count"]
+        )
+        status_counts = _status_counts(record["vertex_circle_status_counts"])
+        status_counts_by_partition[partition].update(status_counts)
+        status_counts_total.update(status_counts)
+        search_nodes += int(record["search_node_count"])
+        empty_domains += int(record["empty_domain_count"])
+        non_original_basic += int(record["non_original_target_basic_assignment_count"])
+
+    connector_available_basic = (
+        basic_counts["endpoint8_connector_available"]
+        + basic_counts["mixed_private_and_endpoint8"]
+    )
+    connector_available_vertex_survivors = (
+        vertex_survivor_counts["endpoint8_connector_available"]
+        + vertex_survivor_counts["mixed_private_and_endpoint8"]
+    )
+    return {
+        "target_row_key": "151:6",
+        "source_record_ids": [151],
+        "cyclic_order": EXPECTED_CYCLIC_ORDER,
+        "target_center": 6,
+        "bootstrap_core_witnesses": [0],
+        "outside_support_pairs": EXPECTED_OUTSIDE_SUPPORT_PAIRS,
+        "connector_avoiding_support_pairs": [PRIVATE_HALO_ONLY_PAIR],
+        "connector_forcing_support_pairs": ENDPOINT8_SUPPORT_PAIRS,
+        "original_target_center_class": ORIGINAL_TARGET_CLASS,
+        "target_center_candidate_count": len(records),
+        "target_row_keys_by_partition": rows_by_partition,
+        "target_row_count_by_partition": _ordered_count_dict(row_counts),
+        "basic_filter_complete_assignment_count_by_partition": _ordered_count_dict(
+            basic_counts
+        ),
+        "vertex_circle_status_counts_by_partition": {
+            partition: dict(sorted(status_counts_by_partition[partition].items()))
+            for partition in PARTITION_ORDER
+        },
+        "vertex_circle_surviving_assignment_count_by_partition": _ordered_count_dict(
+            vertex_survivor_counts
+        ),
+        "connector_avoiding_target_row_count": row_counts[
+            "private_halo_only_connector_avoiding"
+        ],
+        "connector_available_target_row_count": (
+            row_counts["endpoint8_connector_available"]
+            + row_counts["mixed_private_and_endpoint8"]
+        ),
+        "connector_avoiding_basic_survivor_count": basic_counts[
+            "private_halo_only_connector_avoiding"
+        ],
+        "connector_available_basic_survivor_count": connector_available_basic,
+        "connector_avoiding_vertex_circle_survivor_count": vertex_survivor_counts[
+            "private_halo_only_connector_avoiding"
+        ],
+        "connector_available_vertex_circle_survivor_count": (
+            connector_available_vertex_survivors
+        ),
+        "basic_filter_complete_assignment_count": sum(basic_counts.values()),
+        "basic_filter_non_original_row6_assignment_count": non_original_basic,
+        "vertex_circle_status_counts": dict(sorted(status_counts_total.items())),
+        "vertex_circle_surviving_assignment_count": sum(
+            vertex_survivor_counts.values()
+        ),
+        "search_node_count": search_nodes,
+        "empty_domain_count": empty_domains,
+        "scan_status": SCAN_STATUS,
+        "remaining_gap": (
+            "The private-halo-only connector-avoiding family survives basic "
+            "filters, so the remaining proof-facing task is support existence "
+            "and row/rich-class forcing. This artifact does not prove pair "
+            "[3,5] impossible, does not prove an endpoint-8 support is forced, "
+            "and does not promote the review-pending n=9 checker."
+        ),
+    }
+
+
+def _validate_source_full_neighborhood(
+    source: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "schema": SOURCE_FULL_NEIGHBORHOOD_SCHEMA,
+        "status": SOURCE_FULL_NEIGHBORHOOD_STATUS,
+        "trust": TRUST,
+    }
+    _validate_source_meta("source full-neighborhood", source, expected, errors)
+    summary = _mapping(source.get("summary"), "source full-neighborhood summary", errors)
+    if not summary:
+        return
+    expected_summary = {
+        "target_row_key": "151:6",
+        "source_record_ids": [151],
+        "cyclic_order": EXPECTED_CYCLIC_ORDER,
+        "target_center": 6,
+        "bootstrap_core_witnesses": [0],
+        "outside_support_pairs": EXPECTED_OUTSIDE_SUPPORT_PAIRS,
+        "original_target_center_class": ORIGINAL_TARGET_CLASS,
+        "target_center_candidate_count": 13,
+        "basic_filter_complete_assignment_count": 28,
+        "basic_filter_non_original_row6_assignment_count": 21,
+        "vertex_circle_status_counts": {"self_edge": 20, "strict_cycle": 8},
+        "vertex_circle_surviving_assignment_count": 0,
+        "non_original_vertex_circle_surviving_assignment_count": 0,
+        "scan_status": SOURCE_SCAN_STATUS,
+    }
+    for key, expected_value in expected_summary.items():
+        _expect_mapping_field(
+            "source full-neighborhood summary", summary, key, expected_value, errors
+        )
+
+
+def _validate_source_connector_contract(
+    source: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "schema": SOURCE_CONNECTOR_CONTRACT_SCHEMA,
+        "status": SOURCE_CONNECTOR_CONTRACT_STATUS,
+        "trust": TRUST,
+    }
+    _validate_source_meta("source connector contract", source, expected, errors)
+    summary = _mapping(source.get("summary"), "source connector contract summary", errors)
+    if not summary:
+        return
+    expected_summary = {
+        "target_row_key": "151:6",
+        "source_record_ids": [151],
+        "target_row_center": 6,
+        "bootstrap_core_witnesses": [0],
+        "outside_support_pairs": EXPECTED_OUTSIDE_SUPPORT_PAIRS,
+        "connector_forcing_support_pairs": ENDPOINT8_SUPPORT_PAIRS,
+        "connector_avoiding_support_pairs": [PRIVATE_HALO_ONLY_PAIR],
+        "escape_status": "CONNECTOR_ESCAPE_REQUIRES_PRIVATE_HALO_ONLY_PAIR_3_5",
+        "rich_support_existence_status": "OPEN_TARGET_NOT_PROVED",
+    }
+    for key, expected_value in expected_summary.items():
+        _expect_mapping_field(
+            "source connector contract summary", summary, key, expected_value, errors
+        )
+
+
+def _validate_source_alignment(
+    full_neighborhood: Mapping[str, Any],
+    connector_contract: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    full_summary = _mapping(
+        full_neighborhood.get("summary"), "source full-neighborhood summary", errors
+    )
+    contract_summary = _mapping(
+        connector_contract.get("summary"), "source connector contract summary", errors
+    )
+    if not full_summary or not contract_summary:
+        return
+    for key in ("target_row_key", "source_record_ids", "bootstrap_core_witnesses"):
+        if full_summary.get(key) != contract_summary.get(key):
+            errors.append(f"source alignment mismatch for {key}")
+    if full_summary.get("target_center") != contract_summary.get("target_row_center"):
+        errors.append("source alignment mismatch for target center")
+    if full_summary.get("outside_support_pairs") != contract_summary.get(
+        "outside_support_pairs"
+    ):
+        errors.append("source alignment mismatch for outside support pairs")
+
+
+def _validate_source_meta(
+    label: str,
+    source: Mapping[str, Any],
+    expected: Mapping[str, str],
+    errors: list[str],
+) -> None:
+    for key, expected_value in expected.items():
+        if source.get(key) != expected_value:
+            errors.append(
+                f"{label} {key} mismatch: expected {expected_value!r}, "
+                f"got {source.get(key)!r}"
+            )
+
+
+def _validate_target_record(record: Mapping[str, Any], errors: list[str]) -> None:
+    if set(record) != EXPECTED_TARGET_RECORD_KEYS:
+        errors.append(
+            f"{record.get('target_center_class_key')} target keys mismatch: "
+            f"expected {sorted(EXPECTED_TARGET_RECORD_KEYS)!r}, got {sorted(record)!r}"
+        )
+        return
+    row = record.get("target_center_class")
+    if not isinstance(row, list) or len(row) != 4:
+        errors.append(f"{record.get('target_center_class_key')} target row invalid")
+        return
+    key = _row_key(_int_list(row))
+    if record.get("target_center_class_key") != key:
+        errors.append(f"{key} target row key mismatch")
+    expected_partition = _target_partition(_int_list(row))
+    if record.get("partition") != expected_partition:
+        errors.append(f"{key} partition mismatch")
+    expected_supports = _support_pairs_present(_int_list(row))
+    if record.get("support_pairs_present") != expected_supports:
+        errors.append(f"{key} support pairs mismatch")
+    status_counts = record.get("vertex_circle_status_counts")
+    if not isinstance(status_counts, Mapping):
+        errors.append(f"{key} vertex_circle_status_counts must be an object")
+    else:
+        status_total = sum(int(value) for value in status_counts.values())
+        if status_total != record.get("basic_filter_complete_assignment_count"):
+            errors.append(f"{key} status counts do not sum to basic survivors")
+    if record.get("vertex_circle_surviving_assignment_count") != 0:
+        errors.append(f"{key} must have zero vertex-circle survivors")
+
+
+def _validate_summary(
+    summary: object,
+    records: Sequence[object],
+    errors: list[str],
+) -> None:
+    if not isinstance(summary, Mapping):
+        errors.append("summary must be an object")
+        return
+    typed_records = [record for record in records if isinstance(record, Mapping)]
+    expected = _summary(typed_records)
+    for key, expected_value in expected.items():
+        if summary.get(key) != expected_value:
+            errors.append(
+                f"summary.{key} mismatch: expected {expected_value!r}, "
+                f"got {summary.get(key)!r}"
+            )
+    pinned = {
+        "target_row_key": "151:6",
+        "source_record_ids": [151],
+        "cyclic_order": EXPECTED_CYCLIC_ORDER,
+        "target_center": 6,
+        "target_center_candidate_count": 13,
+        "target_row_keys_by_partition": EXPECTED_TARGET_ROW_KEYS_BY_PARTITION,
+        "target_row_count_by_partition": EXPECTED_PARTITION_COUNTS,
+        "basic_filter_complete_assignment_count_by_partition": (
+            EXPECTED_BASIC_BY_PARTITION
+        ),
+        "vertex_circle_status_counts_by_partition": EXPECTED_STATUS_BY_PARTITION,
+        "vertex_circle_surviving_assignment_count_by_partition": (
+            EXPECTED_ZERO_SURVIVORS_BY_PARTITION
+        ),
+        "connector_avoiding_target_row_count": 4,
+        "connector_available_target_row_count": 9,
+        "connector_avoiding_basic_survivor_count": 12,
+        "connector_available_basic_survivor_count": 16,
+        "connector_avoiding_vertex_circle_survivor_count": 0,
+        "connector_available_vertex_circle_survivor_count": 0,
+        "basic_filter_complete_assignment_count": 28,
+        "basic_filter_non_original_row6_assignment_count": 21,
+        "vertex_circle_status_counts": {"self_edge": 20, "strict_cycle": 8},
+        "vertex_circle_surviving_assignment_count": 0,
+        "search_node_count": 13_439,
+        "empty_domain_count": 7_097,
+        "scan_status": SCAN_STATUS,
+    }
+    for key, expected_value in pinned.items():
+        if summary.get(key) != expected_value:
+            errors.append(
+                f"summary.{key} pinned mismatch: expected {expected_value!r}, "
+                f"got {summary.get(key)!r}"
+            )
+
+
+def _source_summary(path: Path, role: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": display_path(path, ROOT),
+        "role": role,
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+    }
+
+
+def _target_partition(row: Sequence[int]) -> str:
+    has_private_pair = _contains_pair(row, PRIVATE_HALO_ONLY_PAIR)
+    has_endpoint8 = 8 in set(row)
+    has_endpoint8_pair = any(_contains_pair(row, pair) for pair in ENDPOINT8_SUPPORT_PAIRS)
+    if has_private_pair and not has_endpoint8:
+        return "private_halo_only_connector_avoiding"
+    if has_private_pair and has_endpoint8:
+        return "mixed_private_and_endpoint8"
+    if has_endpoint8_pair:
+        return "endpoint8_connector_available"
+    raise AssertionError(f"target row {list(row)!r} has no expected support-pair role")
+
+
+def _support_pairs_present(row: Sequence[int]) -> list[list[int]]:
+    return [pair for pair in EXPECTED_OUTSIDE_SUPPORT_PAIRS if _contains_pair(row, pair)]
+
+
+def _support_pair_roles_present(support_pairs: Sequence[Sequence[int]]) -> list[str]:
+    roles = []
+    for pair in support_pairs:
+        int_pair = _int_list(pair)
+        if int_pair == PRIVATE_HALO_ONLY_PAIR:
+            roles.append("connector_avoiding_escape_support")
+        elif int_pair in ENDPOINT8_SUPPORT_PAIRS:
+            roles.append("endpoint8_connector_support")
+        else:
+            raise AssertionError(f"unexpected support pair {int_pair!r}")
+    return roles
+
+
+def _contains_pair(row: Sequence[int], pair: Sequence[int]) -> bool:
+    return set(int(label) for label in pair) <= set(int(label) for label in row)
+
+
+def _ordered_count_dict(counter: Counter[str]) -> dict[str, int]:
+    return {partition: int(counter[partition]) for partition in PARTITION_ORDER}
+
+
+def _mapping(value: object, name: str, errors: list[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        errors.append(f"{name} must be an object")
+        return {}
+    return value
+
+
+def _sequence(value: object, name: str) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise AssertionError(f"{name} must be a sequence")
+    return value
+
+
+def _expect_mapping_field(
+    label: str,
+    mapping: Mapping[str, Any],
+    key: str,
+    expected: object,
+    errors: list[str],
+) -> None:
+    if mapping.get(key) != expected:
+        errors.append(
+            f"{label}.{key} mismatch: expected {expected!r}, got {mapping.get(key)!r}"
+        )
+
+
+def _status_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): int(value[key]) for key in sorted(value)}
+
+
+def _int_list(values: Sequence[Any]) -> list[int]:
+    return [int(value) for value in values]
+
+
+def _int(value: object) -> int:
+    if not isinstance(value, int):
+        raise AssertionError(f"expected integer, got {value!r}")
+    return value
+
+
+def _row_key(row: Sequence[int]) -> str:
+    return ",".join(str(label) for label in row)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument(
+        "--source-full-neighborhood",
+        type=Path,
+        default=DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    )
+    parser.add_argument(
+        "--source-connector-contract",
+        type=Path,
+        default=DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+    )
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    artifact = _resolve(args.artifact)
+    source_full_neighborhood = _resolve(args.source_full_neighborhood)
+    source_connector_contract = _resolve(args.source_connector_contract)
+
+    generated = build_escape_partition_payload(
+        load_artifact(source_full_neighborhood),
+        load_artifact(source_connector_contract),
+        full_neighborhood_path=source_full_neighborhood,
+        connector_contract_path=source_connector_contract,
+    )
+    payload = generated
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{display_path(artifact, ROOT)} is stale")
+        payload = stored
+
+    errors = validate_payload(
+        payload,
+        full_neighborhood_path=source_full_neighborhood,
+        connector_contract_path=source_connector_contract,
+    )
+    if args.assert_expected:
+        assert_expected_escape_partition(payload)
+    if args.write:
+        write_json(generated, artifact)
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("bootstrap/T12 151:6 outside-pair escape partition")
+        print(f"target row: {summary['target_row_key']}")
+        print(f"partitions: {summary['target_row_count_by_partition']}")
+        print(
+            "basic survivors by partition: "
+            f"{summary['basic_filter_complete_assignment_count_by_partition']}"
+        )
+        print(
+            "vertex-circle survivors: "
+            f"{summary['vertex_circle_surviving_assignment_count']}"
+        )
+        if errors:
+            print("validation errors:")
+            for error in errors:
+                print(f"- {error}")
+        else:
+            print("OK: 151:6 outside-pair escape partition verified")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2495,6 +2495,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_151_6_outside_pair_escape_partition",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Escape-partition crosswalk for source 151 row 6 outside-pair "
+            "full-neighborhood survivors; not outside-pair support existence, "
+            "row forcing, an n=9 proof, a bridge proof, or a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_151_singleton_support_audit",
         command=(
             "python",

--- a/tests/test_bootstrap_t12_151_6_outside_pair_escape_partition.py
+++ b/tests/test_bootstrap_t12_151_6_outside_pair_escape_partition.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.check_bootstrap_t12_151_6_outside_pair_escape_partition import (
+    DEFAULT_ARTIFACT,
+    DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+    DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    SCAN_STATUS,
+    assert_expected_escape_partition,
+    build_escape_partition_payload,
+    load_artifact,
+    summary_payload,
+    validate_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
+
+
+@pytest.fixture(scope="module")
+def source_full_neighborhood() -> dict[str, object]:
+    return load_artifact(DEFAULT_SOURCE_FULL_NEIGHBORHOOD)
+
+
+@pytest.fixture(scope="module")
+def source_connector_contract() -> dict[str, object]:
+    return load_artifact(DEFAULT_SOURCE_CONNECTOR_CONTRACT)
+
+
+def test_151_6_outside_pair_escape_partition_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_escape_partition(payload)
+    assert payload["status"] == (
+        "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_ESCAPE_PARTITION_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert payload["summary"] == {
+        "basic_filter_complete_assignment_count": 28,
+        "basic_filter_complete_assignment_count_by_partition": {
+            "endpoint8_connector_available": 9,
+            "mixed_private_and_endpoint8": 7,
+            "private_halo_only_connector_avoiding": 12,
+        },
+        "basic_filter_non_original_row6_assignment_count": 21,
+        "bootstrap_core_witnesses": [0],
+        "connector_available_basic_survivor_count": 16,
+        "connector_available_target_row_count": 9,
+        "connector_available_vertex_circle_survivor_count": 0,
+        "connector_avoiding_basic_survivor_count": 12,
+        "connector_avoiding_support_pairs": [[3, 5]],
+        "connector_avoiding_target_row_count": 4,
+        "connector_avoiding_vertex_circle_survivor_count": 0,
+        "connector_forcing_support_pairs": [[3, 8], [5, 8]],
+        "cyclic_order": list(range(9)),
+        "empty_domain_count": 7097,
+        "original_target_center_class": [0, 3, 5, 8],
+        "outside_support_pairs": [[3, 5], [3, 8], [5, 8]],
+        "remaining_gap": (
+            "The private-halo-only connector-avoiding family survives basic "
+            "filters, so the remaining proof-facing task is support existence "
+            "and row/rich-class forcing. This artifact does not prove pair "
+            "[3,5] impossible, does not prove an endpoint-8 support is forced, "
+            "and does not promote the review-pending n=9 checker."
+        ),
+        "scan_status": SCAN_STATUS,
+        "search_node_count": 13439,
+        "source_record_ids": [151],
+        "target_center": 6,
+        "target_center_candidate_count": 13,
+        "target_row_count_by_partition": {
+            "endpoint8_connector_available": 8,
+            "mixed_private_and_endpoint8": 1,
+            "private_halo_only_connector_avoiding": 4,
+        },
+        "target_row_key": "151:6",
+        "target_row_keys_by_partition": {
+            "endpoint8_connector_available": [
+                "0,1,3,8",
+                "0,1,5,8",
+                "0,2,3,8",
+                "0,2,5,8",
+                "0,3,4,8",
+                "0,3,7,8",
+                "0,4,5,8",
+                "0,5,7,8",
+            ],
+            "mixed_private_and_endpoint8": ["0,3,5,8"],
+            "private_halo_only_connector_avoiding": [
+                "0,1,3,5",
+                "0,2,3,5",
+                "0,3,4,5",
+                "0,3,5,7",
+            ],
+        },
+        "vertex_circle_status_counts": {"self_edge": 20, "strict_cycle": 8},
+        "vertex_circle_status_counts_by_partition": {
+            "endpoint8_connector_available": {"self_edge": 7, "strict_cycle": 2},
+            "mixed_private_and_endpoint8": {"self_edge": 3, "strict_cycle": 4},
+            "private_halo_only_connector_avoiding": {
+                "self_edge": 10,
+                "strict_cycle": 2,
+            },
+        },
+        "vertex_circle_surviving_assignment_count": 0,
+        "vertex_circle_surviving_assignment_count_by_partition": {
+            "endpoint8_connector_available": 0,
+            "mixed_private_and_endpoint8": 0,
+            "private_halo_only_connector_avoiding": 0,
+        },
+    }
+    claim_scope = str(payload["claim_scope"])
+    for phrase in (
+        "does not prove outside-pair support existence",
+        "does not prove row forcing",
+        "does not prove the private-halo-only pair is impossible",
+        "does not prove n=9",
+        "does not prove the bridge",
+        "not a counterexample",
+        "not a global status update",
+    ):
+        assert phrase in claim_scope
+
+
+def test_151_6_outside_pair_escape_partition_records() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    by_key = {
+        record["target_center_class_key"]: record
+        for record in payload["target_row_partition"]
+    }
+
+    assert by_key["0,3,5,7"]["partition"] == (
+        "private_halo_only_connector_avoiding"
+    )
+    assert by_key["0,3,5,7"]["support_pairs_present"] == [[3, 5]]
+    assert by_key["0,3,5,7"]["basic_filter_complete_assignment_count"] == 12
+    assert by_key["0,3,5,7"]["vertex_circle_status_counts"] == {
+        "self_edge": 10,
+        "strict_cycle": 2,
+    }
+
+    assert by_key["0,2,5,8"]["partition"] == "endpoint8_connector_available"
+    assert by_key["0,2,5,8"]["contains_endpoint8"] is True
+    assert by_key["0,2,5,8"]["support_pairs_present"] == [[5, 8]]
+    assert by_key["0,2,5,8"]["basic_filter_complete_assignment_count"] == 3
+
+    assert by_key["0,3,5,8"]["partition"] == "mixed_private_and_endpoint8"
+    assert by_key["0,3,5,8"]["target_center_class_is_original"] is True
+    assert by_key["0,3,5,8"]["support_pairs_present"] == [
+        [3, 5],
+        [3, 8],
+        [5, 8],
+    ]
+    assert by_key["0,3,5,8"]["basic_filter_complete_assignment_count"] == 7
+    assert by_key["0,3,5,8"]["vertex_circle_status_counts"] == {
+        "self_edge": 3,
+        "strict_cycle": 4,
+    }
+
+
+def test_151_6_outside_pair_escape_partition_rejects_tampered_summary() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["summary"]["connector_avoiding_basic_survivor_count"] = 11
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("connector_avoiding_basic_survivor_count" in error for error in errors)
+
+
+def test_151_6_outside_pair_escape_partition_rejects_tampered_status_sum() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["target_row_partition"][8]["vertex_circle_status_counts"]["self_edge"] = 9
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("status counts do not sum" in error for error in errors)
+
+
+def test_151_6_outside_pair_escape_partition_rejects_source_drift(
+    source_full_neighborhood: dict[str, object],
+    source_connector_contract: dict[str, object],
+) -> None:
+    tampered = json.loads(json.dumps(source_connector_contract))
+    tampered["summary"]["connector_avoiding_support_pairs"] = []
+
+    with pytest.raises(AssertionError, match="connector_avoiding_support_pairs"):
+        build_escape_partition_payload(source_full_neighborhood, tampered)
+
+
+def test_151_6_outside_pair_escape_partition_artifact_matches_generator(
+    source_full_neighborhood: dict[str, object],
+    source_connector_contract: dict[str, object],
+) -> None:
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == build_escape_partition_payload(
+        source_full_neighborhood,
+        source_connector_contract,
+    )
+
+
+def test_151_6_outside_pair_escape_partition_checker_passes() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    errors = validate_payload(payload)
+    summary = summary_payload(DEFAULT_ARTIFACT, payload, errors)
+
+    assert errors == []
+    assert summary["ok"] is True
+    assert summary["target_center_candidate_count"] == 13
+    assert summary["connector_avoiding_basic_survivor_count"] == 12
+    assert summary["connector_available_basic_survivor_count"] == 16
+
+
+def test_151_6_outside_pair_escape_partition_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["target_row_key"] == "151:6"
+    assert payload["connector_avoiding_basic_survivor_count"] == 12

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -366,6 +366,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_bootstrap_t12_151_singleton_support_audit.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -254,6 +254,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
     ) < ordered_command_texts.index(
@@ -446,6 +451,12 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_6_outside_pair_audit.py --check "
         "--assert-expected --json",
+        "python scripts/check_bootstrap_t12_151_6_outside_pair_two_row_drop.py "
+        "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.py "
+        "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py "
+        "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check "
         "--assert-expected --json",
         "python scripts/check_closure_activation_wrong_fourth_negative_control.py "


### PR DESCRIPTION
## Summary

- Add a generated/checkable `151:6` outside-pair escape-partition artifact over the existing full-neighborhood vertex-circle packet and connector contract.
- Document that the private-halo-only connector-avoiding lane has 12 basic-filter survivors, endpoint-8 connector-available lanes have 16, and exact vertex-circle replay kills all 28.
- Wire the checker into bridge-frontier verification, artifact audit, generated-artifact provenance, docs, and regression tests.

## Claim scope

Diagnostic only. This does not prove outside-pair support existence, row forcing, `n=9`, the bridge, Erdos Problem #97, or a counterexample. It also does not prove the private-halo-only pair `[3,5]` is impossible.

## Validation

- `python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --check --assert-expected --json`
- `python scripts/check_bootstrap_t12_151_6_outside_pair_connector_contract.py --check --assert-expected --json`
- `python scripts/check_bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_151_6_outside_pair_escape_partition.py tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` -> `1363 passed, 510 deselected`