### PR TITLE
[codex] Add FR cut homotopy provenance

### DIFF
--- a/data/runs/fr_cut_homotopy_2026-06-09/FR20_cutmatrix_nearest4_mixed_radius_homotopy_20260609T224640Z_seed97333.json
+++ b/data/runs/fr_cut_homotopy_2026-06-09/FR20_cutmatrix_nearest4_mixed_radius_homotopy_20260609T224640Z_seed97333.json
@@ -1,0 +1,830 @@
+{
+  "S3": [
+    [
+      15,
+      18,
+      19
+    ],
+    [
+      14,
+      17,
+      19
+    ],
+    [
+      13,
+      16,
+      19
+    ],
+    [
+      12,
+      17,
+      18
+    ],
+    [
+      11,
+      16,
+      18
+    ],
+    [
+      10,
+      16,
+      17
+    ],
+    [
+      12,
+      14,
+      15
+    ],
+    [
+      11,
+      13,
+      15
+    ],
+    [
+      10,
+      13,
+      14
+    ],
+    [
+      10,
+      11,
+      12
+    ],
+    [
+      5,
+      8,
+      9
+    ],
+    [
+      4,
+      7,
+      9
+    ],
+    [
+      3,
+      6,
+      9
+    ],
+    [
+      2,
+      7,
+      8
+    ],
+    [
+      1,
+      6,
+      8
+    ],
+    [
+      0,
+      6,
+      7
+    ],
+    [
+      2,
+      4,
+      5
+    ],
+    [
+      1,
+      3,
+      5
+    ],
+    [
+      0,
+      3,
+      4
+    ],
+    [
+      0,
+      1,
+      2
+    ]
+  ],
+  "S4": [
+    [
+      15,
+      18,
+      19,
+      17
+    ],
+    [
+      14,
+      17,
+      19,
+      18
+    ],
+    [
+      13,
+      16,
+      19,
+      17
+    ],
+    [
+      12,
+      17,
+      18,
+      16
+    ],
+    [
+      11,
+      16,
+      18,
+      17
+    ],
+    [
+      10,
+      16,
+      17,
+      18
+    ],
+    [
+      12,
+      14,
+      15,
+      13
+    ],
+    [
+      11,
+      13,
+      15,
+      14
+    ],
+    [
+      10,
+      13,
+      14,
+      15
+    ],
+    [
+      10,
+      11,
+      12,
+      13
+    ],
+    [
+      5,
+      8,
+      9,
+      7
+    ],
+    [
+      4,
+      7,
+      9,
+      8
+    ],
+    [
+      3,
+      6,
+      9,
+      7
+    ],
+    [
+      2,
+      7,
+      8,
+      6
+    ],
+    [
+      1,
+      6,
+      8,
+      7
+    ],
+    [
+      0,
+      6,
+      7,
+      8
+    ],
+    [
+      2,
+      4,
+      5,
+      3
+    ],
+    [
+      1,
+      3,
+      5,
+      4
+    ],
+    [
+      0,
+      3,
+      4,
+      5
+    ],
+    [
+      0,
+      1,
+      2,
+      3
+    ]
+  ],
+  "config": {
+    "common_w": 1.0,
+    "conv_floor": 1e-08,
+    "edge_floor": 0.0001,
+    "exact_trigger_margin": 0.0001,
+    "exact_trigger_rms": 1e-10,
+    "gap_floor_fraction": 0.003,
+    "gap_w": 2.0,
+    "geom_w": 0.0,
+    "initial_step": 1.0,
+    "lr_tether": 1e-05,
+    "max_nfev_corrector": 20,
+    "max_nfev_seed": 80,
+    "max_step": 1.0,
+    "max_steps": 1,
+    "min_step": 0.2,
+    "pair_floor": 0.0001,
+    "seed_jitter": 0.0,
+    "y_pad": 0.025
+  },
+  "environment": {
+    "created_utc": "2026-06-09T22:46:40.869014+00:00",
+    "numpy": "2.3.5",
+    "python": "3.13.5 (main, Jun 25 2025, 18:55:22) [GCC 14.2.0]",
+    "scipy": "1.17.0"
+  },
+  "exact_verifier_results": [],
+  "exact_verifier_triggered": false,
+  "fishburn_reeds_seed": {
+    "A_i": "(-x_i,y_i), labels 0..9",
+    "B_i": "(x_i,y_i), labels 10..19",
+    "boundary_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      19,
+      18,
+      17,
+      16,
+      15,
+      14,
+      13,
+      12,
+      11,
+      10
+    ],
+    "coordinate_table_scaled_by": 0.001,
+    "seed_matrix_edges_1_indexed": [
+      [
+        1,
+        6
+      ],
+      [
+        1,
+        9
+      ],
+      [
+        1,
+        10
+      ],
+      [
+        2,
+        5
+      ],
+      [
+        2,
+        8
+      ],
+      [
+        2,
+        10
+      ],
+      [
+        3,
+        4
+      ],
+      [
+        3,
+        7
+      ],
+      [
+        3,
+        10
+      ],
+      [
+        4,
+        3
+      ],
+      [
+        4,
+        8
+      ],
+      [
+        4,
+        9
+      ],
+      [
+        5,
+        2
+      ],
+      [
+        5,
+        7
+      ],
+      [
+        5,
+        9
+      ],
+      [
+        6,
+        1
+      ],
+      [
+        6,
+        7
+      ],
+      [
+        6,
+        8
+      ],
+      [
+        7,
+        3
+      ],
+      [
+        7,
+        5
+      ],
+      [
+        7,
+        6
+      ],
+      [
+        8,
+        2
+      ],
+      [
+        8,
+        4
+      ],
+      [
+        8,
+        6
+      ],
+      [
+        9,
+        1
+      ],
+      [
+        9,
+        4
+      ],
+      [
+        9,
+        5
+      ],
+      [
+        10,
+        1
+      ],
+      [
+        10,
+        2
+      ],
+      [
+        10,
+        3
+      ]
+    ]
+  },
+  "fourth_witness_rule": "nearest",
+  "fourth_witnesses_by_center_label": [
+    17,
+    18,
+    17,
+    16,
+    17,
+    18,
+    13,
+    14,
+    15,
+    13,
+    7,
+    8,
+    7,
+    6,
+    7,
+    8,
+    3,
+    4,
+    5,
+    3
+  ],
+  "homotopy": {
+    "step_control": {
+      "acceptance_order": "convexity margin, min edge, min pair checked before residual",
+      "corrector": "scipy.optimize.least_squares(method='lm')",
+      "initial_step": 1.0,
+      "max_step": 1.0,
+      "min_step": 0.2,
+      "predictor": "previous corrected point",
+      "reject_action": "halve step; terminate below min_step"
+    },
+    "t0": "Fishburn--Reeds 3-neighbor cut matrix with soft common-radius tie",
+    "t1": "same rows plus closest non-edge fourth witness; per-center radii independent"
+  },
+  "interpretation": {
+    "label": "FAILED_APPROACH",
+    "text": "No counterexample candidate is claimed; floating-point equalities are diagnostics only."
+  },
+  "paths": [
+    {
+      "accepted_points": [
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              6,
+              7,
+              8
+            ],
+            "active_min_edge": [
+              6,
+              7
+            ],
+            "active_min_pair": [
+              6,
+              7
+            ],
+            "class_geometry": {
+              "A_diameter": 1.01639340809872,
+              "A_x_range": [
+                -1.0276583201351523,
+                -0.7686587400052852
+              ],
+              "B_diameter": 1.01639340809872,
+              "B_x_range": [
+                0.768658740005285,
+                1.027658320135152
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 1.5373174800105702
+            },
+            "convexity_margin": 1.5158141958273918e-07,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.02129769282943345,
+              "max_spread": 0.0821074954883163,
+              "rms_centered_residual": 0.011255038974842717
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.08210749548610385,
+              "rms": 0.01299619956373039
+            },
+            "min_edge_length": 0.004145366745006794,
+            "min_gap_A": 0.002003622208999966,
+            "min_gap_B": 0.002003622208999966,
+            "min_pair_distance": 0.004145366745006794,
+            "seed3_equal_distance": {
+              "max_relative_spread": 2.0309535256185574e-12,
+              "max_spread": 7.87148124459236e-12,
+              "rms_centered_residual": 2.408229526945243e-12
+            },
+            "seed3_radius_residual": {
+              "max_abs": 5.24558174674894e-12,
+              "rms": 2.408229544006119e-12
+            },
+            "signed_area2_in_boundary_order": -3.7299287260192444,
+            "t": 0.0
+          },
+          "solver": {
+            "cost": 0.012877207673696002,
+            "message": "t=0 is the Fishburn-Reeds coordinate-table seed; no geometry-improving correction applied",
+            "nfev": 0,
+            "stage": "published_FR_table_no_t0_corrector",
+            "success": true
+          },
+          "step_index": 0
+        }
+      ],
+      "final_geometry_first_diagnostics": {
+        "active_convexity_edge_vertex": [
+          6,
+          7,
+          8
+        ],
+        "active_min_edge": [
+          6,
+          7
+        ],
+        "active_min_pair": [
+          6,
+          7
+        ],
+        "convexity_margin": 1.5158141958273918e-07,
+        "min_edge_length": 0.004145366745006794,
+        "min_pair_distance": 0.004145366745006794
+      },
+      "final_residual_diagnostics": {
+        "full4_equal_distance": {
+          "max_relative_spread": 0.02129769282943345,
+          "max_spread": 0.0821074954883163,
+          "rms_centered_residual": 0.011255038974842717
+        },
+        "full4_radius_residual": {
+          "max_abs": 0.08210749548610385,
+          "rms": 0.01299619956373039
+        },
+        "seed3_equal_distance": {
+          "max_relative_spread": 2.0309535256185574e-12,
+          "max_spread": 7.87148124459236e-12,
+          "rms_centered_residual": 2.408229526945243e-12
+        },
+        "seed3_radius_residual": {
+          "max_abs": 5.24558174674894e-12,
+          "rms": 2.408229544006119e-12
+        }
+      },
+      "final_t": 0.0,
+      "final_x": [
+        -3.109360995122399,
+        -5.225118721082378,
+        -5.2564599593696,
+        -1.5656470274685261,
+        -5.2296245313224885,
+        -5.196834708499499,
+        -0.603033935579718,
+        -5.633280173002911,
+        -5.605751200787768,
+        -2.072246062605903,
+        -3.1093609951223975,
+        -3.109360995122399,
+        -5.225118721082378,
+        -5.2564599593696,
+        -1.5656470274685261,
+        -5.2296245313224885,
+        -5.196834708499499,
+        -0.603033935579718,
+        -5.633280173002911,
+        -5.605751200787768,
+        -2.072246062605903,
+        -3.1093609951223975,
+        -0.7558019905383236,
+        -0.7520180873706149,
+        -0.7483931601969699,
+        -0.6539264674066639,
+        -0.6520124409706478,
+        -0.6500876910994983,
+        -0.8442674962514765,
+        -0.8457748465517891,
+        -0.8473721892298568,
+        -0.9404786085713086,
+        -0.7558019905383236,
+        -0.7520180873706149,
+        -0.7483931601969699,
+        -0.6539264674066639,
+        -0.6520124409706478,
+        -0.6500876910994983,
+        -0.8442674962514765,
+        -0.8457748465517891,
+        -0.8473721892298568,
+        -0.9404786085713086,
+        1.3547408589469792,
+        1.354740858945969,
+        1.35474085894759,
+        1.3547408589481373,
+        1.3547408589468053,
+        1.3547408589482424,
+        1.354740858947904,
+        1.3547408589470153,
+        1.3547408589473193,
+        1.3547408589464662,
+        1.3547408589469792,
+        1.3547408589459693,
+        1.3547408589475902,
+        1.3547408589481371,
+        1.3547408589468048,
+        1.3547408589482421,
+        1.3547408589479044,
+        1.3547408589470153,
+        1.3547408589473195,
+        1.3547408589464662
+      ],
+      "path_seed": 97333,
+      "rejected_points": [
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              5,
+              6,
+              8
+            ],
+            "active_min_edge": [
+              18,
+              17
+            ],
+            "active_min_pair": [
+              17,
+              18
+            ],
+            "class_geometry": {
+              "A_diameter": 0.8365119809667314,
+              "A_x_range": [
+                -1.0318558805816729,
+                -0.8962935140773196
+              ],
+              "B_diameter": 0.8365122831407683,
+              "B_x_range": [
+                0.8962934451157071,
+                1.0318558807608007
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 1.7925869591930268
+            },
+            "convexity_margin": -0.0030298865234886924,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.004894284091892577,
+              "max_spread": 0.01921244203037764,
+              "rms_centered_residual": 0.005447335503713594
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.013126361035308065,
+              "rms": 0.005481570016201213
+            },
+            "min_edge_length": 0.021932674473330017,
+            "min_gap_A": 0.010526740731902384,
+            "min_gap_B": 0.010526699464804659,
+            "min_pair_distance": 0.021932674473330017,
+            "seed3_equal_distance": {
+              "max_relative_spread": 0.0038879769313398564,
+              "max_spread": 0.015296658016363818,
+              "rms_centered_residual": 0.0037683238203431177
+            },
+            "seed3_radius_residual": {
+              "max_abs": 0.010491400519065497,
+              "rms": 0.004515101799769711
+            },
+            "signed_area2_in_boundary_order": -3.249988245549315,
+            "t": 1.0
+          },
+          "from_t": 0.0,
+          "incoming_step": 1.0,
+          "reason": "convexity_collapse",
+          "solver_message": "The maximum number of function evaluations is exceeded.",
+          "solver_status": 0,
+          "solver_success": false,
+          "target_t": 1.0
+        },
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              16,
+              15,
+              18
+            ],
+            "active_min_edge": [
+              18,
+              17
+            ],
+            "active_min_pair": [
+              17,
+              18
+            ],
+            "class_geometry": {
+              "A_diameter": 0.8734551088090838,
+              "A_x_range": [
+                -1.0346007126982992,
+                -0.8821479575819849
+              ],
+              "B_diameter": 0.8734549746394824,
+              "B_x_range": [
+                0.8821480218554049,
+                1.0346007109414994
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 1.7642959794373898
+            },
+            "convexity_margin": -0.003718331383782923,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.006745665482609486,
+              "max_spread": 0.02644770184345191,
+              "rms_centered_residual": 0.006766118118281962
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.022288015276321627,
+              "rms": 0.0070428279767468386
+            },
+            "min_edge_length": 0.03276347679925828,
+            "min_gap_A": 0.015608920036845659,
+            "min_gap_B": 0.015608906492763868,
+            "min_pair_distance": 0.03276347679925828,
+            "seed3_equal_distance": {
+              "max_relative_spread": 0.0035741904912814162,
+              "max_spread": 0.014043014670390708,
+              "rms_centered_residual": 0.003408186640008851
+            },
+            "seed3_radius_residual": {
+              "max_abs": 0.009310342936968752,
+              "rms": 0.00394298602098654
+            },
+            "signed_area2_in_boundary_order": -3.3811846683332365,
+            "t": 0.5
+          },
+          "from_t": 0.0,
+          "incoming_step": 0.5,
+          "reason": "convexity_collapse",
+          "solver_message": "The maximum number of function evaluations is exceeded.",
+          "solver_status": 0,
+          "solver_success": false,
+          "target_t": 0.5
+        },
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              5,
+              6,
+              8
+            ],
+            "active_min_edge": [
+              18,
+              17
+            ],
+            "active_min_pair": [
+              17,
+              18
+            ],
+            "class_geometry": {
+              "A_diameter": 0.8728598116351934,
+              "A_x_range": [
+                -1.0324763053978274,
+                -0.8837489496196506
+              ],
+              "B_diameter": 0.8728597441927367,
+              "B_x_range": [
+                0.8837489305313994,
+                1.0324762810806671
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 1.76749788015105
+            },
+            "convexity_margin": -0.004917966248670372,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.009696894155182677,
+              "max_spread": 0.0380399055188545,
+              "rms_centered_residual": 0.008927742040308245
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.03458084904687597,
+              "rms": 0.009672987697246596
+            },
+            "min_edge_length": 0.04449431083058697,
+            "min_gap_A": 0.021202337414542027,
+            "min_gap_B": 0.021202300509580073,
+            "min_pair_distance": 0.04449431083058697,
+            "seed3_equal_distance": {
+              "max_relative_spread": 0.002827766620823744,
+              "max_spread": 0.011122474677457195,
+              "rms_centered_residual": 0.002721340754104114
+            },
+            "seed3_radius_residual": {
+              "max_abs": 0.007355379391947192,
+              "rms": 0.0031053500925375685
+            },
+            "signed_area2_in_boundary_order": -3.379265851228692,
+            "t": 0.25
+          },
+          "from_t": 0.0,
+          "incoming_step": 0.25,
+          "reason": "convexity_collapse",
+          "solver_message": "The maximum number of function evaluations is exceeded.",
+          "solver_status": 0,
+          "solver_success": false,
+          "target_t": 0.25
+        }
+      ],
+      "termination_reason": "convexity_collapse"
+    }
+  ],
+  "pattern_name": "FR20_cut_matrix_nearest4_mixed_radius_cut_arc_homotopy",
+  "schema": "erdos97.numerical_run.v1",
+  "seed": 97333,
+  "summary": {
+    "all_terminated_by_geometry_collapse": true,
+    "best_full4_rms_point": {
+      "convexity_margin": 1.5158141958273918e-07,
+      "full4_max_spread": 0.0821074954883163,
+      "full4_rms_centered_residual": 0.011255038974842717,
+      "min_edge_length": 0.004145366745006794,
+      "path_seed": 97333,
+      "t": 0.0
+    },
+    "deepest_path": {
+      "final_convexity_margin": 1.5158141958273918e-07,
+      "final_full4_rms_centered_residual": 0.011255038974842717,
+      "final_t": 0.0,
+      "path_seed": 97333,
+      "termination_reason": "convexity_collapse"
+    },
+    "num_paths": 1,
+    "num_paths_geometry_collapse": 1,
+    "num_paths_reached_t1": 0
+  },
+  "trust_label": "FAILED_APPROACH"
+}

