### PR TITLE
[codex] Add quarter-cell signed-band preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ The fixed abstract patterns `C19_skew` and `C13_sidon_1_2_4_10` are killed
 across all cyclic orders by exact Kalmanson/Farkas certificate searches. That
 does not settle the larger sparse frontier and does not prove Erdos #97.
 
+Restricted symmetry-family diagnostics are also recorded. The two-orbit
+circulant family has a review-pending obstruction note, and the three-orbit
+program closes the `m = 4` quarter cell exactly while reducing the remaining
+`m = 8, 12, 16` quarter cells to a signed boundary-band turn target. The
+latest signed-band preflight narrows that target to `12` cells with negative
+boundary-leading killer turns, but those cells remain open. See
+[`docs/quarter-cell-signed-band-preflight.md`](docs/quarter-cell-signed-band-preflight.md).
+
 ### Review-pending frontier artifacts
 
 The repo records an exhaustive `n=9` vertex-circle checker as a candidate

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1654,6 +1654,20 @@ orbit-coincidence limit. See `docs/quarter-cell-closure.md`,
 `scripts/check_quarter_cell_closure.py --assert-clear`, and
 `data/certificates/quarter_cell_closure.json`.
 
+A signed-band preflight sharpens the open target without closing it. The
+boundary-band witness locus splits into the three band orders `LL`, `LH`, and
+`HH`, and the two radius signs give `12` signed cells. For each signed cell,
+the packet records one fixed per-period turn determinant whose first nonzero
+term at the orbit-coincidence boundary is negative for `m >= 8`; a
+deterministic grid stress of the same fixed killer turns over
+`m = 8, 12, 16, 20, 40, 100` finds no sampled violation. This is a
+`REVIEW_PENDING_DIAGNOSTIC` and a precise exact-sign target only. It is not a
+certificate for `m >= 8`, does not close the `m = 8, 12, 16` quarter cells, and
+does not prove an all-`m` three-orbit obstruction. See
+`docs/quarter-cell-signed-band-preflight.md`,
+`scripts/check_quarter_cell_signed_band_preflight.py --check --assert-expected --json`,
+and `data/certificates/quarter_cell_signed_band_preflight.json`.
+
 ## Numerical Attempts
 
 ### Dynamic-witness free-pattern sweep (2026-06-09)

--- a/STATE.md
+++ b/STATE.md
@@ -1013,7 +1013,14 @@ clean open lemma is: on the witness locus inside the window, the minimum
 per-period turn determinant is `<= 0`, with equality only at the degenerate
 orbit-coincidence limit. See `docs/quarter-cell-closure.md`,
 `scripts/check_quarter_cell_closure.py`, and
-`data/certificates/quarter_cell_closure.json`.
+`data/certificates/quarter_cell_closure.json`. A signed-band preflight now
+splits that remaining turn-sign target into `12` boundary-band/radius-sign
+cells and records a fixed per-cell killer turn whose first nonzero boundary
+term is negative for `m >= 8`, with deterministic grid stress of the same
+killer turns for `m = 8, 12, 16, 20, 40, 100`. This narrows the exact target
+but is not the global sign proof; the `m = 8, 12, 16` quarter cells remain
+open. See `docs/quarter-cell-signed-band-preflight.md` and
+`data/certificates/quarter_cell_signed_band_preflight.json`.
 
 ## Best saved near-miss
 

