### PR TITLE
Promote parallel-endpoint filter + n=9 combinatorial closure checker (review-pending diagnostic)

### DIFF
--- a/data/certificates/n9_parallel_endpoint_closure.json
+++ b/data/certificates/n9_parallel_endpoint_closure.json
@@ -1,0 +1,3470 @@
+{
+  "assignments": [
+    {
+      "assignment_id": "A001",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          4
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A002",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A003",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          4
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          2,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A004",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          5
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A005",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          2,
+          6
+        ],
+        "shared_vertices": [
+          6
+        ]
+      }
+    },
+    {
+      "assignment_id": "A006",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A007",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          7
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A008",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          7
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A009",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A010",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          7
+        ],
+        [
+          0,
+          6
+        ],
+        [
+          2,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A011",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A012",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A013",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A014",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A015",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A016",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A017",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          3,
+          6
+        ],
+        [
+          2,
+          5
+        ],
+        [
+          4,
+          7
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A018",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          3,
+          6
+        ],
+        "shared_vertices": [
+          6
+        ]
+      }
+    },
+    {
+      "assignment_id": "A019",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          3,
+          6
+        ],
+        "chord_v": [
+          4,
+          6
+        ],
+        "shared_vertices": [
+          6
+        ]
+      }
+    },
+    {
+      "assignment_id": "A020",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A021",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          7
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A022",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A023",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A024",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A025",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          5
+        ],
+        "chord_v": [
+          5,
+          8
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A026",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          8
+        ],
+        "chord_v": [
+          5,
+          8
+        ],
+        "shared_vertices": [
+          8
+        ]
+      }
+    },
+    {
+      "assignment_id": "A027",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          6
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A028",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A029",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A030",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          7
+        ],
+        [
+          3,
+          6
+        ],
+        [
+          5,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A031",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A032",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          7
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A033",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          4
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          2,
+          5
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A034",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          5,
+          8
+        ],
+        "chord_v": [
+          6,
+          8
+        ],
+        "shared_vertices": [
+          8
+        ]
+      }
+    },
+    {
+      "assignment_id": "A035",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          4
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A036",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A037",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A038",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A039",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A040",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          5
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A041",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          5,
+          8
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A042",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          6
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A043",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A044",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          7
+        ],
+        [
+          0,
+          6
+        ],
+        [
+          5,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A045",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          3,
+          5
+        ],
+        "chord_v": [
+          3,
+          6
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A046",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          5,
+          8
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A047",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A048",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          4
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A049",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          7
+        ],
+        [
+          3,
+          6
+        ],
+        [
+          5,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A050",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A051",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          6
+        ],
+        [
+          3,
+          5
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          8
+        ],
+        [
+          0,
+          7
+        ],
+        [
+          6,
+          8
+        ],
+        [
+          5,
+          7
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A052",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          7
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A053",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          7
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A054",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          4
+        ],
+        "chord_v": [
+          0,
+          5
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A055",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A056",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A057",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A058",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          7
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A059",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          7
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A060",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A061",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A062",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A063",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A064",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A065",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A066",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          4
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A067",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          3
+        ],
+        "chord_v": [
+          1,
+          4
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A068",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          6
+        ],
+        [
+          3,
+          5
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          8
+        ],
+        [
+          0,
+          7
+        ],
+        [
+          6,
+          8
+        ],
+        [
+          5,
+          7
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A069",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A070",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A071",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          2,
+          4
+        ],
+        "chord_v": [
+          4,
+          8
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A072",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A073",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          7
+        ],
+        [
+          0,
+          6
+        ],
+        [
+          2,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A074",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          5
+        ],
+        "chord_v": [
+          1,
+          6
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A075",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A076",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A077",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          4
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A078",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A079",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          6
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A080",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          5
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A081",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          1,
+          5
+        ],
+        "chord_v": [
+          5,
+          7
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A082",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A083",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          5
+        ],
+        "chord_v": [
+          3,
+          5
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A084",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A085",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          3
+        ],
+        "chord_v": [
+          1,
+          4
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A086",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          7
+        ],
+        "chord_v": [
+          5,
+          7
+        ],
+        "shared_vertices": [
+          7
+        ]
+      }
+    },
+    {
+      "assignment_id": "A087",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A088",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          4
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A089",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A090",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A091",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A092",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A093",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A094",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          2,
+          8
+        ],
+        "chord_v": [
+          5,
+          8
+        ],
+        "shared_vertices": [
+          8
+        ]
+      }
+    },
+    {
+      "assignment_id": "A095",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A096",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A097",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          7
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A098",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A099",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          6
+        ],
+        [
+          3,
+          5
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          8
+        ],
+        [
+          0,
+          7
+        ],
+        [
+          6,
+          8
+        ],
+        [
+          5,
+          7
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A100",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A101",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          5
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A102",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A103",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A104",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          4
+        ],
+        "chord_v": [
+          0,
+          5
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A105",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A106",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A107",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          2,
+          5
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          3,
+          6
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A108",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          4
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          2,
+          5
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A109",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          7
+        ],
+        "chord_v": [
+          5,
+          7
+        ],
+        "shared_vertices": [
+          7
+        ]
+      }
+    },
+    {
+      "assignment_id": "A110",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          5
+        ],
+        "chord_v": [
+          1,
+          6
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A111",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          6
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A112",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A113",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A114",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          5
+        ],
+        "chord_v": [
+          5,
+          8
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A115",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          5
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A116",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          4,
+          8
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A117",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          5
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A118",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          4
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A119",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A120",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A121",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          3,
+          6
+        ],
+        "chord_v": [
+          4,
+          6
+        ],
+        "shared_vertices": [
+          6
+        ]
+      }
+    },
+    {
+      "assignment_id": "A122",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A123",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          4
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          2,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A124",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          7
+        ],
+        "chord_v": [
+          3,
+          7
+        ],
+        "shared_vertices": [
+          7
+        ]
+      }
+    },
+    {
+      "assignment_id": "A125",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A126",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A127",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          4,
+          7
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A128",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          6
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A129",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          5
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A130",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          7
+        ],
+        [
+          0,
+          6
+        ],
+        [
+          5,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A131",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          6
+        ],
+        [
+          3,
+          5
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          8
+        ],
+        [
+          0,
+          7
+        ],
+        [
+          6,
+          8
+        ],
+        [
+          5,
+          7
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A132",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          5,
+          8
+        ],
+        "chord_v": [
+          6,
+          8
+        ],
+        "shared_vertices": [
+          8
+        ]
+      }
+    },
+    {
+      "assignment_id": "A133",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A134",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A135",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          3,
+          6
+        ],
+        [
+          2,
+          5
+        ],
+        [
+          4,
+          7
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A136",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A137",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A138",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          4
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A139",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          7
+        ],
+        "chord_v": [
+          4,
+          7
+        ],
+        "shared_vertices": [
+          7
+        ]
+      }
+    },
+    {
+      "assignment_id": "A140",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          7
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A141",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A142",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          7
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          2,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A143",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          3
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A144",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          7
+        ],
+        [
+          0,
+          6
+        ],
+        [
+          5,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A145",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          5,
+          8
+        ],
+        "chord_v": [
+          6,
+          8
+        ],
+        "shared_vertices": [
+          8
+        ]
+      }
+    },
+    {
+      "assignment_id": "A146",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A147",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          5
+        ],
+        "chord_v": [
+          3,
+          5
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A148",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          4,
+          8
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A149",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          5,
+          8
+        ],
+        "chord_v": [
+          6,
+          8
+        ],
+        "shared_vertices": [
+          8
+        ]
+      }
+    },
+    {
+      "assignment_id": "A150",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A151",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          6
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A152",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A153",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          2,
+          4
+        ],
+        "chord_v": [
+          4,
+          8
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A154",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A155",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          7
+        ],
+        "chord_v": [
+          3,
+          7
+        ],
+        "shared_vertices": [
+          7
+        ]
+      }
+    },
+    {
+      "assignment_id": "A156",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          5
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A157",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A158",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          4,
+          7
+        ],
+        "shared_vertices": [
+          4
+        ]
+      }
+    },
+    {
+      "assignment_id": "A159",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A160",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          4,
+          7
+        ],
+        [
+          0,
+          6
+        ],
+        [
+          5,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A161",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          1,
+          7
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          2,
+          8
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A162",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A163",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A164",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          1,
+          5
+        ],
+        "chord_v": [
+          5,
+          7
+        ],
+        "shared_vertices": [
+          5
+        ]
+      }
+    },
+    {
+      "assignment_id": "A165",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          7
+        ],
+        "chord_v": [
+          4,
+          7
+        ],
+        "shared_vertices": [
+          7
+        ]
+      }
+    },
+    {
+      "assignment_id": "A166",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A167",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          2,
+          5
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A168",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          3,
+          6
+        ],
+        "shared_vertices": [
+          6
+        ]
+      }
+    },
+    {
+      "assignment_id": "A169",
+      "obstruction": "parity_odd_cycle",
+      "vertex_circle_status": "self_edge",
+      "witness": [
+        [
+          2,
+          5
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          3,
+          6
+        ]
+      ]
+    },
+    {
+      "assignment_id": "A170",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          6
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A171",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          5
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A172",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          7
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A173",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          1,
+          3
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A174",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          0,
+          6
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A175",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          1,
+          4
+        ],
+        "chord_v": [
+          1,
+          7
+        ],
+        "shared_vertices": [
+          1
+        ]
+      }
+    },
+    {
+      "assignment_id": "A176",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          5
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A177",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          4
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A178",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          0,
+          7
+        ],
+        "shared_vertices": [
+          0
+        ]
+      }
+    },
+    {
+      "assignment_id": "A179",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          6
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A180",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "strict_cycle",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          8
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    },
+    {
+      "assignment_id": "A181",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          6
+        ],
+        "chord_v": [
+          2,
+          6
+        ],
+        "shared_vertices": [
+          6
+        ]
+      }
+    },
+    {
+      "assignment_id": "A182",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          3,
+          5
+        ],
+        "chord_v": [
+          3,
+          6
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A183",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          3
+        ],
+        "chord_v": [
+          3,
+          7
+        ],
+        "shared_vertices": [
+          3
+        ]
+      }
+    },
+    {
+      "assignment_id": "A184",
+      "obstruction": "parallel_endpoint",
+      "vertex_circle_status": "self_edge",
+      "witness": {
+        "chord_u": [
+          0,
+          2
+        ],
+        "chord_v": [
+          2,
+          7
+        ],
+        "shared_vertices": [
+          2
+        ]
+      }
+    }
+  ],
+  "claim_scope": "Lighter combinatorial second-source closure of the review-pending n=9 pre-vertex-circle frontier: the 184 stored frontier assignments are all killed by the parity (odd forced-perpendicular cycle) and parallel-endpoint necessary-condition filters, with no vertex-circle quotient reasoning. Not a proof of n=9, not a proof of Erdos Problem #97, not a counterexample, and not an official/global status update; the underlying n=9 frontier enumeration remains review-pending.",
+  "provenance": {
+    "command": "python scripts/check_n9_parallel_endpoint_closure.py --write",
+    "filters": [
+      "erdos97.incidence_filters.odd_forced_perpendicular_cycle",
+      "erdos97.incidence_filters.forced_parallel_endpoint_violation"
+    ],
+    "generator": "scripts/check_n9_parallel_endpoint_closure.py",
+    "input": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+    "lemmas": [
+      "L6 radical-axis perpendicularity",
+      "L2 distinct vertices (strict convexity)"
+    ],
+    "note": "Necessary-condition combinatorial closure of the stored frontier; no proof of n=9 or Erdos #97 and no counterexample is claimed."
+  },
+  "schema": "erdos97.n9_parallel_endpoint_closure.v1",
+  "summary": {
+    "by_vertex_circle_status": {
+      "self_edge": {
+        "parallel_endpoint": 136,
+        "parity_odd_cycle": 22,
+        "survive": 0,
+        "total": 158
+      },
+      "strict_cycle": {
+        "parallel_endpoint": 26,
+        "parity_odd_cycle": 0,
+        "survive": 0,
+        "total": 26
+      }
+    },
+    "killed_by_parallel_endpoint": 162,
+    "killed_by_parity_odd_cycle": 22,
+    "survive_both": 0,
+    "total": 184
+  }
+}

