### PR TITLE
[codex] Add 151:6 endpoint-8 forcing preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_full_neighborhood_vertex_circle.py --check --assert-expected --json

--- a/data/certificates/bootstrap_t12_151_6_endpoint8_forcing_preflight.json
+++ b/data/certificates/bootstrap_t12_151_6_endpoint8_forcing_preflight.json
@@ -1,0 +1,126 @@
+{
+  "claim_scope": "Proof-mining preflight for the source-151 row-6 endpoint-8 outside-pair forcing question. It checks the current connector contract and escape partition and records that endpoint-8 support is not forced by current evidence because the private-halo-only pair [3,5] remains a live connector-avoiding support lane under basic incidence/crossing filters. This does not prove endpoint-8 support existence, does not prove row forcing, does not prove pair [3,5] impossible, does not prove n=9, does not prove the bridge, is not a counterexample, and is not a global status update.",
+  "decision": {
+    "answer": "do_not_accept_endpoint8_forcing_claim",
+    "blocking_basic_survivor_count": 12,
+    "blocking_escape_status": "PRIVATE_HALO_ONLY_PAIR_3_5_REMAINS_OPEN",
+    "blocking_escape_support_pairs": [
+      [
+        3,
+        5
+      ]
+    ],
+    "can_use_connector_if_endpoint8_support_hypothesis_supplied": true,
+    "decision_question": "Can current checked evidence accept the lemma that any genuine 151:6 outside-pair support must include endpoint 8?",
+    "endpoint8_forced_by_current_evidence": false,
+    "gate_status": "NOT_READY_PRIVATE_HALO_ONLY_ESCAPE_SURVIVES_BASIC_FILTERS",
+    "required_next_lemma": "Prove under genuine minimal/rich-class hypotheses that endpoint 8 is forced in the outside-pair support, or prove that the private-halo-only pair [3,5] cannot occur."
+  },
+  "interpretation": [
+    "The connector contract is useful only conditionally: if a genuine center-6 rich class contains witnesses 0 and 8, then the equality connector [0,6]=[8,6] is available.",
+    "The current outside-pair ledger still has the connector-avoiding support pair [3,5].",
+    "The escape partition shows that private-halo-only rows survive basic filters, so endpoint-8 forcing is not justified by incidence/crossing evidence alone.",
+    "The vertex-circle replay kills all selected-row diagnostic survivors, but it is not a support-existence or row-forcing lemma."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py"
+  },
+  "schema": "erdos97.bootstrap_t12_151_6_endpoint8_forcing_preflight.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_151_6_outside_pair_connector_contract.json",
+      "role": "source 151:6 outside-pair connector contract",
+      "schema": "erdos97.bootstrap_t12_151_6_outside_pair_connector_contract.v1",
+      "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_CONNECTOR_CONTRACT_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_151_6_outside_pair_escape_partition.json",
+      "role": "source 151:6 outside-pair escape partition",
+      "schema": "erdos97.bootstrap_t12_151_6_outside_pair_escape_partition.v1",
+      "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_ESCAPE_PARTITION_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_151_6_ENDPOINT8_FORCING_PREFLIGHT_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_selected_row_diagnostic_survivors_vertex_circle_obstructed": true,
+    "blocking_escape_support_pairs": [
+      [
+        3,
+        5
+      ]
+    ],
+    "bootstrap_core_witnesses": [
+      0
+    ],
+    "connector_conditional_available": true,
+    "connector_contract_escape_status": "CONNECTOR_ESCAPE_REQUIRES_PRIVATE_HALO_ONLY_PAIR_3_5",
+    "connector_contract_support_existence_status": "OPEN_TARGET_NOT_PROVED",
+    "connector_distance_pairs": [
+      [
+        0,
+        6
+      ],
+      [
+        8,
+        6
+      ]
+    ],
+    "connector_pair": [
+      0,
+      8
+    ],
+    "endpoint8_connector_available_basic_survivor_count": 16,
+    "endpoint8_connector_available_target_row_count": 9,
+    "endpoint8_connector_available_vertex_circle_survivor_count": 0,
+    "endpoint8_forced_by_current_evidence": false,
+    "endpoint8_forcing_blocked_by_private_halo_escape": true,
+    "endpoint8_support_pairs": [
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "gate_status": "NOT_READY_PRIVATE_HALO_ONLY_ESCAPE_SURVIVES_BASIC_FILTERS",
+    "next_required_lemma": "Prove under genuine minimal/rich-class hypotheses that endpoint 8 is forced in the outside-pair support, or prove that the private-halo-only pair [3,5] cannot occur.",
+    "outside_support_pairs": [
+      [
+        3,
+        5
+      ],
+      [
+        3,
+        8
+      ],
+      [
+        5,
+        8
+      ]
+    ],
+    "preflight_reasons": [
+      "The endpoint-8 support pairs [3,8] and [5,8] would supply the connector conditionally.",
+      "The connector-avoiding support pair [3,5] still exists in the outside-pair ledger.",
+      "The private-halo-only lane has 12 complete assignments after basic filters.",
+      "Vertex-circle replay kills those selected-row assignments but does not prove support existence or row forcing."
+    ],
+    "private_halo_escape_status": "PRIVATE_HALO_ONLY_PAIR_3_5_REMAINS_OPEN",
+    "private_halo_only_basic_survivor_count": 12,
+    "private_halo_only_target_row_count": 4,
+    "private_halo_only_vertex_circle_survivor_count": 0,
+    "source_escape_partition_scan_status": "PRIVATE_HALO_ONLY_AND_ENDPOINT8_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED",
+    "source_record_ids": [
+      151
+    ],
+    "target_center": 6,
+    "target_row_key": "151:6"
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": [],
+  "validation_status": "passed"
+}

--- a/docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md
+++ b/docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md
@@ -1,0 +1,98 @@
+# Bootstrap T12 151:6 Endpoint-8 Forcing Preflight
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note records the current gate decision for the source-`151` row-`6`
+outside-pair question:
+
+```text
+Can current checked evidence force endpoint 8 into every genuine outside-pair
+support at center 6?
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --write --assert-expected
+```
+
+to:
+
+```text
+data/certificates/bootstrap_t12_151_6_endpoint8_forcing_preflight.json
+```
+
+## Inputs
+
+This preflight is a derivative check over:
+
+- `data/certificates/bootstrap_t12_151_6_outside_pair_connector_contract.json`;
+- `data/certificates/bootstrap_t12_151_6_outside_pair_escape_partition.json`.
+
+The connector contract says that an endpoint-`8` support would be enough:
+if a genuine rich class at center `6` contains witnesses `0` and `8`, then
+the connector equality `[0,6]=[8,6]` is available.
+
+The escape partition says that the current selected-row diagnostics do not
+force such an endpoint support: the private-halo-only connector-avoiding lane
+with support pair `[3,5]` has `12` complete assignments after the basic
+incidence/crossing filters.
+
+## Gate Result
+
+The preflight result is:
+
+```text
+NOT_READY_PRIVATE_HALO_ONLY_ESCAPE_SURVIVES_BASIC_FILTERS
+```
+
+Pinned summary:
+
+| Quantity | Value |
+| --- | ---: |
+| endpoint-`8` support pairs | `[[3,8], [5,8]]` |
+| connector-avoiding support pairs | `[[3,5]]` |
+| private-halo-only target rows | `4` |
+| private-halo-only basic survivors | `12` |
+| private-halo-only vertex-circle survivors | `0` |
+| endpoint-`8` connector-available basic survivors | `16` |
+| endpoint-`8` forced by current evidence | `false` |
+
+The red-light reason is not that endpoint-`8` supports are useless. They would
+supply the connector conditionally. The reason is that current evidence still
+has a connector-avoiding support lane, and that lane is not killed by the
+basic filters.
+
+## Remaining Target
+
+The next proof-facing lemma is still one of:
+
+```text
+Force an endpoint-8 outside-pair support under genuine minimal/rich-class
+hypotheses.
+```
+
+or:
+
+```text
+Prove that the private-halo-only pair [3,5] cannot occur under those
+hypotheses.
+```
+
+The vertex-circle replay killing all selected-row survivors is useful
+diagnostic evidence, but it is not a support-existence theorem, not a row
+forcing theorem, and not an endpoint-`8` forcing theorem.
+
+## What This Does Not Prove
+
+This artifact does not prove endpoint-`8` support existence, does not prove
+row forcing, does not prove that pair `[3,5]` is impossible, does not prove
+`n=9`, does not prove the bootstrap bridge, and does not prove Erdos Problem
+#97.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -495,9 +495,13 @@ minimal/rich-class hypotheses.
    `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` now shows this
    private-halo-only lane has `12` basic-filter survivors, while the
    endpoint-`8` connector-available lanes have `16`; vertex-circle replay kills
-   all `28`. This is a diagnostic split only, so the next useful PR should
-   attack support existence or forcing for endpoint-`8` versus `[3,5]`, not
-   another selected-row neighborhood widening around `151:6`. The
+   all `28`. The endpoint-`8` forcing preflight
+   `python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json`
+   records the current red-light gate: endpoint `8` is not forced by present
+   evidence because `[3,5]` remains a connector-avoiding basic-filter escape.
+   This is a diagnostic split only, so the next useful PR should attack
+   support existence or forcing for endpoint-`8` versus `[3,5]`, not another
+   selected-row neighborhood widening around `151:6`. The
    source-`151` singleton-support audit in
    `docs/bootstrap-t12-151-singleton-support-audit.md` applies the same local
    audit shape to rows `151:5` and `151:8`; it also leaves the genuine

--- a/docs/index.md
+++ b/docs/index.md
@@ -396,6 +396,10 @@ put detailed reconciliation in the canonical synthesis.
 - [`bootstrap-t12-151-6-outside-pair-escape-partition.md`](bootstrap-t12-151-6-outside-pair-escape-partition.md):
   crosswalk partitioning the source-`151` row-`6` full-neighborhood survivors
   by private-halo-only versus endpoint-`8` support role.
+- [`bootstrap-t12-151-6-endpoint8-forcing-preflight.md`](bootstrap-t12-151-6-endpoint8-forcing-preflight.md):
+  checked red-light preflight recording that current evidence does not force
+  endpoint `8` because the private-halo-only `[3,5]` lane survives basic
+  filters.
 - [`bootstrap-t12-151-singleton-support-audit.md`](bootstrap-t12-151-singleton-support-audit.md):
   source-`151` singleton-support audit covering rows `151:5` and `151:8`.
 - [`bootstrap-t12-151-singleton-two-row-drop.md`](bootstrap-t12-151-singleton-two-row-drop.md):

--- a/docs/lemma-driven-bridge-targets.md
+++ b/docs/lemma-driven-bridge-targets.md
@@ -53,7 +53,7 @@ force one of the stored local templates by themselves.
 | `T01`--`T12` local templates | `docs/n9-vertex-circle-local-lemma-review-packet.md` packages 12 templates, 16 families, and 184 stored assignments | A proof that a minimal/rich-support counterexample must contain one of these local cores, without enumerating the whole frontier |
 | non-ear frontier rows `81` and `151` | `docs/bridge-lemma-frontier.md` and `docs/bootstrap-vertex-circle-overlay.md` isolate the two tight `n=9` non-ear rows and their `T12/F16` strict-cycle landing | A bootstrap/rich-class lemma that makes the needed T12 row relations genuinely available |
 | source `81`, row `3` | `docs/bootstrap-t12-81-3-closure-target.md` and `docs/bootstrap-t12-81-3-rich-triple-contract.md` reduce the target to the connector pair `[0,1]` | Force a genuine center-`3` rich class containing `[0,1]`, or classify the label-`6` connector-avoiding escape |
-| source `151`, row `6` | `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` splits endpoint-`8` supports from private-halo-only pair `[3,5]`; `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` shows the private-halo-only lane has `12` basic survivors before vertex-circle replay | Force an endpoint-`8` outside-pair support, or prove the `[3,5]` private-halo-only escape is geometrically impossible |
+| source `151`, row `6` | `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` splits endpoint-`8` supports from private-halo-only pair `[3,5]`; `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` shows the private-halo-only lane has `12` basic survivors before vertex-circle replay; `docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md` records that endpoint-`8` forcing is not ready from current evidence | Force an endpoint-`8` outside-pair support, or prove the `[3,5]` private-halo-only escape is geometrically impossible |
 | source `151`, rows `7` and `8` | `docs/bootstrap-t12-hard-strict-endpoints.md` isolates missing strict-edge endpoint sets | Supply the hard endpoint labels from genuine closure/support geometry, not fixed-row bookkeeping |
 | block-6 fragile family | `docs/block6-fragile-vertex-circle-extension-audit.md` and `docs/bridge-negative-controls.md` record exact negative controls | A minimal/rich-class condition that rejects the family beyond fixed natural/block-preserving order slices |
 
@@ -123,6 +123,7 @@ Useful evidence:
 - `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md`
 - `docs/bootstrap-t12-151-6-outside-pair-full-neighborhood-vertex-circle.md`
 - `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md`
+- `docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md`
 - `docs/bootstrap-t12-relation-sufficient-rows.md`
 
 Required guardrails:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -933,6 +933,13 @@ condition that the surviving multi-block family does not automatically satisfy:
   witnesses `0` and `8` supplies `[0,6]=[8,6]`. The remaining target is to
   force an endpoint-`8` support or analyze the private-halo-only pair `[3,5]`;
   this is not support existence, row forcing, or a bridge proof.
+- bootstrap/T12 focused `151:6` endpoint-`8` forcing preflight evidence, as
+  recorded in
+  `docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md`, checking that
+  current connector-contract plus escape-partition evidence is not enough to
+  accept endpoint-`8` forcing: the private-halo-only `[3,5]` lane has `12`
+  basic-filter survivors. This is a gate-status diagnostic only, not a proof
+  that endpoint `8` is forced and not a proof that `[3,5]` is impossible.
 - bootstrap/T12 focused source-`151` singleton-support evidence, as recorded
   in `docs/bootstrap-t12-151-singleton-support-audit.md`, showing that rows
   `151:5` and `151:8` have no non-original activation survivor in the fixed

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -7502,6 +7502,73 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_151_6_endpoint8_forcing_preflight
+    path: data/certificates/bootstrap_t12_151_6_endpoint8_forcing_preflight.json
+    sha256: c4cb7c3cfe0de353b0ce9c701d8878b9d99f80a06c2f4d5e95e74c901fc565c0
+    size_bytes: 5575
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
+    command: python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
+    check_command: python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-151 row-6 endpoint-8 forcing preflight; current connector-contract plus escape-partition evidence does not force endpoint 8 because the private-halo-only pair [3,5] remains a connector-avoiding basic-filter escape. This is not endpoint-8 support existence, not row forcing, not a proof that [3,5] is impossible, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_151_6_endpoint8_forcing_preflight.v1
+      status: BOOTSTRAP_T12_151_6_ENDPOINT8_FORCING_PREFLIGHT_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "151:6"
+      summary.source_record_ids:
+        - 151
+      summary.target_center: 6
+      summary.bootstrap_core_witnesses:
+        - 0
+      summary.connector_pair:
+        - 0
+        - 8
+      summary.endpoint8_support_pairs:
+        - [3, 8]
+        - [5, 8]
+      summary.blocking_escape_support_pairs:
+        - [3, 5]
+      summary.connector_conditional_available: true
+      summary.private_halo_only_target_row_count: 4
+      summary.private_halo_only_basic_survivor_count: 12
+      summary.private_halo_only_vertex_circle_survivor_count: 0
+      summary.endpoint8_connector_available_target_row_count: 9
+      summary.endpoint8_connector_available_basic_survivor_count: 16
+      summary.endpoint8_connector_available_vertex_circle_survivor_count: 0
+      summary.all_selected_row_diagnostic_survivors_vertex_circle_obstructed: true
+      summary.gate_status: NOT_READY_PRIVATE_HALO_ONLY_ESCAPE_SURVIVES_BASIC_FILTERS
+      summary.endpoint8_forced_by_current_evidence: false
+      summary.endpoint8_forcing_blocked_by_private_halo_escape: true
+      summary.private_halo_escape_status: PRIVATE_HALO_ONLY_PAIR_3_5_REMAINS_OPEN
+      decision.answer: do_not_accept_endpoint8_forcing_claim
+      decision.endpoint8_forced_by_current_evidence: false
+      decision.blocking_basic_survivor_count: 12
+      provenance.generator: scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
+      provenance.command: python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - outside pair support proves row-center forcing
+      - the 151:6 row is forced
+      - endpoint-8 support exists
+      - endpoint-8 support is forced
+      - the private-halo-only pair 3,5 is impossible
+      - the endpoint-8 forcing preflight proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_151_singleton_support_audit
     path: data/certificates/bootstrap_t12_151_singleton_support_audit.json
     sha256: 9647c2062ffdc1363dab531a70aa3e2e97e4bb4330b337516f286591eb1dfc5e

--- a/scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
+++ b/scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 151:6 endpoint-8 forcing preflight packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from erdos97.path_display import display_path  # noqa: E402
+
+from scripts.check_bootstrap_t12_151_6_outside_pair_escape_partition import (  # noqa: E402
+    DEFAULT_ARTIFACT as DEFAULT_SOURCE_ESCAPE_PARTITION,
+    load_artifact,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_151_6_endpoint8_forcing_preflight.v1"
+STATUS = "BOOTSTRAP_T12_151_6_ENDPOINT8_FORCING_PREFLIGHT_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+GATE_STATUS = "NOT_READY_PRIVATE_HALO_ONLY_ESCAPE_SURVIVES_BASIC_FILTERS"
+PRIVATE_ESCAPE_STATUS = "PRIVATE_HALO_ONLY_PAIR_3_5_REMAINS_OPEN"
+CLAIM_SCOPE = (
+    "Proof-mining preflight for the source-151 row-6 endpoint-8 outside-pair "
+    "forcing question. It checks the current connector contract and escape "
+    "partition and records that endpoint-8 support is not forced by current "
+    "evidence because the private-halo-only pair [3,5] remains a live "
+    "connector-avoiding support lane under basic incidence/crossing filters. "
+    "This does not prove endpoint-8 support existence, does not prove row "
+    "forcing, does not prove pair [3,5] impossible, does not prove n=9, does "
+    "not prove the bridge, is not a counterexample, and is not a global status "
+    "update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py",
+    "command": (
+        "python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py "
+        "--write --assert-expected"
+    ),
+}
+
+DEFAULT_SOURCE_CONNECTOR_CONTRACT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_outside_pair_connector_contract.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_endpoint8_forcing_preflight.json"
+)
+
+SOURCE_CONNECTOR_CONTRACT_SCHEMA = (
+    "erdos97.bootstrap_t12_151_6_outside_pair_connector_contract.v1"
+)
+SOURCE_CONNECTOR_CONTRACT_STATUS = (
+    "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_CONNECTOR_CONTRACT_DIAGNOSTIC_ONLY"
+)
+SOURCE_ESCAPE_PARTITION_SCHEMA = (
+    "erdos97.bootstrap_t12_151_6_outside_pair_escape_partition.v1"
+)
+SOURCE_ESCAPE_PARTITION_STATUS = (
+    "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_ESCAPE_PARTITION_DIAGNOSTIC_ONLY"
+)
+SOURCE_ESCAPE_PARTITION_SCAN_STATUS = (
+    "PRIVATE_HALO_ONLY_AND_ENDPOINT8_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED"
+)
+
+TARGET_ROW_KEY = "151:6"
+TARGET_CENTER = 6
+BOOTSTRAP_CORE_WITNESSES = [0]
+CONNECTOR_PAIR = [0, 8]
+CONNECTOR_DISTANCE_PAIRS = [[0, 6], [8, 6]]
+OUTSIDE_SUPPORT_PAIRS = [[3, 5], [3, 8], [5, 8]]
+ENDPOINT8_SUPPORT_PAIRS = [[3, 8], [5, 8]]
+PRIVATE_HALO_ONLY_SUPPORT_PAIRS = [[3, 5]]
+PRIVATE_HALO_PARTITION = "private_halo_only_connector_avoiding"
+ENDPOINT8_PARTITION = "endpoint8_connector_available"
+MIXED_PARTITION = "mixed_private_and_endpoint8"
+
+EXPECTED_TOP_LEVEL_KEYS = {
+    "claim_scope",
+    "decision",
+    "interpretation",
+    "provenance",
+    "schema",
+    "source_artifacts",
+    "status",
+    "summary",
+    "trust",
+    "validation_errors",
+    "validation_status",
+}
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def build_endpoint8_forcing_preflight_payload(
+    connector_contract: Mapping[str, Any],
+    escape_partition: Mapping[str, Any],
+    *,
+    connector_contract_path: Path = DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+    escape_partition_path: Path = DEFAULT_SOURCE_ESCAPE_PARTITION,
+) -> dict[str, Any]:
+    """Return the deterministic endpoint-8 forcing preflight payload."""
+
+    errors: list[str] = []
+    _validate_connector_contract(connector_contract, errors)
+    _validate_escape_partition(escape_partition, errors)
+    _validate_source_alignment(connector_contract, escape_partition, errors)
+
+    summary = _summary(connector_contract, escape_partition)
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "summary": summary,
+        "decision": {
+            "decision_question": (
+                "Can current checked evidence accept the lemma that any genuine "
+                "151:6 outside-pair support must include endpoint 8?"
+            ),
+            "answer": "do_not_accept_endpoint8_forcing_claim",
+            "gate_status": GATE_STATUS,
+            "endpoint8_forced_by_current_evidence": False,
+            "can_use_connector_if_endpoint8_support_hypothesis_supplied": True,
+            "blocking_escape_status": PRIVATE_ESCAPE_STATUS,
+            "blocking_escape_support_pairs": PRIVATE_HALO_ONLY_SUPPORT_PAIRS,
+            "blocking_basic_survivor_count": summary[
+                "private_halo_only_basic_survivor_count"
+            ],
+            "required_next_lemma": summary["next_required_lemma"],
+        },
+        "interpretation": [
+            (
+                "The connector contract is useful only conditionally: if a "
+                "genuine center-6 rich class contains witnesses 0 and 8, then "
+                "the equality connector [0,6]=[8,6] is available."
+            ),
+            (
+                "The current outside-pair ledger still has the connector-"
+                "avoiding support pair [3,5]."
+            ),
+            (
+                "The escape partition shows that private-halo-only rows survive "
+                "basic filters, so endpoint-8 forcing is not justified by "
+                "incidence/crossing evidence alone."
+            ),
+            (
+                "The vertex-circle replay kills all selected-row diagnostic "
+                "survivors, but it is not a support-existence or row-forcing "
+                "lemma."
+            ),
+        ],
+        "source_artifacts": [
+            _source_summary(
+                connector_contract_path,
+                "source 151:6 outside-pair connector contract",
+                connector_contract,
+            ),
+            _source_summary(
+                escape_partition_path,
+                "source 151:6 outside-pair escape partition",
+                escape_partition,
+            ),
+        ],
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "provenance": PROVENANCE,
+    }
+    assert_expected_endpoint8_forcing_preflight(payload)
+    return payload
+
+
+def assert_expected_endpoint8_forcing_preflight(payload: Mapping[str, Any]) -> None:
+    """Assert the pinned endpoint-8 forcing preflight packet."""
+
+    errors = validate_payload(payload, recompute=False)
+    if errors:
+        raise AssertionError("; ".join(errors))
+
+
+def validate_payload(
+    payload: Mapping[str, Any],
+    *,
+    recompute: bool = True,
+    connector_contract_path: Path = DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+    escape_partition_path: Path = DEFAULT_SOURCE_ESCAPE_PARTITION,
+) -> list[str]:
+    """Return validation errors for an endpoint-8 forcing preflight payload."""
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+        return errors
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "validation_status": "passed",
+        "validation_errors": [],
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        if payload.get(key) != expected:
+            errors.append(
+                f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}"
+            )
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str):
+        errors.append("claim_scope must be a string")
+    else:
+        for phrase in (
+            "does not prove endpoint-8 support existence",
+            "does not prove row forcing",
+            "does not prove pair [3,5] impossible",
+            "does not prove n=9",
+            "does not prove the bridge",
+            "not a counterexample",
+            "not a global status update",
+        ):
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must contain {phrase!r}")
+
+    summary = _mapping(payload.get("summary"), "summary", errors)
+    _validate_summary(summary, errors)
+    decision = _mapping(payload.get("decision"), "decision", errors)
+    _validate_decision(decision, summary, errors)
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list):
+        errors.append("interpretation must be a list")
+    elif not any("not a support-existence" in item for item in interpretation):
+        errors.append("interpretation must preserve the support-existence nonclaim")
+
+    if recompute and not errors:
+        generated = build_endpoint8_forcing_preflight_payload(
+            load_artifact(connector_contract_path),
+            load_artifact(escape_partition_path),
+            connector_contract_path=connector_contract_path,
+            escape_partition_path=escape_partition_path,
+        )
+        if dict(payload) != generated:
+            errors.append("stored artifact is stale relative to source packets")
+    return errors
+
+
+def summary_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    errors: Sequence[str],
+) -> dict[str, Any]:
+    """Return a compact CLI summary."""
+
+    summary = payload.get("summary", {})
+    if not isinstance(summary, Mapping):
+        summary = {}
+    decision = payload.get("decision", {})
+    if not isinstance(decision, Mapping):
+        decision = {}
+    return {
+        "artifact": display_path(path, ROOT),
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "ok": not errors,
+        "target_row_key": summary.get("target_row_key"),
+        "gate_status": summary.get("gate_status"),
+        "endpoint8_forced_by_current_evidence": summary.get(
+            "endpoint8_forced_by_current_evidence"
+        ),
+        "blocking_escape_support_pairs": summary.get("blocking_escape_support_pairs"),
+        "private_halo_only_basic_survivor_count": summary.get(
+            "private_halo_only_basic_survivor_count"
+        ),
+        "private_halo_only_vertex_circle_survivor_count": summary.get(
+            "private_halo_only_vertex_circle_survivor_count"
+        ),
+        "endpoint8_connector_available_basic_survivor_count": summary.get(
+            "endpoint8_connector_available_basic_survivor_count"
+        ),
+        "decision_answer": decision.get("answer"),
+        "validation_errors": list(errors),
+    }
+
+
+def _summary(
+    connector_contract: Mapping[str, Any],
+    escape_partition: Mapping[str, Any],
+) -> dict[str, Any]:
+    connector_summary = _required_mapping(
+        connector_contract.get("summary"), "source connector summary"
+    )
+    partition_summary = _required_mapping(
+        escape_partition.get("summary"), "source escape-partition summary"
+    )
+    private_basic = int(partition_summary["connector_avoiding_basic_survivor_count"])
+    private_vertex = int(
+        partition_summary["connector_avoiding_vertex_circle_survivor_count"]
+    )
+    endpoint_basic = int(partition_summary["connector_available_basic_survivor_count"])
+    endpoint_vertex = int(
+        partition_summary["connector_available_vertex_circle_survivor_count"]
+    )
+    return {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [151],
+        "target_center": TARGET_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+        "outside_support_pairs": OUTSIDE_SUPPORT_PAIRS,
+        "endpoint8_support_pairs": ENDPOINT8_SUPPORT_PAIRS,
+        "blocking_escape_support_pairs": PRIVATE_HALO_ONLY_SUPPORT_PAIRS,
+        "connector_contract_escape_status": connector_summary["escape_status"],
+        "connector_contract_support_existence_status": connector_summary[
+            "rich_support_existence_status"
+        ],
+        "connector_conditional_available": (
+            connector_summary["local_conditional_lemma_status"]
+            == "EXACT_LOCAL_CONDITIONAL"
+        ),
+        "private_halo_only_target_row_count": int(
+            partition_summary["connector_avoiding_target_row_count"]
+        ),
+        "private_halo_only_basic_survivor_count": private_basic,
+        "private_halo_only_vertex_circle_survivor_count": private_vertex,
+        "endpoint8_connector_available_target_row_count": int(
+            partition_summary["connector_available_target_row_count"]
+        ),
+        "endpoint8_connector_available_basic_survivor_count": endpoint_basic,
+        "endpoint8_connector_available_vertex_circle_survivor_count": endpoint_vertex,
+        "all_selected_row_diagnostic_survivors_vertex_circle_obstructed": (
+            int(partition_summary["vertex_circle_surviving_assignment_count"]) == 0
+        ),
+        "source_escape_partition_scan_status": partition_summary["scan_status"],
+        "gate_status": GATE_STATUS,
+        "endpoint8_forced_by_current_evidence": False,
+        "endpoint8_forcing_blocked_by_private_halo_escape": private_basic > 0,
+        "private_halo_escape_status": PRIVATE_ESCAPE_STATUS,
+        "preflight_reasons": [
+            "The endpoint-8 support pairs [3,8] and [5,8] would supply the connector conditionally.",
+            "The connector-avoiding support pair [3,5] still exists in the outside-pair ledger.",
+            "The private-halo-only lane has 12 complete assignments after basic filters.",
+            "Vertex-circle replay kills those selected-row assignments but does not prove support existence or row forcing.",
+        ],
+        "next_required_lemma": (
+            "Prove under genuine minimal/rich-class hypotheses that endpoint 8 "
+            "is forced in the outside-pair support, or prove that the "
+            "private-halo-only pair [3,5] cannot occur."
+        ),
+    }
+
+
+def _validate_connector_contract(
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "schema": SOURCE_CONNECTOR_CONTRACT_SCHEMA,
+        "status": SOURCE_CONNECTOR_CONTRACT_STATUS,
+        "trust": TRUST,
+    }
+    _validate_source_meta("connector contract", payload, expected, errors)
+    summary = _mapping(payload.get("summary"), "connector contract summary", errors)
+    if not summary:
+        return
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [151],
+        "target_row_center": TARGET_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+        "outside_support_pairs": OUTSIDE_SUPPORT_PAIRS,
+        "connector_forcing_support_pairs": ENDPOINT8_SUPPORT_PAIRS,
+        "connector_avoiding_support_pairs": PRIVATE_HALO_ONLY_SUPPORT_PAIRS,
+        "local_conditional_lemma_status": "EXACT_LOCAL_CONDITIONAL",
+        "rich_support_existence_status": "OPEN_TARGET_NOT_PROVED",
+        "escape_status": "CONNECTOR_ESCAPE_REQUIRES_PRIVATE_HALO_ONLY_PAIR_3_5",
+    }
+    _expect_fields("connector contract summary", summary, expected_summary, errors)
+
+
+def _validate_escape_partition(
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "schema": SOURCE_ESCAPE_PARTITION_SCHEMA,
+        "status": SOURCE_ESCAPE_PARTITION_STATUS,
+        "trust": TRUST,
+    }
+    _validate_source_meta("escape partition", payload, expected, errors)
+    summary = _mapping(payload.get("summary"), "escape partition summary", errors)
+    if not summary:
+        return
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [151],
+        "target_center": TARGET_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "outside_support_pairs": OUTSIDE_SUPPORT_PAIRS,
+        "connector_avoiding_support_pairs": PRIVATE_HALO_ONLY_SUPPORT_PAIRS,
+        "connector_forcing_support_pairs": ENDPOINT8_SUPPORT_PAIRS,
+        "connector_avoiding_target_row_count": 4,
+        "connector_available_target_row_count": 9,
+        "connector_avoiding_basic_survivor_count": 12,
+        "connector_available_basic_survivor_count": 16,
+        "connector_avoiding_vertex_circle_survivor_count": 0,
+        "connector_available_vertex_circle_survivor_count": 0,
+        "vertex_circle_surviving_assignment_count": 0,
+        "scan_status": SOURCE_ESCAPE_PARTITION_SCAN_STATUS,
+    }
+    _expect_fields("escape partition summary", summary, expected_summary, errors)
+
+
+def _validate_source_alignment(
+    connector_contract: Mapping[str, Any],
+    escape_partition: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    connector_summary = _mapping(
+        connector_contract.get("summary"), "connector contract summary", errors
+    )
+    partition_summary = _mapping(
+        escape_partition.get("summary"), "escape partition summary", errors
+    )
+    if not connector_summary or not partition_summary:
+        return
+    pairs = (
+        ("target_row_key", "target_row_key"),
+        ("source_record_ids", "source_record_ids"),
+        ("target_row_center", "target_center"),
+        ("bootstrap_core_witnesses", "bootstrap_core_witnesses"),
+        ("outside_support_pairs", "outside_support_pairs"),
+        ("connector_avoiding_support_pairs", "connector_avoiding_support_pairs"),
+        ("connector_forcing_support_pairs", "connector_forcing_support_pairs"),
+    )
+    for left_key, right_key in pairs:
+        if connector_summary.get(left_key) != partition_summary.get(right_key):
+            errors.append(
+                "source alignment mismatch: "
+                f"connector.{left_key} != partition.{right_key}"
+            )
+
+
+def _validate_summary(summary: Mapping[str, Any], errors: list[str]) -> None:
+    pinned = {
+        "target_row_key": TARGET_ROW_KEY,
+        "source_record_ids": [151],
+        "target_center": TARGET_CENTER,
+        "bootstrap_core_witnesses": BOOTSTRAP_CORE_WITNESSES,
+        "connector_pair": CONNECTOR_PAIR,
+        "connector_distance_pairs": CONNECTOR_DISTANCE_PAIRS,
+        "outside_support_pairs": OUTSIDE_SUPPORT_PAIRS,
+        "endpoint8_support_pairs": ENDPOINT8_SUPPORT_PAIRS,
+        "blocking_escape_support_pairs": PRIVATE_HALO_ONLY_SUPPORT_PAIRS,
+        "connector_contract_escape_status": (
+            "CONNECTOR_ESCAPE_REQUIRES_PRIVATE_HALO_ONLY_PAIR_3_5"
+        ),
+        "connector_contract_support_existence_status": "OPEN_TARGET_NOT_PROVED",
+        "connector_conditional_available": True,
+        "private_halo_only_target_row_count": 4,
+        "private_halo_only_basic_survivor_count": 12,
+        "private_halo_only_vertex_circle_survivor_count": 0,
+        "endpoint8_connector_available_target_row_count": 9,
+        "endpoint8_connector_available_basic_survivor_count": 16,
+        "endpoint8_connector_available_vertex_circle_survivor_count": 0,
+        "all_selected_row_diagnostic_survivors_vertex_circle_obstructed": True,
+        "source_escape_partition_scan_status": SOURCE_ESCAPE_PARTITION_SCAN_STATUS,
+        "gate_status": GATE_STATUS,
+        "endpoint8_forced_by_current_evidence": False,
+        "endpoint8_forcing_blocked_by_private_halo_escape": True,
+        "private_halo_escape_status": PRIVATE_ESCAPE_STATUS,
+    }
+    for key, expected in pinned.items():
+        if summary.get(key) != expected:
+            errors.append(
+                f"summary.{key} mismatch: expected {expected!r}, got {summary.get(key)!r}"
+            )
+    reasons = summary.get("preflight_reasons")
+    if not isinstance(reasons, list) or len(reasons) != 4:
+        errors.append("summary.preflight_reasons must contain four reasons")
+    elif not any("[3,5]" in reason for reason in reasons):
+        errors.append("summary.preflight_reasons must name [3,5]")
+    next_required = summary.get("next_required_lemma")
+    if not isinstance(next_required, str) or "[3,5]" not in next_required:
+        errors.append("summary.next_required_lemma must name the [3,5] escape")
+
+
+def _validate_decision(
+    decision: Mapping[str, Any],
+    summary: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "answer": "do_not_accept_endpoint8_forcing_claim",
+        "gate_status": GATE_STATUS,
+        "endpoint8_forced_by_current_evidence": False,
+        "can_use_connector_if_endpoint8_support_hypothesis_supplied": True,
+        "blocking_escape_status": PRIVATE_ESCAPE_STATUS,
+        "blocking_escape_support_pairs": PRIVATE_HALO_ONLY_SUPPORT_PAIRS,
+        "blocking_basic_survivor_count": summary.get(
+            "private_halo_only_basic_survivor_count"
+        ),
+        "required_next_lemma": summary.get("next_required_lemma"),
+    }
+    _expect_fields("decision", decision, expected, errors)
+    question = decision.get("decision_question")
+    if not isinstance(question, str) or "endpoint 8" not in question:
+        errors.append("decision.decision_question must name endpoint 8")
+
+
+def _source_summary(path: Path, role: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": display_path(path, ROOT),
+        "role": role,
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+    }
+
+
+def _validate_source_meta(
+    label: str,
+    source: Mapping[str, Any],
+    expected: Mapping[str, str],
+    errors: list[str],
+) -> None:
+    for key, expected_value in expected.items():
+        if source.get(key) != expected_value:
+            errors.append(
+                f"{label} {key} mismatch: expected {expected_value!r}, "
+                f"got {source.get(key)!r}"
+            )
+
+
+def _expect_fields(
+    label: str,
+    mapping: Mapping[str, Any],
+    expected: Mapping[str, object],
+    errors: list[str],
+) -> None:
+    for key, expected_value in expected.items():
+        if mapping.get(key) != expected_value:
+            errors.append(
+                f"{label}.{key} mismatch: expected {expected_value!r}, "
+                f"got {mapping.get(key)!r}"
+            )
+
+
+def _mapping(value: object, name: str, errors: list[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        errors.append(f"{name} must be an object")
+        return {}
+    return value
+
+
+def _required_mapping(value: object, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise AssertionError(f"{name} must be an object")
+    return value
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument(
+        "--source-connector-contract",
+        type=Path,
+        default=DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+    )
+    parser.add_argument(
+        "--source-escape-partition",
+        type=Path,
+        default=DEFAULT_SOURCE_ESCAPE_PARTITION,
+    )
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    artifact = _resolve(args.artifact)
+    source_connector_contract = _resolve(args.source_connector_contract)
+    source_escape_partition = _resolve(args.source_escape_partition)
+
+    generated = build_endpoint8_forcing_preflight_payload(
+        load_artifact(source_connector_contract),
+        load_artifact(source_escape_partition),
+        connector_contract_path=source_connector_contract,
+        escape_partition_path=source_escape_partition,
+    )
+    payload = generated
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{display_path(artifact, ROOT)} is stale")
+        payload = stored
+
+    errors = validate_payload(
+        payload,
+        connector_contract_path=source_connector_contract,
+        escape_partition_path=source_escape_partition,
+    )
+    if args.assert_expected:
+        assert_expected_endpoint8_forcing_preflight(payload)
+    if args.write:
+        write_json(generated, artifact)
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("bootstrap/T12 151:6 endpoint-8 forcing preflight")
+        print(f"target row: {summary['target_row_key']}")
+        print(f"gate status: {summary['gate_status']}")
+        print(
+            "endpoint-8 forced by current evidence: "
+            f"{summary['endpoint8_forced_by_current_evidence']}"
+        )
+        print(
+            "private-halo-only basic survivors: "
+            f"{summary['private_halo_only_basic_survivor_count']}"
+        )
+        if errors:
+            print("validation errors:")
+            for error in errors:
+                print(f"- {error}")
+        else:
+            print("OK: 151:6 endpoint-8 forcing preflight verified")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2510,6 +2510,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_151_6_endpoint8_forcing_preflight",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Endpoint-8 forcing red-light preflight for source 151 row 6; "
+            "not endpoint-8 support existence, not a proof that [3,5] is "
+            "impossible, not row forcing, not an n=9 proof, not a bridge "
+            "proof, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_151_singleton_support_audit",
         command=(
             "python",

--- a/tests/test_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
+++ b/tests/test_bootstrap_t12_151_6_endpoint8_forcing_preflight.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.check_bootstrap_t12_151_6_endpoint8_forcing_preflight import (
+    DEFAULT_ARTIFACT,
+    DEFAULT_SOURCE_CONNECTOR_CONTRACT,
+    DEFAULT_SOURCE_ESCAPE_PARTITION,
+    GATE_STATUS,
+    PRIVATE_ESCAPE_STATUS,
+    assert_expected_endpoint8_forcing_preflight,
+    build_endpoint8_forcing_preflight_payload,
+    load_artifact,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
+
+
+@pytest.fixture(scope="module")
+def source_connector_contract() -> dict[str, object]:
+    return load_artifact(DEFAULT_SOURCE_CONNECTOR_CONTRACT)
+
+
+@pytest.fixture(scope="module")
+def source_escape_partition() -> dict[str, object]:
+    return load_artifact(DEFAULT_SOURCE_ESCAPE_PARTITION)
+
+
+def test_endpoint8_forcing_preflight_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_endpoint8_forcing_preflight(payload)
+    assert (
+        payload["status"]
+        == "BOOTSTRAP_T12_151_6_ENDPOINT8_FORCING_PREFLIGHT_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    for phrase in (
+        "does not prove endpoint-8 support existence",
+        "does not prove row forcing",
+        "does not prove pair [3,5] impossible",
+        "does not prove n=9",
+        "does not prove the bridge",
+        "not a counterexample",
+    ):
+        assert phrase in claim_scope
+
+
+def test_endpoint8_forcing_preflight_summary() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "151:6"
+    assert summary["target_center"] == 6
+    assert summary["connector_pair"] == [0, 8]
+    assert summary["endpoint8_support_pairs"] == [[3, 8], [5, 8]]
+    assert summary["blocking_escape_support_pairs"] == [[3, 5]]
+    assert summary["connector_conditional_available"] is True
+    assert summary["private_halo_only_target_row_count"] == 4
+    assert summary["private_halo_only_basic_survivor_count"] == 12
+    assert summary["private_halo_only_vertex_circle_survivor_count"] == 0
+    assert summary["endpoint8_connector_available_basic_survivor_count"] == 16
+    assert summary["gate_status"] == GATE_STATUS
+    assert summary["endpoint8_forced_by_current_evidence"] is False
+    assert summary["endpoint8_forcing_blocked_by_private_halo_escape"] is True
+    assert summary["private_halo_escape_status"] == PRIVATE_ESCAPE_STATUS
+    assert "[3,5]" in summary["next_required_lemma"]
+
+
+def test_endpoint8_forcing_preflight_decision_blocks_overclaim() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    decision = payload["decision"]
+
+    assert decision["answer"] == "do_not_accept_endpoint8_forcing_claim"
+    assert decision["gate_status"] == GATE_STATUS
+    assert decision["endpoint8_forced_by_current_evidence"] is False
+    assert decision["can_use_connector_if_endpoint8_support_hypothesis_supplied"] is True
+    assert decision["blocking_escape_support_pairs"] == [[3, 5]]
+    assert decision["blocking_basic_survivor_count"] == 12
+
+
+def test_endpoint8_forcing_preflight_artifact_matches_generator(
+    source_connector_contract: dict[str, object],
+    source_escape_partition: dict[str, object],
+) -> None:
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == build_endpoint8_forcing_preflight_payload(
+        source_connector_contract,
+        source_escape_partition,
+    )
+
+
+def test_endpoint8_forcing_preflight_rejects_tampered_summary() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["summary"]["endpoint8_forced_by_current_evidence"] = True
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("endpoint8_forced_by_current_evidence" in error for error in errors)
+
+
+def test_endpoint8_forcing_preflight_rejects_source_drift(
+    source_connector_contract: dict[str, object],
+    source_escape_partition: dict[str, object],
+) -> None:
+    tampered = json.loads(json.dumps(source_escape_partition))
+    tampered["summary"]["connector_avoiding_basic_survivor_count"] = 0
+
+    with pytest.raises(AssertionError, match="connector_avoiding_basic_survivor_count"):
+        build_endpoint8_forcing_preflight_payload(
+            source_connector_contract,
+            tampered,
+        )
+
+
+def test_endpoint8_forcing_preflight_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["target_row_key"] == "151:6"
+    assert payload["gate_status"] == GATE_STATUS
+    assert payload["endpoint8_forced_by_current_evidence"] is False

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -370,6 +370,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_bootstrap_t12_151_singleton_support_audit.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -259,6 +259,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
     ) < ordered_command_texts.index(
@@ -456,6 +461,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py "
+        "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check "
         "--assert-expected --json",


### PR DESCRIPTION
## Summary

- Add a checked `151:6` endpoint-8 forcing preflight over the existing connector-contract and escape-partition packets.
- Record the current gate status as `NOT_READY_PRIVATE_HALO_ONLY_ESCAPE_SURVIVES_BASIC_FILTERS`: endpoint `8` is not forced by present evidence because `[3,5]` remains a connector-avoiding basic-filter lane.
- Wire the preflight into bridge-frontier verification, artifact audit, generated-artifact provenance, docs, and regression tests.

## Claim scope

Diagnostic only. This does not prove endpoint-8 support existence, row forcing, `n=9`, the bridge, Erdos Problem #97, or a counterexample. It also does not prove the private-halo-only pair `[3,5]` is impossible.

## Validation

- `python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json`
- `python -m pytest -q tests/test_bootstrap_t12_151_6_endpoint8_forcing_preflight.py tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python -m ruff check scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py tests/test_bootstrap_t12_151_6_endpoint8_forcing_preflight.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` -> `1363 passed, 517 deselected`