--- a/data/certificates/quarter_cell_signed_band_preflight.json
+++ b/data/certificates/quarter_cell_signed_band_preflight.json
@@ -1,0 +1,1554 @@
+{
+ "claim_scope": "Quarter-cell signed-band turn preflight for the three-orbit (t=3) m=0 mod 4 residual. Records the exact boundary-band case split and the first nonzero negative turn term in each signed cell, plus deterministic float stress of those fixed killer turns. This is not the global sign proof: m=8,12,16 quarter cells remain open, and this is not an all-m three-orbit obstruction, proof of Erdos Problem #97, counterexample, or official/global status update.",
+ "definitions": {
+  "A": "sin(T)+cos(T)-1",
+  "B": "cos(T)-sin(T)-1",
+  "C": "1+sin(T)-cos(T)",
+  "D": "1-sin(T)-cos(T)",
+  "P(r)": "(r^2 - 1)/(2*r)",
+  "T": "2*pi/m",
+  "radius_sign": "P(y)=y_sign*sin(d), P(z)=z_sign*sin(e)",
+  "turns": [
+   "turn_1 = orient(C_{-1}, A_0, B_0)",
+   "turn_2 = orient(A_0, B_0, C_0)",
+   "turn_3 = orient(B_0, C_0, A_1)"
+  ]
+ },
+ "does_not_claim": [
+  "m=8,12,16 quarter cells closed",
+  "exact certificate for m>=8 quarter cells",
+  "all-m quarter-cell obstruction",
+  "all-m three-orbit obstruction",
+  "general proof of Erdos Problem #97",
+  "counterexample to Erdos Problem #97",
+  "official/global status update"
+ ],
+ "leading_killer_case_count": 12,
+ "leading_sign_constants": [
+  {
+   "A=sinT+cosT-1": 0.41421356237309515,
+   "B=cosT-sinT-1": -1.0,
+   "C=1+sinT-cosT": 0.9999999999999999,
+   "D=1-sinT-cosT": -0.41421356237309515,
+   "T": 0.7853981633974483,
+   "m": 8,
+   "signs_ok_for_0_lt_T_le_pi_over_4": true
+  },
+  {
+   "A=sinT+cosT-1": 0.3660254037844386,
+   "B=cosT-sinT-1": -0.6339745962155612,
+   "C=1+sinT-cosT": 0.6339745962155613,
+   "D=1-sinT-cosT": -0.3660254037844387,
+   "T": 0.5235987755982988,
+   "m": 12,
+   "signs_ok_for_0_lt_T_le_pi_over_4": true
+  },
+  {
+   "A=sinT+cosT-1": 0.3065629648763766,
+   "B=cosT-sinT-1": -0.4588038998538031,
+   "C=1+sinT-cosT": 0.4588038998538031,
+   "D=1-sinT-cosT": -0.3065629648763766,
+   "T": 0.39269908169872414,
+   "m": 16,
+   "signs_ok_for_0_lt_T_le_pi_over_4": true
+  },
+  {
+   "A=sinT+cosT-1": 0.26007351067010087,
+   "B=cosT-sinT-1": -0.3579604780797938,
+   "C=1+sinT-cosT": 0.3579604780797939,
+   "D=1-sinT-cosT": -0.260073510670101,
+   "T": 0.3141592653589793,
+   "m": 20,
+   "signs_ok_for_0_lt_T_le_pi_over_4": true
+  },
+  {
+   "A=sinT+cosT-1": 0.14412280563536872,
+   "B=cosT-sinT-1": -0.16874612444509307,
+   "C=1+sinT-cosT": 0.16874612444509318,
+   "D=1-sinT-cosT": -0.1441228056353686,
+   "T": 0.15707963267948966,
+   "m": 40,
+   "signs_ok_for_0_lt_T_le_pi_over_4": true
+  },
+  {
+   "A=sinT+cosT-1": 0.06081724795758503,
+   "B=cosT-sinT-1": -0.0647637911010418,
+   "C=1+sinT-cosT": 0.06476379110104191,
+   "D=1-sinT-cosT": -0.06081724795758492,
+   "T": 0.06283185307179587,
+   "m": 100,
+   "signs_ok_for_0_lt_T_le_pi_over_4": true
+  }
+ ],
+ "leading_sign_ok_for_sample_ms": true,
+ "next_exact_target": "Prove the listed killer turn is negative on each full signed band cell, or produce a different exact CAD/resultant/interval certificate. The leading-term table only proves the boundary tangent direction.",
+ "open_quarter_cells_still_open": [
+  8,
+  12,
+  16
+ ],
+ "provenance": {
+  "command": "python scripts/check_quarter_cell_signed_band_preflight.py --write --assert-expected",
+  "generator": "scripts/check_quarter_cell_signed_band_preflight.py"
+ },
+ "sample_grid": 72,
+ "sample_ms": [
+  8,
+  12,
+  16,
+  20,
+  40,
+  100
+ ],
+ "sample_records": [
+  {
+   "case_records": [
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.002173686163665736,
+      "turns": [
+       -0.0004531830830104705,
+       2.575998072132216e-09,
+       0.001087880210322124
+      ]
+     },
+     "case_id": "LL_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -0.0004531830830104705,
+     "max_min_turn": -0.0004531830830104705,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.07825270189196651,
+      "turns": [
+       -0.00033001890419954825,
+       0.00016339312814932648,
+       -0.034868119010758494
+      ]
+     },
+     "case_id": "LL_y+_z-",
+     "killer_turn": 1,
+     "max_killer_turn": -0.00033001890419954825,
+     "max_min_turn": -0.00198421458104426,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.002173686163665736,
+      "turns": [
+       0.0010831519781985465,
+       -4.727474492172225e-06,
+       0.0026208691229465727
+      ]
+     },
+     "case_id": "LL_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -4.727474492172225e-06,
+     "max_min_turn": -4.727474492172225e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.002173686163665736,
+      "turns": [
+       0.00108316286772064,
+       2.559254510137224e-09,
+       -0.00045121539795710784
+      ]
+     },
+     "case_id": "LL_y-_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -0.00045121539795710784,
+     "max_min_turn": -0.00045121539795710784,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.001086843081832868,
+      "turns": [
+       -2.3650224530126096e-06,
+       0.001085514433031015,
+       0.001085514433030925
+      ]
+     },
+     "case_id": "LH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -2.3650224530126096e-06,
+     "max_min_turn": -2.3650224530126096e-06,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.001086843081832868,
+      "turns": [
+       2.567617192225803e-09,
+       0.0010855198837160962,
+       -0.0004521990793986747
+      ]
+     },
+     "case_id": "LH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -0.0004521990793986747,
+     "max_min_turn": -0.0004521990793986747,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.001086843081832868,
+      "turns": [
+       2.567617192126065e-09,
+       -0.0004521990793985967,
+       0.0010855198837160065
+      ]
+     },
+     "case_id": "LH_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -0.0004521990793985967,
+     "max_min_turn": -0.0004521990793985967,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.001086843081832868,
+      "e": 0.07825270189196651,
+      "turns": [
+       0.00016320896943266346,
+       -0.00033072029367091,
+       -0.03382451346946408
+      ]
+     },
+     "case_id": "LH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -0.00033072029367091,
+     "max_min_turn": -0.0004488598832468104,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.002173686163665736,
+      "e": 0.001086843081832868,
+      "turns": [
+       -0.00045318308301048376,
+       0.0010878802103221836,
+       2.5759980721987198e-09
+      ]
+     },
+     "case_id": "HH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -0.00045318308301048376,
+     "max_min_turn": -0.00045318308301048376,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.002173686163665736,
+      "e": 0.001086843081832868,
+      "turns": [
+       0.0010831519781985333,
+       0.00262086912294662,
+       -4.727474492172382e-06
+      ]
+     },
+     "case_id": "HH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -4.727474492172382e-06,
+     "max_min_turn": -4.727474492172382e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.07825270189196651,
+      "e": 0.001086843081832868,
+      "turns": [
+       -0.0003300189041995619,
+       -0.03486811901075845,
+       0.00016339312814931469
+      ]
+     },
+     "case_id": "HH_y-_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -0.0003300189041995619,
+     "max_min_turn": -0.0019842145810441904,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.002173686163665736,
+      "e": 0.001086843081832868,
+      "turns": [
+       0.0010831628677206266,
+       -0.0004512153979570507,
+       2.5592545098507277e-09
+      ]
+     },
+     "case_id": "HH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -0.0004512153979570507,
+     "max_min_turn": -0.0004512153979570507,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    }
+   ],
+   "delta": 0.07933954497379937,
+   "grid": 72,
+   "m": 8,
+   "max_killer_turn_over_cases": -2.3650224530126096e-06,
+   "sampled_fixed_killer_all_negative": true
+  },
+  {
+   "case_records": [
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.0009501953299426902,
+      "turns": [
+       -0.0001743191049696408,
+       2.1478180332909644e-10,
+       0.00030129056952093677
+      ]
+     },
+     "case_id": "LL_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -0.0001743191049696408,
+     "max_min_turn": -0.0001743191049696408,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.03420703187793684,
+      "turns": [
+       -0.0001459338026673319,
+       3.1949352093128946e-05,
+       -0.012931846542116644
+      ]
+     },
+     "case_id": "LL_y+_z-",
+     "killer_turn": 1,
+     "max_killer_turn": -0.0001459338026673319,
+     "max_min_turn": -0.0006482436702749969,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.0009501953299426902,
+      "turns": [
+       0.0003003873765707781,
+       -9.030854709897482e-07,
+       0.000775545343642891
+      ]
+     },
+     "case_id": "LL_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -9.030854709897482e-07,
+     "max_min_turn": -9.030854709897482e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.0009501953299426902,
+      "turns": [
+       0.0003007186505126708,
+       2.1417042118582183e-10,
+       -0.00017398803824927173
+      ]
+     },
+     "case_id": "LL_y-_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -0.00017398803824927173,
+     "max_min_turn": -0.00017398803824927173,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.0004750976649713451,
+      "turns": [
+       -4.51650024475372e-07,
+       0.00030083881208196227,
+       0.00030083881208186247
+      ]
+     },
+     "case_id": "LH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.51650024475372e-07,
+     "max_min_turn": -4.51650024475372e-07,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.0004750976649713451,
+      "turns": [
+       2.1447596689274846e-10,
+       0.00030100452778403984,
+       -0.00017415354659077738
+      ]
+     },
+     "case_id": "LH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -0.00017415354659077738,
+     "max_min_turn": -0.00017415354659077738,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.0004750976649713451,
+      "turns": [
+       2.1447596688380167e-10,
+       -0.00017415354659070745,
+       0.00030100452778394015
+      ]
+     },
+     "case_id": "LH_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -0.00017415354659070745,
+     "max_min_turn": -0.00017415354659070745,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004750976649713451,
+      "e": 0.03420703187793684,
+      "turns": [
+       3.193392155919905e-05,
+       -0.00014600018669293295,
+       -0.012634638006527974
+      ]
+     },
+     "case_id": "LH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -0.00014600018669293295,
+     "max_min_turn": -0.00017353713851039654,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0009501953299426902,
+      "e": 0.0004750976649713451,
+      "turns": [
+       -0.00017431910496964204,
+       0.00030129056952105516,
+       2.1478180312035576e-10
+      ]
+     },
+     "case_id": "HH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -0.00017431910496964204,
+     "max_min_turn": -0.00017431910496964204,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0009501953299426902,
+      "e": 0.0004750976649713451,
+      "turns": [
+       0.0003003873765707768,
+       0.0007755453436429796,
+       -9.030854709898765e-07
+      ]
+     },
+     "case_id": "HH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -9.030854709898765e-07,
+     "max_min_turn": -9.030854709898765e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.03420703187793684,
+      "e": 0.0004750976649713451,
+      "turns": [
+       -0.00014593380266733332,
+       -0.012931846542116567,
+       3.194935209312223e-05
+      ]
+     },
+     "case_id": "HH_y-_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -0.00014593380266733332,
+     "max_min_turn": -0.0006482436702748571,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0009501953299426902,
+      "e": 0.0004750976649713451,
+      "turns": [
+       0.0003007186505126695,
+       -0.00017398803824916165,
+       2.1417042101356974e-10
+      ]
+     },
+     "case_id": "HH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -0.00017398803824916165,
+     "max_min_turn": -0.00017398803824916165,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    }
+   ],
+   "delta": 0.03468212954290819,
+   "grid": 72,
+   "m": 12,
+   "max_killer_turn_over_cases": -4.51650024475372e-07,
+   "sampled_fixed_killer_all_negative": true
+  },
+  {
+   "case_records": [
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.0005316207276521191,
+      "turns": [
+       -8.159039227192121e-05,
+       3.7591701504814204e-11,
+       0.00012197097382529575
+      ]
+     },
+     "case_id": "LL_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -8.159039227192121e-05,
+     "max_min_turn": -8.159039227192121e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.019138346195476292,
+      "turns": [
+       -7.213557069465584e-05,
+       1.0077741726901008e-05,
+       -0.00600492794803181
+      ]
+     },
+     "case_id": "LL_y+_z-",
+     "killer_turn": 1,
+     "max_killer_turn": -7.213557069465584e-05,
+     "max_min_turn": -0.0002846743200527165,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.0005316207276521191,
+      "turns": [
+       0.00012168829246927595,
+       -2.826581431589322e-07,
+       0.0003251414698876946
+      ]
+     },
+     "case_id": "LL_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -2.826581431589322e-07,
+     "max_min_turn": -2.826581431589322e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.0005316207276521191,
+      "turns": [
+       0.00012184137250397897,
+       3.753179571767576e-11,
+       -8.150367374336025e-05
+      ]
+     },
+     "case_id": "LL_y-_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -8.150367374336025e-05,
+     "max_min_turn": -8.150367374336025e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.00026581036382605956,
+      "turns": [
+       -1.4134785744456142e-07,
+       0.00012182960275952778,
+       0.0001218296027595187
+      ]
+     },
+     "case_id": "LH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -1.4134785744456142e-07,
+     "max_min_turn": -1.4134785744456142e-07,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.00026581036382605956,
+      "turns": [
+       3.7561740702809374e-11,
+       0.00012190616312741759,
+       -8.154702866983136e-05
+      ]
+     },
+     "case_id": "LH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -8.154702866983136e-05,
+     "max_min_turn": -8.154702866983136e-05,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.00026581036382605956,
+      "turns": [
+       3.756174070189617e-11,
+       -8.15470286698417e-05,
+       0.00012190616312740856
+      ]
+     },
+     "case_id": "LH_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -8.15470286698417e-05,
+     "max_min_turn": -8.15470286698417e-05,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00026581036382605956,
+      "e": 0.019138346195476292,
+      "turns": [
+       1.0075037932494447e-05,
+       -7.21478100146593e-05,
+       -0.005883700307976095
+      ]
+     },
+     "case_id": "LH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -7.21478100146593e-05,
+     "max_min_turn": -8.136245290934494e-05,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0005316207276521191,
+      "e": 0.00026581036382605956,
+      "turns": [
+       -8.159039227192134e-05,
+       0.00012197097382530189,
+       3.7591701494345406e-11
+      ]
+     },
+     "case_id": "HH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -8.159039227192134e-05,
+     "max_min_turn": -8.159039227192134e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0005316207276521191,
+      "e": 0.00026581036382605956,
+      "turns": [
+       0.00012168829246927583,
+       0.0003251414698876813,
+       -2.826581431589424e-07
+      ]
+     },
+     "case_id": "HH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -2.826581431589424e-07,
+     "max_min_turn": -2.826581431589424e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.019138346195476292,
+      "e": 0.00026581036382605956,
+      "turns": [
+       -7.213557069465599e-05,
+       -0.006004927948031785,
+       1.0077741726901038e-05
+      ]
+     },
+     "case_id": "HH_y-_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -7.213557069465599e-05,
+     "max_min_turn": -0.0002846743200527125,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0005316207276521191,
+      "e": 0.00026581036382605956,
+      "turns": [
+       0.00012184137250397884,
+       -8.150367374337562e-05,
+       3.7531795742378684e-11
+      ]
+     },
+     "case_id": "HH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -8.150367374337562e-05,
+     "max_min_turn": -8.150367374337562e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    }
+   ],
+   "delta": 0.01940415655930235,
+   "grid": 72,
+   "m": 16,
+   "max_killer_turn_over_cases": -1.4134785744456142e-07,
+   "sampled_fixed_killer_all_negative": true
+  },
+  {
+   "case_records": [
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.0003394166985600983,
+      "turns": [
+       -4.417083514334694e-05,
+       9.780492096318297e-12,
+       6.0753113983127765e-05
+      ]
+     },
+     "case_id": "LL_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.417083514334694e-05,
+     "max_min_turn": -4.417083514334694e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.012219001148163539,
+      "turns": [
+       -4.020711889927457e-05,
+       4.122246699612369e-06,
+       -0.003241371523882753
+      ]
+     },
+     "case_id": "LL_y+_z-",
+     "killer_turn": 1,
+     "max_killer_turn": -4.020711889927457e-05,
+     "max_min_turn": -0.00014891401876882012,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.0003394166985600983,
+      "turns": [
+       6.0637893755924415e-05,
+       -1.1521346800963122e-07,
+       0.00016552623598545808
+      ]
+     },
+     "case_id": "LL_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -1.1521346800963122e-07,
+     "max_min_turn": -1.1521346800963122e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.0003394166985600983,
+      "turns": [
+       6.071188975269054e-05,
+       9.770538272706658e-12,
+       -4.414085766443302e-05
+      ]
+     },
+     "case_id": "LL_y-_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -4.414085766443302e-05,
+     "max_min_turn": -4.414085766443302e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.00016970834928004916,
+      "turns": [
+       -5.761162259174397e-08,
+       6.069549560195235e-05,
+       6.0695495601983695e-05
+      ]
+     },
+     "case_id": "LH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -5.761162259174397e-08,
+     "max_min_turn": -5.761162259174397e-08,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.00016970834928004916,
+      "turns": [
+       9.775514328780899e-12,
+       6.0732499880270255e-05,
+       -4.415584537056993e-05
+      ]
+     },
+     "case_id": "LH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -4.415584537056993e-05,
+     "max_min_turn": -4.415584537056993e-05,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.00016970834928004916,
+      "turns": [
+       9.775514325664083e-12,
+       -4.415584537056182e-05,
+       6.0732499880301575e-05
+      ]
+     },
+     "case_id": "LH_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -4.415584537056182e-05,
+     "max_min_turn": -4.415584537056182e-05,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.00016970834928004916,
+      "e": 0.012219001148163539,
+      "turns": [
+       4.12154293199924e-06,
+       -4.021039260639335e-05,
+       -0.003180815817937876
+      ]
+     },
+     "case_id": "LH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -4.021039260639335e-05,
+     "max_min_turn": -4.4083278383259795e-05,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0003394166985600983,
+      "e": 0.00016970834928004916,
+      "turns": [
+       -4.417083514334739e-05,
+       6.075311398311523e-05,
+       9.780492099908261e-12
+      ]
+     },
+     "case_id": "HH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.417083514334739e-05,
+     "max_min_turn": -4.417083514334739e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0003394166985600983,
+      "e": 0.00016970834928004916,
+      "turns": [
+       6.063789375592397e-05,
+       0.00016552623598548502,
+       -1.152134680096474e-07
+      ]
+     },
+     "case_id": "HH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -1.152134680096474e-07,
+     "max_min_turn": -1.152134680096474e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.012219001148163539,
+      "e": 0.00016970834928004916,
+      "turns": [
+       -4.020711889927509e-05,
+       -0.003241371523882732,
+       4.122246699613809e-06
+      ]
+     },
+     "case_id": "HH_y-_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.020711889927509e-05,
+     "max_min_turn": -0.000148914018768851,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0003394166985600983,
+      "e": 0.00016970834928004916,
+      "turns": [
+       6.0711889752690086e-05,
+       -4.414085766442443e-05,
+       9.770538276071629e-12
+      ]
+     },
+     "case_id": "HH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -4.414085766442443e-05,
+     "max_min_turn": -4.414085766442443e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    }
+   ],
+   "delta": 0.01238870949744359,
+   "grid": 72,
+   "m": 20,
+   "max_killer_turn_over_cases": -5.761162259174397e-08,
+   "sampled_fixed_killer_all_negative": true
+  },
+  {
+   "case_records": [
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 8.458732273681252e-05,
+      "turns": [
+       -6.096578318804738e-06,
+       1.5132510273795482e-13,
+       7.1369576103320596e-06
+      ]
+     },
+     "case_id": "LL_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -6.096578318804738e-06,
+     "max_min_turn": -6.096578318804738e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 0.0030451436185252507,
+      "turns": [
+       -5.841371856024258e-06,
+       2.571934130061181e-07,
+       -0.00044586547233076195
+      ]
+     },
+     "case_id": "LL_y+_z-",
+     "killer_turn": 1,
+     "max_killer_turn": -5.841371856024258e-06,
+     "max_min_turn": -1.932080889413307e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 8.458732273681252e-05,
+      "turns": [
+       7.129802316233332e-06,
+       -7.155166462999442e-09,
+       2.0362218903337947e-05
+      ]
+     },
+     "case_id": "LL_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -7.155166462999442e-09,
+     "max_min_turn": -7.155166462999442e-09,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 8.458732273681252e-05,
+      "turns": [
+       7.1357503438583395e-06,
+       1.5128669939901811e-13,
+       -6.095546995903603e-06
+      ]
+     },
+     "case_id": "LL_y-_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -6.095546995903603e-06,
+     "max_min_turn": -6.095546995903603e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       -3.5776588876563802e-09,
+       7.133379823827624e-06,
+       7.133379823830129e-06
+      ]
+     },
+     "case_id": "LH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -3.5776588876563802e-09,
+     "max_min_turn": -3.5776588876563802e-09,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       1.5130588945549105e-13,
+       7.136353963427384e-06,
+       -6.09606264738276e-06
+      ]
+     },
+     "case_id": "LH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -6.09606264738276e-06,
+     "max_min_turn": -6.09606264738276e-06,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       1.5130588920444174e-13,
+       -6.096062647366611e-06,
+       7.136353963429887e-06
+      ]
+     },
+     "case_id": "LH_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -6.096062647366611e-06,
+     "max_min_turn": -6.096062647366611e-06,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 4.229366136840626e-05,
+      "e": 0.0030451436185252507,
+      "turns": [
+       2.571825190485908e-07,
+       -5.841424961880018e-06,
+       -0.0004387316740948597
+      ]
+     },
+     "case_id": "LH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -5.841424961880018e-06,
+     "max_min_turn": -6.091969814589817e-06,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 8.458732273681252e-05,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       -6.096578318804774e-06,
+       7.136957610332173e-06,
+       1.5132510205139491e-13
+      ]
+     },
+     "case_id": "HH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -6.096578318804774e-06,
+     "max_min_turn": -6.096578318804774e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 8.458732273681252e-05,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       7.129802316233296e-06,
+       2.0362218903356714e-05,
+       -7.155166463009458e-09
+      ]
+     },
+     "case_id": "HH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -7.155166463009458e-09,
+     "max_min_turn": -7.155166463009458e-09,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0030451436185252507,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       -5.841371856024302e-06,
+       -0.00044586547233077,
+       2.571934130061903e-07
+      ]
+     },
+     "case_id": "HH_y-_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -5.841371856024302e-06,
+     "max_min_turn": -1.9320808894154733e-05,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 8.458732273681252e-05,
+      "e": 4.229366136840626e-05,
+      "turns": [
+       7.135750343858303e-06,
+       -6.095546995906619e-06,
+       1.5128669686887941e-13
+      ]
+     },
+     "case_id": "HH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -6.095546995906619e-06,
+     "max_min_turn": -6.095546995906619e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    }
+   ],
+   "delta": 0.003087437279893657,
+   "grid": 72,
+   "m": 40,
+   "max_killer_turn_over_cases": -3.5776588876563802e-09,
+   "sampled_fixed_killer_all_negative": true
+  },
+  {
+   "case_records": [
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 1.3522231664248669e-05,
+      "turns": [
+       -4.1120384860532935e-07,
+       6.181492332130574e-16,
+       4.3787576450591895e-07
+      ]
+     },
+     "case_id": "LL_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.1120384860532935e-07,
+     "max_min_turn": -4.1120384860532935e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 0.0004868003399129521,
+      "turns": [
+       -4.0462420809534954e-07,
+       6.581046751216842e-09,
+       -3.003761422716484e-05
+      ]
+     },
+     "case_id": "LL_y+_z-",
+     "killer_turn": 1,
+     "max_killer_turn": -4.0462420809534954e-07,
+     "max_min_turn": -1.2600780101930419e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 1.3522231664248669e-05,
+      "turns": [
+       4.3769291255832534e-07,
+       -1.8285136731312797e-10,
+       1.2867610442959707e-06
+      ]
+     },
+     "case_id": "LL_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -1.8285136731312797e-10,
+     "max_min_turn": -1.8285136731312797e-10,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 1.3522231664248669e-05,
+      "turns": [
+       4.3786392258885404e-07,
+       6.181243606739821e-16,
+       -4.1119272793044003e-07
+      ]
+     },
+     "case_id": "LL_y-_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -4.1119272793044003e-07,
+     "max_min_turn": -4.1119272793044003e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       -9.142599272628606e-11,
+       4.3778433792594085e-07,
+       4.3778433793167367e-07
+      ]
+     },
+     "case_id": "LH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -9.142599272628606e-11,
+     "max_min_turn": -9.142599272628606e-11,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       6.181382628012693e-16,
+       4.378698435193183e-07,
+       -4.111982882488922e-07
+      ]
+     },
+     "case_id": "LH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -4.111982882488922e-07,
+     "max_min_turn": -4.111982882488922e-07,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       6.181383336156845e-16,
+       -4.1119828825619603e-07,
+       4.37869843525051e-07
+      ]
+     },
+     "case_id": "LH_y-_z+",
+     "killer_turn": 2,
+     "max_killer_turn": -4.1119828825619603e-07,
+     "max_min_turn": -4.1119828825619603e-07,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 6.7611158321243345e-06,
+      "e": 0.0004868003399129521,
+      "turns": [
+       6.581002245374479e-09,
+       -4.046244301342415e-07,
+       -2.9599751572276808e-05
+      ]
+     },
+     "case_id": "LH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -4.046244301342415e-07,
+     "max_min_turn": -4.1110130383695366e-07,
+     "sample_count": 5184,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 1.3522231664248669e-05,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       -4.112038486053191e-07,
+       4.3787576450104724e-07,
+       6.181503687963291e-16
+      ]
+     },
+     "case_id": "HH_y+_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.112038486053191e-07,
+     "max_min_turn": -4.112038486053191e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 1.3522231664248669e-05,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       4.376929125583356e-07,
+       1.2867610442895286e-06,
+       -1.828513673114214e-10
+      ]
+     },
+     "case_id": "HH_y+_z-",
+     "killer_turn": 3,
+     "max_killer_turn": -1.828513673114214e-10,
+     "max_min_turn": -1.828513673114214e-10,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 0.0004868003399129521,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       -4.0462420809533684e-07,
+       -3.0037614227172556e-05,
+       6.58104675125893e-09
+      ]
+     },
+     "case_id": "HH_y-_z+",
+     "killer_turn": 1,
+     "max_killer_turn": -4.0462420809533684e-07,
+     "max_min_turn": -1.2600780101994054e-06,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    },
+    {
+     "argmax": {
+      "d": 1.3522231664248669e-05,
+      "e": 6.7611158321243345e-06,
+      "turns": [
+       4.3786392258886447e-07,
+       -4.11192727938374e-07,
+       6.1812588329377e-16
+      ]
+     },
+     "case_id": "HH_y-_z-",
+     "killer_turn": 2,
+     "max_killer_turn": -4.11192727938374e-07,
+     "max_min_turn": -4.11192727938374e-07,
+     "sample_count": 2556,
+     "sampled_killer_negative": true
+    }
+   ],
+   "delta": 0.0004935614557450764,
+   "grid": 72,
+   "m": 100,
+   "max_killer_turn_over_cases": -9.142599272628606e-11,
+   "sampled_fixed_killer_all_negative": true
+  }
+ ],
+ "sampled_fixed_killer_all_negative": true,
+ "schema": "erdos97.quarter_cell_signed_band_preflight.v1",
+ "side_cases": [
+  {
+   "band_case": "LL",
+   "beta": "d",
+   "cone": "0 < d < e",
+   "gamma": "e"
+  },
+  {
+   "band_case": "LH",
+   "beta": "d",
+   "cone": "d,e>0 and d+e<T",
+   "gamma": "T-e"
+  },
+  {
+   "band_case": "HH",
+   "beta": "T-d",
+   "cone": "0 < e < d",
+   "gamma": "T-e"
+  }
+ ],
+ "signed_case_count": 12,
+ "signed_cases": [
+  {
+   "band_case": "LL",
+   "beta_form": "d",
+   "case_id": "LL_y+_z+",
+   "cone": "0 < d < e",
+   "gamma_form": "e",
+   "killer_turn": 1,
+   "leading_term": "-d*A",
+   "sign_reason": "A>0",
+   "y_sign": 1,
+   "z_sign": 1
+  },
+  {
+   "band_case": "LL",
+   "beta_form": "d",
+   "case_id": "LL_y+_z-",
+   "cone": "0 < d < e",
+   "gamma_form": "e",
+   "killer_turn": 1,
+   "leading_term": "-d*A",
+   "sign_reason": "A>0",
+   "y_sign": 1,
+   "z_sign": -1
+  },
+  {
+   "band_case": "LL",
+   "beta_form": "d",
+   "case_id": "LL_y-_z+",
+   "cone": "0 < d < e",
+   "gamma_form": "e",
+   "killer_turn": 2,
+   "leading_term": "-2*d*e",
+   "sign_reason": "d,e>0",
+   "y_sign": -1,
+   "z_sign": 1
+  },
+  {
+   "band_case": "LL",
+   "beta_form": "d",
+   "case_id": "LL_y-_z-",
+   "cone": "0 < d < e",
+   "gamma_form": "e",
+   "killer_turn": 3,
+   "leading_term": "(d-e)*A",
+   "sign_reason": "d-e<0 and A>0",
+   "y_sign": -1,
+   "z_sign": -1
+  },
+  {
+   "band_case": "LH",
+   "beta_form": "d",
+   "case_id": "LH_y+_z+",
+   "cone": "d,e>0 and d+e<T",
+   "gamma_form": "T-e",
+   "killer_turn": 1,
+   "leading_term": "-2*d*e",
+   "sign_reason": "d,e>0",
+   "y_sign": 1,
+   "z_sign": 1
+  },
+  {
+   "band_case": "LH",
+   "beta_form": "d",
+   "case_id": "LH_y+_z-",
+   "cone": "d,e>0 and d+e<T",
+   "gamma_form": "T-e",
+   "killer_turn": 3,
+   "leading_term": "e*D",
+   "sign_reason": "e>0 and D<0",
+   "y_sign": 1,
+   "z_sign": -1
+  },
+  {
+   "band_case": "LH",
+   "beta_form": "d",
+   "case_id": "LH_y-_z+",
+   "cone": "d,e>0 and d+e<T",
+   "gamma_form": "T-e",
+   "killer_turn": 2,
+   "leading_term": "-d*A",
+   "sign_reason": "d>0 and A>0",
+   "y_sign": -1,
+   "z_sign": 1
+  },
+  {
+   "band_case": "LH",
+   "beta_form": "d",
+   "case_id": "LH_y-_z-",
+   "cone": "d,e>0 and d+e<T",
+   "gamma_form": "T-e",
+   "killer_turn": 2,
+   "leading_term": "-d*A",
+   "sign_reason": "d>0 and A>0",
+   "y_sign": -1,
+   "z_sign": -1
+  },
+  {
+   "band_case": "HH",
+   "beta_form": "T-d",
+   "case_id": "HH_y+_z+",
+   "cone": "0 < e < d",
+   "gamma_form": "T-e",
+   "killer_turn": 1,
+   "leading_term": "-e*A",
+   "sign_reason": "e>0 and A>0",
+   "y_sign": 1,
+   "z_sign": 1
+  },
+  {
+   "band_case": "HH",
+   "beta_form": "T-d",
+   "case_id": "HH_y+_z-",
+   "cone": "0 < e < d",
+   "gamma_form": "T-e",
+   "killer_turn": 3,
+   "leading_term": "-2*d*e",
+   "sign_reason": "d,e>0",
+   "y_sign": 1,
+   "z_sign": -1
+  },
+  {
+   "band_case": "HH",
+   "beta_form": "T-d",
+   "case_id": "HH_y-_z+",
+   "cone": "0 < e < d",
+   "gamma_form": "T-e",
+   "killer_turn": 1,
+   "leading_term": "-e*A",
+   "sign_reason": "e>0 and A>0",
+   "y_sign": -1,
+   "z_sign": 1
+  },
+  {
+   "band_case": "HH",
+   "beta_form": "T-d",
+   "case_id": "HH_y-_z-",
+   "cone": "0 < e < d",
+   "gamma_form": "T-e",
+   "killer_turn": 2,
+   "leading_term": "(d-e)*D",
+   "sign_reason": "d-e>0 and D<0",
+   "y_sign": -1,
+   "z_sign": -1
+  }
+ ],
+ "status": "QUARTER_CELL_SIGNED_BAND_TURN_PREFLIGHT_ONLY",
+ "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -1194,6 +1194,55 @@ Forbidden overclaiming text:
 - "near miss"
 - "intervals prove exact equality" unless the interval certificate really does
 