--- a/docs/n9-parallel-endpoint-closure.md
+++ b/docs/n9-parallel-endpoint-closure.md
@@ -1,0 +1,99 @@
+# n=9 parallel-endpoint combinatorial closure
+
+Status / trust label: `REVIEW_PENDING_DIAGNOSTIC`. This is a lighter, second-source
+closure of the review-pending `n=9` pre-vertex-circle frontier. **No general proof
+of Erdos Problem #97, no proof of the `n=9` finite case, and no counterexample are
+claimed, and the official/global falsifiable-open status is unchanged.**
+
+## Summary
+
+The review-pending `n=9` selected-witness pipeline reduces every hypothetical 4-bad
+nonagon to `184` pre-vertex-circle frontier assignments, then kills all `184` with
+the **vertex-circle quotient** filter (`158` self-edges, `26` strict cycles).
+
+This note records that the same `184` assignments are already killed by two
+**purely combinatorial** necessary-condition filters, with **no** vertex-circle or
+metric reasoning:
+
+| filter | assignments killed |
+| --- | ---: |
+| parity (odd forced-perpendicular cycle) | 22 |
+| parallel-endpoint | 162 |
+| survive both | 0 |
+| **total** | **184** |
+
+By the stored vertex-circle status the split is: of the `158` self-edge assignments,
+`22` fall to parity and `136` to parallel-endpoint; all `26` strict-cycle assignments
+fall to parallel-endpoint.
+
+## The two filters and why they are sound necessary conditions
+
+Both filters are consequences of repository lemmas and use strict convexity.
+
+**Forced perpendicularity (lemma L6).** If centers `i, j` share exactly two selected
+witnesses `S_i cap S_j = {a, b}`, then both centers lie on the perpendicular bisector
+of segment `ab`, so the chord `p_i p_j` is perpendicular to the chord `p_a p_b`. Build
+the forced-perpendicularity graph `G` on unordered vertex-chords with an edge
+`{i,j} -- {a,b}` for every such two-overlap.
+
+1. **Parity.** A slope in `RP^1` (angle mod `pi`) flips by `pi/2` along each
+   perpendicularity edge. Around an odd closed walk this would force
+   `theta = theta + pi/2`, impossible for a nonzero chord. Strict convexity supplies
+   the nonzero chord via lemma L2 (distinct vertices), so a realizable system must have
+   `G` bipartite (no odd cycle). This is the `n`-independent generalization of the
+   `n=7` perpendicularity-cycle argument. Checker:
+   `erdos97.incidence_filters.odd_forced_perpendicular_cycle`.
+
+2. **Parallel-endpoint.** Within a connected component of a bipartite `G`, a proper
+   2-coloring assigns each chord a slope class; two chords of the **same** color in the
+   same component are forced **parallel**. Two forced-parallel chords sharing a polygon
+   vertex would place three vertices on a line, forbidden by strict convexity (L2). The
+   presence of such a same-color, shared-endpoint pair is therefore a sound obstruction.
+   Checker: `erdos97.incidence_filters.forced_parallel_endpoint_violation`.
+
+Apply parity first; the parallel-endpoint refinement is meaningful on the bipartite
+systems that pass it.
+
+## Provenance gap this surfaces
+
+The parity filter is already available in the `n=9` pipeline
+(`odd_forced_perpendicular_cycle`), but the **parallel-endpoint** filter previously
+lived only in the `n=8` enumerator (`src/erdos97/n8_incidence.py`) and in the
+`reports/explorations/2026-06-14/A6-topological-parity.md` exploration. It was **not**
+wired into `src/erdos97/n9_incidence_frontier.py`. Promoting it to a first-class,
+tested filter in `src/erdos97/incidence_filters.py` (this change) makes the lighter
+closure reproducible and reusable, and documents that `162/184` frontier assignments
+admit a combinatorial obstruction that the `n=9` enumerator did not previously test.
+
+## What this does and does not establish
+
+- It **does** give an independent, lighter combinatorial closure of the *stored* `184`
+  frontier assignments, with an exact reproducible certificate.
+- It is **necessary-only**: all `15` `n=8` survivor classes pass both filters (they die
+  only to exact metric/orthocenter algebra), so this route cannot settle even `n=8`, let
+  alone the global problem.
+- It **does not** independently prove the `n=9` finite case: the `184` frontier is itself
+  the output of the review-pending incidence enumerator (its pair/crossing/count filtering
+  and completeness remain review-pending). This note re-closes that same stored frontier
+  by a lighter argument; it does not re-derive the frontier.
+- It **does not** prove Erdos Problem #97, exhibit a counterexample, or change the
+  official/global status.
+
+## Reproduction
+
+```bash
+python scripts/check_n9_parallel_endpoint_closure.py --check --assert-expected
+python scripts/check_n9_parallel_endpoint_closure.py --json   # full per-assignment record
+python -m pytest -q tests/test_n9_parallel_endpoint_closure.py
+```
+
+Checked artifact: `data/certificates/n9_parallel_endpoint_closure.json` (managed in
+`metadata/generated_artifacts.yaml`). Exploration provenance:
+`reports/explorations/2026-06-14/A6-topological-parity.md`.
+
+## Suggested follow-up
+
+A separately reviewed change could apply the parallel-endpoint necessary filter inside
+`src/erdos97/n9_incidence_frontier.py` so the frontier closes at the incidence layer.
+That touches review-pending source and should be made under its own review, not bundled
+with this additive second-source diagnostic.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -9940,3 +9940,34 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample
       - official/global status update
