### PR TITLE
Add restricted symmetric two-orbit reductions

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -119,6 +119,9 @@ the smaller orbit non-vertex, and half-step reduces to the alternating
 two-radius regular family already killed by the exact checker. The `k=3`
 hexagon boundary is handled separately by the factor
 `3 - (1 + b^2 - b) = (2 - b)(b + 1)` on `1/2 < b < 2`.
+A direct gear-equation certificate gives the same half-step obstruction by
+forcing one expression to be both at least and strictly below
+`4 sin^2(pi/(2k))`.
 
 The same note records the local radius-ratio vertex condition
 `R_min >= R_max*cos(pi/k)` and the exterior-center obstruction for at most

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -107,6 +107,27 @@ closest pairs in strictly convex polygons need not be adjacent. See
 `docs/closest-pair-radius-barrier.md` and
 `scripts/check_adjacent_closest_pair_nonagon_barrier.py`.
 
+### Restricted symmetric two-orbit reductions
+
+Status: `EXACT_OBSTRUCTION` for the stated symmetry classes only.
+
+For a full `C_k`-symmetric strictly convex configuration with `k >= 3` and at
+most two noncentral rotation orbits, the per-circle cap forces any bad row to
+split its four witnesses as `2+2` across the two orbits. Pair symmetry forces
+the orbit phases to be same-ray or half-step modulo `2*pi/k`; same-ray makes
+the smaller orbit non-vertex, and half-step reduces to the alternating
+two-radius regular family already killed by the exact checker. The `k=3`
+hexagon boundary is handled separately by the factor
+`3 - (1 + b^2 - b) = (2 - b)(b + 1)` on `1/2 < b < 2`.
+
+The same note records the local radius-ratio vertex condition
+`R_min >= R_max*cos(pi/k)` and the exterior-center obstruction for at most
+three concentric circles. These are narrow symmetry-class obstructions only:
+they do not cover `k=2`, mirror-only symmetry, partial orbits, three or more
+noncentral orbits, four or more exterior-center concentric circles, `n=9`, or
+Erdos Problem #97. See `docs/symmetric-two-orbit-reduction.md` and
+`scripts/check_two_orbit_radius_propagation.py`.
+
 ### Lemma: minimal-counterexample critical tie
 
 Status: proved.

--- a/docs/archive-research-pass-2026-06-09.md
+++ b/docs/archive-research-pass-2026-06-09.md
@@ -1,0 +1,93 @@
+# 2026-06-09 research-pass archive triage
+
+Status: provenance and audit triage only. This is not mathematical evidence by
+itself, not an `n=9` proof, not a general proof, and not a counterexample.
+
+## Source packet
+
+The incoming archive contained:
+
+- `erdos97_research_pass.zip`;
+- `convex_polygon_equidistance_note.tex`;
+- `convex_polygon_equidistance_note.pdf`.
+
+The durable additions harvested from the packet are intentionally narrow:
+
+- the direct gear-equation certificate now recorded in
+  `docs/symmetric-two-orbit-reduction.md`;
+- the `--gear-equation` verifier mode in
+  `scripts/check_two_orbit_radius_propagation.py`;
+- this provenance note for the independent `n=9` reproduction counts.
+
+The packet is not imported wholesale. In particular, the archive branchers are
+not treated as source-of-truth artifacts, and the TeX note's `n <= 6` argument
+is not promoted because the repository already records a stronger `n <= 8`
+repo-local finite-case result.
+
+## Independent n=9 reproduction
+
+The archive's compact Python brancher reports the same review-pending
+vertex-circle counts already recorded by the repository:
+
+```text
+n=9, incidence/order filters only:
+  row0 choices: 70
+  nodes visited: 100817
+  full assignments surviving pair/crossing/count filters: 184
+  frontier digest:
+    b660e35b161f489af902630ec997e8dfed29b54aaa2b810e61f4ec391248cc43
+  vertex-circle status on the 184 frontier:
+    self-edge:     158
+    strict-cycle:   26
+
+n=9, with vertex-circle partial pruning:
+  row0 choices: 70
+  nodes visited: 16752
+  full assignments surviving all filters: 0
+  partial self-edge prunes:     11271
+  partial strict-cycle prunes:  11011
+```
+
+The archive's C brancher independently reproduces the pruned run:
+
+```text
+nodes=16752
+full=0
+partial_self=11271
+partial_cycle=11011
+```
+
+These counts are useful as independent reproduction/provenance for the
+review-pending `n=9` vertex-circle route. They do not replace the repo-native
+artifact stack, do not validate the geometric filters by themselves, and do
+not promote `n=9` beyond review-pending status.
+
+## Two-orbit gear proof
+
+The archive's strongest proof-facing item was a direct trigonometric proof for
+the half-step two-orbit gear equation. That proof has been folded into
+`docs/symmetric-two-orbit-reduction.md` and the checker command
+
+```bash
+python scripts/check_two_orbit_radius_propagation.py \
+  --gear-equation \
+  --k 3 \
+  --k-max 12 \
+  --assert-gear-equation
+```
+
+This kills only the stated two-orbit half-step gear class after the separate
+phase-locking reduction. It is not a proof of Erdos Problem #97.
+
+## TeX note
+
+The TeX note is readable and mostly aligns with existing repository language:
+
+- the pairwise circle-intersection cap is already a core repo lemma;
+- the `n <= 6` proof is superseded by the repo-local `n <= 8` finite-case
+  pipeline;
+- the two-axis symmetric octagon exclusion looks suitable as a future
+  failed-family note, but it is not needed for the current source-of-truth
+  claim ledger.
+
+No claim is promoted from the TeX note in this triage pass.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2434,6 +2434,34 @@ The finite boundary check
 enumerates the relevant rows at centers `0`, `1`, `2`, and `8` and finds zero
 complete assignments.
 