+## Task CB-ORBIT-QC - Prove the Quarter-Cell Signed-Band Turn Target
+
+Issue: none yet.
+
+Read first:
+
+- `docs/codex-strategy-instructions.md`
+- `docs/three-orbit-window-closure.md`
+- `docs/quarter-cell-closure.md`
+- `docs/quarter-cell-signed-band-preflight.md`
+- `scripts/check_quarter_cell_closure.py`
+- `scripts/check_quarter_cell_signed_band_preflight.py`
+
+Commands:
+
+```bash
+python scripts/check_quarter_cell_signed_band_preflight.py --check --assert-expected --json
+python scripts/check_quarter_cell_closure.py --assert-clear
+python scripts/check_three_square_m4_closure.py --assert-clear
+```
+
+Expected artifacts:
+
+- an exact analytic, CAD/resultant, or interval certificate proving that the
+  listed fixed killer turn is negative throughout each signed boundary-band
+  cell; or
+- a counter-diagnostic showing exactly which signed cell escapes the proposed
+  fixed killer turn.
+
+Acceptance criteria:
+
+- The result keeps `m = 8, 12, 16` open unless the certificate really covers
+  them.
+- Any closure claim identifies whether it is finite-`m`, all `m = 0 mod 4`,
+  or only a checked sub-band.
+- The result remains scoped to the restricted three-orbit quarter-cell family.
+
+Trust delta: may turn the current tangent preflight into an exact restricted
+family obstruction. It may not prove Erdos Problem #97 or any arbitrary
+selected-witness bridge by itself.
+
+Forbidden overclaiming text:
+
+- "all three-orbit configurations are ruled out" unless the half-step and
+  non-quarter branches are also covered at the same trust level
+- "the quarter cells are closed" without specifying the exact covered `m`
+  range and certificate type
+- "this proves Erdos #97"
+
 ## Cross-Cutting Rules
 
 - Run `make verify-fast` or the raw fast tier after code or documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -831,6 +831,10 @@ put detailed reconciliation in the canonical synthesis.
   float grid showing the witness locus is tangent to the convexity boundary;
   exact lemmas + `NUMERICAL_EVIDENCE` for `m = 8, 12, 16` (which remain open),
   with the exact-SMT route recorded as not scaling past `m = 4`.