--- a/data/runs/fr_cut_homotopy_2026-06-09/FR20_cutmatrix_nearest4_mixed_radius_homotopy_20260609T224751Z_seed97444.json
+++ b/data/runs/fr_cut_homotopy_2026-06-09/FR20_cutmatrix_nearest4_mixed_radius_homotopy_20260609T224751Z_seed97444.json
@@ -1,0 +1,773 @@
+{
+  "S3": [
+    [
+      15,
+      18,
+      19
+    ],
+    [
+      14,
+      17,
+      19
+    ],
+    [
+      13,
+      16,
+      19
+    ],
+    [
+      12,
+      17,
+      18
+    ],
+    [
+      11,
+      16,
+      18
+    ],
+    [
+      10,
+      16,
+      17
+    ],
+    [
+      12,
+      14,
+      15
+    ],
+    [
+      11,
+      13,
+      15
+    ],
+    [
+      10,
+      13,
+      14
+    ],
+    [
+      10,
+      11,
+      12
+    ],
+    [
+      5,
+      8,
+      9
+    ],
+    [
+      4,
+      7,
+      9
+    ],
+    [
+      3,
+      6,
+      9
+    ],
+    [
+      2,
+      7,
+      8
+    ],
+    [
+      1,
+      6,
+      8
+    ],
+    [
+      0,
+      6,
+      7
+    ],
+    [
+      2,
+      4,
+      5
+    ],
+    [
+      1,
+      3,
+      5
+    ],
+    [
+      0,
+      3,
+      4
+    ],
+    [
+      0,
+      1,
+      2
+    ]
+  ],
+  "S4": [
+    [
+      15,
+      18,
+      19,
+      17
+    ],
+    [
+      14,
+      17,
+      19,
+      18
+    ],
+    [
+      13,
+      16,
+      19,
+      17
+    ],
+    [
+      12,
+      17,
+      18,
+      16
+    ],
+    [
+      11,
+      16,
+      18,
+      17
+    ],
+    [
+      10,
+      16,
+      17,
+      18
+    ],
+    [
+      12,
+      14,
+      15,
+      13
+    ],
+    [
+      11,
+      13,
+      15,
+      14
+    ],
+    [
+      10,
+      13,
+      14,
+      15
+    ],
+    [
+      10,
+      11,
+      12,
+      13
+    ],
+    [
+      5,
+      8,
+      9,
+      7
+    ],
+    [
+      4,
+      7,
+      9,
+      8
+    ],
+    [
+      3,
+      6,
+      9,
+      7
+    ],
+    [
+      2,
+      7,
+      8,
+      6
+    ],
+    [
+      1,
+      6,
+      8,
+      7
+    ],
+    [
+      0,
+      6,
+      7,
+      8
+    ],
+    [
+      2,
+      4,
+      5,
+      3
+    ],
+    [
+      1,
+      3,
+      5,
+      4
+    ],
+    [
+      0,
+      3,
+      4,
+      5
+    ],
+    [
+      0,
+      1,
+      2,
+      3
+    ]
+  ],
+  "config": {
+    "common_w": 1.0,
+    "conv_floor": 1e-08,
+    "edge_floor": 0.0001,
+    "exact_trigger_margin": 0.0001,
+    "exact_trigger_rms": 1e-10,
+    "gap_floor_fraction": 0.003,
+    "gap_w": 2.0,
+    "geom_w": 10.0,
+    "initial_step": 0.5,
+    "lr_tether": 1e-05,
+    "max_nfev_corrector": 20,
+    "max_nfev_seed": 80,
+    "max_step": 0.5,
+    "max_steps": 2,
+    "min_step": 0.05,
+    "pair_floor": 0.0001,
+    "seed_jitter": 0.0,
+    "y_pad": 0.025
+  },
+  "environment": {
+    "created_utc": "2026-06-09T22:47:51.184126+00:00",
+    "numpy": "2.3.5",
+    "python": "3.13.5 (main, Jun 25 2025, 18:55:22) [GCC 14.2.0]",
+    "scipy": "1.17.0"
+  },
+  "exact_verifier_results": [],
+  "exact_verifier_triggered": false,
+  "fishburn_reeds_seed": {
+    "A_i": "(-x_i,y_i), labels 0..9",
+    "B_i": "(x_i,y_i), labels 10..19",
+    "boundary_order": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      19,
+      18,
+      17,
+      16,
+      15,
+      14,
+      13,
+      12,
+      11,
+      10
+    ],
+    "coordinate_table_scaled_by": 0.001,
+    "seed_matrix_edges_1_indexed": [
+      [
+        1,
+        6
+      ],
+      [
+        1,
+        9
+      ],
+      [
+        1,
+        10
+      ],
+      [
+        2,
+        5
+      ],
+      [
+        2,
+        8
+      ],
+      [
+        2,
+        10
+      ],
+      [
+        3,
+        4
+      ],
+      [
+        3,
+        7
+      ],
+      [
+        3,
+        10
+      ],
+      [
+        4,
+        3
+      ],
+      [
+        4,
+        8
+      ],
+      [
+        4,
+        9
+      ],
+      [
+        5,
+        2
+      ],
+      [
+        5,
+        7
+      ],
+      [
+        5,
+        9
+      ],
+      [
+        6,
+        1
+      ],
+      [
+        6,
+        7
+      ],
+      [
+        6,
+        8
+      ],
+      [
+        7,
+        3
+      ],
+      [
+        7,
+        5
+      ],
+      [
+        7,
+        6
+      ],
+      [
+        8,
+        2
+      ],
+      [
+        8,
+        4
+      ],
+      [
+        8,
+        6
+      ],
+      [
+        9,
+        1
+      ],
+      [
+        9,
+        4
+      ],
+      [
+        9,
+        5
+      ],
+      [
+        10,
+        1
+      ],
+      [
+        10,
+        2
+      ],
+      [
+        10,
+        3
+      ]
+    ]
+  },
+  "fourth_witness_rule": "nearest",
+  "fourth_witnesses_by_center_label": [
+    17,
+    18,
+    17,
+    16,
+    17,
+    18,
+    13,
+    14,
+    15,
+    13,
+    7,
+    8,
+    7,
+    6,
+    7,
+    8,
+    3,
+    4,
+    5,
+    3
+  ],
+  "homotopy": {
+    "step_control": {
+      "acceptance_order": "convexity margin, min edge, min pair checked before residual",
+      "corrector": "scipy.optimize.least_squares(method='lm')",
+      "initial_step": 0.5,
+      "max_step": 0.5,
+      "min_step": 0.05,
+      "predictor": "previous corrected point",
+      "reject_action": "halve step; terminate below min_step"
+    },
+    "t0": "Fishburn--Reeds 3-neighbor cut matrix with soft common-radius tie",
+    "t1": "same rows plus closest non-edge fourth witness; per-center radii independent"
+  },
+  "interpretation": {
+    "label": "NUMERICAL_EVIDENCE",
+    "text": "No counterexample candidate is claimed; floating-point equalities are diagnostics only."
+  },
+  "paths": [
+    {
+      "accepted_points": [
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              6,
+              7,
+              8
+            ],
+            "active_min_edge": [
+              6,
+              7
+            ],
+            "active_min_pair": [
+              6,
+              7
+            ],
+            "class_geometry": {
+              "A_diameter": 1.01639340809872,
+              "A_x_range": [
+                -1.0276583201351523,
+                -0.7686587400052852
+              ],
+              "B_diameter": 1.01639340809872,
+              "B_x_range": [
+                0.768658740005285,
+                1.027658320135152
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 1.5373174800105702
+            },
+            "convexity_margin": 1.5158141958273918e-07,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.02129769282943345,
+              "max_spread": 0.0821074954883163,
+              "rms_centered_residual": 0.011255038974842717
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.08210749548610385,
+              "rms": 0.01299619956373039
+            },
+            "min_edge_length": 0.004145366745006794,
+            "min_gap_A": 0.002003622208999966,
+            "min_gap_B": 0.002003622208999966,
+            "min_pair_distance": 0.004145366745006794,
+            "seed3_equal_distance": {
+              "max_relative_spread": 2.0309535256185574e-12,
+              "max_spread": 7.87148124459236e-12,
+              "rms_centered_residual": 2.408229526945243e-12
+            },
+            "seed3_radius_residual": {
+              "max_abs": 5.24558174674894e-12,
+              "rms": 2.408229544006119e-12
+            },
+            "signed_area2_in_boundary_order": -3.7299287260192444,
+            "t": 0.0
+          },
+          "solver": {
+            "cost": 5.709325660318806,
+            "message": "t=0 is the Fishburn-Reeds coordinate-table seed; no geometry-improving correction applied",
+            "nfev": 0,
+            "stage": "published_FR_table_no_t0_corrector",
+            "success": true
+          },
+          "step_index": 0
+        },
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              18,
+              17,
+              16
+            ],
+            "active_min_edge": [
+              7,
+              8
+            ],
+            "active_min_pair": [
+              7,
+              8
+            ],
+            "class_geometry": {
+              "A_diameter": 1.7195948891843102,
+              "A_x_range": [
+                -1.1888597258622737,
+                -0.22355562600117174
+              ],
+              "B_diameter": 1.7195949243895137,
+              "B_x_range": [
+                0.22355570726898735,
+                1.1888597297554142
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 0.44711133327015906
+            },
+            "convexity_margin": 0.00024598215304482904,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.10515609176724441,
+              "max_spread": 0.3497915506123377,
+              "rms_centered_residual": 0.0783604180491692
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.17795178570613546,
+              "rms": 0.07961368178102335
+            },
+            "min_edge_length": 0.11097570024416799,
+            "min_gap_A": 2.681039651344721e-05,
+            "min_gap_B": 2.6811949016240858e-05,
+            "min_pair_distance": 0.11097570024416799,
+            "seed3_equal_distance": {
+              "max_relative_spread": 0.08449460261693274,
+              "max_spread": 0.29282656417245256,
+              "rms_centered_residual": 0.06503782737803623
+            },
+            "seed3_radius_residual": {
+              "max_abs": 0.171839768582299,
+              "rms": 0.06732712947365069
+            },
+            "signed_area2_in_boundary_order": -5.801919223086172,
+            "t": 0.5
+          },
+          "solver": {
+            "cost": 0.9527011870031961,
+            "incoming_step": 0.5,
+            "message": "The maximum number of function evaluations is exceeded.",
+            "nfev": 20,
+            "optimality": 0.050383327776676146,
+            "status": 0,
+            "success": false
+          },
+          "step_index": 1
+        },
+        {
+          "diagnostics": {
+            "active_convexity_edge_vertex": [
+              6,
+              7,
+              8
+            ],
+            "active_min_edge": [
+              7,
+              8
+            ],
+            "active_min_pair": [
+              7,
+              8
+            ],
+            "class_geometry": {
+              "A_diameter": 1.7021251888769684,
+              "A_x_range": [
+                -1.187792761153184,
+                -0.24550607362839477
+              ],
+              "B_diameter": 1.7021248339182544,
+              "B_x_range": [
+                0.24550544991590376,
+                1.1877927834912059
+              ],
+              "cut_gap_min_B_x_minus_max_A_x": 0.49101152354429856
+            },
+            "convexity_margin": 0.00025536184469754884,
+            "full4_equal_distance": {
+              "max_relative_spread": 0.09558976077814474,
+              "max_spread": 0.3198066940630344,
+              "rms_centered_residual": 0.07221496028106647
+            },
+            "full4_radius_residual": {
+              "max_abs": 0.18926921026221377,
+              "rms": 0.07221937026978872
+            },
+            "min_edge_length": 0.10047858088905424,
+            "min_gap_A": 0.013445988575788353,
+            "min_gap_B": 0.013445989055879433,
+            "min_pair_distance": 0.10047858088905424,
+            "seed3_equal_distance": {
+              "max_relative_spread": 0.0778531545075432,
+              "max_spread": 0.27079055018953113,
+              "rms_centered_residual": 0.06453818475657648
+            },
+            "seed3_radius_residual": {
+              "max_abs": 0.18926921026221377,
+              "rms": 0.06966021904615083
+            },
+            "signed_area2_in_boundary_order": -5.764655269845146,
+            "t": 1.0
+          },
+          "solver": {
+            "cost": 0.9895768137921966,
+            "incoming_step": 0.5,
+            "message": "The maximum number of function evaluations is exceeded.",
+            "nfev": 20,
+            "optimality": 0.038536222217914196,
+            "status": 0,
+            "success": false
+          },
+          "step_index": 2
+        }
+      ],
+      "final_geometry_first_diagnostics": {
+        "active_convexity_edge_vertex": [
+          6,
+          7,
+          8
+        ],
+        "active_min_edge": [
+          7,
+          8
+        ],
+        "active_min_pair": [
+          7,
+          8
+        ],
+        "convexity_margin": 0.00025536184469754884,
+        "min_edge_length": 0.10047858088905424,
+        "min_pair_distance": 0.10047858088905424
+      },
+      "final_residual_diagnostics": {
+        "full4_equal_distance": {
+          "max_relative_spread": 0.09558976077814474,
+          "max_spread": 0.3198066940630344,
+          "rms_centered_residual": 0.07221496028106647
+        },
+        "full4_radius_residual": {
+          "max_abs": 0.18926921026221377,
+          "rms": 0.07221937026978872
+        },
+        "seed3_equal_distance": {
+          "max_relative_spread": 0.0778531545075432,
+          "max_spread": 0.27079055018953113,
+          "rms_centered_residual": 0.06453818475657648
+        },
+        "seed3_radius_residual": {
+          "max_abs": 0.18926921026221377,
+          "rms": 0.06966021904615083
+        }
+      },
+      "final_t": 1.0,
+      "final_x": [
+        -2.2082809074394,
+        -2.0458334091848775,
+        -1.1508053577277366,
+        -0.5201744661754808,
+        -0.6852210974243039,
+        -1.1005908777254467,
+        0.512899347617327,
+        -1.7587601522873835,
+        -1.8624647548322004,
+        -1.6768477102590764,
+        -2.2770439063229273,
+        -2.2083613305317096,
+        -2.045923757697161,
+        -1.1508949874032977,
+        -0.520265921517886,
+        -0.6853132965457677,
+        -1.100681486109049,
+        0.5128061784382388,
+        -1.7588499140591543,
+        -1.8625564930945617,
+        -1.676941729212736,
+        -2.2771356256836803,
+        -1.9669275591133326,
+        -1.6460575265125676,
+        -1.3548878577195158,
+        -1.1214240650924632,
+        -1.0138242194715807,
+        -0.9834306710681989,
+        -1.7375157884968655,
+        -1.8949234581038508,
+        -2.070634801806873,
+        -2.5599611098834103,
+        -1.9669257349889828,
+        -1.646056587906257,
+        -1.3548871432113734,
+        -1.1214236869906125,
+        -1.0138241220074113,
+        -0.9834306083122085,
+        -1.7375163453899387,
+        -1.8949245830401311,
+        -2.070636316781833,
+        -2.5599634377693086,
+        1.191737607423439,
+        1.234993140073777,
+        1.2527680665731256,
+        1.2602165819302888,
+        1.2460223487619533,
+        1.2073244467527602,
+        1.2772244447177155,
+        1.237298178668305,
+        1.203836969122834,
+        1.206886565230612,
+        1.1917376423137496,
+        1.2349931273947994,
+        1.2527680362994191,
+        1.2602166226690996,
+        1.2460223638036791,
+        1.207324447448383,
+        1.2772244543313613,
+        1.2372981392183817,
+        1.2038369408431997,
+        1.2068865885617115
+      ],
+      "path_seed": 97444,
+      "rejected_points": [],
+      "termination_reason": "reached_t1"
+    }
+  ],
+  "pattern_name": "FR20_cut_matrix_nearest4_mixed_radius_cut_arc_homotopy",
+  "schema": "erdos97.numerical_run.v1",
+  "seed": 97444,
+  "summary": {
+    "all_terminated_by_geometry_collapse": false,
+    "best_full4_rms_point": {
+      "convexity_margin": 1.5158141958273918e-07,
+      "full4_max_spread": 0.0821074954883163,
+      "full4_rms_centered_residual": 0.011255038974842717,
+      "min_edge_length": 0.004145366745006794,
+      "path_seed": 97444,
+      "t": 0.0
+    },
+    "deepest_path": {
+      "final_convexity_margin": 0.00025536184469754884,
+      "final_full4_rms_centered_residual": 0.07221496028106647,
+      "final_t": 1.0,
+      "path_seed": 97444,
+      "termination_reason": "reached_t1"
+    },
+    "num_paths": 1,
+    "num_paths_geometry_collapse": 0,
+    "num_paths_reached_t1": 1
+  },
+  "trust_label": "NUMERICAL_EVIDENCE"
+}