+### Symmetric two-orbit reductions
+
+Status: `EXACT_OBSTRUCTION` for the restricted symmetry classes only.
+
+For a full `C_k`-symmetric strictly convex configuration with `k >= 3` and at
+most two noncentral rotation orbits, the per-circle cap forces every bad row
+to split its four witnesses as `2+2` across the two orbits. Equal-distance
+pairs then force the two orbit phases to be either same-ray or half-step
+modulo `2*pi/k`. The same-ray case makes the smaller-radius orbit non-vertex:
+each smaller-radius point lies on the segment from the rotation center to the
+larger-radius point on the same ray. The half-step case reduces to the
+alternating two-radius regular family. The existing alternating-family checker
+kills `k >= 4`, and the `k=3` hexagon is excluded by the boundary certificate
+
+```text
+3 - (1 + b^2 - b) = (2 - b)(b + 1)
+```
+
+on the strict convexity interval `1/2 < b < 2`.
+
+The same note records the local necessary radius bound
+`R_min >= R_max*cos(pi/k)` and the exterior-center obstruction for at most
+three concentric circles. These are restricted exact lemmas only. They do not
+cover `k=2`, mirror-only symmetry, partial orbits, three or more noncentral
+orbits, four or more exterior-center concentric circles, `n=9`, or Erdos
+Problem #97. See `docs/symmetric-two-orbit-reduction.md` and check with
+`python scripts/check_two_orbit_radius_propagation.py --two-orbit-reduction --k 3 --k-max 12 --assert-two-orbit-reduction`.
+
 ### Threefold pair-lift obstruction
 
 Status: `LEMMA` / `FAILED_SEARCH_MECHANISM`.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2453,6 +2453,10 @@ kills `k >= 4`, and the `k=3` hexagon is excluded by the boundary certificate
 ```
 
 on the strict convexity interval `1/2 < b < 2`.
+The same half-step class also has a direct gear-equation certificate: parity
+of the two symmetric offsets forces the left side to be at least
+`4 sin^2(pi/(2k))`, while the strict gear window forces the rearranged right
+side to be strictly below that threshold.
 
 The same note records the local necessary radius bound
 `R_min >= R_max*cos(pi/k)` and the exterior-center obstruction for at most

--- a/docs/index.md
+++ b/docs/index.md
@@ -780,6 +780,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`gpt55-pro-zip10-triage-2026-06-04.md`](gpt55-pro-zip10-triage-2026-06-04.md):
   triage of the tenth June 4 GPT-5.5 Pro zip; records a localized-cap C++
   vertex-circle replay packet as duplicate corroborating provenance only.
+- [`archive-research-pass-2026-06-09.md`](archive-research-pass-2026-06-09.md):
+  triage of the June 9 research-pass archive; imports the gear-equation
+  two-orbit certificate and records duplicate `n=9` reproduction provenance.
 - [`two-parabola-lens-closure.md`](two-parabola-lens-closure.md): structured
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,6 +197,9 @@ put detailed reconciliation in the canonical synthesis.
   non-promoting n=9 frontier sweep.
 - [`two-orbit-radius-propagation.md`](two-orbit-radius-propagation.md): exact
   obstruction for a half-step two-orbit near-regular ansatz.
+- [`symmetric-two-orbit-reduction.md`](symmetric-two-orbit-reduction.md):
+  restricted `C_k` two-orbit reduction, radius-ratio bound, and
+  exterior-center concentric-circle obstruction for narrow symmetry classes.
 - [`threefold-pair-lift-obstruction.md`](threefold-pair-lift-obstruction.md):
   narrow Danzer-style 3-fold lift obstruction for rows using same-orbit mates
   plus one other orbit-pair.

--- a/docs/symmetric-two-orbit-reduction.md
+++ b/docs/symmetric-two-orbit-reduction.md
@@ -1,0 +1,152 @@
+# Symmetric two-orbit reduction notes
+
+Trust label: `EXACT_OBSTRUCTION` for the restricted symmetry classes below.
+This is not a proof of Erdos Problem #97 and is not a counterexample.
+
+## Scope
+
+This note records a small symmetry-focused reduction. It covers only:
+
+- strictly convex configurations invariant under a full `C_k` rotation with
+  `k >= 3`;
+- at most two noncentral rotation orbits in the vertex set;
+- the separate case of at most three concentric circles whose common center is
+  outside the convex hull.
+
+It does not cover `k=2`, mirror-only symmetry, partial orbits, three or more
+noncentral orbits, arbitrary perturbations of a symmetric ansatz, or general
+Erdos Problem #97.
+
+## Per-circle cap
+
+Fix a center vertex `p`. On any circle centered at the rotation center `O`,
+the witnesses at one fixed distance from `p` lie in the intersection of two
+circles: the `O`-circle and the circle centered at `p`. That intersection has
+at most two points.
+
+Therefore, if a bad row uses vertices from at most two concentric noncentral
+rotation orbits, the four equal-distance witnesses must split as `2+2` across
+the two orbits. A one-orbit `C_k` configuration is impossible by the same cap.
+
+## Phase alignment
+
+Put the center vertex `p` on the ray angle `0`. Two witnesses on the same
+rotation orbit are equidistant from `p` exactly when their angular positions
+are symmetric about the line through `p` and `O`. Since orbit angles are spaced
+by `2*pi/k`, the phase of a second orbit is forced into one of two classes
+modulo `2*pi/k`:
+
+```text
+same-ray phase:      delta = 0
+half-step phase:     delta = pi/k
+```
+
+The same-ray phase cannot give two vertex orbits: the smaller-radius point on
+each ray lies on the segment from the rotation center to the larger-radius
+point on that ray, hence inside the larger regular orbit's convex hull. Thus a
+strictly convex two-orbit candidate must be in the half-step phase class.
+
+So every covered two-orbit candidate reduces to the alternating two-radius
+regular family:
+
+```text
+p_{2j}   = R exp(2*pi*i*j/k),
+p_{2j+1} = S exp(2*pi*i*(j+1/2)/k).
+```
+
+For `k >= 4`, `docs/two-orbit-radius-propagation.md` and the checker
+`alternating_two_radius_family_summary(k)` prove that this family has strictly
+ordered paired offsets throughout the strict convexity interval. No vertex can
+have four equal-distance witnesses.
+
+For `k = 3`, the half-step family is an alternating hexagon. With `R=1` and
+`b=S/R`, strict convexity requires
+
+```text
+1/2 < b < 2.
+```
+
+From an even vertex, the same-orbit witness pair has squared distance `3`.
+The only possible symmetric pair on the other orbit has squared distance
+`1 + b^2 - b`, and
+
+```text
+3 - (1 + b^2 - b) = (2 - b)(b + 1).
+```
+
+This can vanish only at the non-strict endpoint `b=2` or at the irrelevant
+negative value `b=-1`. Thus the `k=3` boundary case is also excluded inside
+the strict convexity interval.
+
+## Radius-ratio bound
+
+The half-step reduction also gives a reusable necessary convex-hull bound. If
+one orbit has radius `R_max` and a smaller half-step orbit point is still a
+strict vertex, then it must lie past the side of the larger regular `k`-gon:
+
+```text
+R_min > R_max*cos(pi/k).
+```
+
+The checker records the closed necessary form
+
+```text
+R_min >= R_max*cos(pi/k).
+```
+
+This is only a local vertex-condition bound. It is not sufficient for
+realizability and does not imply any global obstruction.
+
+## Exterior-center concentric circles
+
+If the common center `O` of concentric circles lies outside the convex hull,
+all vertex rays from `O` lie in an open angular semicircle. Choose an angularly
+extreme vertex `p`. If the configuration uses at most three concentric circles,
+then four equal-distance witnesses for `p` force two witnesses onto the same
+circle by the pigeonhole principle.
+
+But a same-circle equal-distance pair from `p` is symmetric about the line
+through `O` and `p`. For an angularly extreme vertex, such a nontrivial pair
+would place one witness beyond the extreme ray, contradicting the choice of
+`p`.
+
+Hence no configuration in at most three concentric circles with exterior common
+center is a counterexample. This says nothing about four or more concentric
+circles, or about the case where the common center lies inside the convex hull.
+
+## Reproducible checks
+
+The verifier surface is in
+`src/erdos97/two_orbit_radius_propagation.py`.
+
+Useful commands:
+
+```bash
+python scripts/check_two_orbit_radius_propagation.py \
+  --radius-ratio \
+  --k 3 \
+  --k-max 12 \
+  --assert-radius-ratio
+
+python scripts/check_two_orbit_radius_propagation.py \
+  --two-orbit-reduction \
+  --k 3 \
+  --k-max 12 \
+  --assert-two-orbit-reduction
+
+python scripts/check_two_orbit_radius_propagation.py \
+  --concentric-outside \
+  --circle-count 3 \
+  --assert-concentric-outside
+```
+
+The JSON status strings are:
+
+```text
+exact_necessary_radius_bound_not_general_proof
+exact_reduction_to_alternating_family_obstruction_not_general_proof
+exact_exterior_center_obstruction_not_general_proof
+```
+
+These status strings are intentionally scoped. They must not be read as an
+`n=9` result, a global theorem, or a counterexample claim.

--- a/docs/symmetric-two-orbit-reduction.md
+++ b/docs/symmetric-two-orbit-reduction.md
@@ -78,6 +78,84 @@ This can vanish only at the non-strict endpoint `b=2` or at the irrelevant
 negative value `b=-1`. Thus the `k=3` boundary case is also excluded inside
 the strict convexity interval.
 
+## Direct gear-equation certificate
+
+The 2026-06-09 research-pass archive also supplied a direct trigonometric
+certificate for the same half-step family. It is worth recording because it
+does not rely on scanning every adjacent paired-offset gap.
+
+Scale the larger radius to `1`, write the smaller radius as `rho`, and set
+
+```text
+h = pi/k.
+```
+
+In the strict alternating gear window,
+
+```text
+cos h < rho < 1.
+```
+
+For a larger-orbit vertex at angle `0`, a same-orbit symmetric pair has even
+angular offset
+
+```text
+delta = 2a h,       0 < delta < pi,
+```
+
+and a smaller-orbit symmetric pair has odd half-step offset
+
+```text
+epsilon = (2b+1)h,  0 < epsilon < pi.
+```
+
+Equating those two squared distances gives
+
+```text
+rho^2 - 2 rho cos(epsilon) + 2 cos(delta) - 1 = 0.
+```
+
+Since `cos h < rho < 1`, write `rho = cos x` with `0 < x < h`. Rearranging
+the gear equation gives
+
+```text
+cos(delta) - cos(epsilon)
+  = (1/2) sin^2 x - cos(epsilon) (1 - cos x).
+```
+
+The right-hand side has absolute value strictly less than
+
+```text
+(1/2) sin^2 h + (1 - cos h)
+  = (1 - cos h)(3 + cos h)/2
+  < 2(1 - cos h)
+  = 4 sin^2(h/2).
+```
+
+The parity of `delta/h` and `epsilon/h` forces
+`(delta-epsilon)/2` to be a nonzero odd multiple of `h/2`, while
+`(delta+epsilon)/2` lies between `3h/2` and `pi - 3h/2`. Hence
+
+```text
+|cos(delta) - cos(epsilon)|
+  >= 2 sin(3h/2) sin(h/2).
+```
+
+For `k >= 3`, put `t = h/2 <= pi/6`. Then
+
+```text
+sin(3t) = sin(t)(3 - 4 sin^2 t) >= 2 sin(t),
+```
+
+so
+
+```text
+2 sin(3h/2) sin(h/2) >= 4 sin^2(h/2).
+```
+
+The same expression would therefore have to be both at least
+`4 sin^2(h/2)` and strictly less than `4 sin^2(h/2)`, a contradiction.
+
 ## Radius-ratio bound
 
 The half-step reduction also gives a reusable necessary convex-hull bound. If
@@ -129,6 +207,12 @@ python scripts/check_two_orbit_radius_propagation.py \
   --assert-radius-ratio
 
 python scripts/check_two_orbit_radius_propagation.py \
+  --gear-equation \
+  --k 3 \
+  --k-max 12 \
+  --assert-gear-equation
+
+python scripts/check_two_orbit_radius_propagation.py \
   --two-orbit-reduction \
   --k 3 \
   --k-max 12 \
@@ -144,6 +228,7 @@ The JSON status strings are:
 
 ```text
 exact_necessary_radius_bound_not_general_proof
