### PR TITLE
[codex] Add 151:6 private-lane core catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json
+	$(PYTHON) scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_support_audit.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_two_row_drop.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_151_singleton_full_neighborhood_vertex_circle.py --check --assert-expected --json

--- a/data/certificates/bootstrap_t12_151_6_private_lane_core_catalog.json
+++ b/data/certificates/bootstrap_t12_151_6_private_lane_core_catalog.json
@@ -1,0 +1,1705 @@
+{
+  "catalog_records": [
+    {
+      "assignment_index": 0,
+      "chosen_core_centers": [
+        1,
+        5,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 3,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            2,
+            6
+          ],
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            2,
+            6
+          ],
+          "outer_class": [
+            0,
+            6
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            3,
+            6
+          ],
+          "row": 5,
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ]
+        },
+        {
+          "inner_class": [
+            2,
+            8
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            2,
+            8
+          ],
+          "outer_class": [
+            2,
+            6
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            2,
+            6
+          ],
+          "row": 5,
+          "witness_order": [
+            6,
+            8,
+            2,
+            3
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            6
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            2,
+            5
+          ],
+          "outer_class": [
+            2,
+            8
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            2,
+            8
+          ],
+          "row": 1,
+          "witness_order": [
+            2,
+            5,
+            7,
+            8
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 1,
+          "witnesses": [
+            2,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 5,
+          "witnesses": [
+            2,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 14,
+      "minimal_core_size_counts": {
+        "3": 9,
+        "4": 5
+      },
+      "row6_minimal_core_count": 6,
+      "row6_minimal_core_size_counts": {
+        "3": 2,
+        "4": 4
+      },
+      "source_vertex_circle_status": "strict_cycle"
+    },
+    {
+      "assignment_index": 1,
+      "chosen_core_centers": [
+        0,
+        6,
+        7
+      ],
+      "chosen_core_cycle_edge_count": 3,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            2,
+            7
+          ],
+          "inner_interval": [
+            1,
+            3
+          ],
+          "inner_pair": [
+            2,
+            7
+          ],
+          "outer_class": [
+            0,
+            6
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            7
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "inner_class": [
+            5,
+            7
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            5,
+            7
+          ],
+          "outer_class": [
+            2,
+            7
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            2,
+            7
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            6
+          ],
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            3,
+            7
+          ],
+          "outer_class": [
+            5,
+            7
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            5,
+            7
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        },
+        {
+          "center": 7,
+          "witnesses": [
+            1,
+            3,
+            6,
+            8
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 28,
+      "minimal_core_size_counts": {
+        "3": 12,
+        "4": 14,
+        "5": 2
+      },
+      "row6_minimal_core_count": 11,
+      "row6_minimal_core_size_counts": {
+        "3": 4,
+        "4": 6,
+        "5": 1
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 2,
+      "chosen_core_centers": [
+        0,
+        2,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            5
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            0,
+            8
+          ],
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            0,
+            3
+          ],
+          "row": 2,
+          "witness_order": [
+            3,
+            4,
+            8,
+            0
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 2,
+          "witnesses": [
+            0,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 16,
+      "minimal_core_size_counts": {
+        "3": 13,
+        "4": 2,
+        "5": 1
+      },
+      "row6_minimal_core_count": 7,
+      "row6_minimal_core_size_counts": {
+        "3": 4,
+        "4": 2,
+        "5": 1
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 3,
+      "chosen_core_centers": [
+        0,
+        3,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            3,
+            7
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            3,
+            7
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            3,
+            8
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            3,
+            7
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            3,
+            7
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 3,
+          "witnesses": [
+            0,
+            2,
+            4,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 20,
+      "minimal_core_size_counts": {
+        "3": 14,
+        "4": 4,
+        "5": 2
+      },
+      "row6_minimal_core_count": 6,
+      "row6_minimal_core_size_counts": {
+        "3": 5,
+        "5": 1
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 4,
+      "chosen_core_centers": [
+        1,
+        5,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            6
+          ],
+          "inner_interval": [
+            1,
+            3
+          ],
+          "inner_pair": [
+            0,
+            6
+          ],
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            0,
+            3
+          ],
+          "row": 1,
+          "witness_order": [
+            3,
+            6,
+            8,
+            0
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            0,
+            6
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            5,
+            7
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 1,
+          "witnesses": [
+            0,
+            3,
+            6,
+            8
+          ]
+        },
+        {
+          "center": 5,
+          "witnesses": [
+            2,
+            4,
+            6,
+            7
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 30,
+      "minimal_core_size_counts": {
+        "3": 7,
+        "4": 22,
+        "5": 1
+      },
+      "row6_minimal_core_count": 16,
+      "row6_minimal_core_size_counts": {
+        "3": 4,
+        "4": 12
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 5,
+      "chosen_core_centers": [
+        3,
+        5,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 3,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            1,
+            5
+          ],
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            1,
+            5
+          ],
+          "outer_class": [
+            0,
+            5
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            2,
+            5
+          ],
+          "row": 3,
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ]
+        },
+        {
+          "inner_class": [
+            5,
+            7
+          ],
+          "inner_interval": [
+            0,
+            1
+          ],
+          "inner_pair": [
+            5,
+            7
+          ],
+          "outer_class": [
+            1,
+            5
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            5
+          ],
+          "row": 3,
+          "witness_order": [
+            5,
+            7,
+            1,
+            2
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            5
+          ],
+          "inner_interval": [
+            1,
+            3
+          ],
+          "inner_pair": [
+            0,
+            5
+          ],
+          "outer_class": [
+            5,
+            7
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            5,
+            7
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 3,
+          "witnesses": [
+            1,
+            2,
+            5,
+            7
+          ]
+        },
+        {
+          "center": 5,
+          "witnesses": [
+            0,
+            2,
+            4,
+            6
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 28,
+      "minimal_core_size_counts": {
+        "3": 12,
+        "4": 14,
+        "5": 2
+      },
+      "row6_minimal_core_count": 11,
+      "row6_minimal_core_size_counts": {
+        "3": 4,
+        "4": 6,
+        "5": 1
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 6,
+      "chosen_core_centers": [
+        0,
+        1,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            5
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            0,
+            8
+          ],
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            3
+          ],
+          "row": 1,
+          "witness_order": [
+            2,
+            3,
+            8,
+            0
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            5,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 1,
+          "witnesses": [
+            0,
+            2,
+            3,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 33,
+      "minimal_core_size_counts": {
+        "3": 7,
+        "4": 25,
+        "5": 1
+      },
+      "row6_minimal_core_count": 13,
+      "row6_minimal_core_size_counts": {
+        "3": 5,
+        "4": 8
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 7,
+      "chosen_core_centers": [
+        0,
+        1,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            5
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            0,
+            8
+          ],
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            0,
+            3
+          ],
+          "row": 1,
+          "witness_order": [
+            3,
+            4,
+            8,
+            0
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            2,
+            5,
+            8
+          ]
+        },
+        {
+          "center": 1,
+          "witnesses": [
+            0,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 14,
+      "minimal_core_size_counts": {
+        "3": 9,
+        "4": 5
+      },
+      "row6_minimal_core_count": 6,
+      "row6_minimal_core_size_counts": {
+        "3": 2,
+        "4": 4
+      },
+      "source_vertex_circle_status": "strict_cycle"
+    },
+    {
+      "assignment_index": 8,
+      "chosen_core_centers": [
+        0,
+        1,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 3,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            1,
+            7
+          ],
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            1,
+            7
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "inner_class": [
+            3,
+            7
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            3,
+            7
+          ],
+          "outer_class": [
+            1,
+            7
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            7
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            3,
+            7
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            3,
+            7
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 1,
+          "witnesses": [
+            0,
+            2,
+            5,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 33,
+      "minimal_core_size_counts": {
+        "3": 7,
+        "4": 25,
+        "5": 1
+      },
+      "row6_minimal_core_count": 13,
+      "row6_minimal_core_size_counts": {
+        "3": 5,
+        "4": 8
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 9,
+      "chosen_core_centers": [
+        0,
+        1,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 3,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            1,
+            7
+          ],
+          "inner_interval": [
+            0,
+            2
+          ],
+          "inner_pair": [
+            1,
+            7
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            1,
+            8
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "inner_class": [
+            3,
+            7
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            3,
+            7
+          ],
+          "outer_class": [
+            1,
+            7
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            1,
+            7
+          ],
+          "row": 0,
+          "witness_order": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            3,
+            7
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            3,
+            7
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            3,
+            7,
+            8
+          ]
+        },
+        {
+          "center": 1,
+          "witnesses": [
+            0,
+            2,
+            5,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 30,
+      "minimal_core_size_counts": {
+        "3": 7,
+        "4": 22,
+        "5": 1
+      },
+      "row6_minimal_core_count": 16,
+      "row6_minimal_core_size_counts": {
+        "3": 4,
+        "4": 12
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 10,
+      "chosen_core_centers": [
+        0,
+        1,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            3
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            5
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            2,
+            3
+          ],
+          "inner_pair": [
+            0,
+            8
+          ],
+          "outer_class": [
+            0,
+            3
+          ],
+          "outer_interval": [
+            0,
+            3
+          ],
+          "outer_pair": [
+            0,
+            3
+          ],
+          "row": 1,
+          "witness_order": [
+            3,
+            4,
+            8,
+            0
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            2,
+            5,
+            8
+          ]
+        },
+        {
+          "center": 1,
+          "witnesses": [
+            0,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 16,
+      "minimal_core_size_counts": {
+        "3": 13,
+        "4": 2,
+        "5": 1
+      },
+      "row6_minimal_core_count": 7,
+      "row6_minimal_core_size_counts": {
+        "3": 4,
+        "4": 2,
+        "5": 1
+      },
+      "source_vertex_circle_status": "self_edge"
+    },
+    {
+      "assignment_index": 11,
+      "chosen_core_centers": [
+        0,
+        3,
+        6
+      ],
+      "chosen_core_cycle_edge_count": 2,
+      "chosen_core_cycle_edges": [
+        {
+          "inner_class": [
+            0,
+            5
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            5
+          ],
+          "outer_class": [
+            0,
+            1
+          ],
+          "outer_interval": [
+            0,
+            2
+          ],
+          "outer_pair": [
+            0,
+            4
+          ],
+          "row": 3,
+          "witness_order": [
+            4,
+            5,
+            0,
+            2
+          ]
+        },
+        {
+          "inner_class": [
+            0,
+            1
+          ],
+          "inner_interval": [
+            1,
+            2
+          ],
+          "inner_pair": [
+            0,
+            3
+          ],
+          "outer_class": [
+            0,
+            5
+          ],
+          "outer_interval": [
+            1,
+            3
+          ],
+          "outer_pair": [
+            0,
+            5
+          ],
+          "row": 6,
+          "witness_order": [
+            7,
+            0,
+            3,
+            5
+          ]
+        }
+      ],
+      "chosen_core_rows": [
+        {
+          "center": 0,
+          "witnesses": [
+            1,
+            3,
+            4,
+            8
+          ]
+        },
+        {
+          "center": 3,
+          "witnesses": [
+            0,
+            2,
+            4,
+            5
+          ]
+        },
+        {
+          "center": 6,
+          "witnesses": [
+            0,
+            3,
+            5,
+            7
+          ]
+        }
+      ],
+      "chosen_core_self_edge_count": 0,
+      "chosen_core_status": "strict_cycle",
+      "chosen_core_strict_edge_count": 27,
+      "minimal_core_count": 20,
+      "minimal_core_size_counts": {
+        "3": 14,
+        "4": 4,
+        "5": 2
+      },
+      "row6_minimal_core_count": 6,
+      "row6_minimal_core_size_counts": {
+        "3": 5,
+        "5": 1
+      },
+      "source_vertex_circle_status": "self_edge"
+    }
+  ],
+  "claim_scope": "Proof-mining diagnostic for the source-151 row-6 private-halo-only outside-pair lane. It extracts minimal vertex-circle obstruction cores from the 12 basic-filter survivors with target row [0,3,5,7] and records that every survivor has a three-row strict-cycle core including center 6. This does not prove outside-pair support existence, does not prove row forcing, does not prove pair [3,5] impossible, does not prove endpoint-8 forcing, does not prove n=9, does not prove the bridge, is not a counterexample, and is not a global status update.",
+  "interpretation": [
+    "The selected-row private lane is sharper than the aggregate partition: all 12 survivors use row 6 -> [0,3,5,7].",
+    "Each survivor has a three-row strict-cycle core that includes that row-6 private-lane support.",
+    "These cores are local obstruction targets inside the selected-row diagnostic; they do not prove support existence or row forcing.",
+    "The remaining proof-facing task is still genuine minimal/rich-class support geometry for endpoint 8 versus [3,5]."
+  ],
+  "provenance": {
+    "command": "python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --write --assert-expected",
+    "generator": "scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py"
+  },
+  "schema": "erdos97.bootstrap_t12_151_6_private_lane_core_catalog.v1",
+  "source_artifacts": [
+    {
+      "path": "data/certificates/bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.json",
+      "role": "source 151:6 outside-pair full-neighborhood packet",
+      "schema": "erdos97.bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.v1",
+      "status": "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    },
+    {
+      "path": "data/certificates/bootstrap_t12_151_6_endpoint8_forcing_preflight.json",
+      "role": "source 151:6 endpoint-8 forcing preflight",
+      "schema": "erdos97.bootstrap_t12_151_6_endpoint8_forcing_preflight.v1",
+      "status": "BOOTSTRAP_T12_151_6_ENDPOINT8_FORCING_PREFLIGHT_DIAGNOSTIC_ONLY",
+      "trust": "REVIEW_PENDING_DIAGNOSTIC"
+    }
+  ],
+  "status": "BOOTSTRAP_T12_151_6_PRIVATE_LANE_CORE_CATALOG_DIAGNOSTIC_ONLY",
+  "summary": {
+    "all_minimal_core_occurrence_count": 282,
+    "all_minimal_core_size_counts": {
+      "3": 124,
+      "4": 144,
+      "5": 14
+    },
+    "all_minimal_core_status_counts": {
+      "self_edge": 42,
+      "strict_cycle": 240
+    },
+    "assignments_with_row6_minimal_core": 12,
+    "assignments_with_row6_three_row_core": 12,
+    "catalog_status": "PRIVATE_HALO_ONLY_LANE_HAS_ROW6_THREE_ROW_STRICT_CYCLE_CORES",
+    "chosen_distinct_exact_core_count": 10,
+    "chosen_row6_core_count": 12,
+    "chosen_row6_core_size_counts": {
+      "3": 12
+    },
+    "chosen_row6_core_status_counts": {
+      "strict_cycle": 12
+    },
+    "private_support_pair": [
+      3,
+      5
+    ],
+    "private_target_center_class": [
+      0,
+      3,
+      5,
+      7
+    ],
+    "row6_minimal_core_occurrence_count": 118,
+    "row6_minimal_core_size_counts": {
+      "3": 48,
+      "4": 64,
+      "5": 6
+    },
+    "row6_minimal_core_status_counts": {
+      "self_edge": 6,
+      "strict_cycle": 112
+    },
+    "source_private_lane_survivor_count": 12,
+    "source_vertex_circle_status_counts": {
+      "self_edge": 10,
+      "strict_cycle": 2
+    },
+    "target_center": 6,
+    "target_row_key": "151:6"
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
+  "validation_errors": [],
+  "validation_status": "passed"
+}

--- a/docs/bootstrap-t12-151-6-private-lane-core-catalog.md
+++ b/docs/bootstrap-t12-151-6-private-lane-core-catalog.md
@@ -1,0 +1,90 @@
+# Bootstrap T12 151:6 Private-Lane Core Catalog
+
+Status: `REVIEW_PENDING_DIAGNOSTIC`. No general proof of Erdos Problem #97 is
+claimed. No counterexample is claimed.
+
+This note sharpens the selected-row diagnostic for the source-`151` row-`6`
+private-halo-only outside-pair lane. The previous endpoint-`8` forcing
+preflight records that endpoint `8` is not forced by current evidence because
+the private pair `[3,5]` still survives the basic filters. This packet asks a
+smaller follow-up question inside that lane:
+
+```text
+When the private target row is [0,3,5,7], how local are the exact
+vertex-circle obstructions?
+```
+
+The checked artifact is:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --check --assert-expected --json
+```
+
+The generator writes:
+
+```bash
+python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --write --assert-expected
+```
+
+to:
+
+```text
+data/certificates/bootstrap_t12_151_6_private_lane_core_catalog.json
+```
+
+## Inputs
+
+This packet is a derivative check over:
+
+- `data/certificates/bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.json`;
+- `data/certificates/bootstrap_t12_151_6_endpoint8_forcing_preflight.json`.
+
+It uses the `12` basic-filter survivors in the private-halo-only target row:
+
+```text
+6 -> [0,3,5,7]
+```
+
+For each survivor, it enumerates row-subset-minimal vertex-circle obstruction
+cores and then chooses one deterministic minimal core that includes center
+`6`.
+
+## Catalog Result
+
+Pinned summary:
+
+| Quantity | Value |
+| --- | ---: |
+| private-lane survivors | `12` |
+| source survivor statuses | `self_edge: 10`, `strict_cycle: 2` |
+| all minimal core occurrences | `282` |
+| all minimal core sizes | `3: 124`, `4: 144`, `5: 14` |
+| all minimal core statuses | `self_edge: 42`, `strict_cycle: 240` |
+| row-`6` minimal core occurrences | `118` |
+| row-`6` minimal core sizes | `3: 48`, `4: 64`, `5: 6` |
+| row-`6` minimal core statuses | `self_edge: 6`, `strict_cycle: 112` |
+| survivors with a row-`6` three-row core | `12` |
+| chosen row-`6` core statuses | `strict_cycle: 12` |
+| distinct chosen exact cores | `10` |
+
+Thus every private-lane survivor has a three-row strict-cycle obstruction
+core containing the private target row `6 -> [0,3,5,7]`.
+
+## Reading
+
+This is a useful narrowing of the `[3,5]` escape target. It says that, inside
+the selected-row full-neighborhood diagnostic, the private lane does not need
+a large global obstruction: row `6` plus two other rows already force an exact
+vertex-circle strict cycle in each survivor.
+
+The remaining proof-facing question is still support geometry. A bridge lemma
+would need to explain why genuine minimal/rich-class hypotheses force one of
+these row-`6` local cores, force endpoint `8`, or rule out the private pair
+`[3,5]` directly.
+
+## What This Does Not Prove
+
+This artifact does not prove outside-pair support existence, does not prove
+row forcing, does not prove that pair `[3,5]` is impossible, does not prove
+endpoint-`8` forcing, does not prove `n=9`, does not prove the bootstrap
+bridge, and does not prove Erdos Problem #97.

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -499,8 +499,13 @@ minimal/rich-class hypotheses.
    `python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py --check --assert-expected --json`
    records the current red-light gate: endpoint `8` is not forced by present
    evidence because `[3,5]` remains a connector-avoiding basic-filter escape.
-   This is a diagnostic split only, so the next useful PR should attack
-   support existence or forcing for endpoint-`8` versus `[3,5]`, not another
+   The private-lane core catalog
+   `python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --check --assert-expected --json`
+   then shows that every one of the `12` private-lane survivors has a
+   three-row strict-cycle core containing row `6 -> [0,3,5,7]`. This is still
+   selected-row diagnostic evidence only, so the next useful PR should attack
+   genuine support existence or forcing for endpoint-`8` versus `[3,5]`, or
+   prove a reusable lemma forcing one of those row-`6` local cores, not another
    selected-row neighborhood widening around `151:6`. The
    source-`151` singleton-support audit in
    `docs/bootstrap-t12-151-singleton-support-audit.md` applies the same local

--- a/docs/index.md
+++ b/docs/index.md
@@ -400,6 +400,9 @@ put detailed reconciliation in the canonical synthesis.
   checked red-light preflight recording that current evidence does not force
   endpoint `8` because the private-halo-only `[3,5]` lane survives basic
   filters.
+- [`bootstrap-t12-151-6-private-lane-core-catalog.md`](bootstrap-t12-151-6-private-lane-core-catalog.md):
+  checked catalog showing every private-halo `[3,5]` lane survivor has a
+  three-row strict-cycle core containing row `6 -> [0,3,5,7]`.
 - [`bootstrap-t12-151-singleton-support-audit.md`](bootstrap-t12-151-singleton-support-audit.md):
   source-`151` singleton-support audit covering rows `151:5` and `151:8`.
 - [`bootstrap-t12-151-singleton-two-row-drop.md`](bootstrap-t12-151-singleton-two-row-drop.md):

--- a/docs/lemma-driven-bridge-targets.md
+++ b/docs/lemma-driven-bridge-targets.md
@@ -53,7 +53,7 @@ force one of the stored local templates by themselves.
 | `T01`--`T12` local templates | `docs/n9-vertex-circle-local-lemma-review-packet.md` packages 12 templates, 16 families, and 184 stored assignments | A proof that a minimal/rich-support counterexample must contain one of these local cores, without enumerating the whole frontier |
 | non-ear frontier rows `81` and `151` | `docs/bridge-lemma-frontier.md` and `docs/bootstrap-vertex-circle-overlay.md` isolate the two tight `n=9` non-ear rows and their `T12/F16` strict-cycle landing | A bootstrap/rich-class lemma that makes the needed T12 row relations genuinely available |
 | source `81`, row `3` | `docs/bootstrap-t12-81-3-closure-target.md` and `docs/bootstrap-t12-81-3-rich-triple-contract.md` reduce the target to the connector pair `[0,1]` | Force a genuine center-`3` rich class containing `[0,1]`, or classify the label-`6` connector-avoiding escape |
-| source `151`, row `6` | `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` splits endpoint-`8` supports from private-halo-only pair `[3,5]`; `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` shows the private-halo-only lane has `12` basic survivors before vertex-circle replay; `docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md` records that endpoint-`8` forcing is not ready from current evidence | Force an endpoint-`8` outside-pair support, or prove the `[3,5]` private-halo-only escape is geometrically impossible |
+| source `151`, row `6` | `docs/bootstrap-t12-151-6-outside-pair-connector-contract.md` splits endpoint-`8` supports from private-halo-only pair `[3,5]`; `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md` shows the private-halo-only lane has `12` basic survivors before vertex-circle replay; `docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md` records that endpoint-`8` forcing is not ready from current evidence; `docs/bootstrap-t12-151-6-private-lane-core-catalog.md` shows every private-lane survivor has a row-`6` three-row strict-cycle core | Force an endpoint-`8` outside-pair support, or prove the `[3,5]` private-halo-only escape is geometrically impossible |
 | source `151`, rows `7` and `8` | `docs/bootstrap-t12-hard-strict-endpoints.md` isolates missing strict-edge endpoint sets | Supply the hard endpoint labels from genuine closure/support geometry, not fixed-row bookkeeping |
 | block-6 fragile family | `docs/block6-fragile-vertex-circle-extension-audit.md` and `docs/bridge-negative-controls.md` record exact negative controls | A minimal/rich-class condition that rejects the family beyond fixed natural/block-preserving order slices |
 
@@ -124,6 +124,7 @@ Useful evidence:
 - `docs/bootstrap-t12-151-6-outside-pair-full-neighborhood-vertex-circle.md`
 - `docs/bootstrap-t12-151-6-outside-pair-escape-partition.md`
 - `docs/bootstrap-t12-151-6-endpoint8-forcing-preflight.md`
+- `docs/bootstrap-t12-151-6-private-lane-core-catalog.md`
 - `docs/bootstrap-t12-relation-sufficient-rows.md`
 
 Required guardrails:

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -940,6 +940,13 @@ condition that the surviving multi-block family does not automatically satisfy:
   accept endpoint-`8` forcing: the private-halo-only `[3,5]` lane has `12`
   basic-filter survivors. This is a gate-status diagnostic only, not a proof
   that endpoint `8` is forced and not a proof that `[3,5]` is impossible.
+- bootstrap/T12 focused `151:6` private-lane core-catalog evidence, as
+  recorded in
+  `docs/bootstrap-t12-151-6-private-lane-core-catalog.md`, extracting minimal
+  vertex-circle cores from those `12` private-lane survivors. Every survivor
+  has a three-row strict-cycle core containing row `6 -> [0,3,5,7]`. This is
+  local selected-row proof-mining data only; it does not prove the private
+  pair `[3,5]` is impossible under genuine rich-class support geometry.
 - bootstrap/T12 focused source-`151` singleton-support evidence, as recorded
   in `docs/bootstrap-t12-151-singleton-support-audit.md`, showing that rows
   `151:5` and `151:8` have no non-original activation survivor in the fixed

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -7569,6 +7569,76 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
 
+  - id: bootstrap_t12_151_6_private_lane_core_catalog
+    path: data/certificates/bootstrap_t12_151_6_private_lane_core_catalog.json
+    sha256: 4f9802827253e56620c8149080918fe6e615b3455824911423b89fa91e7cd1e8
+    size_bytes: 32712
+    kind: proof_mining_diagnostic_artifact
+    generator: scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py
+    command: python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --write --assert-expected
+    checker: scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py
+    check_command: python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Source-151 row-6 private-halo [3,5] lane minimal-core catalogue; every selected-row diagnostic survivor in the private lane has a three-row strict-cycle core containing row 6 -> [0,3,5,7]. This is not outside-pair support existence, not row forcing, not a proof that [3,5] is impossible, not endpoint-8 forcing, not a proof of n=9, not a proof of the bridge, not a counterexample, and not a global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.bootstrap_t12_151_6_private_lane_core_catalog.v1
+      status: BOOTSTRAP_T12_151_6_PRIVATE_LANE_CORE_CATALOG_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      summary.target_row_key: "151:6"
+      summary.target_center: 6
+      summary.private_target_center_class:
+        - 0
+        - 3
+        - 5
+        - 7
+      summary.private_support_pair:
+        - 3
+        - 5
+      summary.source_private_lane_survivor_count: 12
+      summary.source_vertex_circle_status_counts.self_edge: 10
+      summary.source_vertex_circle_status_counts.strict_cycle: 2
+      summary.all_minimal_core_occurrence_count: 282
+      summary.all_minimal_core_size_counts.3: 124
+      summary.all_minimal_core_size_counts.4: 144
+      summary.all_minimal_core_size_counts.5: 14
+      summary.all_minimal_core_status_counts.self_edge: 42
+      summary.all_minimal_core_status_counts.strict_cycle: 240
+      summary.row6_minimal_core_occurrence_count: 118
+      summary.row6_minimal_core_size_counts.3: 48
+      summary.row6_minimal_core_size_counts.4: 64
+      summary.row6_minimal_core_size_counts.5: 6
+      summary.row6_minimal_core_status_counts.self_edge: 6
+      summary.row6_minimal_core_status_counts.strict_cycle: 112
+      summary.assignments_with_row6_minimal_core: 12
+      summary.assignments_with_row6_three_row_core: 12
+      summary.chosen_row6_core_count: 12
+      summary.chosen_row6_core_size_counts.3: 12
+      summary.chosen_row6_core_status_counts.strict_cycle: 12
+      summary.chosen_distinct_exact_core_count: 10
+      summary.catalog_status: PRIVATE_HALO_ONLY_LANE_HAS_ROW6_THREE_ROW_STRICT_CYCLE_CORES
+      provenance.generator: scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py
+      provenance.command: python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - the n=9 vertex-circle checker has been independently reviewed
+      - bootstrap-core capacity proves the bridge
+      - T12/F16 proves the bridge
+      - the missing T12 row centers are forced
+      - relation-sufficient rows are forced
+      - outside pair support proves row-center forcing
+      - the 151:6 row is forced
+      - endpoint-8 support exists
+      - endpoint-8 support is forced
+      - the private-halo-only pair 3,5 is impossible
+      - the private-lane core catalog proves the bridge
+      - official/global status update
+      - source-of-truth strongest result
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+
   - id: bootstrap_t12_151_singleton_support_audit
     path: data/certificates/bootstrap_t12_151_singleton_support_audit.json
     sha256: 9647c2062ffdc1363dab531a70aa3e2e97e4bb4330b337516f286591eb1dfc5e

--- a/scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py
+++ b/scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env python3
+"""Check the bootstrap/T12 151:6 private-lane core catalogue."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.path_display import display_path  # noqa: E402
+from erdos97.vertex_circle_quotient_replay import (  # noqa: E402
+    SelectedRow,
+    replay_vertex_circle_quotient,
+    result_to_json,
+)
+
+
+SCHEMA = "erdos97.bootstrap_t12_151_6_private_lane_core_catalog.v1"
+STATUS = "BOOTSTRAP_T12_151_6_PRIVATE_LANE_CORE_CATALOG_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CATALOG_STATUS = "PRIVATE_HALO_ONLY_LANE_HAS_ROW6_THREE_ROW_STRICT_CYCLE_CORES"
+CLAIM_SCOPE = (
+    "Proof-mining diagnostic for the source-151 row-6 private-halo-only "
+    "outside-pair lane. It extracts minimal vertex-circle obstruction cores "
+    "from the 12 basic-filter survivors with target row [0,3,5,7] and records "
+    "that every survivor has a three-row strict-cycle core including center 6. "
+    "This does not prove outside-pair support existence, does not prove row "
+    "forcing, does not prove pair [3,5] impossible, does not prove endpoint-8 "
+    "forcing, does not prove n=9, does not prove the bridge, is not a "
+    "counterexample, and is not a global status update."
+)
+PROVENANCE = {
+    "generator": "scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py",
+    "command": (
+        "python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py "
+        "--write --assert-expected"
+    ),
+}
+
+DEFAULT_SOURCE_FULL_NEIGHBORHOOD = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.json"
+)
+DEFAULT_SOURCE_PREFLIGHT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_endpoint8_forcing_preflight.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "bootstrap_t12_151_6_private_lane_core_catalog.json"
+)
+
+SOURCE_FULL_SCHEMA = (
+    "erdos97.bootstrap_t12_151_6_outside_pair_full_neighborhood_vertex_circle.v1"
+)
+SOURCE_FULL_STATUS = (
+    "BOOTSTRAP_T12_151_6_OUTSIDE_PAIR_FULL_NEIGHBORHOOD_VERTEX_CIRCLE_"
+    "DIAGNOSTIC_ONLY"
+)
+SOURCE_PREFLIGHT_SCHEMA = (
+    "erdos97.bootstrap_t12_151_6_endpoint8_forcing_preflight.v1"
+)
+SOURCE_PREFLIGHT_STATUS = (
+    "BOOTSTRAP_T12_151_6_ENDPOINT8_FORCING_PREFLIGHT_DIAGNOSTIC_ONLY"
+)
+
+N = 9
+CYCLIC_ORDER = list(range(N))
+TARGET_ROW_KEY = "151:6"
+TARGET_CENTER = 6
+PRIVATE_TARGET_CLASS = [0, 3, 5, 7]
+PRIVATE_SUPPORT_PAIR = [3, 5]
+EXPECTED_SOURCE_STATUS_COUNTS = {"self_edge": 10, "strict_cycle": 2}
+EXPECTED_TOP_LEVEL_KEYS = {
+    "catalog_records",
+    "claim_scope",
+    "interpretation",
+    "provenance",
+    "schema",
+    "source_artifacts",
+    "status",
+    "summary",
+    "trust",
+    "validation_errors",
+    "validation_status",
+}
+EXPECTED_SUMMARY = {
+    "target_row_key": TARGET_ROW_KEY,
+    "target_center": TARGET_CENTER,
+    "private_target_center_class": PRIVATE_TARGET_CLASS,
+    "private_support_pair": PRIVATE_SUPPORT_PAIR,
+    "source_private_lane_survivor_count": 12,
+    "source_vertex_circle_status_counts": EXPECTED_SOURCE_STATUS_COUNTS,
+    "all_minimal_core_occurrence_count": 282,
+    "all_minimal_core_size_counts": {"3": 124, "4": 144, "5": 14},
+    "all_minimal_core_status_counts": {"self_edge": 42, "strict_cycle": 240},
+    "row6_minimal_core_occurrence_count": 118,
+    "row6_minimal_core_size_counts": {"3": 48, "4": 64, "5": 6},
+    "row6_minimal_core_status_counts": {"self_edge": 6, "strict_cycle": 112},
+    "assignments_with_row6_minimal_core": 12,
+    "assignments_with_row6_three_row_core": 12,
+    "chosen_row6_core_count": 12,
+    "chosen_row6_core_size_counts": {"3": 12},
+    "chosen_row6_core_status_counts": {"strict_cycle": 12},
+    "chosen_distinct_exact_core_count": 10,
+    "catalog_status": CATALOG_STATUS,
+}
+
+
+def load_artifact(path: Path) -> Any:
+    """Load a JSON artifact."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(payload: object, path: Path) -> None:
+    """Write stable LF-terminated JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def build_private_lane_core_catalog_payload(
+    full_neighborhood: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+    *,
+    full_neighborhood_path: Path = DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    preflight_path: Path = DEFAULT_SOURCE_PREFLIGHT,
+) -> dict[str, Any]:
+    """Return the deterministic private-lane core catalogue payload."""
+
+    errors: list[str] = []
+    _validate_source_full_neighborhood(full_neighborhood, errors)
+    _validate_source_preflight(preflight, errors)
+    survivors = _private_lane_survivors(full_neighborhood, errors)
+    records, summary = _catalogue(survivors)
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "summary": summary,
+        "catalog_records": records,
+        "source_artifacts": [
+            _source_summary(
+                full_neighborhood_path,
+                "source 151:6 outside-pair full-neighborhood packet",
+                full_neighborhood,
+            ),
+            _source_summary(
+                preflight_path,
+                "source 151:6 endpoint-8 forcing preflight",
+                preflight,
+            ),
+        ],
+        "interpretation": [
+            (
+                "The selected-row private lane is sharper than the aggregate "
+                "partition: all 12 survivors use row 6 -> [0,3,5,7]."
+            ),
+            (
+                "Each survivor has a three-row strict-cycle core that includes "
+                "that row-6 private-lane support."
+            ),
+            (
+                "These cores are local obstruction targets inside the selected-"
+                "row diagnostic; they do not prove support existence or row "
+                "forcing."
+            ),
+            (
+                "The remaining proof-facing task is still genuine minimal/"
+                "rich-class support geometry for endpoint 8 versus [3,5]."
+            ),
+        ],
+        "validation_status": "passed" if not errors else "failed",
+        "validation_errors": errors,
+        "provenance": PROVENANCE,
+    }
+    assert_expected_private_lane_core_catalog(payload)
+    return payload
+
+
+def assert_expected_private_lane_core_catalog(payload: Mapping[str, Any]) -> None:
+    """Assert the pinned private-lane core catalogue."""
+
+    errors = validate_payload(payload, recompute=False)
+    if errors:
+        raise AssertionError("; ".join(errors))
+
+
+def validate_payload(
+    payload: Mapping[str, Any],
+    *,
+    recompute: bool = True,
+    full_neighborhood_path: Path = DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    preflight_path: Path = DEFAULT_SOURCE_PREFLIGHT,
+) -> list[str]:
+    """Return validation errors for a private-lane core catalogue payload."""
+
+    errors: list[str] = []
+    if set(payload) != EXPECTED_TOP_LEVEL_KEYS:
+        errors.append(
+            "top-level keys mismatch: "
+            f"expected {sorted(EXPECTED_TOP_LEVEL_KEYS)!r}, got {sorted(payload)!r}"
+        )
+        return errors
+
+    expected_meta = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "validation_status": "passed",
+        "validation_errors": [],
+        "provenance": PROVENANCE,
+    }
+    for key, expected in expected_meta.items():
+        if payload.get(key) != expected:
+            errors.append(
+                f"{key} mismatch: expected {expected!r}, got {payload.get(key)!r}"
+            )
+
+    claim_scope = payload.get("claim_scope")
+    if not isinstance(claim_scope, str):
+        errors.append("claim_scope must be a string")
+    else:
+        for phrase in (
+            "does not prove outside-pair support existence",
+            "does not prove row forcing",
+            "does not prove pair [3,5] impossible",
+            "does not prove endpoint-8 forcing",
+            "does not prove n=9",
+            "does not prove the bridge",
+            "not a counterexample",
+            "not a global status update",
+        ):
+            if phrase not in claim_scope:
+                errors.append(f"claim_scope must contain {phrase!r}")
+
+    summary = _mapping(payload.get("summary"), "summary", errors)
+    _validate_summary(summary, errors)
+    records = payload.get("catalog_records")
+    if not isinstance(records, list):
+        errors.append("catalog_records must be a list")
+    else:
+        _validate_catalog_records(records, errors)
+    interpretation = payload.get("interpretation")
+    if not isinstance(interpretation, list):
+        errors.append("interpretation must be a list")
+    elif not any("do not prove support existence" in item for item in interpretation):
+        errors.append("interpretation must preserve the support-existence nonclaim")
+
+    if recompute and not errors:
+        generated = build_private_lane_core_catalog_payload(
+            load_artifact(full_neighborhood_path),
+            load_artifact(preflight_path),
+            full_neighborhood_path=full_neighborhood_path,
+            preflight_path=preflight_path,
+        )
+        if dict(payload) != generated:
+            errors.append("stored artifact is stale relative to source packets")
+    return errors
+
+
+def summary_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    errors: Sequence[str],
+) -> dict[str, Any]:
+    """Return a compact CLI summary."""
+
+    summary = payload.get("summary", {})
+    if not isinstance(summary, Mapping):
+        summary = {}
+    return {
+        "artifact": display_path(path, ROOT),
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+        "ok": not errors,
+        "target_row_key": summary.get("target_row_key"),
+        "source_private_lane_survivor_count": summary.get(
+            "source_private_lane_survivor_count"
+        ),
+        "all_minimal_core_occurrence_count": summary.get(
+            "all_minimal_core_occurrence_count"
+        ),
+        "row6_minimal_core_occurrence_count": summary.get(
+            "row6_minimal_core_occurrence_count"
+        ),
+        "assignments_with_row6_three_row_core": summary.get(
+            "assignments_with_row6_three_row_core"
+        ),
+        "chosen_row6_core_status_counts": summary.get(
+            "chosen_row6_core_status_counts"
+        ),
+        "catalog_status": summary.get("catalog_status"),
+        "validation_errors": list(errors),
+    }
+
+
+def _catalogue(
+    survivors: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    all_minimal_size_counts: Counter[int] = Counter()
+    all_minimal_status_counts: Counter[str] = Counter()
+    row6_size_counts: Counter[int] = Counter()
+    row6_status_counts: Counter[str] = Counter()
+    chosen_size_counts: Counter[int] = Counter()
+    chosen_status_counts: Counter[str] = Counter()
+    chosen_keys: Counter[tuple[tuple[int, tuple[int, ...]], ...]] = Counter()
+    assignments_with_row6_core = 0
+    assignments_with_row6_three_row_core = 0
+
+    for index, survivor in enumerate(survivors):
+        selected_rows = _selected_rows(survivor)
+        minimal = _minimal_cores(selected_rows)
+        row6_minimal = [core for core in minimal if TARGET_CENTER in core.centers]
+        if row6_minimal:
+            assignments_with_row6_core += 1
+        if any(len(core.centers) == 3 for core in row6_minimal):
+            assignments_with_row6_three_row_core += 1
+
+        for core in minimal:
+            all_minimal_size_counts[len(core.centers)] += 1
+            all_minimal_status_counts[core.status] += 1
+        for core in row6_minimal:
+            row6_size_counts[len(core.centers)] += 1
+            row6_status_counts[core.status] += 1
+
+        chosen = _choose_row6_core(row6_minimal)
+        chosen_size_counts[len(chosen.centers)] += 1
+        chosen_status_counts[chosen.status] += 1
+        chosen_keys[_core_key(selected_rows, chosen.centers)] += 1
+        replay_json = result_to_json(
+            _replay(selected_rows, chosen.centers)
+        )
+        records.append(
+            {
+                "assignment_index": index,
+                "source_vertex_circle_status": str(
+                    survivor["vertex_circle_status"]
+                ),
+                "minimal_core_count": len(minimal),
+                "minimal_core_size_counts": _json_counter(
+                    Counter(len(core.centers) for core in minimal)
+                ),
+                "row6_minimal_core_count": len(row6_minimal),
+                "row6_minimal_core_size_counts": _json_counter(
+                    Counter(len(core.centers) for core in row6_minimal)
+                ),
+                "chosen_core_centers": list(chosen.centers),
+                "chosen_core_status": chosen.status,
+                "chosen_core_rows": [
+                    {
+                        "center": center,
+                        "witnesses": list(selected_rows[center]),
+                    }
+                    for center in chosen.centers
+                ],
+                "chosen_core_strict_edge_count": replay_json["strict_edge_count"],
+                "chosen_core_cycle_edge_count": len(replay_json["cycle_edges"]),
+                "chosen_core_self_edge_count": len(
+                    replay_json["self_edge_conflicts"]
+                ),
+                "chosen_core_cycle_edges": replay_json["cycle_edges"],
+            }
+        )
+
+    summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "target_center": TARGET_CENTER,
+        "private_target_center_class": PRIVATE_TARGET_CLASS,
+        "private_support_pair": PRIVATE_SUPPORT_PAIR,
+        "source_private_lane_survivor_count": len(survivors),
+        "source_vertex_circle_status_counts": _json_counter(
+            Counter(str(row["vertex_circle_status"]) for row in survivors)
+        ),
+        "all_minimal_core_occurrence_count": sum(all_minimal_size_counts.values()),
+        "all_minimal_core_size_counts": _json_counter(all_minimal_size_counts),
+        "all_minimal_core_status_counts": _json_counter(all_minimal_status_counts),
+        "row6_minimal_core_occurrence_count": sum(row6_size_counts.values()),
+        "row6_minimal_core_size_counts": _json_counter(row6_size_counts),
+        "row6_minimal_core_status_counts": _json_counter(row6_status_counts),
+        "assignments_with_row6_minimal_core": assignments_with_row6_core,
+        "assignments_with_row6_three_row_core": assignments_with_row6_three_row_core,
+        "chosen_row6_core_count": len(records),
+        "chosen_row6_core_size_counts": _json_counter(chosen_size_counts),
+        "chosen_row6_core_status_counts": _json_counter(chosen_status_counts),
+        "chosen_distinct_exact_core_count": len(chosen_keys),
+        "catalog_status": CATALOG_STATUS,
+    }
+    return records, summary
+
+
+class _Core(tuple):
+    @property
+    def centers(self) -> tuple[int, ...]:
+        return self[0]
+
+    @property
+    def status(self) -> str:
+        return self[1]
+
+
+def _minimal_cores(selected_rows: Mapping[int, tuple[int, ...]]) -> list[_Core]:
+    centers = sorted(selected_rows)
+    minimal: list[_Core] = []
+    for size in range(2, len(centers) + 1):
+        for combo in itertools.combinations(centers, size):
+            center_set = set(combo)
+            if any(set(core.centers) <= center_set for core in minimal):
+                continue
+            status = _replay(selected_rows, combo).status
+            if status != "ok":
+                minimal.append(_Core((tuple(combo), status)))
+    return minimal
+
+
+def _choose_row6_core(cores: Sequence[_Core]) -> _Core:
+    if not cores:
+        raise AssertionError("private-lane survivor has no row-6 minimal core")
+    return min(
+        cores,
+        key=lambda core: (
+            len(core.centers),
+            core.status != "strict_cycle",
+            core.centers,
+        ),
+    )
+
+
+def _replay(
+    selected_rows: Mapping[int, tuple[int, ...]],
+    centers: Sequence[int],
+) -> Any:
+    rows = [
+        SelectedRow(center=center, witnesses=selected_rows[center])
+        for center in centers
+    ]
+    return replay_vertex_circle_quotient(N, CYCLIC_ORDER, rows)
+
+
+def _validate_catalog_records(records: Sequence[object], errors: list[str]) -> None:
+    if len(records) != EXPECTED_SUMMARY["chosen_row6_core_count"]:
+        errors.append("catalog_records length mismatch")
+    for index, record in enumerate(records):
+        if not isinstance(record, Mapping):
+            errors.append(f"catalog_records[{index}] must be an object")
+            continue
+        if record.get("assignment_index") != index:
+            errors.append(f"catalog_records[{index}] assignment_index mismatch")
+        if record.get("chosen_core_status") != "strict_cycle":
+            errors.append(f"catalog_records[{index}] chosen core must be strict_cycle")
+        if record.get("chosen_core_centers") is None:
+            errors.append(f"catalog_records[{index}] missing chosen_core_centers")
+            continue
+        centers = tuple(int(center) for center in record["chosen_core_centers"])
+        if len(centers) != 3 or TARGET_CENTER not in centers:
+            errors.append(
+                f"catalog_records[{index}] chosen core must be a 3-row core with row 6"
+            )
+        if record.get("chosen_core_self_edge_count") != 0:
+            errors.append(f"catalog_records[{index}] chosen core has a self edge")
+        if int(record.get("chosen_core_cycle_edge_count", 0)) <= 0:
+            errors.append(f"catalog_records[{index}] chosen core has no cycle edges")
+
+
+def _validate_summary(summary: Mapping[str, Any], errors: list[str]) -> None:
+    for key, expected in EXPECTED_SUMMARY.items():
+        if summary.get(key) != expected:
+            errors.append(
+                f"summary.{key} mismatch: expected {expected!r}, got {summary.get(key)!r}"
+            )
+
+
+def _validate_source_full_neighborhood(
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "schema": SOURCE_FULL_SCHEMA,
+        "status": SOURCE_FULL_STATUS,
+        "trust": TRUST,
+    }
+    _validate_source_meta("full-neighborhood source", payload, expected, errors)
+    summary = _mapping(payload.get("summary"), "full-neighborhood summary", errors)
+    if not summary:
+        return
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "target_center": TARGET_CENTER,
+        "outside_support_pairs": [[3, 5], [3, 8], [5, 8]],
+        "vertex_circle_surviving_assignment_count": 0,
+        "scan_status": "FULL_NEIGHBORHOOD_BASIC_SURVIVORS_ALL_VERTEX_CIRCLE_OBSTRUCTED",
+    }
+    _expect_fields("full-neighborhood summary", summary, expected_summary, errors)
+
+
+def _validate_source_preflight(
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> None:
+    expected = {
+        "schema": SOURCE_PREFLIGHT_SCHEMA,
+        "status": SOURCE_PREFLIGHT_STATUS,
+        "trust": TRUST,
+    }
+    _validate_source_meta("endpoint-8 preflight source", payload, expected, errors)
+    summary = _mapping(payload.get("summary"), "endpoint-8 preflight summary", errors)
+    if not summary:
+        return
+    expected_summary = {
+        "target_row_key": TARGET_ROW_KEY,
+        "target_center": TARGET_CENTER,
+        "blocking_escape_support_pairs": [PRIVATE_SUPPORT_PAIR],
+        "private_halo_only_basic_survivor_count": 12,
+        "endpoint8_forced_by_current_evidence": False,
+        "endpoint8_forcing_blocked_by_private_halo_escape": True,
+    }
+    _expect_fields("endpoint-8 preflight summary", summary, expected_summary, errors)
+
+
+def _private_lane_survivors(
+    payload: Mapping[str, Any],
+    errors: list[str],
+) -> list[Mapping[str, Any]]:
+    per_target = payload.get("per_target_center_class")
+    if not isinstance(per_target, list):
+        errors.append("source per_target_center_class must be a list")
+        return []
+    matches = [
+        record
+        for record in per_target
+        if isinstance(record, Mapping)
+        and record.get("target_center_class") == PRIVATE_TARGET_CLASS
+    ]
+    if len(matches) != 1:
+        errors.append("expected exactly one private target-center class record")
+        return []
+    record = matches[0]
+    if record.get("basic_filter_complete_assignment_count") != 12:
+        errors.append("private target-center class must have 12 survivors")
+    if record.get("vertex_circle_status_counts") != EXPECTED_SOURCE_STATUS_COUNTS:
+        errors.append("private target-center class status counts drifted")
+    survivors = record.get("basic_filter_survivors")
+    if not isinstance(survivors, list):
+        errors.append("private target-center class survivors must be a list")
+        return []
+    return [survivor for survivor in survivors if isinstance(survivor, Mapping)]
+
+
+def _selected_rows(survivor: Mapping[str, Any]) -> dict[int, tuple[int, ...]]:
+    raw_rows = survivor.get("selected_rows")
+    if not isinstance(raw_rows, Mapping):
+        raise AssertionError("survivor selected_rows must be an object")
+    rows = {
+        int(center): tuple(int(witness) for witness in witnesses)
+        for center, witnesses in raw_rows.items()
+    }
+    target = rows.get(TARGET_CENTER)
+    if list(target or ()) != PRIVATE_TARGET_CLASS:
+        raise AssertionError("survivor row 6 does not match private target class")
+    return rows
+
+
+def _core_key(
+    selected_rows: Mapping[int, tuple[int, ...]],
+    centers: Sequence[int],
+) -> tuple[tuple[int, tuple[int, ...]], ...]:
+    return tuple((center, selected_rows[center]) for center in centers)
+
+
+def _source_summary(path: Path, role: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "path": display_path(path, ROOT),
+        "role": role,
+        "schema": payload.get("schema"),
+        "status": payload.get("status"),
+        "trust": payload.get("trust"),
+    }
+
+
+def _validate_source_meta(
+    label: str,
+    source: Mapping[str, Any],
+    expected: Mapping[str, str],
+    errors: list[str],
+) -> None:
+    for key, expected_value in expected.items():
+        if source.get(key) != expected_value:
+            errors.append(
+                f"{label} {key} mismatch: expected {expected_value!r}, "
+                f"got {source.get(key)!r}"
+            )
+
+
+def _expect_fields(
+    label: str,
+    mapping: Mapping[str, Any],
+    expected: Mapping[str, object],
+    errors: list[str],
+) -> None:
+    for key, expected_value in expected.items():
+        if mapping.get(key) != expected_value:
+            errors.append(
+                f"{label}.{key} mismatch: expected {expected_value!r}, "
+                f"got {mapping.get(key)!r}"
+            )
+
+
+def _mapping(value: object, name: str, errors: list[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        errors.append(f"{name} must be an object")
+        return {}
+    return value
+
+
+def _json_counter(counter: Counter[Any]) -> dict[str, int]:
+    return {str(key): int(counter[key]) for key in sorted(counter)}
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument(
+        "--source-full-neighborhood",
+        type=Path,
+        default=DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    )
+    parser.add_argument(
+        "--source-preflight",
+        type=Path,
+        default=DEFAULT_SOURCE_PREFLIGHT,
+    )
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    args = parser.parse_args()
+
+    artifact = _resolve(args.artifact)
+    source_full_neighborhood = _resolve(args.source_full_neighborhood)
+    source_preflight = _resolve(args.source_preflight)
+
+    generated = build_private_lane_core_catalog_payload(
+        load_artifact(source_full_neighborhood),
+        load_artifact(source_preflight),
+        full_neighborhood_path=source_full_neighborhood,
+        preflight_path=source_preflight,
+    )
+    payload = generated
+
+    if args.check:
+        stored = load_artifact(artifact)
+        if stored != generated:
+            raise AssertionError(f"{display_path(artifact, ROOT)} is stale")
+        payload = stored
+
+    errors = validate_payload(
+        payload,
+        full_neighborhood_path=source_full_neighborhood,
+        preflight_path=source_preflight,
+    )
+    if args.assert_expected:
+        assert_expected_private_lane_core_catalog(payload)
+    if args.write:
+        write_json(generated, artifact)
+
+    summary = summary_payload(artifact, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print("bootstrap/T12 151:6 private-lane core catalogue")
+        print(f"target row: {summary['target_row_key']}")
+        print(
+            "private-lane survivors: "
+            f"{summary['source_private_lane_survivor_count']}"
+        )
+        print(
+            "row-6 minimal cores: "
+            f"{summary['row6_minimal_core_occurrence_count']}"
+        )
+        print(
+            "assignments with row-6 three-row core: "
+            f"{summary['assignments_with_row6_three_row_core']}"
+        )
+        if errors:
+            print("validation errors:")
+            for error in errors:
+                print(f"- {error}")
+        else:
+            print("OK: 151:6 private-lane core catalogue verified")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -2526,6 +2526,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="bootstrap_t12_151_6_private_lane_core_catalog",
+        command=(
+            "python",
+            "scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Private-halo [3,5] lane minimal-core catalogue for source 151 "
+            "row 6; not outside-pair support existence, not row forcing, not "
+            "a proof that [3,5] is impossible, not endpoint-8 forcing, not "
+            "an n=9 proof, not a bridge proof, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="bootstrap_t12_151_singleton_support_audit",
         command=(
             "python",

--- a/tests/test_bootstrap_t12_151_6_private_lane_core_catalog.py
+++ b/tests/test_bootstrap_t12_151_6_private_lane_core_catalog.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.check_bootstrap_t12_151_6_private_lane_core_catalog import (
+    CATALOG_STATUS,
+    DEFAULT_ARTIFACT,
+    DEFAULT_SOURCE_FULL_NEIGHBORHOOD,
+    DEFAULT_SOURCE_PREFLIGHT,
+    assert_expected_private_lane_core_catalog,
+    build_private_lane_core_catalog_payload,
+    load_artifact,
+    validate_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.artifact
+
+
+@pytest.fixture(scope="module")
+def source_full_neighborhood() -> dict[str, object]:
+    return load_artifact(DEFAULT_SOURCE_FULL_NEIGHBORHOOD)
+
+
+@pytest.fixture(scope="module")
+def source_preflight() -> dict[str, object]:
+    return load_artifact(DEFAULT_SOURCE_PREFLIGHT)
+
+
+def test_private_lane_core_catalog_counts_and_scope() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+
+    assert_expected_private_lane_core_catalog(payload)
+    assert (
+        payload["status"]
+        == "BOOTSTRAP_T12_151_6_PRIVATE_LANE_CORE_CATALOG_DIAGNOSTIC_ONLY"
+    )
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    claim_scope = str(payload["claim_scope"])
+    for phrase in (
+        "does not prove outside-pair support existence",
+        "does not prove row forcing",
+        "does not prove pair [3,5] impossible",
+        "does not prove endpoint-8 forcing",
+        "does not prove n=9",
+        "not a counterexample",
+    ):
+        assert phrase in claim_scope
+
+
+def test_private_lane_core_catalog_summary() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    summary = payload["summary"]
+
+    assert summary["target_row_key"] == "151:6"
+    assert summary["target_center"] == 6
+    assert summary["private_target_center_class"] == [0, 3, 5, 7]
+    assert summary["private_support_pair"] == [3, 5]
+    assert summary["source_private_lane_survivor_count"] == 12
+    assert summary["source_vertex_circle_status_counts"] == {
+        "self_edge": 10,
+        "strict_cycle": 2,
+    }
+    assert summary["all_minimal_core_occurrence_count"] == 282
+    assert summary["all_minimal_core_size_counts"] == {
+        "3": 124,
+        "4": 144,
+        "5": 14,
+    }
+    assert summary["row6_minimal_core_occurrence_count"] == 118
+    assert summary["row6_minimal_core_size_counts"] == {
+        "3": 48,
+        "4": 64,
+        "5": 6,
+    }
+    assert summary["assignments_with_row6_three_row_core"] == 12
+    assert summary["chosen_row6_core_status_counts"] == {"strict_cycle": 12}
+    assert summary["chosen_distinct_exact_core_count"] == 10
+    assert summary["catalog_status"] == CATALOG_STATUS
+
+
+def test_private_lane_core_catalog_records_are_row6_strict_cycles() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    records = payload["catalog_records"]
+
+    assert len(records) == 12
+    for index, record in enumerate(records):
+        assert record["assignment_index"] == index
+        assert record["chosen_core_status"] == "strict_cycle"
+        assert len(record["chosen_core_centers"]) == 3
+        assert 6 in record["chosen_core_centers"]
+        assert record["chosen_core_self_edge_count"] == 0
+        assert record["chosen_core_cycle_edge_count"] > 0
+        row6 = [
+            row for row in record["chosen_core_rows"] if row["center"] == 6
+        ]
+        assert row6 == [{"center": 6, "witnesses": [0, 3, 5, 7]}]
+
+
+def test_private_lane_core_catalog_artifact_matches_generator(
+    source_full_neighborhood: dict[str, object],
+    source_preflight: dict[str, object],
+) -> None:
+    checked_in = load_artifact(DEFAULT_ARTIFACT)
+
+    assert checked_in == build_private_lane_core_catalog_payload(
+        source_full_neighborhood,
+        source_preflight,
+    )
+
+
+def test_private_lane_core_catalog_rejects_tampered_summary() -> None:
+    payload = load_artifact(DEFAULT_ARTIFACT)
+    payload["summary"]["assignments_with_row6_three_row_core"] = 11
+
+    errors = validate_payload(payload, recompute=False)
+
+    assert any("assignments_with_row6_three_row_core" in error for error in errors)
+
+
+def test_private_lane_core_catalog_rejects_source_drift(
+    source_full_neighborhood: dict[str, object],
+    source_preflight: dict[str, object],
+) -> None:
+    tampered = json.loads(json.dumps(source_full_neighborhood))
+    for record in tampered["per_target_center_class"]:
+        if record["target_center_class"] == [0, 3, 5, 7]:
+            record["basic_filter_complete_assignment_count"] = 11
+            break
+
+    with pytest.raises(AssertionError, match="private target-center class"):
+        build_private_lane_core_catalog_payload(tampered, source_preflight)
+
+
+def test_private_lane_core_catalog_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["target_row_key"] == "151:6"
+    assert payload["source_private_lane_survivor_count"] == 12
+    assert payload["assignments_with_row6_three_row_core"] == 12

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -374,6 +374,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "--check --assert-expected --json"
         ),
         (
+            "python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py "
+            "--check --assert-expected --json"
+        ),
+        (
             "python scripts/check_bootstrap_t12_151_singleton_support_audit.py "
             "--check --assert-expected --json"
         ),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -264,6 +264,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
         in command_texts
     )
+    assert (
+        "python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py "
+        "--check --assert-expected --json"
+        in command_texts
+    )
     assert ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
     ) < ordered_command_texts.index(
@@ -463,6 +468,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_bootstrap_t12_151_6_outside_pair_escape_partition.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_6_endpoint8_forcing_preflight.py "
+        "--check --assert-expected --json",
+        "python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py "
         "--check --assert-expected --json",
         "python scripts/check_bootstrap_t12_151_singleton_support_audit.py --check "
         "--assert-expected --json",


### PR DESCRIPTION
## Summary

Adds a checked diagnostic catalog for the source-151 row-6 private-halo-only lane. The artifact records the 12 private-lane basic-filter survivors and their row-subset-minimal vertex-circle obstruction cores, including chosen row-6 strict-cycle cores for every survivor.

The packet wires the checker into the bridge-frontier verification target, artifact audit, provenance manifest, docs index, lemma-driven bridge notes, review priorities, and backlog.

## Claim Scope

This is diagnostic evidence only. It does not claim outside-pair support existence, row forcing, impossibility of `[3,5]`, endpoint-8 forcing, an `n=9` result, a bridge theorem, a proof, a counterexample, or any global-status update.

## Validation

- `python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --write --assert-expected --json`
- `python scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py --check --assert-expected --json`
- `python -m pytest -q -m artifact tests/test_bootstrap_t12_151_6_private_lane_core_catalog.py`
- `python -m pytest -q tests/test_makefile_targets.py tests/test_run_artifact_audit.py`
- `python scripts/check_artifact_provenance.py`
- `python -m ruff check scripts/check_bootstrap_t12_151_6_private_lane_core_catalog.py tests/test_bootstrap_t12_151_6_private_lane_core_catalog.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q`