--- a/data/runs/fr_cut_homotopy_2026-06-09/README.md
+++ b/data/runs/fr_cut_homotopy_2026-06-09/README.md
@@ -1,0 +1,18 @@
+# Fishburn-Reeds cut homotopy imports
+
+These JSON files are selected numerical artifacts from the 2026-06-09
+Fishburn--Reeds cut-matrix mixed-radius homotopy session.
+
+They are failed-route diagnostics only. The source archive also contained
+earlier same-seed warmup runs, which were not imported because these two files
+capture the useful collapse and endpoint-degradation outcomes.
+
+Reproduce fresh runs with:
+
+```bash
+python scripts/fr_cut_homotopy.py --seed 97333 --paths 1
+python scripts/fr_cut_homotopy.py --seed 97444 --paths 1
+```
+
+The checked-in JSONs retain the original session output. Interpret them under
+the repository exactification threshold in `docs/exactification-plan.md`.

--- a/docs/failed-ideas.md
+++ b/docs/failed-ideas.md
@@ -262,6 +262,32 @@ not proof routes.
 
 Current status: failed proof shortcut / provenance guardrail.
 
+## 20. Fishburn--Reeds cut-matrix nearest-fourth homotopy
+
+Trust label: `FAILED_APPROACH` / `NUMERICAL_EVIDENCE`.
+
+What was tried: a decimal transcription of the Fishburn--Reeds 20-point
+`k=3` table was used as a two-class cut-matrix scaffold. The 30 cross-cut
+Fishburn--Reeds rows supplied the three-witness `t=0` system, and each row was
+augmented by its nearest non-edge fourth witness. The homotopy then tracked
+toward a row-wise mixed-radius four-witness system with independent
+per-center radii.
+
+Failure mode: the informative imported runs either stayed on the
+strict-convexity boundary before leaving `t=0`, or reached `t=1` with
+four-witness residuals far above candidate scale. The clearest collapse run
+records best four-witness RMS residual about `1.13e-2`, max spread about
+`8.21e-2`, convexity margin about `1.52e-7`, and minimum edge length about
+`4.15e-3`. The endpoint-reaching run has final four-witness RMS residual about
+`7.22e-2`, so it is not a near candidate.
+
+Scope caveat: this is not an exact Fishburn--Reeds coordinate continuation.
+The imported script embeds a decimal table transcription and treats the
+Fishburn--Reeds construction as a `k=3` scaffold only. No run met the
+exactification threshold in `docs/exactification-plan.md`, no standalone exact
+verifier was invoked, and no `COUNTEREXAMPLE_CANDIDATE` is recorded. See
+`docs/fr-cut-homotopy.md`.
+
 [^lit]: Public consolidation: `public-provenance.md#literature-digest`.
 [^forest]: Public consolidation: `public-provenance.md#forest-lemma-failure`.
 [^rank]: Public consolidation: `public-provenance.md#rank-and-bridge-status`.