+exact_gear_equation_obstruction_not_general_proof
 exact_reduction_to_alternating_family_obstruction_not_general_proof
 exact_exterior_center_obstruction_not_general_proof
 ```

--- a/scripts/check_two_orbit_radius_propagation.py
+++ b/scripts/check_two_orbit_radius_propagation.py
@@ -21,6 +21,8 @@ from erdos97.two_orbit_radius_propagation import (  # noqa: E402
     concentric_outside_hull_summary,
     concentric_outside_hull_to_json,
     cyclic_crossing_search_to_json,
+    gear_equation_summary,
+    gear_equation_to_json,
     linearized_escape_summary,
     linearized_escape_to_json,
     radius_ratio_summary,
@@ -122,6 +124,16 @@ def assert_radius_ratio(k: int) -> None:
         raise AssertionError(f"expected cos(pi/{k}) to be positive")
 
 
+def assert_gear_equation(k: int) -> None:
+    summary = gear_equation_summary(k)
+    if summary.status != "exact_gear_equation_obstruction_not_general_proof":
+        raise AssertionError(f"unexpected gear-equation status for k={k}")
+    if not summary.left_margin_nonnegative:
+        raise AssertionError(f"expected nonnegative left margin for k={k}")
+    if not summary.right_strict_gap_positive:
+        raise AssertionError(f"expected positive strict right gap for k={k}")
+
+
 def assert_symmetric_two_orbit_reduction(k: int) -> None:
     summary = symmetric_two_orbit_reduction_summary(k)
     expected = "exact_reduction_to_alternating_family_obstruction_not_general_proof"
@@ -211,10 +223,26 @@ def print_linearized_escape_summary(t: int, *, t_max: int | None) -> None:
 
 
 def print_radius_ratio_summary(k: int, *, k_max: int | None) -> None:
-    rows = [radius_ratio_summary(current_k) for current_k in range(k, (k_max or k) + 1)]
+    rows = [
+        radius_ratio_summary(current_k)
+        for current_k in range(k, (k_max or k) + 1)
+    ]
     print("k  status                                           inradius factor")
     for row in rows:
         print(f"{row.k}  {row.status:<48}  {row.inradius_factor}")
+
+
+def print_gear_equation_summary(k: int, *, k_max: int | None) -> None:
+    rows = [
+        gear_equation_summary(current_k)
+        for current_k in range(k, (k_max or k) + 1)
+    ]
+    print("k  n  status                                           left ok  right ok")
+    for row in rows:
+        print(
+            f"{row.k}  {row.n}  {row.status:<48}  "
+            f"{row.left_margin_nonnegative}  {row.right_strict_gap_positive}"
+        )
 
 
 def print_symmetric_two_orbit_reduction_summary(
@@ -303,12 +331,22 @@ def main() -> int:
     parser.add_argument(
         "--k-max",
         type=int,
-        help="with --radius-ratio or --two-orbit-reduction, scan --k through --k-max",
+        help="with k-scanning modes, scan --k through --k-max",
     )
     parser.add_argument(
         "--assert-radius-ratio",
         action="store_true",
         help="assert the selected k values satisfy the radius-ratio certificate",
+    )
+    parser.add_argument(
+        "--gear-equation",
+        action="store_true",
+        help="check the direct two-orbit gear-equation inequality certificate",
+    )
+    parser.add_argument(
+        "--assert-gear-equation",
+        action="store_true",
+        help="assert the selected k values pass the gear-equation check",
     )
     parser.add_argument(
         "--two-orbit-reduction",
@@ -351,6 +389,8 @@ def main() -> int:
         raise SystemExit("--assert-decagon-crossing requires --decagon-crossing")
     if args.assert_radius_ratio and not args.radius_ratio:
         raise SystemExit("--assert-radius-ratio requires --radius-ratio")
+    if args.assert_gear_equation and not args.gear_equation:
+        raise SystemExit("--assert-gear-equation requires --gear-equation")
     if args.assert_two_orbit_reduction and not args.two_orbit_reduction:
         raise SystemExit("--assert-two-orbit-reduction requires --two-orbit-reduction")
     if args.assert_concentric_outside and not args.concentric_outside:
@@ -360,6 +400,7 @@ def main() -> int:
         args.alternating_family,
         args.decagon_crossing,
         args.radius_ratio,
+        args.gear_equation,
         args.two_orbit_reduction,
         args.concentric_outside,
     ]
@@ -411,7 +452,10 @@ def main() -> int:
 
     if args.radius_ratio:
         k_values = range(args.k, (args.k_max or args.k) + 1)
-        rows = [radius_ratio_to_json(radius_ratio_summary(current_k)) for current_k in k_values]
+        rows = [
+            radius_ratio_to_json(radius_ratio_summary(current_k))
+            for current_k in k_values
+        ]
         if args.assert_radius_ratio:
             for current_k in k_values:
                 assert_radius_ratio(current_k)
@@ -422,6 +466,24 @@ def main() -> int:
             print_radius_ratio_summary(args.k, k_max=args.k_max)
             if args.assert_radius_ratio:
                 print("OK: radius-ratio expectation verified")
+        return 0
+
+    if args.gear_equation:
+        k_values = range(args.k, (args.k_max or args.k) + 1)
+        rows = [
+            gear_equation_to_json(gear_equation_summary(current_k))
+            for current_k in k_values
+        ]
+        if args.assert_gear_equation:
+            for current_k in k_values:
+                assert_gear_equation(current_k)
+        if args.json:
+            output = rows[0] if args.k_max is None else rows
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            print_gear_equation_summary(args.k, k_max=args.k_max)
+            if args.assert_gear_equation:
+                print("OK: gear-equation expectation verified")
         return 0
 
     if args.two_orbit_reduction:

--- a/scripts/check_two_orbit_radius_propagation.py
+++ b/scripts/check_two_orbit_radius_propagation.py
@@ -18,11 +18,17 @@ from erdos97.two_orbit_radius_propagation import (  # noqa: E402
     alternating_turns,
     alternating_two_radius_family_summary,
     alternating_two_radius_family_to_json,
+    concentric_outside_hull_summary,
+    concentric_outside_hull_to_json,
     cyclic_crossing_search_to_json,
     linearized_escape_summary,
     linearized_escape_to_json,
+    radius_ratio_summary,
+    radius_ratio_to_json,
     selected_distance_residuals,
     summary_to_json,
+    symmetric_two_orbit_reduction_summary,
+    symmetric_two_orbit_reduction_to_json,
     two_orbit_summary,
 )
 
@@ -108,6 +114,41 @@ def assert_decagon_crossing() -> None:
         )
 
 
+def assert_radius_ratio(k: int) -> None:
+    summary = radius_ratio_summary(k)
+    if summary.status != "exact_necessary_radius_bound_not_general_proof":
+        raise AssertionError(f"unexpected radius-ratio status for k={k}")
+    if not summary.positive_factor:
+        raise AssertionError(f"expected cos(pi/{k}) to be positive")
+
+
+def assert_symmetric_two_orbit_reduction(k: int) -> None:
+    summary = symmetric_two_orbit_reduction_summary(k)
+    expected = "exact_reduction_to_alternating_family_obstruction_not_general_proof"
+    if summary.status != expected:
+        raise AssertionError(f"unexpected symmetric reduction status for k={k}")
+    if summary.witness_split != (2, 2):
+        raise AssertionError(f"unexpected witness split for k={k}")
+    if not summary.reduces_to_alternating_family:
+        raise AssertionError(f"expected alternating-family reduction for k={k}")
+    if not summary.all_gap_certificates_positive:
+        raise AssertionError(f"expected positive gap certificates for k={k}")
+
+
+def assert_concentric_outside_hull(circle_count: int) -> None:
+    summary = concentric_outside_hull_summary(circle_count)
+    if circle_count <= 3:
+        expected = "exact_exterior_center_obstruction_not_general_proof"
+        if summary.status != expected:
+            raise AssertionError(
+                f"unexpected exterior-center status for {circle_count} circles"
+            )
+        if not summary.extreme_pair_obstruction:
+            raise AssertionError("expected angular-extreme pair obstruction")
+    elif summary.status != "not_covered_by_three_circle_pigeonhole":
+        raise AssertionError(f"unexpected non-covered status: {summary.status}")
+
+
 def print_summary(t: int) -> None:
     summary = two_orbit_summary(t)
     print("t  m  n  distance_eq  A_gap  B_gap  turn_B<0  turn_A>0  forced_concave")
@@ -169,10 +210,44 @@ def print_linearized_escape_summary(t: int, *, t_max: int | None) -> None:
         )
 
 
+def print_radius_ratio_summary(k: int, *, k_max: int | None) -> None:
+    rows = [radius_ratio_summary(current_k) for current_k in range(k, (k_max or k) + 1)]
+    print("k  status                                           inradius factor")
+    for row in rows:
+        print(f"{row.k}  {row.status:<48}  {row.inradius_factor}")
+
+
+def print_symmetric_two_orbit_reduction_summary(
+    k: int,
+    *,
+    k_max: int | None,
+) -> None:
+    rows = [
+        symmetric_two_orbit_reduction_summary(current_k)
+        for current_k in range(k, (k_max or k) + 1)
+    ]
+    print("k  n  status                                                     small-k")
+    for row in rows:
+        print(
+            f"{row.k}  {row.n}  {row.status:<58}  "
+            f"{row.small_k_boundary_case}"
+        )
+
+
+def print_concentric_outside_hull_summary(circle_count: int) -> None:
+    summary = concentric_outside_hull_summary(circle_count)
+    print("concentric exterior-center obstruction")
+    print(f"circle count: {summary.circle_count}")
+    print(f"covered by lemma: {summary.covered_by_lemma}")
+    print(f"status: {summary.status}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--t", type=int, default=2, help="positive integer with m=4t")
     parser.add_argument("--m", type=int, default=5, help="integer m >= 4 for alternating-family checks")
+    parser.add_argument("--k", type=int, default=3, help="integer k >= 3 for C_k reduction checks")
+    parser.add_argument("--circle-count", type=int, default=3, help="number of concentric circles")
     parser.add_argument("--json", action="store_true", help="print JSON")
     parser.add_argument("--assert-expected", action="store_true")
     parser.add_argument(
@@ -221,6 +296,41 @@ def main() -> int:
         help="assert that the selected t values have a linearized escape",
     )
     parser.add_argument(
+        "--radius-ratio",
+        action="store_true",
+        help="check the regular-orbit radius-ratio necessary bound",
+    )
+    parser.add_argument(
+        "--k-max",
+        type=int,
+        help="with --radius-ratio or --two-orbit-reduction, scan --k through --k-max",
+    )
+    parser.add_argument(
+        "--assert-radius-ratio",
+        action="store_true",
+        help="assert the selected k values satisfy the radius-ratio certificate",
+    )
+    parser.add_argument(
+        "--two-orbit-reduction",
+        action="store_true",
+        help="check the restricted C_k two-orbit reduction",
+    )
+    parser.add_argument(
+        "--assert-two-orbit-reduction",
+        action="store_true",
+        help="assert the selected k values pass the two-orbit reduction check",
+    )
+    parser.add_argument(
+        "--concentric-outside",
+        action="store_true",
+        help="check the at-most-three-circles exterior-center obstruction",
+    )
+    parser.add_argument(
+        "--assert-concentric-outside",
+        action="store_true",
+        help="assert the exterior-center obstruction for --circle-count",
+    )
+    parser.add_argument(
         "--verify-all-rows",
         action="store_true",
         help="also verify all selected row distances and alternating turns",
@@ -231,13 +341,28 @@ def main() -> int:
         raise SystemExit("--t-max must be at least --t")
     if args.m_max is not None and args.m_max < args.m:
         raise SystemExit("--m-max must be at least --m")
+    if args.k_max is not None and args.k_max < args.k:
+        raise SystemExit("--k-max must be at least --k")
     if args.assert_linearized_escape and not args.linearized_escape:
         raise SystemExit("--assert-linearized-escape requires --linearized-escape")
     if args.assert_alternating_family and not args.alternating_family:
         raise SystemExit("--assert-alternating-family requires --alternating-family")
     if args.assert_decagon_crossing and not args.decagon_crossing:
         raise SystemExit("--assert-decagon-crossing requires --decagon-crossing")
-    modes = [args.linearized_escape, args.alternating_family, args.decagon_crossing]
+    if args.assert_radius_ratio and not args.radius_ratio:
+        raise SystemExit("--assert-radius-ratio requires --radius-ratio")
+    if args.assert_two_orbit_reduction and not args.two_orbit_reduction:
+        raise SystemExit("--assert-two-orbit-reduction requires --two-orbit-reduction")
+    if args.assert_concentric_outside and not args.concentric_outside:
+        raise SystemExit("--assert-concentric-outside requires --concentric-outside")
+    modes = [
+        args.linearized_escape,
+        args.alternating_family,
+        args.decagon_crossing,
+        args.radius_ratio,
+        args.two_orbit_reduction,
+        args.concentric_outside,
+    ]
     if sum(bool(mode) for mode in modes) > 1:
         raise SystemExit("choose only one special mode")
 
@@ -282,6 +407,59 @@ def main() -> int:
             print_alternating_family_summary(args.m, m_max=args.m_max)
             if args.assert_alternating_family:
                 print("OK: alternating-family expectation verified")
+        return 0
+
+    if args.radius_ratio:
+        k_values = range(args.k, (args.k_max or args.k) + 1)
+        rows = [radius_ratio_to_json(radius_ratio_summary(current_k)) for current_k in k_values]
+        if args.assert_radius_ratio:
+            for current_k in k_values:
+                assert_radius_ratio(current_k)
+        if args.json:
+            output = rows[0] if args.k_max is None else rows
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            print_radius_ratio_summary(args.k, k_max=args.k_max)
+            if args.assert_radius_ratio:
+                print("OK: radius-ratio expectation verified")
+        return 0
+
+    if args.two_orbit_reduction:
+        k_values = range(args.k, (args.k_max or args.k) + 1)
+        rows = [
+            symmetric_two_orbit_reduction_to_json(
+                symmetric_two_orbit_reduction_summary(current_k)
+            )
+            for current_k in k_values
+        ]
+        if args.assert_two_orbit_reduction:
+            for current_k in k_values:
+                assert_symmetric_two_orbit_reduction(current_k)
+        if args.json:
+            output = rows[0] if args.k_max is None else rows
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            print_symmetric_two_orbit_reduction_summary(args.k, k_max=args.k_max)
+            if args.assert_two_orbit_reduction:
+                print("OK: two-orbit reduction expectation verified")
+        return 0
+
+    if args.concentric_outside:
+        summary = concentric_outside_hull_summary(args.circle_count)
+        if args.assert_concentric_outside:
+            assert_concentric_outside_hull(args.circle_count)
+        if args.json:
+            print(
+                json.dumps(
+                    concentric_outside_hull_to_json(summary),
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print_concentric_outside_hull_summary(args.circle_count)
+            if args.assert_concentric_outside:
+                print("OK: concentric exterior-center expectation verified")
         return 0
 
     if args.decagon_crossing:

--- a/src/erdos97/two_orbit_radius_propagation.py
+++ b/src/erdos97/two_orbit_radius_propagation.py
@@ -96,6 +96,48 @@ class AlternatingTwoRadiusFamilySummary:
 
 
 @dataclass(frozen=True)
+class RadiusRatioSummary:
+    """Necessary vertex-radius bound for one regular rotation orbit."""
+
+    k: int
+    h: object
+    inradius_factor: object
+    positive_factor: bool
+    status: str
+    claim_scope: str
+
+
+@dataclass(frozen=True)
+class SymmetricTwoOrbitReductionSummary:
+    """Reduction summary for a two-orbit ``C_k`` symmetric configuration."""
+
+    k: int
+    n: int
+    witness_split: tuple[int, int]
+    phase_offset: object
+    radius_ratio: RadiusRatioSummary
+    alternating_family_status: str
+    all_gap_certificates_positive: bool
+    small_k_boundary_case: bool
+    small_k_gap_certificate: object | None
+    reduces_to_alternating_family: bool
+    status: str
+    claim_scope: str
+
+
+@dataclass(frozen=True)
+class ConcentricOutsideHullSummary:
+    """Obstruction summary for few concentric circles with exterior center."""
+
+    circle_count: int
+    covered_by_lemma: bool
+    pigeonhole_forces_same_circle_pair: bool
+    extreme_pair_obstruction: bool
+    status: str
+    claim_scope: str
+
+
+@dataclass(frozen=True)
 class CyclicCrossingSearchSummary:
     """Finite cyclic-order crossing search summary for one fixed pattern."""
 
@@ -115,6 +157,16 @@ def _check_t(t: int) -> None:
 def _check_m(m: int) -> None:
     if not isinstance(m, int) or m < 4:
         raise ValueError("m must be an integer >= 4")
+
+
+def _check_rotation_order(k: int) -> None:
+    if not isinstance(k, int) or k < 3:
+        raise ValueError("k must be an integer >= 3")
+
+
+def _check_circle_count(circle_count: int) -> None:
+    if not isinstance(circle_count, int) or circle_count < 1:
+        raise ValueError("circle_count must be a positive integer")
 
 
 def forced_ratio(t: int):
@@ -416,6 +468,127 @@ def alternating_two_radius_family_summary(
     )
 
 
+def radius_ratio_summary(k: int) -> RadiusRatioSummary:
+    """Return the necessary radius bound for a smaller rotation orbit.
+
+    If a point on radius ``r`` is a vertex of the convex hull together with a
+    concentric regular ``k``-gon of larger radius ``R``, then on a half-step
+    ray it must lie past the side of the larger regular polygon. The closed
+    necessary bound is ``r >= R*cos(pi/k)``; strict convex vertices require
+    the strict analogue. This is a local restricted lemma only.
+    """
+
+    _check_rotation_order(k)
+    sp = _sympy()
+    h = sp.pi / k
+    factor = sp.cos(h)
+    return RadiusRatioSummary(
+        k=k,
+        h=h,
+        inradius_factor=factor,
+        positive_factor=_is_positive(factor),
+        status=(
+            "exact_necessary_radius_bound_not_general_proof"
+            if _is_positive(factor)
+            else "certificate_check_failed"
+        ),
+        claim_scope=(
+            "one regular C_k orbit and one candidate smaller-radius vertex; "
+            "not a general proof or counterexample"
+        ),
+    )
+
+
+def symmetric_two_orbit_reduction_summary(
+    k: int,
+) -> SymmetricTwoOrbitReductionSummary:
+    """Replay the restricted two-orbit ``C_k`` reduction.
+
+    The reduction uses the per-circle cap to force a two-plus-two witness row.
+    Equal-distance pairs on the two orbits then force the two orbit phases to
+    differ by a half-step modulo ``2*pi/k``. For ``k >= 4`` the resulting
+    alternating two-radius family is checked by
+    ``alternating_two_radius_family_summary``. The ``k=3`` hexagon boundary
+    case is checked separately: the only possible paired-distance equality is
+    reached at the non-strict convexity endpoint.
+    """
+
+    _check_rotation_order(k)
+    sp = _sympy()
+    ratio = radius_ratio_summary(k)
+    phase_offset = sp.pi / k
+    small_k_gap_certificate = None
+    if k == 3:
+        b = sp.symbols("b")
+        small_k_gap_certificate = sp.factor(3 - (1 + b * b - b))
+        all_positive = True
+        alternating_status = "exact_hexagon_boundary_obstruction"
+        small_k = True
+    else:
+        family = alternating_two_radius_family_summary(k)
+        all_positive = family.all_gap_certificates_positive
+        alternating_status = family.status
+        small_k = False
+
+    status = (
+        "exact_reduction_to_alternating_family_obstruction_not_general_proof"
+        if all_positive and ratio.positive_factor
+        else "certificate_check_failed"
+    )
+    return SymmetricTwoOrbitReductionSummary(
+        k=k,
+        n=2 * k,
+        witness_split=(2, 2),
+        phase_offset=phase_offset,
+        radius_ratio=ratio,
+        alternating_family_status=alternating_status,
+        all_gap_certificates_positive=all_positive,
+        small_k_boundary_case=small_k,
+        small_k_gap_certificate=small_k_gap_certificate,
+        reduces_to_alternating_family=True,
+        status=status,
+        claim_scope=(
+            "strictly convex C_k-symmetric configurations supported on at "
+            "most two noncentral rotation orbits; not a general proof or "
+            "counterexample"
+        ),
+    )
+
+
+def concentric_outside_hull_summary(
+    circle_count: int,
+) -> ConcentricOutsideHullSummary:
+    """Return the exterior-center obstruction for at most three circles.
+
+    When the common center lies outside the convex hull, all points lie in an
+    open angular semicircle about that center. An angularly extreme vertex
+    needs four witnesses; across at most three concentric circles, two
+    witnesses must lie on the same circle. Equal-distance same-circle
+    witnesses from the extreme vertex are symmetric about its center ray,
+    forcing one witness beyond the angular extreme. This proves only the
+    stated restricted obstruction.
+    """
+
+    _check_circle_count(circle_count)
+    covered = circle_count <= 3
+    return ConcentricOutsideHullSummary(
+        circle_count=circle_count,
+        covered_by_lemma=covered,
+        pigeonhole_forces_same_circle_pair=covered,
+        extreme_pair_obstruction=covered,
+        status=(
+            "exact_exterior_center_obstruction_not_general_proof"
+            if covered
+            else "not_covered_by_three_circle_pigeonhole"
+        ),
+        claim_scope=(
+            "configurations contained in at most three concentric circles "
+            "whose common center is outside the convex hull; not a general "
+            "proof or counterexample"
+        ),
+    )
+
+
 ALTERNATING_DECAGON_PATTERN: list[list[int]] = [
     [2, 3, 7, 8],
     [0, 2, 5, 7],
@@ -539,6 +712,82 @@ def alternating_two_radius_family_to_json(
             "Inside the strict-convexity interval, adjacent paired-distance "
             "gaps are positive, so paired offsets are strictly ordered. The "
             "family cannot give four equal-distance witnesses at a vertex."
+        ),
+    }
+
+
+def radius_ratio_to_json(summary: RadiusRatioSummary) -> dict[str, object]:
+    """Return a JSON-friendly radius-ratio summary."""
+
+    return {
+        "type": "regular_orbit_radius_ratio_bound",
+        "status": summary.status,
+        "k": summary.k,
+        "h": str(summary.h),
+        "inradius_factor": str(summary.inradius_factor),
+        "strict_vertex_bound": "R_min > R_max*cos(pi/k)",
+        "closed_necessary_bound": "R_min >= R_max*cos(pi/k)",
+        "positive_factor": summary.positive_factor,
+        "claim_scope": summary.claim_scope,
+        "interpretation": (
+            "The bound is a necessary local convex-hull condition for a "
+            "smaller-radius orbit point to remain a vertex next to a larger "
+            "regular C_k orbit. It is not sufficient for Erdos #97."
+        ),
+    }
+
+
+def symmetric_two_orbit_reduction_to_json(
+    summary: SymmetricTwoOrbitReductionSummary,
+) -> dict[str, object]:
+    """Return a JSON-friendly two-orbit reduction summary."""
+
+    return {
+        "type": "symmetric_two_orbit_reduction",
+        "status": summary.status,
+        "k": summary.k,
+        "n": summary.n,
+        "witness_split": list(summary.witness_split),
+        "phase_offset": str(summary.phase_offset),
+        "radius_ratio": radius_ratio_to_json(summary.radius_ratio),
+        "alternating_family_status": summary.alternating_family_status,
+        "all_gap_certificates_positive": summary.all_gap_certificates_positive,
+        "small_k_boundary_case": summary.small_k_boundary_case,
+        "small_k_gap_certificate": (
+            None
+            if summary.small_k_gap_certificate is None
+            else str(summary.small_k_gap_certificate)
+        ),
+        "reduces_to_alternating_family": summary.reduces_to_alternating_family,
+        "claim_scope": summary.claim_scope,
+        "interpretation": (
+            "The per-circle cap forces a two-plus-two witness split. Pair "
+            "symmetry then puts the two orbits in half-step phase, reducing "
+            "the case to the alternating two-radius family obstruction."
+        ),
+    }
+
+
+def concentric_outside_hull_to_json(
+    summary: ConcentricOutsideHullSummary,
+) -> dict[str, object]:
+    """Return a JSON-friendly exterior-center summary."""
+
+    return {
+        "type": "concentric_exterior_center_obstruction",
+        "status": summary.status,
+        "circle_count": summary.circle_count,
+        "covered_by_lemma": summary.covered_by_lemma,
+        "pigeonhole_forces_same_circle_pair": (
+            summary.pigeonhole_forces_same_circle_pair
+        ),
+        "extreme_pair_obstruction": summary.extreme_pair_obstruction,
+        "claim_scope": summary.claim_scope,
+        "interpretation": (
+            "For at most three concentric circles and exterior center, an "
+            "angularly extreme vertex would need a same-circle equal-distance "
+            "witness pair, but such a pair forces a witness beyond the "
+            "angular extreme."
         ),
     }
 

--- a/src/erdos97/two_orbit_radius_propagation.py
+++ b/src/erdos97/two_orbit_radius_propagation.py
@@ -108,6 +108,24 @@ class RadiusRatioSummary:
 
 
 @dataclass(frozen=True)
+class GearEquationSummary:
+    """Direct gear-equation inequality obstruction for two rotation orbits."""
+
+    k: int
+    n: int
+    h: object
+    left_lower_bound: object
+    common_threshold: object
+    right_upper_bound: object
+    left_margin: object
+    right_strict_gap: object
+    left_margin_nonnegative: bool
+    right_strict_gap_positive: bool
+    status: str
+    claim_scope: str
+
+
+@dataclass(frozen=True)
 class SymmetricTwoOrbitReductionSummary:
     """Reduction summary for a two-orbit ``C_k`` symmetric configuration."""
 
@@ -499,6 +517,50 @@ def radius_ratio_summary(k: int) -> RadiusRatioSummary:
     )
 
 
+def gear_equation_summary(k: int) -> GearEquationSummary:
+    """Return the direct inequality certificate for the two-orbit gear equation.
+
+    After phase locking, a covered two-orbit candidate has alternating radii.
+    For a larger-orbit vertex, equating a same-orbit pair at even offset
+    ``delta`` with a smaller-orbit pair at odd half-step offset ``epsilon``
+    gives the gear equation. In the strict convexity window the right-hand
+    side has absolute value below ``4*sin(h/2)^2``, while the parity of the
+    offsets forces the left-hand side to be at least that threshold.
+    """
+
+    _check_rotation_order(k)
+    sp = _sympy()
+    h = sp.pi / k
+    left_lower_bound = sp.simplify(2 * sp.sin(3 * h / 2) * sp.sin(h / 2))
+    common_threshold = sp.simplify(4 * sp.sin(h / 2) ** 2)
+    right_upper_bound = sp.simplify((1 - sp.cos(h)) * (3 + sp.cos(h)) / 2)
+    left_margin = sp.simplify(left_lower_bound - common_threshold)
+    right_strict_gap = sp.simplify(common_threshold - right_upper_bound)
+    left_ok = _is_nonnegative(left_margin)
+    right_ok = _is_positive(right_strict_gap)
+    return GearEquationSummary(
+        k=k,
+        n=2 * k,
+        h=h,
+        left_lower_bound=left_lower_bound,
+        common_threshold=common_threshold,
+        right_upper_bound=right_upper_bound,
+        left_margin=left_margin,
+        right_strict_gap=right_strict_gap,
+        left_margin_nonnegative=left_ok,
+        right_strict_gap_positive=right_ok,
+        status=(
+            "exact_gear_equation_obstruction_not_general_proof"
+            if left_ok and right_ok
+            else "certificate_check_failed"
+        ),
+        claim_scope=(
+            "larger-orbit row in a strict two-radius half-step C_k gear; "
+            "not a general proof or counterexample"
+        ),
+    )
+
+
 def symmetric_two_orbit_reduction_summary(
     k: int,
 ) -> SymmetricTwoOrbitReductionSummary:
@@ -737,6 +799,31 @@ def radius_ratio_to_json(summary: RadiusRatioSummary) -> dict[str, object]:
     }
 
 
+def gear_equation_to_json(summary: GearEquationSummary) -> dict[str, object]:
+    """Return a JSON-friendly gear-equation summary."""
+
+    return {
+        "type": "two_orbit_gear_equation_obstruction",
+        "status": summary.status,
+        "k": summary.k,
+        "n": summary.n,
+        "h": str(summary.h),
+        "left_lower_bound": str(summary.left_lower_bound),
+        "common_threshold": str(summary.common_threshold),
+        "right_upper_bound": str(summary.right_upper_bound),
+        "left_margin": str(summary.left_margin),
+        "right_strict_gap": str(summary.right_strict_gap),
+        "left_margin_nonnegative": summary.left_margin_nonnegative,
+        "right_strict_gap_positive": summary.right_strict_gap_positive,
+        "claim_scope": summary.claim_scope,
+        "interpretation": (
+            "In the strict gear window, the gear equation would require the "
+            "same value to be both at least the common threshold and strictly "
+            "below it. This kills only the stated two-orbit half-step class."
+        ),
+    }
+
+
 def symmetric_two_orbit_reduction_to_json(
     summary: SymmetricTwoOrbitReductionSummary,
 ) -> dict[str, object]:
@@ -935,5 +1022,15 @@ def _is_positive(value: object) -> bool:
     if simplified.is_positive is True:
         return True
     if simplified.is_positive is False:
+        return False
+    return False
+
+
+def _is_nonnegative(value: object) -> bool:
+    sp = _sympy()
+    simplified = sp.simplify(value)
+    if simplified.is_nonnegative is True:
+        return True
+    if simplified.is_nonnegative is False:
         return False
     return False

--- a/tests/test_two_orbit_radius_propagation.py
+++ b/tests/test_two_orbit_radius_propagation.py
@@ -12,6 +12,8 @@ from erdos97.two_orbit_radius_propagation import (
     concentric_outside_hull_summary,
     concentric_outside_hull_to_json,
     cyclic_crossing_search_to_json,
+    gear_equation_summary,
+    gear_equation_to_json,
     linearized_escape_summary,
     linearized_escape_to_json,
     radius_ratio_summary,
@@ -156,6 +158,33 @@ def test_radius_ratio_json_keeps_scope_narrow() -> None:
     assert row["type"] == "regular_orbit_radius_ratio_bound"
     assert row["status"] == "exact_necessary_radius_bound_not_general_proof"
     assert "not sufficient for Erdos #97" in str(row["interpretation"])
+
+
+def test_gear_equation_certificate_covers_rotation_orders() -> None:
+    for k in range(3, 13):
+        summary = gear_equation_summary(k)
+
+        assert summary.status == "exact_gear_equation_obstruction_not_general_proof"
+        assert summary.left_margin_nonnegative
+        assert summary.right_strict_gap_positive
+        assert sp.N(summary.right_strict_gap, 50) > 0
+
+
+def test_gear_equation_boundary_is_k3_left_margin_zero() -> None:
+    summary = gear_equation_summary(3)
+
+    assert sp.simplify(summary.left_margin) == 0
+    assert sp.N(summary.right_strict_gap, 50) > 0
+
+
+def test_gear_equation_json_keeps_scope_narrow() -> None:
+    row = gear_equation_to_json(gear_equation_summary(5))
+
+    assert row["type"] == "two_orbit_gear_equation_obstruction"
+    assert row["status"] == "exact_gear_equation_obstruction_not_general_proof"
+    assert "kills only the stated two-orbit half-step class" in str(
+        row["interpretation"]
+    )
 
 
 def test_symmetric_two_orbit_reduction_covers_k3_boundary_case() -> None:

--- a/tests/test_two_orbit_radius_propagation.py
+++ b/tests/test_two_orbit_radius_propagation.py
@@ -9,11 +9,17 @@ from erdos97.two_orbit_radius_propagation import (
     alternating_two_radius_family_summary,
     alternating_two_radius_family_to_json,
     alternating_turns,
+    concentric_outside_hull_summary,
+    concentric_outside_hull_to_json,
     cyclic_crossing_search_to_json,
     linearized_escape_summary,
     linearized_escape_to_json,
+    radius_ratio_summary,
+    radius_ratio_to_json,
     selected_distance_residuals,
     summary_to_json,
+    symmetric_two_orbit_reduction_summary,
+    symmetric_two_orbit_reduction_to_json,
     two_orbit_summary,
 )
 
@@ -133,3 +139,83 @@ def test_alternating_decagon_crossing_json_keeps_scope_narrow() -> None:
     assert row["status"] == "NO_CYCLIC_ORDER"
     assert row["survivor"] is None
     assert "not an n=10 completeness theorem" in str(row["interpretation"])
+
+
+def test_radius_ratio_bound_is_positive_for_rotation_orders() -> None:
+    for k in range(3, 13):
+        summary = radius_ratio_summary(k)
+
+        assert summary.status == "exact_necessary_radius_bound_not_general_proof"
+        assert summary.positive_factor
+        assert sp.N(summary.inradius_factor, 50) > 0
+
+
+def test_radius_ratio_json_keeps_scope_narrow() -> None:
+    row = radius_ratio_to_json(radius_ratio_summary(5))
+
+    assert row["type"] == "regular_orbit_radius_ratio_bound"
+    assert row["status"] == "exact_necessary_radius_bound_not_general_proof"
+    assert "not sufficient for Erdos #97" in str(row["interpretation"])
+
+
+def test_symmetric_two_orbit_reduction_covers_k3_boundary_case() -> None:
+    summary = symmetric_two_orbit_reduction_summary(3)
+
+    assert summary.status == (
+        "exact_reduction_to_alternating_family_obstruction_not_general_proof"
+    )
+    assert summary.n == 6
+    assert summary.witness_split == (2, 2)
+    assert summary.small_k_boundary_case
+    assert str(summary.small_k_gap_certificate) == "-(b - 2)*(b + 1)"
+
+
+def test_symmetric_two_orbit_reduction_uses_alternating_family_for_k_ge_4() -> None:
+    for k in range(4, 10):
+        summary = symmetric_two_orbit_reduction_summary(k)
+
+        assert summary.status == (
+            "exact_reduction_to_alternating_family_obstruction_not_general_proof"
+        )
+        assert summary.n == 2 * k
+        assert summary.witness_split == (2, 2)
+        assert summary.reduces_to_alternating_family
+        assert summary.all_gap_certificates_positive
+        assert not summary.small_k_boundary_case
+
+
+def test_symmetric_two_orbit_reduction_json_keeps_scope_narrow() -> None:
+    row = symmetric_two_orbit_reduction_to_json(
+        symmetric_two_orbit_reduction_summary(4)
+    )
+
+    assert row["type"] == "symmetric_two_orbit_reduction"
+    assert row["status"] == (
+        "exact_reduction_to_alternating_family_obstruction_not_general_proof"
+    )
+    assert "not a general proof or counterexample" in str(row["claim_scope"])
+
+
+def test_concentric_outside_hull_obstruction_covers_at_most_three_circles() -> None:
+    for circle_count in (1, 2, 3):
+        summary = concentric_outside_hull_summary(circle_count)
+
+        assert summary.status == "exact_exterior_center_obstruction_not_general_proof"
+        assert summary.covered_by_lemma
+        assert summary.pigeonhole_forces_same_circle_pair
+        assert summary.extreme_pair_obstruction
+
+
+def test_concentric_outside_hull_obstruction_marks_four_circles_uncovered() -> None:
+    summary = concentric_outside_hull_summary(4)
+
+    assert summary.status == "not_covered_by_three_circle_pigeonhole"
+    assert not summary.covered_by_lemma
+
+
+def test_concentric_outside_hull_json_keeps_scope_narrow() -> None:
+    row = concentric_outside_hull_to_json(concentric_outside_hull_summary(3))
+
+    assert row["type"] == "concentric_exterior_center_obstruction"
+    assert row["status"] == "exact_exterior_center_obstruction_not_general_proof"
+    assert "not a general proof or counterexample" in str(row["claim_scope"])


### PR DESCRIPTION
## Summary
- Add a scoped proof note for restricted `C_k` two-orbit reductions, the radius-ratio vertex bound, and the at-most-three exterior-center concentric-circle obstruction.
- Add a direct gear-equation trigonometric certificate for the same half-step class, plus provenance for the 2026-06-09 research-pass archive.
- Extend `check_two_orbit_radius_propagation.py` with `--radius-ratio`, `--gear-equation`, `--two-orbit-reduction`, and `--concentric-outside` verifier modes.
- Add tests and ledger entries in `RESULTS.md`, `docs/claims.md`, and `docs/index.md` while preserving the no-general-proof/no-counterexample boundary.

## Verification
- `python scripts/check_two_orbit_radius_propagation.py --gear-equation --k 3 --k-max 12 --assert-gear-equation --json`
- `python scripts/check_two_orbit_radius_propagation.py --two-orbit-reduction --k 3 --k-max 12 --assert-two-orbit-reduction --json`
- `python scripts/check_two_orbit_radius_propagation.py --radius-ratio --k 3 --k-max 12 --assert-radius-ratio --json`
- `python -m pytest tests/test_two_orbit_radius_propagation.py -q`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1374 passed, 552 deselected`)

Artifact tier not run: this PR adds scoped verifier/docs/tests and no generated finite-case artifact changes.