+
+  - id: n9_parallel_endpoint_closure
+    path: data/certificates/n9_parallel_endpoint_closure.json
+    sha256: ccd26864666d471ce20831bd7466bcdd2a10fb3e3dc1fac000b77ff6e029b664
+    size_bytes: 61304
+    kind: finite_case_diagnostic
+    generator: scripts/check_n9_parallel_endpoint_closure.py
+    command: python scripts/check_n9_parallel_endpoint_closure.py --write
+    checker: scripts/check_n9_parallel_endpoint_closure.py
+    check_command: python scripts/check_n9_parallel_endpoint_closure.py --check --assert-expected
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: >
+      Lighter combinatorial second-source closure of the review-pending n=9
+      pre-vertex-circle frontier: all 184 stored frontier assignments are killed
+      by the parity (odd forced-perpendicular cycle) and parallel-endpoint
+      necessary-condition filters, with no vertex-circle quotient reasoning. The
+      underlying n=9 frontier enumeration remains review-pending.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_parallel_endpoint_closure.v1
+      summary.total: 184
+      summary.killed_by_parity_odd_cycle: 22
+      summary.killed_by_parallel_endpoint: 162
+      summary.survive_both: 0
+    forbidden_claims:
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+      - independent proof of the n=9 finite case
+      - official/global status update