--- a/docs/fr-cut-homotopy.md
+++ b/docs/fr-cut-homotopy.md
@@ -1,0 +1,90 @@
+# Fishburn-Reeds cut-matrix mixed-radius homotopy
+
+Status: `FAILED_APPROACH` / `NUMERICAL_EVIDENCE`.
+
+This note records a 2026-06-09 numerical homotopy probe based on a decimal
+transcription of the Fishburn--Reeds 20-point `k=3` table. It is not an exact
+Fishburn--Reeds coordinate certificate, not a proof, and not a counterexample
+candidate.
+
+The script is:
+
+```bash
+python scripts/fr_cut_homotopy.py
+```
+
+The imported run artifacts are:
+
+```text
+data/runs/fr_cut_homotopy_2026-06-09/FR20_cutmatrix_nearest4_mixed_radius_homotopy_20260609T224640Z_seed97333.json
+data/runs/fr_cut_homotopy_2026-06-09/FR20_cutmatrix_nearest4_mixed_radius_homotopy_20260609T224751Z_seed97444.json
+```
+
+The larger archive also contained early same-seed warmup runs. They were not
+imported because these two artifacts capture the useful outcomes without
+duplicating weaker session provenance.
+
+## Setup
+
+The decimal table is interpreted as two 10-point classes
+
+```text
+A_i = (-x_i, y_i), labels 0..9
+B_i = ( x_i, y_i), labels 10..19
+```
+
+using the 30-edge Fishburn--Reeds cut matrix as the `t=0` three-witness seed.
+For each center, the `nearest` augmentation adds the closest non-edge across
+the cut as a fourth witness. The homotopy then tracks from the three-witness
+cut-matrix equations toward a row-wise mixed-radius four-witness system with
+independent per-center radii.
+
+At every accepted path point, strict convexity margin, minimum edge length, and
+minimum pair distance are checked before residual quality is interpreted.
+
+## Imported Outcomes
+
+The `seed97333` run is the clearest collapse diagnostic. It terminates before
+leaving `t=0`:
+
+```text
+termination:              convexity_collapse
+best full4 RMS residual:  1.1255038974842717e-2
+best full4 max spread:    8.21074954883163e-2
+convexity margin:         1.5158141958273918e-7
+minimum edge length:      4.145366745006794e-3
+```
+
+The `seed97444` run reaches `t=1`, but only with poor four-witness residuals:
+
+```text
+termination:              reached_t1
+final full4 RMS residual: 7.221496028106647e-2
+final convexity margin:   2.5536184469754884e-4
+```
+
+Neither run approaches the repo exactification threshold from
+`docs/exactification-plan.md`:
+
+```text
+max selected-distance spread < 1e-10
+convexity margin            > 1e-3
+minimum edge length         > 1e-3
+minimum pair distance       > 1e-3
+independent verifier passes
+```
+
+No standalone exact verifier was run and no `COUNTEREXAMPLE_CANDIDATE` is
+recorded.
+
+## Interpretation
+
+The useful lesson is negative: the decimal Fishburn--Reeds cut-matrix seed is
+an excellent three-witness scaffold, but the nearest fourth-witness
+mixed-radius continuation either rides the strict-convexity boundary or reaches
+the endpoint with residuals far above candidate scale.
+
+This does not obstruct arbitrary fourth-witness choices, arbitrary cyclic
+orders, or exact historical Fishburn--Reeds coordinates. It only records that
+this specific cut-matrix augmentation is not a productive counterexample path
+under the tested numerical homotopy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -791,6 +791,9 @@ put detailed reconciliation in the canonical synthesis.
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded
   equivariant sweep; `NUMERICAL_EVIDENCE` only, no candidate found.
