### PR TITLE
[codex] Fix verifier and artifact generation CLIs

### DIFF
--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -458,7 +458,7 @@ artifacts:
     size_bytes: 93632
     kind: independent_audit_diagnostic_artifact
     generator: scripts/n9_vertex_circle_minimal_cores.py
-    command: python scripts/n9_vertex_circle_minimal_cores.py --json
+    command: python scripts/n9_vertex_circle_minimal_cores.py --write --json
     checker: scripts/n9_vertex_circle_minimal_cores.py
     check_command: python scripts/n9_vertex_circle_minimal_cores.py --check --assert-expected --json
     direct_edit_allowed: false

--- a/scripts/n9_vertex_circle_minimal_cores.py
+++ b/scripts/n9_vertex_circle_minimal_cores.py
@@ -115,8 +115,13 @@ def main() -> int:
     ap.add_argument("--check", action="store_true")
     ap.add_argument("--assert-expected", action="store_true")
     ap.add_argument("--json", action="store_true")
-    ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--write", action="store_true", help="write generated artifact")
+    ap.add_argument("--no-write", action="store_true", help="deprecated no-op; output is not written unless --write is set")
     args = ap.parse_args()
+    if args.write and args.no_write:
+        ap.error("--write cannot be combined with --no-write")
+    if args.write and args.check:
+        ap.error("--write cannot be combined with --check")
 
     frontier = rec.enumerate_frontier()
     assert len(frontier) == 184, f"expected 184 frontier systems, got {len(frontier)}"
@@ -213,7 +218,7 @@ def main() -> int:
         else:
             ok = ok and stored == json_report
 
-    if not args.no_write and not args.check:
+    if args.write:
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
         with open(out_path, "w", encoding="utf-8") as fh:
             json.dump(json_report, fh, indent=2)

--- a/src/erdos97/search.py
+++ b/src/erdos97/search.py
@@ -1003,7 +1003,7 @@ def main() -> None:
     if args.verify:
         diag = verify_json(args.verify, tol=args.tol, min_margin=args.min_margin)
         print(json.dumps(diag, indent=2))
-        return
+        raise SystemExit(0 if diag.get("ok_at_tol") is True else 1)
 
     if args.pattern not in pats:
         raise SystemExit(f"unknown pattern {args.pattern}; use --list-patterns")

--- a/tests/test_n9_vertex_circle_minimal_cores.py
+++ b/tests/test_n9_vertex_circle_minimal_cores.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+
+from scripts import n9_vertex_circle_minimal_cores
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -28,3 +31,92 @@ def test_n9_vertex_circle_minimal_core_summary_counts() -> None:
         "strict_cycle": 183,
     }
     assert payload["isolated_recheck_mismatches"] == 0
+
+
+def _patch_minimal_core_runner(monkeypatch) -> None:
+    frontier = [object() for _ in range(184)]
+    monkeypatch.setattr(
+        n9_vertex_circle_minimal_cores.rec,
+        "enumerate_frontier",
+        lambda: frontier,
+    )
+    monkeypatch.setattr(
+        n9_vertex_circle_minimal_cores,
+        "minimal_cores",
+        lambda assign: [{0}],
+    )
+    monkeypatch.setattr(
+        n9_vertex_circle_minimal_cores,
+        "canon_core",
+        lambda assign, centers: ((0, 1, 2, 3, 4),),
+    )
+    monkeypatch.setattr(
+        n9_vertex_circle_minimal_cores,
+        "status_of_subset",
+        lambda assign, centers: "self_edge",
+    )
+    monkeypatch.setattr(
+        n9_vertex_circle_minimal_cores,
+        "core_status_isolated",
+        lambda rows: "self_edge",
+    )
+    monkeypatch.setattr(n9_vertex_circle_minimal_cores, "EXPECTED_SUMMARY", {})
+
+
+def test_n9_vertex_circle_minimal_cores_json_does_not_write_by_default(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    _patch_minimal_core_runner(monkeypatch)
+    out = tmp_path / "minimal_cores.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "n9_vertex_circle_minimal_cores.py",
+            "--json",
+            "--out",
+            str(out),
+        ],
+    )
+
+    result = n9_vertex_circle_minimal_cores.main()
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.err == ""
+    assert not out.exists()
+    payload = json.loads(captured.out)
+    assert payload["schema"] == "erdos97.n9_vertex_circle_minimal_cores.v1"
+
+
+def test_n9_vertex_circle_minimal_cores_write_is_explicit(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    _patch_minimal_core_runner(monkeypatch)
+    out = tmp_path / "minimal_cores.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "n9_vertex_circle_minimal_cores.py",
+            "--write",
+            "--json",
+            "--out",
+            str(out),
+        ],
+    )
+
+    result = n9_vertex_circle_minimal_cores.main()
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert captured.err == ""
+    assert out.exists()
+    stored = json.loads(out.read_text(encoding="utf-8"))
+    printed = json.loads(captured.out)
+    assert stored["schema"] == "erdos97.n9_vertex_circle_minimal_cores.v1"
+    assert printed["schema"] == stored["schema"]

--- a/tests/test_verify_candidate_cli.py
+++ b/tests/test_verify_candidate_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,6 +25,41 @@ def test_verify_candidate_cli_rejects_invalid_candidate(tmp_path: Path) -> None:
     result = subprocess.run(
         [sys.executable, "scripts/verify_candidate.py", str(candidate)],
         cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok_at_tol"] is False
+    assert payload["validation_errors"]
+
+
+def test_search_module_verify_cli_rejects_invalid_candidate(tmp_path: Path) -> None:
+    candidate = tmp_path / "bad.json"
+    candidate.write_text(
+        json.dumps(
+            {
+                "coordinates": [[0.0, 0.0], [1.0, 0.0]],
+                "S": [[1, 1, 1, 1], [0, 0, 0, 0]],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    src_path = str(ROOT / "src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "erdos97.search", "--verify", str(candidate)],
+        cwd=ROOT,
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary

Fixes the two review findings in the local tooling:

- make `erdos97-search --verify` exit nonzero when verifier diagnostics reject a candidate
- make `scripts/n9_vertex_circle_minimal_cores.py` write artifacts only when `--write` is explicit
- update the artifact manifest command and add focused regression coverage

## Rationale

The verifier path printed `ok_at_tol: false` but still exited successfully, which could let automation or manual shell checks treat a rejected numerical near-miss as accepted. The minimal-core generator also wrote its artifact by default from a command that looked like JSON/report output; artifact regeneration is now opt-in and explicit.

No mathematical claims or generated certificate contents are changed.

## Validation

- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`
- `python -m pytest -q` (`1406 passed, 655 deselected`)