+- [`quarter-cell-signed-band-preflight.md`](quarter-cell-signed-band-preflight.md):
+  signed boundary-band split for the remaining quarter-cell turn-sign target,
+  recording 12 signed cells and a fixed negative first nonzero boundary term
+  for each; precise proof target only, not closure of `m = 8, 12, 16`.
 - [`n9-base-apex-frontier.md`](n9-base-apex-frontier.md): corrected exploratory
   slack ledger for the first `n=9` base-apex workstream; not a proof.
 - [`n9-base-apex-d3-p19-degree-obstruction.md`](n9-base-apex-d3-p19-degree-obstruction.md):

--- a/docs/quarter-cell-closure.md
+++ b/docs/quarter-cell-closure.md
@@ -120,6 +120,13 @@ factored form vanishing exactly on the degenerate locus would do it). The SMT
 route is recorded as a dead end for this; an analytic turn-sign argument or an
 exact CAD/resultant computation on the confined region is the recommended path.
 
+Follow-up preflight: `docs/quarter-cell-signed-band-preflight.md` splits the
+boundary-band locus into three band orders and `12` radius-sign cells. In each
+cell it records a fixed turn determinant whose first nonzero boundary term is
+negative for `m >= 8`, with deterministic grid stress of the same fixed turns.
+That narrows the exact target but does not prove the full sign-definiteness
+statement, so the `m = 8, 12, 16` cells remain open.
+
 ## Reproduce
 
 ```bash

--- a/docs/quarter-cell-signed-band-preflight.md
+++ b/docs/quarter-cell-signed-band-preflight.md
@@ -1,0 +1,100 @@
+# Quarter-cell signed-band preflight
+
+Trust label: `REVIEW_PENDING_DIAGNOSTIC`.
+
+This note is a follow-up to `docs/quarter-cell-closure.md`. It does not close
+the `m = 8, 12, 16` quarter cells. It records a sharper target for the missing
+exact turn-sign proof.
+
+## Split
+
+In the remaining `m = 0 mod 4` three-orbit quarter cells, the A-row reduction
+forces the B- and C-orbit offsets into the boundary bands. Write
+
+```text
+T = 2*pi/m,
+beta in {d, T-d},
+gamma in {e, T-e},
+P(r) = (r^2 - 1)/(2r).
+```
+
+The radius signs are
+
+```text
+P(y) = +/- sin(d),   P(z) = +/- sin(e).
+```
+
+The angular order `0 < beta < gamma < T` leaves exactly three band-order cases:
+
+```text
+LL: beta=d,   gamma=e,   0 < d < e
+LH: beta=d,   gamma=T-e, d,e>0 and d+e<T
+HH: beta=T-d, gamma=T-e, 0 < e < d
+```
+
+Together with the two radius signs this gives `12` signed cells.
+
+## Boundary killer table
+
+Let
+
+```text
+A = sin(T) + cos(T) - 1,
+D = 1 - sin(T) - cos(T).
+```
+
+For `m >= 8`, so `0 < T <= pi/4`, one has `A > 0` and `D < 0`. Expanding the
+three per-period turn determinants at the orbit-coincidence boundary gives a
+fixed negative leading term in every signed cell:
+
+| cell | killer turn | leading term |
+| --- | ---: | --- |
+| `LL_y+_z+` | 1 | `-d*A` |
+| `LL_y+_z-` | 1 | `-d*A` |
+| `LL_y-_z+` | 2 | `-2*d*e` |
+| `LL_y-_z-` | 3 | `(d-e)*A` |
+| `LH_y+_z+` | 1 | `-2*d*e` |
+| `LH_y+_z-` | 3 | `e*D` |
+| `LH_y-_z+` | 2 | `-d*A` |
+| `LH_y-_z-` | 2 | `-d*A` |
+| `HH_y+_z+` | 1 | `-e*A` |
+| `HH_y+_z-` | 3 | `-2*d*e` |
+| `HH_y-_z+` | 1 | `-e*A` |
+| `HH_y-_z-` | 2 | `(d-e)*D` |
+
+Thus every signed cell approaches the degenerate orbit-coincidence boundary
+from the non-convex side at first nonzero order.
+
+## What remains open
+
+The table is only a boundary/tangency statement. The exact missing lemma is:
+
+```text
+In each signed boundary-band cell, the listed killer turn is negative
+throughout the full strict window.
+```
+
+A deterministic floating grid in
+`data/certificates/quarter_cell_signed_band_preflight.json` checks that same
+fixed killer turn over sampled interiors for `m = 8, 12, 16, 20, 40, 100`; no
+sampled violation is found. This is useful evidence and a precise exact target,
+not a certificate.
+
+## Reproduce
+
+```bash
+python scripts/check_quarter_cell_signed_band_preflight.py --check --assert-expected --json
+```
+
+Regenerate the artifact with:
+
+```bash
+python scripts/check_quarter_cell_signed_band_preflight.py --write --assert-expected
+```
+
+## Non-claims
+
+- Does not close the `m = 8, 12, 16` quarter cells.
+- Does not provide an exact certificate for `m >= 8`.
+- Does not prove an all-`m` quarter-cell obstruction.
+- Does not prove Erdos Problem #97 and does not give a counterexample.

--- a/metadata/erdos97.yaml
+++ b/metadata/erdos97.yaml
@@ -570,6 +570,11 @@ local_repo:
       artifact: "focused packet/catalog, focused mini-replay, aggregate/simple replay, exhaustive/local-lemma, relation-skeleton/local-lemma audit layers, and relation-skeleton/closed-descent companion crosswalk"
       verifier: "scripts/check_n9_vertex_circle_local_lemma_audit_path.py"
       claim_scope: "cross-artifact audit-path bookkeeping only; checks that 5 review-pending local-lemma layers and 4 adjacent handoffs agree on 12 template ids, 16 families, 184 assignments, the 158 self-edge / 26 strict-cycle split, 16 relation skeletons, plus a relation-skeleton/closed-descent companion summary and 33 input artifacts, layer contracts, provenance, manifest contracts, and claim-scope guards, but does not prove packet soundness, mini-replay soundness, local-lemma completeness, frontier coverage, n=9, official/global status movement, or a counterexample"
+    - pattern: "quarter_cell_signed_band_preflight"
+      status: "three-orbit quarter-cell signed-band turn preflight"
+      artifact: "data/certificates/quarter_cell_signed_band_preflight.json"
+      verifier: "scripts/check_quarter_cell_signed_band_preflight.py"
+      claim_scope: "restricted-family proof-mining diagnostic only; records 12 signed boundary-band cells and one first-order negative killer turn per cell for the remaining three-orbit quarter-cell turn-sign target, plus deterministic float stress of those turns, but does not close the m=8,12,16 quarter cells, prove an all-m three-orbit obstruction, prove Erdos #97, or give a counterexample"
   notable_bridge_lemmas:
     - name: "minimal_fragile_cover_bridge"
       status: "proved necessary structure for a minimal counterexample"

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -9900,8 +9900,8 @@ artifacts:
 
   - id: quarter_cell_signed_band_preflight
     path: data/certificates/quarter_cell_signed_band_preflight.json
-    sha256: b4031b25e0ec94c9dd36dadcc8bb577b88ffdb288e0204400e77e624a0cf7794
-    size_bytes: 40485
+    sha256: d77398f17474fc71a5216a305a0d075377cefe1634c3b6917f5b4f9d0fd4e4b6
+    size_bytes: 38931
     kind: restricted_family_screen_artifact
     generator: scripts/check_quarter_cell_signed_band_preflight.py
     command: python scripts/check_quarter_cell_signed_band_preflight.py --write --assert-expected

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -9897,6 +9897,41 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample
       - official/global status update
+
+  - id: quarter_cell_signed_band_preflight
+    path: data/certificates/quarter_cell_signed_band_preflight.json
+    sha256: b4031b25e0ec94c9dd36dadcc8bb577b88ffdb288e0204400e77e624a0cf7794
+    size_bytes: 40485
+    kind: restricted_family_screen_artifact
+    generator: scripts/check_quarter_cell_signed_band_preflight.py
+    command: python scripts/check_quarter_cell_signed_band_preflight.py --write --assert-expected
+    checker: scripts/check_quarter_cell_signed_band_preflight.py
+    check_command: python scripts/check_quarter_cell_signed_band_preflight.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Quarter-cell signed-band turn preflight for the three-orbit (t=3) m=0 mod 4 residual. Records the exact boundary-band case split and the first nonzero negative turn term in each of the 12 signed cells, plus deterministic float stress of those fixed killer turns for m in {8,12,16,20,40,100}. This is not the global sign proof; m=8,12,16 quarter cells remain open, and this is not an all-m three-orbit obstruction, proof of Erdos Problem #97, counterexample, or official/global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.quarter_cell_signed_band_preflight.v1
+      status: QUARTER_CELL_SIGNED_BAND_TURN_PREFLIGHT_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      signed_case_count: 12
+      leading_killer_case_count: 12
+      leading_sign_ok_for_sample_ms: true
+      sampled_fixed_killer_all_negative: true
+      open_quarter_cells_still_open:
+        - 8
+        - 12
+        - 16
+    forbidden_claims:
+      - m=8 m=12 m=16 quarter cells closed
+      - exact certificate for m>=8
+      - all-m quarter-cell obstruction
+      - all-m three-orbit obstruction
+      - general proof of Erdos Problem #97
+      - counterexample
+      - official/global status update
   - id: n8_survivors_smt
     path: data/certificates/n8_survivors_smt.json
     sha256: d515c45dae7c9d21ce85125b8bb58c0b6c8011a61571a5e38db660f9468fe949

--- a/scripts/check_quarter_cell_signed_band_preflight.py
+++ b/scripts/check_quarter_cell_signed_band_preflight.py
@@ -384,10 +384,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     artifact_path = Path(args.artifact)
     if args.write:
         artifact_path.parent.mkdir(parents=True, exist_ok=True)
-        artifact_path.write_text(
-            json.dumps(payload, indent=1, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        with artifact_path.open("w", encoding="utf-8", newline="\n") as fh:
+            fh.write(json.dumps(payload, indent=1, sort_keys=True) + "\n")
     if args.check:
         stored = _read_json(artifact_path)
         if stored != payload:

--- a/scripts/check_quarter_cell_signed_band_preflight.py
+++ b/scripts/check_quarter_cell_signed_band_preflight.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Signed-band preflight for the three-orbit quarter-cell turn-sign lemma.
+
+Context: ``docs/quarter-cell-closure.md`` reduces the remaining
+``m = 0 mod 4`` three-orbit quarter cells to the A-row witness locus.  In
+that locus the cross-orbit offsets live in two boundary bands.  Writing
+
+    T = 2*pi/m,  beta in {d, T-d},  gamma in {e, T-e},
+
+and choosing radius signs
+
+    P(y) = +/- sin(d),  P(z) = +/- sin(e),
+
+splits the locus into three band-order cases and twelve signed cells:
+
+    LL: beta=d,   gamma=e,   d < e
+    LH: beta=d,   gamma=T-e, d + e < T
+    HH: beta=T-d, gamma=T-e, d > e
+
+This script records the exact first nonzero boundary term for a fixed
+"killer" per-period turn determinant in each signed cell.  For
+``0 < T <= pi/4`` (i.e. ``m >= 8``), every listed leading term is negative on
+its open cone.  Thus every signed cell is infinitesimally on the non-convex
+side of the orbit-coincidence boundary.
+
+Important scope: this is a preflight for the missing global turn-sign proof,
+not that proof.  The packet also runs a deterministic floating grid stress of
+the same fixed killer turns for selected m-values, but the grid is only
+evidence.  It does not close the m=8,12,16 quarter cells, does not prove an
+all-m three-orbit obstruction, and does not prove Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCHEMA = "erdos97.quarter_cell_signed_band_preflight.v1"
+STATUS = "QUARTER_CELL_SIGNED_BAND_TURN_PREFLIGHT_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+DEFAULT_MS = (8, 12, 16, 20, 40, 100)
+OPEN_QUARTER_MS = (8, 12, 16)
+DEFAULT_GRID = 72
+
+
+@dataclass(frozen=True)
+class SignedBandCase:
+    case_id: str
+    band_case: str
+    beta_form: str
+    gamma_form: str
+    cone: str
+    y_sign: int
+    z_sign: int
+    killer_turn: int
+    leading_term: str
+    sign_reason: str
+
+
+SIGNED_CASES: tuple[SignedBandCase, ...] = (
+    SignedBandCase("LL_y+_z+", "LL", "d", "e", "0 < d < e", 1, 1, 1, "-d*A", "A>0"),
+    SignedBandCase("LL_y+_z-", "LL", "d", "e", "0 < d < e", 1, -1, 1, "-d*A", "A>0"),
+    SignedBandCase("LL_y-_z+", "LL", "d", "e", "0 < d < e", -1, 1, 2, "-2*d*e", "d,e>0"),
+    SignedBandCase("LL_y-_z-", "LL", "d", "e", "0 < d < e", -1, -1, 3, "(d-e)*A", "d-e<0 and A>0"),
+    SignedBandCase(
+        "LH_y+_z+",
+        "LH",
+        "d",
+        "T-e",
+        "d,e>0 and d+e<T",
+        1,
+        1,
+        1,
+        "-2*d*e",
+        "d,e>0",
+    ),
+    SignedBandCase(
+        "LH_y+_z-",
+        "LH",
+        "d",
+        "T-e",
+        "d,e>0 and d+e<T",
+        1,
+        -1,
+        3,
+        "e*D",
+        "e>0 and D<0",
+    ),
+    SignedBandCase(
+        "LH_y-_z+",
+        "LH",
+        "d",
+        "T-e",
+        "d,e>0 and d+e<T",
+        -1,
+        1,
+        2,
+        "-d*A",
+        "d>0 and A>0",
+    ),
+    SignedBandCase(
+        "LH_y-_z-",
+        "LH",
+        "d",
+        "T-e",
+        "d,e>0 and d+e<T",
+        -1,
+        -1,
+        2,
+        "-d*A",
+        "d>0 and A>0",
+    ),
+    SignedBandCase("HH_y+_z+", "HH", "T-d", "T-e", "0 < e < d", 1, 1, 1, "-e*A", "e>0 and A>0"),
+    SignedBandCase("HH_y+_z-", "HH", "T-d", "T-e", "0 < e < d", 1, -1, 3, "-2*d*e", "d,e>0"),
+    SignedBandCase("HH_y-_z+", "HH", "T-d", "T-e", "0 < e < d", -1, 1, 1, "-e*A", "e>0 and A>0"),
+    SignedBandCase("HH_y-_z-", "HH", "T-d", "T-e", "0 < e < d", -1, -1, 2, "(d-e)*D", "d-e>0 and D<0"),
+)
+
+
+def _radius(sign: int, band_angle: float) -> float:
+    """Positive radius with P(r) = sign*sin(band_angle)."""
+    return math.exp(math.asinh(sign * math.sin(band_angle)))
+
+
+def _point(radius: float, angle: float) -> tuple[float, float]:
+    return (radius * math.cos(angle), radius * math.sin(angle))
+
+
+def _cross(
+    u: tuple[float, float],
+    v: tuple[float, float],
+    w: tuple[float, float],
+) -> float:
+    return (v[0] - u[0]) * (w[1] - v[1]) - (v[1] - u[1]) * (w[0] - v[0])
+
+
+def _turns(m: int, case: SignedBandCase, d: float, e: float) -> tuple[float, float, float]:
+    t_step = 2 * math.pi / m
+    beta = d if case.beta_form == "d" else t_step - d
+    gamma = e if case.gamma_form == "e" else t_step - e
+    y = _radius(case.y_sign, d)
+    z = _radius(case.z_sign, e)
+    a0 = _point(1.0, 0.0)
+    a1 = _point(1.0, t_step)
+    b0 = _point(y, beta)
+    c0 = _point(z, gamma)
+    c_minus_1 = _point(z, gamma - t_step)
+    return (
+        _cross(c_minus_1, a0, b0),
+        _cross(a0, b0, c0),
+        _cross(b0, c0, a1),
+    )
+
+
+def _omega(m: int) -> float:
+    h = math.pi / m
+    sec_h = 1.0 / math.cos(h)
+    return (sec_h * sec_h - 1.0) / (2.0 * sec_h)
+
+
+def _delta(m: int) -> float:
+    return math.asin(_omega(m))
+
+
+def _case_samples(m: int, band_case: str, grid: int) -> list[tuple[float, float]]:
+    delta = _delta(m)
+    values = [delta * (i + 1) / (grid + 1) for i in range(grid)]
+    if band_case == "LL":
+        return [(d, e) for i, d in enumerate(values) for e in values[i + 1 :]]
+    if band_case == "HH":
+        return [(d, e) for i, d in enumerate(values) for e in values[:i]]
+    if band_case == "LH":
+        t_step = 2 * math.pi / m
+        return [(d, e) for d in values for e in values if d + e < t_step]
+    raise ValueError(f"unknown band case: {band_case}")
+
+
+def _sample_fixed_killers(ms: Sequence[int], grid: int) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for m in ms:
+        m_record: dict[str, Any] = {
+            "m": m,
+            "grid": grid,
+            "delta": _delta(m),
+            "case_records": [],
+        }
+        all_negative = True
+        global_max = -math.inf
+        for case in SIGNED_CASES:
+            samples = _case_samples(m, case.band_case, grid)
+            max_killer = -math.inf
+            max_min_turn = -math.inf
+            argmax: dict[str, Any] | None = None
+            for d, e in samples:
+                turns = _turns(m, case, d, e)
+                killer = turns[case.killer_turn - 1]
+                min_turn = min(turns)
+                if killer > max_killer:
+                    max_killer = killer
+                    argmax = {
+                        "d": d,
+                        "e": e,
+                        "turns": list(turns),
+                    }
+                if min_turn > max_min_turn:
+                    max_min_turn = min_turn
+            case_clear = max_killer < 0.0
+            all_negative = all_negative and case_clear
+            global_max = max(global_max, max_killer)
+            m_record["case_records"].append(
+                {
+                    "case_id": case.case_id,
+                    "killer_turn": case.killer_turn,
+                    "sample_count": len(samples),
+                    "max_killer_turn": max_killer,
+                    "max_min_turn": max_min_turn,
+                    "sampled_killer_negative": case_clear,
+                    "argmax": argmax,
+                }
+            )
+        m_record["sampled_fixed_killer_all_negative"] = all_negative
+        m_record["max_killer_turn_over_cases"] = global_max
+        records.append(m_record)
+    return records
+
+
+def _leading_sign_constants(m: int) -> dict[str, float | bool]:
+    t_step = 2 * math.pi / m
+    sin_t = math.sin(t_step)
+    cos_t = math.cos(t_step)
+    a = sin_t + cos_t - 1.0
+    b = cos_t - sin_t - 1.0
+    c = 1.0 + sin_t - cos_t
+    d = 1.0 - sin_t - cos_t
+    return {
+        "m": m,
+        "T": t_step,
+        "A=sinT+cosT-1": a,
+        "B=cosT-sinT-1": b,
+        "C=1+sinT-cosT": c,
+        "D=1-sinT-cosT": d,
+        "signs_ok_for_0_lt_T_le_pi_over_4": a > 0 and b < 0 and c > 0 and d < 0,
+    }
+
+
+def _validate_inputs(ms: Sequence[int], grid: int) -> None:
+    if not ms:
+        raise ValueError("at least one m-value is required")
+    if any(m < 8 for m in ms):
+        raise ValueError("quarter-cell signed-band preflight is scoped to m >= 8")
+    if grid < 2:
+        raise ValueError("grid must be at least 2 so LL/HH samples are nonempty")
+
+
+def build_payload(ms: Sequence[int], grid: int) -> dict[str, Any]:
+    _validate_inputs(ms, grid)
+    leading_signs = [_leading_sign_constants(m) for m in ms]
+    sample_records = _sample_fixed_killers(ms, grid)
+    all_leading_ok = all(record["signs_ok_for_0_lt_T_le_pi_over_4"] for record in leading_signs)
+    all_sampled_negative = all(record["sampled_fixed_killer_all_negative"] for record in sample_records)
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Quarter-cell signed-band turn preflight for the three-orbit "
+            "(t=3) m=0 mod 4 residual. Records the exact boundary-band "
+            "case split and the first nonzero negative turn term in each "
+            "signed cell, plus deterministic float stress of those fixed "
+            "killer turns. This is not the global sign proof: m=8,12,16 "
+            "quarter cells remain open, and this is not an all-m "
+            "three-orbit obstruction, proof of Erdos Problem #97, "
+            "counterexample, or official/global status update."
+        ),
+        "provenance": {
+            "generator": "scripts/check_quarter_cell_signed_band_preflight.py",
+            "command": (
+                "python scripts/check_quarter_cell_signed_band_preflight.py "
+                "--write --assert-expected"
+            ),
+        },
+        "definitions": {
+            "T": "2*pi/m",
+            "P(r)": "(r^2 - 1)/(2*r)",
+            "radius_sign": "P(y)=y_sign*sin(d), P(z)=z_sign*sin(e)",
+            "A": "sin(T)+cos(T)-1",
+            "B": "cos(T)-sin(T)-1",
+            "C": "1+sin(T)-cos(T)",
+            "D": "1-sin(T)-cos(T)",
+            "turns": [
+                "turn_1 = orient(C_{-1}, A_0, B_0)",
+                "turn_2 = orient(A_0, B_0, C_0)",
+                "turn_3 = orient(B_0, C_0, A_1)",
+            ],
+        },
+        "side_cases": [
+            {
+                "band_case": "LL",
+                "beta": "d",
+                "gamma": "e",
+                "cone": "0 < d < e",
+            },
+            {
+                "band_case": "LH",
+                "beta": "d",
+                "gamma": "T-e",
+                "cone": "d,e>0 and d+e<T",
+            },
+            {
+                "band_case": "HH",
+                "beta": "T-d",
+                "gamma": "T-e",
+                "cone": "0 < e < d",
+            },
+        ],
+        "signed_case_count": len(SIGNED_CASES),
+        "signed_cases": [asdict(case) for case in SIGNED_CASES],
+        "leading_killer_case_count": len(SIGNED_CASES),
+        "leading_sign_constants": leading_signs,
+        "leading_sign_ok_for_sample_ms": all_leading_ok,
+        "sample_grid": grid,
+        "sample_ms": list(ms),
+        "sample_records": sample_records,
+        "sampled_fixed_killer_all_negative": all_sampled_negative,
+        "open_quarter_cells_still_open": list(OPEN_QUARTER_MS),
+        "next_exact_target": (
+            "Prove the listed killer turn is negative on each full signed "
+            "band cell, or produce a different exact CAD/resultant/interval "
+            "certificate. The leading-term table only proves the boundary "
+            "tangent direction."
+        ),
+        "does_not_claim": [
+            "m=8,12,16 quarter cells closed",
+            "exact certificate for m>=8 quarter cells",
+            "all-m quarter-cell obstruction",
+            "all-m three-orbit obstruction",
+            "general proof of Erdos Problem #97",
+            "counterexample to Erdos Problem #97",
+            "official/global status update",
+        ],
+    }
+
+
+def assert_expected(payload: dict[str, Any]) -> None:
+    assert payload["schema"] == SCHEMA
+    assert payload["status"] == STATUS
+    assert payload["trust"] == TRUST
+    assert payload["signed_case_count"] == 12
+    assert payload["leading_killer_case_count"] == 12
+    assert payload["leading_sign_ok_for_sample_ms"] is True
+    assert payload["sampled_fixed_killer_all_negative"] is True
+    assert payload["open_quarter_cells_still_open"] == list(OPEN_QUARTER_MS)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ms", type=int, nargs="*", default=list(DEFAULT_MS))
+    parser.add_argument("--grid", type=int, default=DEFAULT_GRID)
+    parser.add_argument(
+        "--artifact",
+        default="data/certificates/quarter_cell_signed_band_preflight.json",
+    )
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    payload = build_payload(args.ms, args.grid)
+    if args.assert_expected:
+        assert_expected(payload)
+
+    artifact_path = Path(args.artifact)
+    if args.write:
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(
+            json.dumps(payload, indent=1, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.check:
+        stored = _read_json(artifact_path)
+        if stored != payload:
+            print(
+                json.dumps(
+                    {
+                        "schema": SCHEMA,
+                        "status": "ARTIFACT_MISMATCH",
+                        "artifact": str(artifact_path),
+                    },
+                    indent=1,
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+            )
+            return 1
+    if args.json:
+        print(json.dumps(payload, indent=1, sort_keys=True))
+    elif not args.write:
+        print(
+            f"{STATUS}: signed_cases={payload['signed_case_count']} "
+            f"leading_ok={payload['leading_sign_ok_for_sample_ms']} "
+            f"sampled_fixed_killer_all_negative="
+            f"{payload['sampled_fixed_killer_all_negative']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_quarter_cell_signed_band_preflight.py
+++ b/scripts/check_quarter_cell_signed_band_preflight.py
@@ -254,6 +254,8 @@ def _validate_inputs(ms: Sequence[int], grid: int) -> None:
         raise ValueError("at least one m-value is required")
     if any(m < 8 for m in ms):
         raise ValueError("quarter-cell signed-band preflight is scoped to m >= 8")
+    if any(m % 4 != 0 for m in ms):
+        raise ValueError("quarter-cell signed-band preflight is scoped to m = 0 mod 4")
     if grid < 2:
         raise ValueError("grid must be at least 2 so LL/HH samples are nonempty")
 

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -3372,6 +3372,25 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="three_orbit_quarter_cell_signed_band_preflight",
+        command=(
+            "python",
+            "scripts/check_quarter_cell_signed_band_preflight.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Signed-band preflight for the three-orbit quarter-cell turn-sign "
+            "lemma: records the boundary-band split and first nonzero "
+            "negative killer-turn term in each signed cell, plus deterministic "
+            "float stress. It is not the global sign proof, does not close "
+            "the m=8/12/16 quarter cells, is not an all-m three-orbit "
+            "obstruction, and is not a proof of Erdos Problem #97, "
+            "counterexample, or official/global status update."
+        ),
+    ),
+    AuditCommand(
         ident="n8_survivors_smt_cross_check",
         command=(
             "python",

--- a/tests/test_quarter_cell_signed_band_preflight.py
+++ b/tests/test_quarter_cell_signed_band_preflight.py
@@ -48,6 +48,8 @@ def test_payload_rejects_vacuous_sampling_inputs() -> None:
         MOD.build_payload((), grid=12)
     with pytest.raises(ValueError, match="m >= 8"):
         MOD.build_payload((4,), grid=12)
+    with pytest.raises(ValueError, match="m = 0 mod 4"):
+        MOD.build_payload((9,), grid=12)
     with pytest.raises(ValueError, match="grid must be at least 2"):
         MOD.build_payload((8,), grid=1)
 

--- a/tests/test_quarter_cell_signed_band_preflight.py
+++ b/tests/test_quarter_cell_signed_band_preflight.py
@@ -1,0 +1,100 @@
+"""Tests for the quarter-cell signed-band turn preflight."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_quarter_cell_signed_band_preflight",
+    ROOT / "scripts" / "check_quarter_cell_signed_band_preflight.py",
+)
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+def test_signed_case_table_has_all_cells() -> None:
+    payload = MOD.build_payload((8, 12, 16), grid=18)
+
+    assert payload["schema"] == MOD.SCHEMA
+    assert payload["signed_case_count"] == 12
+    assert payload["leading_killer_case_count"] == 12
+    assert payload["leading_sign_ok_for_sample_ms"] is True
+    assert payload["sampled_fixed_killer_all_negative"] is True
+    assert {case["band_case"] for case in payload["signed_cases"]} == {"LL", "LH", "HH"}
+    assert {case["killer_turn"] for case in payload["signed_cases"]} == {1, 2, 3}
+
+
+def test_payload_keeps_open_cells_open() -> None:
+    payload = MOD.build_payload((8,), grid=12)
+
+    assert payload["open_quarter_cells_still_open"] == [8, 12, 16]
+    assert "m=8,12,16 quarter cells closed" in payload["does_not_claim"]
+    assert "all-m three-orbit obstruction" in payload["does_not_claim"]
+    assert "general proof of Erdos Problem #97" in payload["does_not_claim"]
+    assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
+
+
+def test_payload_rejects_vacuous_sampling_inputs() -> None:
+    with pytest.raises(ValueError, match="at least one m-value"):
+        MOD.build_payload((), grid=12)
+    with pytest.raises(ValueError, match="m >= 8"):
+        MOD.build_payload((4,), grid=12)
+    with pytest.raises(ValueError, match="grid must be at least 2"):
+        MOD.build_payload((8,), grid=1)
+
+
+def test_cli_write_check_roundtrip(tmp_path: pathlib.Path) -> None:
+    artifact = tmp_path / "signed_band.json"
+
+    write = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_quarter_cell_signed_band_preflight.py",
+            "--artifact",
+            str(artifact),
+            "--ms",
+            "8",
+            "12",
+            "--grid",
+            "12",
+            "--write",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert write.returncode == 0, write.stderr
+    stored = json.loads(artifact.read_text(encoding="utf-8"))
+    assert stored["signed_case_count"] == 12
+
+    check = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_quarter_cell_signed_band_preflight.py",
+            "--artifact",
+            str(artifact),
+            "--ms",
+            "8",
+            "12",
+            "--grid",
+            "12",
+            "--check",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert check.returncode == 0, check.stderr


### PR DESCRIPTION
## Summary

- add a signed-band preflight checker and generated JSON artifact for the remaining three-orbit quarter-cell turn-sign target
- document the 12 signed boundary-band cells and the fixed killer-turn leading terms
- wire the artifact into provenance metadata, audit commands, source-of-truth docs, and backlog follow-up guidance

## Scope and non-claims

This is a review-pending diagnostic. It records a sharper exact target and deterministic floating stress, but it does not close the `m = 8, 12, 16` quarter cells, prove an all-`m` three-orbit obstruction, prove Erdos Problem #97, or provide a counterexample.

## Validation

- `python scripts/check_quarter_cell_signed_band_preflight.py --check --assert-expected --json`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` -> 1403 passed, 648 deselected