+- [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
+  cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
+  numerical evidence only, not an exact coordinate certificate.
 - [`two-orbit-circulant-obstruction.md`](two-orbit-circulant-obstruction.md):
   review-pending lemma draft excluding all two-orbit circulant
   configurations (any radii, any relative rotation) with its audit checker;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,9 @@ where = ["src"]
 
 [tool.ruff]
 target-version = "py310"
-extend-exclude = ["data/runs/*/*.py"]
+extend-exclude = [
+  ".codex-work",
+  ".codex-worktrees",
+  ".worktrees",
+  "data/runs/*/*.py",
+]

--- a/scripts/fr_cut_homotopy.py
+++ b/scripts/fr_cut_homotopy.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+"""Fishburn-Reeds cut-matrix mixed-radius homotopy diagnostic.
+
+This is a numerical failed-route probe for Erdos Problem #97.  It records
+floating-point homotopy diagnostics only; it does not certify a counterexample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import least_squares
+
+# Fishburn--Reeds Table 1 (published as 1000*x_i, 1000*y_i).  A_i=(-x_i,y_i), B_i=(x_i,y_i).
+FR_X = (
+    np.array(
+        [
+            469.633821777,
+            471.414237018,
+            473.126180256,
+            520.0,
+            520.996246864,
+            522.0,
+            429.872125856,
+            429.224646090,
+            428.539574537,
+            390.440922261,
+        ]
+    )
+    / 1000.0
+)
+FR_Y = (
+    np.array(
+        [
+            -92.982777730,
+            -89.969229800,
+            -87.048665472,
+            30.0,
+            33.0,
+            36.1,
+            342.595442083,
+            344.599064292,
+            346.658610393,
+            417.185267785,
+        ]
+    )
+    / 1000.0
+)
+EDGES = [
+    (1, 6),
+    (1, 9),
+    (1, 10),
+    (2, 5),
+    (2, 8),
+    (2, 10),
+    (3, 4),
+    (3, 7),
+    (3, 10),
+    (4, 3),
+    (4, 8),
+    (4, 9),
+    (5, 2),
+    (5, 7),
+    (5, 9),
+    (6, 1),
+    (6, 7),
+    (6, 8),
+    (7, 3),
+    (7, 5),
+    (7, 6),
+    (8, 2),
+    (8, 4),
+    (8, 6),
+    (9, 1),
+    (9, 4),
+    (9, 5),
+    (10, 1),
+    (10, 2),
+    (10, 3),
+]
+
+
+@dataclass
+class Cfg:
+    y_pad: float = 0.025
+    common_w: float = 1.0
+    conv_floor: float = 1e-8
+    edge_floor: float = 1e-4
+    pair_floor: float = 1e-4
+    geom_w: float = 10.0
+    gap_w: float = 2.0
+    gap_floor_fraction: float = 0.003
+    lr_tether: float = 1e-5
+    seed_jitter: float = 0.0
+    max_nfev_seed: int = 80
+    max_nfev_corrector: int = 30
+    initial_step: float = 0.05
+    max_step: float = 0.10
+    min_step: float = 0.001
+    max_steps: int = 80
+    exact_trigger_spread: float = 1e-10
+    exact_trigger_margin: float = 1e-3
+
+
+def mat():
+    M = np.zeros((10, 10), bool)
+    for i, j in EDGES:
+        M[i - 1, j - 1] = True
+    return M
+
+
+def frD():
+    D = np.zeros((10, 10))
+    for i in range(10):
+        for j in range(10):
+            D[i, j] = math.sqrt((FR_X[i] + FR_X[j]) ** 2 + (FR_Y[j] - FR_Y[i]) ** 2)
+    return D
+
+
+def rows(augment="nearest"):
+    M, D = mat(), frD()
+    S3 = []
+    S4 = []
+    fourth = []
+    for i in range(10):
+        r = [10 + j for j in range(10) if M[i, j]]
+        cand = [j for j in range(10) if not M[i, j]]
+        j = (
+            min(cand, key=lambda k: abs(D[i, k] - 1.0))
+            if augment == "nearest"
+            else cand[(i + 1) % len(cand)]
+        )
+        S3.append(r)
+        S4.append(r + [10 + j])
+        fourth.append(10 + j)
+    for j in range(10):
+        r = [i for i in range(10) if M[i, j]]
+        cand = [i for i in range(10) if not M[i, j]]
+        i = (
+            min(cand, key=lambda k: abs(D[k, j] - 1.0))
+            if augment == "nearest"
+            else cand[(j + 1) % len(cand)]
+        )
+        S3.append(r)
+        S4.append(r + [i])
+        fourth.append(i)
+    return S3, S4, fourth
+
+
+def softmax(z):
+    z = np.asarray(z, float)
+    z = z - np.max(z)
+    e = np.exp(z)
+    return e / e.sum()
+
+
+def hinge(y, scale=30.0):
+    x = np.clip(scale * np.asarray(y, float), -60, 60)
+    return np.log1p(np.exp(x)) / scale
+
+
+def normP(P):
+    Q = P - P.mean(axis=0, keepdims=True)
+    rms = math.sqrt(float(np.mean(np.sum(Q * Q, axis=1))))
+    return Q / rms
+
+
+def order():
+    return list(range(10)) + list(range(19, 9, -1))
+
+
+def yends(cfg):
+    return float(FR_Y[0] - cfg.y_pad), float(FR_Y[-1] + cfg.y_pad)
+
+
+def gaps_logits(y, cfg):
+    lo, hi = yends(cfg)
+    g = np.diff(np.r_[lo, y, hi])
+    return np.log(g / g.sum())
+
+
+def unpack(x, cfg):
+    zA, zB = x[:11], x[11:22]
+    lwA, lwB = x[22:32], x[32:42]
+    lr = x[42:62]
+    lo, hi = yends(cfg)
+    span = hi - lo
+    gA, gB = softmax(zA) * span, softmax(zB) * span
+    yA, yB = lo + np.cumsum(gA[:-1]), lo + np.cumsum(gB[:-1])
+    wA, wB = np.exp(np.clip(lwA, -12, 4)), np.exp(np.clip(lwB, -12, 4))
+    P = np.zeros((20, 2))
+    P[:10, 0] = -wA
+    P[:10, 1] = yA
+    P[10:, 0] = wB
+    P[10:, 1] = yB
+    return (
+        normP(P),
+        np.exp(np.clip(lr, -20, 10)),
+        dict(gA=gA, gB=gB, lr=lr, wA=wA, wB=wB, yA=yA, yB=yB),
+    )
+
+
+def init(seed, cfg, S3):
+    rng = np.random.default_rng(seed)
+    zA = gaps_logits(FR_Y, cfg) + rng.normal(0, cfg.seed_jitter, 11)
+    zB = gaps_logits(FR_Y, cfg) + rng.normal(0, cfg.seed_jitter, 11)
+    lwA = np.log(FR_X) + rng.normal(0, cfg.seed_jitter, 10)
+    lwB = np.log(FR_X) + rng.normal(0, cfg.seed_jitter, 10)
+    x = np.r_[zA, zB, lwA, lwB, np.zeros(20)]
+    P, _, _ = unpack(x, cfg)
+    R = np.array(
+        [np.mean([np.sum((P[i] - P[j]) ** 2) for j in S3[i]]) for i in range(20)]
+    )
+    return np.r_[zA, zB, lwA, lwB, np.log(np.maximum(R, 1e-15))]
+
+
+def area2(P, ordr):
+    Q = P[ordr]
+    return float(
+        np.sum(Q[:, 0] * np.roll(Q[:, 1], -1) - Q[:, 1] * np.roll(Q[:, 0], -1))
+    )
+
+
+def margins(P, ordr):
+    s = 1.0 if area2(P, ordr) >= 0 else -1.0
+    vals = []
+    tri = []
+    for k, a in enumerate(ordr):
+        b = ordr[(k + 1) % len(ordr)]
+        e = P[b] - P[a]
+        for c in ordr:
+            if c == a or c == b:
+                continue
+            vals.append(
+                s * float(e[0] * (P[c, 1] - P[a, 1]) - e[1] * (P[c, 0] - P[a, 0]))
+            )
+            tri.append((a, b, c))
+    vals = np.array(vals)
+    idx = int(np.argmin(vals))
+    return vals, tri[idx]
+
+
+def minedge(P, ordr):
+    pairs = [
+        (
+            float(np.linalg.norm(P[ordr[k]] - P[ordr[(k + 1) % len(ordr)]])),
+            (ordr[k], ordr[(k + 1) % len(ordr)]),
+        )
+        for k in range(len(ordr))
+    ]
+    return min(pairs, key=lambda z: z[0])
+
+
+def minpair(P):
+    pairs = [
+        (float(np.linalg.norm(P[i] - P[j])), (i, j))
+        for i in range(20)
+        for j in range(i + 1, 20)
+    ]
+    return min(pairs, key=lambda z: z[0])
+
+
+def eqstats(P, S):
+    spreads = []
+    rel = []
+    centered = []
+    for i, row in enumerate(S):
+        d = np.array([np.sum((P[i] - P[j]) ** 2) for j in row])
+        m = float(np.mean(d))
+        sp = float(np.max(d) - np.min(d))
+        spreads.append(sp)
+        rel.append(sp / max(abs(m), 1e-15))
+        centered += (d - m).tolist()
+    centered = np.array(centered)
+    return dict(
+        max_spread=float(max(spreads)),
+        max_relative_spread=float(max(rel)),
+        rms_centered_residual=float(math.sqrt(float(np.mean(centered * centered)))),
+    )
+
+
+def rstats(P, R, S):
+    v = np.array(
+        [np.sum((P[i] - P[j]) ** 2) - R[i] for i, row in enumerate(S) for j in row]
+    )
+    return dict(
+        max_abs=float(np.max(np.abs(v))), rms=float(math.sqrt(float(np.mean(v * v))))
+    )
+
+
+def diag(x, t, cfg, S3, S4):
+    P, R, a = unpack(x, cfg)
+    ordr = order()
+    mg, tri = margins(P, ordr)
+    me, mep = minedge(P, ordr)
+    mp, mpp = minpair(P)
+    A, B = P[:10], P[10:]
+    return dict(
+        t=float(t),
+        convexity_margin=float(np.min(mg)),
+        min_edge_length=float(me),
+        min_pair_distance=float(mp),
+        signed_area2_in_boundary_order=area2(P, ordr),
+        active_convexity_edge_vertex=list(tri),
+        active_min_edge=list(mep),
+        active_min_pair=list(mpp),
+        min_gap_A=float(np.min(a["gA"])),
+        min_gap_B=float(np.min(a["gB"])),
+        seed3_equal_distance=eqstats(P, S3),
+        full4_equal_distance=eqstats(P, S4),
+        seed3_radius_residual=rstats(P, R, S3),
+        full4_radius_residual=rstats(P, R, S4),
+        class_geometry=dict(
+            A_x_range=[float(A[:, 0].min()), float(A[:, 0].max())],
+            B_x_range=[float(B[:, 0].min()), float(B[:, 0].max())],
+            cut_gap_min_B_x_minus_max_A_x=float(B[:, 0].min() - A[:, 0].max()),
+            A_diameter=float(
+                max(
+                    np.linalg.norm(A[i] - A[j])
+                    for i in range(10)
+                    for j in range(i + 1, 10)
+                )
+            ),
+            B_diameter=float(
+                max(
+                    np.linalg.norm(B[i] - B[j])
+                    for i in range(10)
+                    for j in range(i + 1, 10)
+                )
+            ),
+        ),
+    )
+
+
+def residual(x, t, cfg, S3, S4):
+    P, R, a = unpack(x, cfg)
+    res = []
+    for i, row in enumerate(S3):
+        for j in row:
+            res.append(float(np.sum((P[i] - P[j]) ** 2) - R[i]))
+    if t > 0:
+        w = math.sqrt(t)
+        for i in range(20):
+            res.append(w * float(np.sum((P[i] - P[S4[i][3]]) ** 2) - R[i]))
+    if t < 1:
+        lr = a["lr"]
+        res += (cfg.common_w * math.sqrt(1 - t) * (lr - lr.mean())).tolist()
+    res += (cfg.lr_tether * a["lr"]).tolist()
+    ordr = order()
+    mg, _ = margins(P, ordr)
+    res += (cfg.geom_w * hinge(cfg.conv_floor - mg)).tolist()
+    edges = np.array(
+        [
+            cfg.edge_floor - np.linalg.norm(P[ordr[k]] - P[ordr[(k + 1) % len(ordr)]])
+            for k in range(len(ordr))
+        ]
+    )
+    res += (cfg.geom_w * hinge(edges)).tolist()
+    pairs = np.array(
+        [
+            cfg.pair_floor - np.linalg.norm(P[i] - P[j])
+            for i in range(20)
+            for j in range(i + 1, 20)
+        ]
+    )
+    res += (cfg.geom_w * hinge(pairs)).tolist()
+    lo, hi = yends(cfg)
+    gf = cfg.gap_floor_fraction * (hi - lo) / 11.0
+    res += (cfg.gap_w * hinge(gf - a["gA"])).tolist()
+    res += (cfg.gap_w * hinge(gf - a["gB"])).tolist()
+    return np.array(res, float)
+
+
+def solve(x, t, cfg, S3, S4, seed_stage=False):
+    return least_squares(
+        lambda y: residual(y, t, cfg, S3, S4),
+        x,
+        method="lm",
+        max_nfev=cfg.max_nfev_seed if seed_stage else cfg.max_nfev_corrector,
+        ftol=1e-11,
+        xtol=1e-11,
+        gtol=1e-11,
+    )
+
+
+def accept(d, cfg):
+    if d["convexity_margin"] <= 0:
+        return False, "convexity_collapse"
+    if d["min_edge_length"] <= 1e-10:
+        return False, "edge_collapse"
+    if d["min_pair_distance"] <= 1e-10:
+        return False, "pair_collision"
+    return True, "geometry_ok"
+
+
+def path(seed, cfg, S3, S4):
+    x = init(seed, cfg, S3)
+    t = 0.0
+    h = cfg.initial_step
+    acc = [
+        dict(
+            step_index=0,
+            diagnostics=diag(x, 0, cfg, S3, S4),
+            solver=dict(
+                stage="published_FR_table_no_t0_corrector",
+                success=True,
+                nfev=0,
+                cost=float(np.sum(residual(x, 0, cfg, S3, S4) ** 2) / 2.0),
+                message="t=0 is the Fishburn-Reeds coordinate-table seed; no geometry-improving correction applied",
+            ),
+        )
+    ]
+    rej = []
+    term = "running"
+    step = 0
+    while t < 1 - 1e-14 and step < cfg.max_steps:
+        target = min(1.0, t + h)
+        print(
+            f"[FR-cut] seed={seed} target={target:.6f} h={h:.2e}",
+            file=sys.stderr,
+            flush=True,
+        )
+        sol = solve(x, target, cfg, S3, S4, False)
+        d = diag(sol.x, target, cfg, S3, S4)
+        ok, why = accept(d, cfg)
+        if ok and np.isfinite(sol.cost):
+            step += 1
+            acc.append(
+                dict(
+                    step_index=step,
+                    diagnostics=d,
+                    solver=dict(
+                        success=bool(sol.success),
+                        status=int(sol.status),
+                        message=str(sol.message),
+                        nfev=int(sol.nfev),
+                        cost=float(sol.cost),
+                        optimality=float(sol.optimality),
+                        incoming_step=float(h),
+                    ),
+                )
+            )
+            x = sol.x.copy()
+            t = target
+            h = (
+                max(cfg.min_step, 0.5 * h)
+                if d["convexity_margin"] < 10 * cfg.conv_floor
+                else min(
+                    cfg.max_step,
+                    h if sol.nfev >= 0.4 * cfg.max_nfev_corrector else 1.25 * h,
+                )
+            )
+            term = "reached_t1" if t >= 1 - 1e-14 else "running"
+        else:
+            rej.append(
+                dict(
+                    from_t=float(t),
+                    target_t=float(target),
+                    incoming_step=float(h),
+                    reason=why,
+                    solver_success=bool(sol.success),
+                    solver_status=int(sol.status),
+                    solver_message=str(sol.message),
+                    diagnostics=d,
+                )
+            )
+            h *= 0.5
+            if h < cfg.min_step:
+                term = why
+                break
+    if step >= cfg.max_steps and term == "running":
+        term = "max_steps_reached"
+    f = acc[-1]["diagnostics"]
+    return dict(
+        path_seed=seed,
+        termination_reason=term,
+        accepted_points=acc,
+        rejected_points=rej,
+        final_t=float(f["t"]),
+        final_geometry_first_diagnostics={
+            k: f[k]
+            for k in [
+                "convexity_margin",
+                "min_edge_length",
+                "min_pair_distance",
+                "active_convexity_edge_vertex",
+                "active_min_edge",
+                "active_min_pair",
+            ]
+        },
+        final_residual_diagnostics=dict(
+            seed3_equal_distance=f["seed3_equal_distance"],
+            full4_equal_distance=f["full4_equal_distance"],
+            seed3_radius_residual=f["seed3_radius_residual"],
+            full4_radius_residual=f["full4_radius_residual"],
+        ),
+        final_x=x.tolist(),
+    )
+
+
+def summary(paths):
+    pts = [
+        (p["path_seed"], pt["diagnostics"])
+        for p in paths
+        for pt in p["accepted_points"]
+    ]
+    best = min(pts, key=lambda z: z[1]["full4_equal_distance"]["rms_centered_residual"])
+    deep = max(paths, key=lambda p: p["final_t"])
+    collapses = [
+        p
+        for p in paths
+        if p["termination_reason"]
+        in {"convexity_collapse", "edge_collapse", "pair_collision"}
+    ]
+    return dict(
+        num_paths=len(paths),
+        num_paths_reached_t1=sum(
+            p["termination_reason"] == "reached_t1" for p in paths
+        ),
+        num_paths_geometry_collapse=len(collapses),
+        all_terminated_by_geometry_collapse=len(collapses) == len(paths),
+        best_full4_rms_point=dict(
+            path_seed=best[0],
+            t=best[1]["t"],
+            full4_rms_centered_residual=best[1]["full4_equal_distance"][
+                "rms_centered_residual"
+            ],
+            full4_max_spread=best[1]["full4_equal_distance"]["max_spread"],
+            convexity_margin=best[1]["convexity_margin"],
+            min_edge_length=best[1]["min_edge_length"],
+        ),
+        deepest_path=dict(
+            path_seed=deep["path_seed"],
+            final_t=deep["final_t"],
+            termination_reason=deep["termination_reason"],
+            final_convexity_margin=deep["final_geometry_first_diagnostics"][
+                "convexity_margin"
+            ],
+            final_full4_rms_centered_residual=deep["final_residual_diagnostics"][
+                "full4_equal_distance"
+            ]["rms_centered_residual"],
+        ),
+    )
+
+
+def exactification_trigger_points(paths, cfg):
+    triggered = []
+    for path_record in paths:
+        for point in path_record["accepted_points"]:
+            diagnostics = point["diagnostics"]
+            if (
+                diagnostics["full4_equal_distance"]["max_spread"]
+                < cfg.exact_trigger_spread
+                and diagnostics["convexity_margin"] > cfg.exact_trigger_margin
+                and diagnostics["min_edge_length"] > cfg.exact_trigger_margin
+                and diagnostics["min_pair_distance"] > cfg.exact_trigger_margin
+            ):
+                triggered.append(
+                    {
+                        "path_seed": path_record["path_seed"],
+                        "step_index": point["step_index"],
+                        "t": diagnostics["t"],
+                        "full4_max_spread": diagnostics["full4_equal_distance"][
+                            "max_spread"
+                        ],
+                        "convexity_margin": diagnostics["convexity_margin"],
+                        "min_edge_length": diagnostics["min_edge_length"],
+                        "min_pair_distance": diagnostics["min_pair_distance"],
+                    }
+                )
+    return triggered
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo-dir", default=".")
+    ap.add_argument("--seed", type=int, default=97120)
+    ap.add_argument("--paths", type=int, default=3)
+    ap.add_argument("--augment", choices=["nearest", "cyclic_next"], default="nearest")
+    ap.add_argument("--max-nfev-seed", type=int)
+    ap.add_argument("--max-nfev-corrector", type=int)
+    ap.add_argument("--initial-step", type=float)
+    ap.add_argument("--max-step", type=float)
+    ap.add_argument("--min-step", type=float)
+    ap.add_argument("--max-steps", type=int)
+    ap.add_argument("--geom-w", type=float)
+    ap.add_argument("--out")
+    a = ap.parse_args()
+    cfg = Cfg()
+    for k, v in [
+        ("max_nfev_seed", a.max_nfev_seed),
+        ("max_nfev_corrector", a.max_nfev_corrector),
+        ("initial_step", a.initial_step),
+        ("max_step", a.max_step),
+        ("min_step", a.min_step),
+        ("max_steps", a.max_steps),
+        ("geom_w", a.geom_w),
+    ]:
+        if v is not None:
+            setattr(cfg, k, v)
+    repo = Path(a.repo_dir).resolve()
+    outdir = repo / "data" / "runs"
+    outdir.mkdir(parents=True, exist_ok=True)
+    S3, S4, fourth = rows(a.augment)
+    paths = []
+    for p in range(a.paths):
+        seed = a.seed + 1009 * p
+        print(f"[FR-cut] path {p} seed={seed}", file=sys.stderr, flush=True)
+        paths.append(path(seed, cfg, S3, S4))
+        print(
+            f"[FR-cut] done {p} final_t={paths[-1]['final_t']:.4f} term={paths[-1]['termination_reason']}",
+            file=sys.stderr,
+            flush=True,
+        )
+    sm = summary(paths)
+    label = (
+        "FAILED_APPROACH"
+        if sm["all_terminated_by_geometry_collapse"]
+        else "NUMERICAL_EVIDENCE"
+    )
+    exact_triggers = exactification_trigger_points(paths, cfg)
+    artifact = dict(
+        schema="erdos97.numerical_run.v1",
+        trust_label=label,
+        pattern_name=f"FR20_cut_matrix_{a.augment}4_mixed_radius_cut_arc_homotopy",
+        seed=a.seed,
+        fishburn_reeds_seed=dict(
+            coordinate_table_scaled_by=0.001,
+            A_i="(-x_i,y_i), labels 0..9",
+            B_i="(x_i,y_i), labels 10..19",
+            boundary_order=order(),
+            seed_matrix_edges_1_indexed=EDGES,
+        ),
+        fourth_witness_rule=a.augment,
+        fourth_witnesses_by_center_label=fourth,
+        S3=S3,
+        S4=S4,
+        homotopy=dict(
+            t0="Fishburn--Reeds 3-neighbor cut matrix with soft common-radius tie",
+            t1="same rows plus closest non-edge fourth witness; per-center radii independent",
+            step_control=dict(
+                predictor="previous corrected point",
+                corrector="scipy.optimize.least_squares(method='lm')",
+                acceptance_order="convexity margin, min edge, min pair checked before residual",
+                initial_step=cfg.initial_step,
+                max_step=cfg.max_step,
+                min_step=cfg.min_step,
+                reject_action="halve step; terminate below min_step",
+            ),
+        ),
+        config=asdict(cfg),
+        paths=paths,
+        summary=sm,
+        exactification_trigger=dict(
+            max_selected_distance_spread=cfg.exact_trigger_spread,
+            convexity_margin=cfg.exact_trigger_margin,
+            min_edge_length=cfg.exact_trigger_margin,
+            min_pair_distance=cfg.exact_trigger_margin,
+            source="docs/exactification-plan.md",
+        ),
+        exact_verifier_triggered=bool(exact_triggers),
+        exact_verifier_results=[],
+        exactification_trigger_points=exact_triggers,
+        interpretation=dict(
+            label=label,
+            text="No counterexample candidate is claimed; floating-point equalities are diagnostics only.",
+        ),
+        environment=dict(
+            python=sys.version,
+            numpy=np.__version__,
+            scipy=sys.modules["scipy"].__version__,
+            created_utc=datetime.now(timezone.utc).isoformat(),
+        ),
+    )
+    out = (
+        Path(a.out)
+        if a.out
+        else outdir
+        / f"FR20_cutmatrix_{a.augment}4_mixed_radius_homotopy_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}_seed{a.seed}.json"
+    )
+    out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+    print(out)
+    print(json.dumps(sm, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a cleaned `scripts/fr_cut_homotopy.py` reproducer for the Fishburn--Reeds cut-matrix nearest-fourth mixed-radius homotopy probe
- import two selected 2026-06-09 JSON run artifacts under `data/runs/fr_cut_homotopy_2026-06-09/`
- document the failed-route interpretation in `docs/fr-cut-homotopy.md`, link it from the docs index, and record it in failed ideas
- exclude local Codex scratch/worktree directories from ruff traversal so `ruff check .` ignores archive extracts

## Notes

This is provenance for a failed numerical route only. It does not claim a proof, a counterexample, or a counterexample candidate. The imported artifacts did not meet the repo exactification threshold and no standalone exact verifier was invoked.

## Validation

- `python scripts\check_text_clean.py`
- `python scripts\check_status_consistency.py`
- `python scripts\check_artifact_provenance.py`
- `git diff --cached --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1384 passed, 587 deselected`)