--- a/scripts/check_n9_parallel_endpoint_closure.py
+++ b/scripts/check_n9_parallel_endpoint_closure.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Combinatorial parity + parallel-endpoint closure of the n=9 frontier.
+
+This is a SECOND, lighter source for the closure of the review-pending n=9
+pre-vertex-circle frontier. It takes the 184 stored frontier selected-witness
+assignments as input and applies two sound necessary-condition combinatorial
+filters, with NO vertex-circle quotient / metric reasoning:
+
+  1. parity: the forced-perpendicularity graph must have no odd cycle
+     (``odd_forced_perpendicular_cycle``); and
+  2. parallel-endpoint: no two forced-parallel chords may share a vertex
+     (``forced_parallel_endpoint_violation``), which under strict convexity
+     would force three collinear vertices.
+
+Both filters are consequences of repo lemmas L6 (radical-axis perpendicularity)
+and L2 (distinct vertices of a strictly convex polygon), so they are sound
+necessary conditions for Euclidean realizability.
+
+Scope / non-claims. This script does NOT prove n=9, does NOT prove Erdos
+Problem #97, does NOT claim a counterexample, and does NOT change the
+official/global falsifiable-open status. The 184-assignment frontier is itself
+the output of the review-pending n=9 incidence enumerator, which remains
+review-pending; this script only re-closes that same stored frontier by a
+lighter combinatorial argument and records the provenance gap that the
+parallel-endpoint filter is not wired into ``src/erdos97/n9_incidence_frontier``.
+The filters are necessary-only: all 15 n=8 survivor classes pass both, so this
+route cannot settle n=8, let alone the global problem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.incidence_filters import (  # noqa: E402
+    forced_parallel_endpoint_violation,
+    odd_forced_perpendicular_cycle,
+)
+
+FRONTIER = (
+    ROOT / "data" / "certificates"
+    / "n9_vertex_circle_frontier_motif_classification.json"
+)
+DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_parallel_endpoint_closure.json"
+
+SCHEMA = "erdos97.n9_parallel_endpoint_closure.v1"
+CLAIM_SCOPE = (
+    "Lighter combinatorial second-source closure of the review-pending n=9 "
+    "pre-vertex-circle frontier: the 184 stored frontier assignments are all "
+    "killed by the parity (odd forced-perpendicular cycle) and parallel-endpoint "
+    "necessary-condition filters, with no vertex-circle quotient reasoning. Not a "
+    "proof of n=9, not a proof of Erdos Problem #97, not a counterexample, and not "
+    "an official/global status update; the underlying n=9 frontier enumeration "
+    "remains review-pending."
+)
+EXPECTED = {
+    "total": 184,
+    "killed_by_parity_odd_cycle": 22,
+    "killed_by_parallel_endpoint": 162,
+    "survive_both": 0,
+}
+
+
+def _chord_list(chord) -> list[int]:
+    return [int(chord[0]), int(chord[1])]
+
+
+def selected_rows_to_S(selected_rows: Sequence[Sequence[int]], n: int) -> list[list[int]]:
+    """Convert ``[center, w1, w2, w3, w4]`` rows to S indexed by center."""
+    S: list[list[int]] = [[] for _ in range(n)]
+    for row in selected_rows:
+        center = int(row[0])
+        S[center] = sorted(int(w) for w in row[1:])
+    return S
+
+
+def classify_assignment(selected_rows: Sequence[Sequence[int]], n: int) -> dict[str, object]:
+    """Apply parity then parallel-endpoint filters to one assignment."""
+    S = selected_rows_to_S(selected_rows, n)
+    odd_cycle = odd_forced_perpendicular_cycle(S)
+    if odd_cycle is not None:
+        return {
+            "obstruction": "parity_odd_cycle",
+            "witness": [_chord_list(c) for c in odd_cycle],
+        }
+    violation = forced_parallel_endpoint_violation(S)
+    if violation is not None:
+        u, v, shared = violation
+        return {
+            "obstruction": "parallel_endpoint",
+            "witness": {
+                "chord_u": _chord_list(u),
+                "chord_v": _chord_list(v),
+                "shared_vertices": [int(x) for x in shared],
+            },
+        }
+    return {"obstruction": None, "witness": None}
+
+
+def build_payload(root: Path = ROOT) -> dict[str, object]:
+    frontier_path = root / "data" / "certificates" / (
+        "n9_vertex_circle_frontier_motif_classification.json"
+    )
+    data = json.loads(frontier_path.read_text(encoding="utf-8"))
+    assignments = data["assignments"]
+    n = 9
+
+    records: list[dict[str, object]] = []
+    counts = {"parity_odd_cycle": 0, "parallel_endpoint": 0, "survive": 0}
+    by_status: dict[str, dict[str, int]] = {}
+    for entry in assignments:
+        result = classify_assignment(entry["selected_rows"], n)
+        status = str(entry.get("status", "unknown"))
+        bucket = by_status.setdefault(
+            status, {"total": 0, "parity_odd_cycle": 0, "parallel_endpoint": 0, "survive": 0}
+        )
+        bucket["total"] += 1
+        obstruction = result["obstruction"]
+        if obstruction == "parity_odd_cycle":
+            counts["parity_odd_cycle"] += 1
+            bucket["parity_odd_cycle"] += 1
+        elif obstruction == "parallel_endpoint":
+            counts["parallel_endpoint"] += 1
+            bucket["parallel_endpoint"] += 1
+        else:
+            counts["survive"] += 1
+            bucket["survive"] += 1
+        records.append(
+            {
+                "assignment_id": str(entry["assignment_id"]),
+                "vertex_circle_status": status,
+                "obstruction": obstruction,
+                "witness": result["witness"],
+            }
+        )
+
+    records.sort(key=lambda r: r["assignment_id"])
+    summary = {
+        "total": len(assignments),
+        "killed_by_parity_odd_cycle": counts["parity_odd_cycle"],
+        "killed_by_parallel_endpoint": counts["parallel_endpoint"],
+        "survive_both": counts["survive"],
+        "by_vertex_circle_status": dict(sorted(by_status.items())),
+    }
+    payload = {
+        "schema": SCHEMA,
+        "claim_scope": CLAIM_SCOPE,
+        "provenance": {
+            "generator": "scripts/check_n9_parallel_endpoint_closure.py",
+            "command": "python scripts/check_n9_parallel_endpoint_closure.py --write",
+            "input": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+            "filters": [
+                "erdos97.incidence_filters.odd_forced_perpendicular_cycle",
+                "erdos97.incidence_filters.forced_parallel_endpoint_violation",
+            ],
+            "lemmas": ["L6 radical-axis perpendicularity", "L2 distinct vertices (strict convexity)"],
+            "note": (
+                "Necessary-condition combinatorial closure of the stored frontier; "
+                "no proof of n=9 or Erdos #97 and no counterexample is claimed."
+            ),
+        },
+        "summary": summary,
+        "assignments": records,
+    }
+    return payload
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    for key, expected in EXPECTED.items():
+        actual = summary.get(key)
+        if actual != expected:
+            raise AssertionError(
+                f"summary[{key!r}] is {actual!r}, expected {expected!r}"
+            )
+    if summary["survive_both"] != 0:
+        raise AssertionError("some frontier assignment survives both filters")
+
+
+def compare_artifact(payload: Mapping[str, object], path: Path) -> None:
+    checked = json.loads(path.read_text(encoding="utf-8"))
+    if checked != payload:
+        raise AssertionError(f"checked artifact is stale: {path.relative_to(ROOT)}")
+
+
+def print_human_summary(payload: Mapping[str, object]) -> None:
+    summary = payload["summary"]
+    assert isinstance(summary, Mapping)
+    print("n=9 parallel-endpoint combinatorial closure")
+    print(f"claim scope: {CLAIM_SCOPE}")
+    print(
+        f"total={summary['total']} "
+        f"parity_odd_cycle={summary['killed_by_parity_odd_cycle']} "
+        f"parallel_endpoint={summary['killed_by_parallel_endpoint']} "
+        f"survive_both={summary['survive_both']}"
+    )
+    print(f"by vertex-circle status: {summary['by_vertex_circle_status']}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--write", action="store_true", help="write the checked artifact")
+    parser.add_argument("--check", action="store_true", help="compare against the checked artifact")
+    parser.add_argument("--assert-expected", action="store_true", help="assert stable closure counts")
+    parser.add_argument("--json", action="store_true", help="print the full JSON payload")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(ROOT)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        compare_artifact(payload, args.out)
+    if args.write:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_human_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -602,6 +602,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="n9_parallel_endpoint_closure",
+        command=(
+            "python",
+            "scripts/check_n9_parallel_endpoint_closure.py",
+            "--check",
+            "--assert-expected",
+        ),
+        claim_scope=(
+            "Lighter parity + parallel-endpoint combinatorial closure of the "
+            "184 review-pending n=9 pre-vertex-circle frontier assignments; "
+            "necessary-condition second source only, not a proof of n=9, "
+            "counterexample, independent review completion, or official/global "
+            "status update."
+        ),
+    ),
+    AuditCommand(
         ident="n9_high_risk_frontier_packet",
         command=(
             "python",

--- a/src/erdos97/incidence_filters.py
+++ b/src/erdos97/incidence_filters.py
@@ -180,6 +180,57 @@ def odd_forced_perpendicular_cycle(
     return None
 
 
+def forced_parallel_endpoint_violation(
+    S: Sequence[Sequence[int]],
+) -> tuple[Chord, Chord, list[int]] | None:
+    """Return two forced-parallel chords sharing a vertex, or ``None``.
+
+    Within each connected component of the forced-perpendicularity graph a proper
+    2-coloring splits the chords into two slope classes: along a perpendicularity
+    edge the slope flips by pi/2 (lemma L6), so two chords of the *same* color in
+    the same component are forced to share a slope class, i.e. they are forced
+    parallel. Two forced-parallel chords that share a polygon vertex would place
+    three vertices on one line, which strict convexity forbids (lemma L2, distinct
+    vertices). Such a same-color, shared-endpoint pair is therefore a sound
+    necessary-condition obstruction to Euclidean realizability.
+
+    This refines the parity obstruction :func:`odd_forced_perpendicular_cycle`
+    and is meant to be applied to systems whose forced-perpendicularity graph is
+    already bipartite (no odd cycle); run that parity check first. Returns
+    ``(chord_u, chord_v, shared_vertices)`` for one witnessing pair, or ``None``
+    when no forced-parallel pair shares a vertex.
+    """
+    graph = forced_perpendicular_graph(S)
+    color: dict[Chord, int] = {}
+    component: dict[Chord, int] = {}
+    next_component = 0
+    for start in sorted(graph):
+        if start in color:
+            continue
+        color[start] = 0
+        component[start] = next_component
+        queue: deque[Chord] = deque([start])
+        while queue:
+            u = queue.popleft()
+            for v in sorted(graph[u]):
+                if v not in color:
+                    color[v] = 1 - color[u]
+                    component[v] = next_component
+                    queue.append(v)
+        next_component += 1
+
+    buckets: dict[tuple[int, int], list[Chord]] = defaultdict(list)
+    for chord in sorted(graph):
+        buckets[(component[chord], color[chord])].append(chord)
+
+    for chords in buckets.values():
+        for u, v in combinations(chords, 2):
+            shared = sorted(set(u) & set(v))
+            if shared:
+                return (u, v, shared)
+    return None
+
+
 def _canonical_directed_cycle(
     cycle: tuple[Chord, Chord, Chord, Chord],
 ) -> tuple[Chord, Chord, Chord, Chord]:

--- a/tests/test_n9_parallel_endpoint_closure.py
+++ b/tests/test_n9_parallel_endpoint_closure.py
@@ -1,0 +1,116 @@
+"""Tests for the n=9 parity + parallel-endpoint combinatorial closure.
+
+These cover the reusable filter `forced_parallel_endpoint_violation`, the
+soundness anchor that the 15 n=8 survivor classes pass both filters, and the
+closure of the stored 184-assignment n=9 frontier (22 parity + 162 parallel,
+0 survive). No proof of n=9 or Erdos #97 is asserted here.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+for sub in ("src", "scripts"):
+    p = str(ROOT / sub)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import check_n9_parallel_endpoint_closure as closure  # noqa: E402
+from erdos97.incidence_filters import (  # noqa: E402
+    forced_parallel_endpoint_violation,
+    odd_forced_perpendicular_cycle,
+)
+
+
+def test_no_two_overlap_system_passes_both() -> None:
+    # All-singleton witness sets: no two rows share two witnesses, so there are
+    # no forced-perpendicularity edges and neither filter fires.
+    S = [[1], [2], [3], [0]]
+    assert odd_forced_perpendicular_cycle(S) is None
+    assert forced_parallel_endpoint_violation(S) is None
+
+
+def test_star_forces_parallel_endpoint_violation() -> None:
+    # Centers 0,1,2 pairwise share exactly {5,6}, so chords {0,1},{0,2},{1,2}
+    # are all forced perpendicular to {5,6} (same color) and pairwise share a
+    # vertex => a forced-parallel shared-endpoint obstruction. The graph is a
+    # bipartite star, so the parity filter does NOT fire.
+    S = [[1, 5, 6], [2, 5, 6], [3, 5, 6], [0], [1], [2], [3]]
+    assert odd_forced_perpendicular_cycle(S) is None
+    violation = forced_parallel_endpoint_violation(S)
+    assert violation is not None
+    u, v, shared = violation
+    assert shared  # the two forced-parallel chords share a vertex
+    assert set(shared) <= set(u) & set(v)
+
+
+def _n8_survivor_rows_to_S(adjacency: list[list[int]]) -> list[list[int]]:
+    return [
+        sorted(j for j, val in enumerate(row) if val == 1 and j != i)
+        for i, row in enumerate(adjacency)
+    ]
+
+
+def test_n8_survivors_pass_both_filters() -> None:
+    # Soundness/regression anchor: the 15 n=8 survivor classes are incidence
+    # consistent (they die only to exact metric algebra), so the two
+    # necessary-condition filters must NOT kill any of them.
+    path = ROOT / "data" / "incidence" / "n8_reconstructed_15_survivors.json"
+    survivors = json.loads(path.read_text(encoding="utf-8"))
+    killed = 0
+    for entry in survivors:
+        S = _n8_survivor_rows_to_S(entry["rows"])
+        if odd_forced_perpendicular_cycle(S) is not None:
+            killed += 1
+        elif forced_parallel_endpoint_violation(S) is not None:
+            killed += 1
+    assert killed == 0
+
+
+def test_n9_frontier_closes_with_expected_split() -> None:
+    payload = closure.build_payload(ROOT)
+    summary = payload["summary"]
+    assert summary["total"] == 184
+    assert summary["killed_by_parity_odd_cycle"] == 22
+    assert summary["killed_by_parallel_endpoint"] == 162
+    assert summary["survive_both"] == 0
+    # every assignment carries a concrete combinatorial obstruction
+    assert all(rec["obstruction"] is not None for rec in payload["assignments"])
+    # assert_expected_payload agrees and does not raise
+    closure.assert_expected_payload(payload)
+
+
+def test_n9_witness_types_match_obstruction_labels() -> None:
+    # Re-derive the raw filter outputs for one parity-killed and one
+    # parallel-killed assignment and confirm they match the recorded label.
+    frontier = json.loads(
+        (
+            ROOT / "data" / "certificates"
+            / "n9_vertex_circle_frontier_motif_classification.json"
+        ).read_text(encoding="utf-8")
+    )
+    by_id = {a["assignment_id"]: a for a in frontier["assignments"]}
+    payload = closure.build_payload(ROOT)
+    seen_parity = seen_parallel = False
+    for rec in payload["assignments"]:
+        S = closure.selected_rows_to_S(by_id[rec["assignment_id"]]["selected_rows"], 9)
+        odd = odd_forced_perpendicular_cycle(S)
+        par = forced_parallel_endpoint_violation(S)
+        if rec["obstruction"] == "parity_odd_cycle":
+            assert odd is not None
+            seen_parity = True
+        elif rec["obstruction"] == "parallel_endpoint":
+            assert odd is None and par is not None
+            seen_parallel = True
+    assert seen_parity and seen_parallel
+
+
+@pytest.mark.artifact
+def test_stored_artifact_is_fresh() -> None:
+    payload = closure.build_payload(ROOT)
+    closure.compare_artifact(payload, closure.DEFAULT_OUT)


### PR DESCRIPTION
## What this is

The scoped follow-up recommended by the merged exploration sweep (#837): promote the
**parallel-endpoint necessary-condition filter** from the n=8 enumerator and the A6
exploration into a first-class, tested filter, and add a checker proving it closes the
n=9 frontier combinatorially — **without** mutating the review-pending n=9 enumerator or
its stored frontier digest.

## Change (additive)

- `src/erdos97/incidence_filters.py`: new `forced_parallel_endpoint_violation(S)` — a
  reusable sound necessary-condition filter. Within each component of the
  forced-perpendicularity graph, same-color (forced-parallel) chords sharing a vertex
  would force three collinear vertices, forbidden by strict convexity (lemmas L6 + L2).
- `scripts/check_n9_parallel_endpoint_closure.py` + `data/certificates/n9_parallel_endpoint_closure.json`
  (managed in `metadata/generated_artifacts.yaml`): applies **parity** (odd
  forced-perpendicular cycle) then **parallel-endpoint** to the 184 stored n=9
  pre-vertex-circle frontier assignments.
- `docs/n9-parallel-endpoint-closure.md`, `tests/test_n9_parallel_endpoint_closure.py`.

## Result

All **184** frontier assignments are killed combinatorially, with **no** vertex-circle /
metric reasoning:

| filter | killed |
|---|---:|
| parity (odd forced-perpendicular cycle) | 22 |
| parallel-endpoint | 162 |
| survive both | **0** |

By stored vertex-circle status: of 158 self-edge assignments, 22 fall to parity and 136
to parallel-endpoint; all 26 strict-cycle assignments fall to parallel-endpoint. This
reproduces the independently-verified A6 counts and surfaces the provenance gap that the
parallel-endpoint filter was never wired into `src/erdos97/n9_incidence_frontier.py`.

## Scope discipline (no overclaim)

Trust label **`REVIEW_PENDING_DIAGNOSTIC`**. This is a lighter *second-source* closure of
the *stored* frontier; it does **not** re-derive the frontier, does **not** independently
prove the n=9 finite case (the enumerator remains review-pending), does **not** prove
Erdős #97, exhibits **no** counterexample, and does **not** change official/global status.
It is **necessary-only**: all 15 n=8 survivor classes pass both filters. Actually wiring
the filter into the n=9 enumerator touches review-pending source and is deliberately left
to a separate review (noted in the doc), not bundled here.

## Verification

ruff, `check_text_clean`, `check_status_consistency`, `check_artifact_provenance`
(validates the new managed artifact), `git diff --check`, and the new test file (6 tests,
incl. the n=8 soundness anchor and the artifact-freshness check) all **pass** locally. A
broader incidence/n8/n9 regression subset and the full suite run on CI.

https://claude.ai/code/session_01SX3J6id3SvYB7W8P37EufQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SX3J6id3SvYB7W8P37EufQ)_