### PR TITLE
Wire parallel-endpoint filter into the n=9 incidence-frontier chain (review-pending)

### DIFF
--- a/data/certificates/n9_incidence_frontier_bounded.json
+++ b/data/certificates/n9_incidence_frontier_bounded.json
@@ -426,6 +426,19 @@
         "crossing_bisector_violations": [],
         "directed_phi_4_cycle_count": 0,
         "forced_equality_classes": [],
+        "forced_parallel_endpoint_violation": [
+          [
+            0,
+            6
+          ],
+          [
+            0,
+            7
+          ],
+          [
+            0
+          ]
+        ],
         "indegrees": [
           4,
           4,
@@ -538,6 +551,19 @@
         "crossing_bisector_violations": [],
         "directed_phi_4_cycle_count": 1,
         "forced_equality_classes": [],
+        "forced_parallel_endpoint_violation": [
+          [
+            0,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            0
+          ]
+        ],
         "indegrees": [
           4,
           4,
@@ -936,6 +962,19 @@
         "crossing_bisector_violations": [],
         "directed_phi_4_cycle_count": 0,
         "forced_equality_classes": [],
+        "forced_parallel_endpoint_violation": [
+          [
+            0,
+            6
+          ],
+          [
+            0,
+            7
+          ],
+          [
+            0
+          ]
+        ],
         "indegrees": [
           4,
           4,
@@ -1240,6 +1279,7 @@
     "mutual_midpoint_collapse",
     "phi4_rectangle_trap",
     "row_ptolemy_product_cancellation",
+    "parallel_endpoint_violation",
     "accepted_frontier"
   ],
   "full_classification_counts": {
@@ -1250,6 +1290,7 @@
     "crossing_bisector": 0,
     "mutual_midpoint_collapse": 0,
     "odd_forced_perpendicular_cycle": 1,
+    "parallel_endpoint_violation": 0,
     "phi4_rectangle_trap": 1,
     "row_pair_intersection_cap": 0,
     "row_ptolemy_product_cancellation": 1
@@ -1291,6 +1332,19 @@
         "crossing_bisector_violations": [],
         "directed_phi_4_cycle_count": 1,
         "forced_equality_classes": [],
+        "forced_parallel_endpoint_violation": [
+          [
+            0,
+            3
+          ],
+          [
+            0,
+            4
+          ],
+          [
+            0
+          ]
+        ],
         "indegrees": [
           4,
           4,

--- a/data/certificates/n9_incidence_frontier_bounded.json
+++ b/data/certificates/n9_incidence_frontier_bounded.json
@@ -426,19 +426,7 @@
         "crossing_bisector_violations": [],
         "directed_phi_4_cycle_count": 0,
         "forced_equality_classes": [],
-        "forced_parallel_endpoint_violation": [
-          [
-            0,
-            6
-          ],
-          [
-            0,
-            7
-          ],
-          [
-            0
-          ]
-        ],
+        "forced_parallel_endpoint_violation": null,
         "indegrees": [
           4,
           4,

--- a/data/certificates/n9_turn_inequality_frontier.json
+++ b/data/certificates/n9_turn_inequality_frontier.json
@@ -14,7 +14,7 @@
         4
       ],
       "name": "gpt_pro_output_10_side_cap_pattern",
-      "natural_order_classify_status": "accepted_frontier",
+      "natural_order_classify_status": "parallel_endpoint_violation",
       "natural_order_phi_edges": 18,
       "natural_order_rectangle_trap_4_cycles": 0,
       "natural_order_row_ptolemy_product_cancellation_count": 0,

--- a/docs/n9-parallel-endpoint-closure.md
+++ b/docs/n9-parallel-endpoint-closure.md
@@ -91,9 +91,32 @@ Checked artifact: `data/certificates/n9_parallel_endpoint_closure.json` (managed
 `metadata/generated_artifacts.yaml`). Exploration provenance:
 `reports/explorations/2026-06-14/A6-topological-parity.md`.
 
-## Suggested follow-up
+## Now wired into the incidence-frontier chain
 
-A separately reviewed change could apply the parallel-endpoint necessary filter inside
-`src/erdos97/n9_incidence_frontier.py` so the frontier closes at the incidence layer.
-That touches review-pending source and should be made under its own review, not bundled
-with this additive second-source diagnostic.
+`src/erdos97/n9_incidence_frontier.py` now applies the parallel-endpoint filter as the
+final gate of its `classify_pattern` necessary-filter chain (after the parity, mutual-
+midpoint, phi4-rectangle-trap, and row-Ptolemy filters, immediately before
+`accepted_frontier`). With it wired in, the natural-order chain closes the entire stored
+184-assignment frontier at the incidence layer:
+
+| `classify_pattern` status (natural order) | assignments |
+| --- | ---: |
+| `odd_forced_perpendicular_cycle` (parity) | 22 |
+| `phi4_rectangle_trap` (fixed-order) | 36 |
+| `row_ptolemy_product_cancellation` (fixed-order) | 26 |
+| `parallel_endpoint_violation` | 100 |
+| `accepted_frontier` | 0 |
+
+No assignment survives to `accepted_frontier`. Parity and parallel-endpoint are
+order-independent filters; the rectangle-trap and row-Ptolemy filters are
+natural-order-specific, so this particular split is a natural-order statement (the
+order-independent parity + parallel-endpoint pair alone already closes all 184 as
+22 + 162, per the summary table above). The previously escaping side-cap benchmark
+pattern recorded in `n9_turn_inequality_frontier` is now caught by the parallel-endpoint
+gate.
+
+This remains `REVIEW_PENDING_DIAGNOSTIC`: wiring the filter in does not re-derive the
+frontier, prove the n=9 finite case, prove Erdos Problem #97, or change official/global
+status. The bounded `run_bounded_scan` diagnostic is unaffected by default (its three
+checked patterns are caught by earlier filters; `parallel_endpoint_violation` and
+`accepted_frontier` both remain 0 there).

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -677,8 +677,8 @@ artifacts:
 
   - id: n9_turn_inequality_frontier
     path: data/certificates/n9_turn_inequality_frontier.json
-    sha256: 9de2666f7bce8e92bb2134caae449588a67ef902ae45b6bbc30c1687588603b8
-    size_bytes: 82873
+    sha256: c18927110eeb7eaaa8ce00c61573b0c72c4b81c0aed29f054b46cd9b8658ee55
+    size_bytes: 82883
     kind: finite_case_artifact
     generator: scripts/check_n9_turn_inequality_frontier.py
     command: python scripts/check_n9_turn_inequality_frontier.py --assert-expected --write

--- a/scripts/check_n9_incidence_frontier.py
+++ b/scripts/check_n9_incidence_frontier.py
@@ -30,6 +30,7 @@ EXPECTED_FILTER_ORDER = [
     "mutual_midpoint_collapse",
     "phi4_rectangle_trap",
     "row_ptolemy_product_cancellation",
+    "parallel_endpoint_violation",
     "accepted_frontier",
 ]
 

--- a/src/erdos97/n9_incidence_frontier.py
+++ b/src/erdos97/n9_incidence_frontier.py
@@ -16,6 +16,7 @@ from erdos97.incidence_filters import (
     adjacent_pairs,
     crossing_bisector_violations,
     forced_equal_classes_from_matrix,
+    forced_parallel_endpoint_violation,
     mutual_midpoint_matrix,
     normalize_chord,
     odd_forced_perpendicular_cycle,
@@ -54,6 +55,7 @@ FULL_CLASSIFICATION_STATUSES = (
     "mutual_midpoint_collapse",
     "phi4_rectangle_trap",
     "row_ptolemy_product_cancellation",
+    "parallel_endpoint_violation",
     "accepted_frontier",
 )
 
@@ -246,6 +248,7 @@ def classify_pattern(
     indegree_violations = _indegree_violations(S)
     column_pair_violations = _column_pair_violations(S)
     odd_cycle = odd_forced_perpendicular_cycle(S)
+    parallel_endpoint = forced_parallel_endpoint_violation(S)
     matrix = mutual_midpoint_matrix(S)
     forced_classes = forced_equal_classes_from_matrix(matrix, N)
     rectangle_traps = phi4_rectangle_trap_certificates(S, order)
@@ -272,6 +275,8 @@ def classify_pattern(
         status = "phi4_rectangle_trap"
     elif row_ptolemy_certificates:
         status = "row_ptolemy_product_cancellation"
+    elif parallel_endpoint is not None:
+        status = "parallel_endpoint_violation"
 
     return {
         "status": status,
@@ -299,6 +304,15 @@ def classify_pattern(
             None
             if odd_cycle is None
             else [_json_chord(chord) for chord in odd_cycle]
+        ),
+        "forced_parallel_endpoint_violation": (
+            None
+            if parallel_endpoint is None
+            else [
+                _json_chord(parallel_endpoint[0]),
+                _json_chord(parallel_endpoint[1]),
+                list(parallel_endpoint[2]),
+            ]
         ),
         "forced_equality_classes": forced_classes[:max_details],
         "rectangle_trap_certificates": rectangle_traps[:max_details],
@@ -573,6 +587,7 @@ def run_bounded_scan(
             "mutual_midpoint_collapse",
             "phi4_rectangle_trap",
             "row_ptolemy_product_cancellation",
+            "parallel_endpoint_violation",
             "accepted_frontier",
         ],
     }

--- a/src/erdos97/n9_incidence_frontier.py
+++ b/src/erdos97/n9_incidence_frontier.py
@@ -248,7 +248,9 @@ def classify_pattern(
     indegree_violations = _indegree_violations(S)
     column_pair_violations = _column_pair_violations(S)
     odd_cycle = odd_forced_perpendicular_cycle(S)
-    parallel_endpoint = forced_parallel_endpoint_violation(S)
+    parallel_endpoint = (
+        None if odd_cycle is not None else forced_parallel_endpoint_violation(S)
+    )
     matrix = mutual_midpoint_matrix(S)
     forced_classes = forced_equal_classes_from_matrix(matrix, N)
     rectangle_traps = phi4_rectangle_trap_certificates(S, order)

--- a/src/erdos97/n9_turn_inequality_frontier.py
+++ b/src/erdos97/n9_turn_inequality_frontier.py
@@ -831,7 +831,7 @@ def assert_expected_payload(payload: dict[str, object] | None = None) -> None:
         raise AssertionError("malformed benchmark")
     expected_benchmark = {
         "frontier_assignment_index_1based": EXPECTED_SIDE_CAP_PATTERN_INDEX,
-        "natural_order_classify_status": "accepted_frontier",
+        "natural_order_classify_status": "parallel_endpoint_violation",
         "vertex_circle_status": "self_edge",
         "turn_z3_status": "unsat",
         "side_sensitive_pair_cap_violation_count": 0,

--- a/tests/test_n9_incidence_frontier.py
+++ b/tests/test_n9_incidence_frontier.py
@@ -134,6 +134,16 @@ def test_default_bounded_scan_has_no_remaining_accepted_frontier() -> None:
     assert payload["full_classification_counts"]["accepted_frontier"] == 0
 
 
+def test_parallel_endpoint_witness_requires_bipartite_parity_graph() -> None:
+    payload = run_bounded_scan(max_examples=1)
+    odd_examples = payload["examples"]["odd_forced_perpendicular_cycle"]
+
+    assert len(odd_examples) == 1
+    assert odd_examples[0]["status"] == "odd_forced_perpendicular_cycle"
+    assert odd_examples[0]["odd_forced_perpendicular_cycle"] is not None
+    assert odd_examples[0]["forced_parallel_endpoint_violation"] is None
+
+
 def test_full_chain_closes_184_frontier_at_incidence_layer() -> None:
     # Wiring the parallel-endpoint necessary filter into the classify_pattern
     # chain closes the entire stored 184 pre-vertex-circle frontier at the

--- a/tests/test_n9_incidence_frontier.py
+++ b/tests/test_n9_incidence_frontier.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+from collections import Counter
+from pathlib import Path
+
 import pytest
 
 from erdos97.incidence_filters import row_ptolemy_product_cancellation_certificates
@@ -24,6 +28,7 @@ EXPECTED_FILTER_ORDER = [
     "mutual_midpoint_collapse",
     "phi4_rectangle_trap",
     "row_ptolemy_product_cancellation",
+    "parallel_endpoint_violation",
     "accepted_frontier",
 ]
 
@@ -127,6 +132,33 @@ def test_default_bounded_scan_has_no_remaining_accepted_frontier() -> None:
     assert payload["full_classification_counts"]["row_ptolemy_product_cancellation"] == 1
     assert payload["accepted_frontier_count"] == 0
     assert payload["full_classification_counts"]["accepted_frontier"] == 0
+
+
+def test_full_chain_closes_184_frontier_at_incidence_layer() -> None:
+    # Wiring the parallel-endpoint necessary filter into the classify_pattern
+    # chain closes the entire stored 184 pre-vertex-circle frontier at the
+    # incidence layer (natural order): no assignment reaches accepted_frontier.
+    # Sound second source; does not re-derive the frontier or prove n=9.
+    frontier_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "certificates"
+        / "n9_vertex_circle_frontier_motif_classification.json"
+    )
+    data = json.loads(frontier_path.read_text(encoding="utf-8"))
+    counts: Counter[str] = Counter()
+    for entry in data["assignments"]:
+        rows: list[list[int]] = [[] for _ in range(9)]
+        for row in entry["selected_rows"]:
+            rows[row[0]] = sorted(row[1:])
+        counts[str(classify_pattern(rows, list(range(9)))["status"])] += 1
+
+    assert sum(counts.values()) == 184
+    assert counts["accepted_frontier"] == 0
+    assert counts["odd_forced_perpendicular_cycle"] == 22
+    assert counts["phi4_rectangle_trap"] == 36
+    assert counts["row_ptolemy_product_cancellation"] == 26
+    assert counts["parallel_endpoint_violation"] == 100
 
 
 def test_checker_assert_expected_allows_zero_example_payloads() -> None:


### PR DESCRIPTION
## What this is

The deferred follow-up noted in the merged `docs/n9-parallel-endpoint-closure.md` (#839): wire the **parallel-endpoint necessary-condition filter** into the n=9 incidence enumerator's classifier so the stored frontier closes at the incidence layer. This is default-on, placed late in the classifier, and remains review-pending.

## Change

- `src/erdos97/n9_incidence_frontier.py`: `classify_pattern` now applies `forced_parallel_endpoint_violation` as the final gate of its necessary-filter chain, after parity / mutual-midpoint / phi4-rectangle-trap / row-Ptolemy and immediately before `accepted_frontier`.
- The helper is evaluated only after the parity graph is known bipartite (`odd_cycle is None`), matching the helper contract and avoiding certificate-like witness output outside its precondition.
- `scripts/check_n9_incidence_frontier.py`, `tests/test_n9_incidence_frontier.py`, and the bounded artifact taxonomy are updated with `parallel_endpoint_violation`.
- `src/erdos97/n9_turn_inequality_frontier.py` and its stored artifact expectation are updated for the side-cap benchmark that is now caught by the parallel-endpoint gate.

## Result

Running the stored 184 pre-vertex-circle frontier through the natural-order `classify_pattern` chain, no assignment reaches `accepted_frontier`:

| status (natural order) | assignments |
|---|---:|
| `odd_forced_perpendicular_cycle` | 22 |
| `phi4_rectangle_trap` | 36 |
| `row_ptolemy_product_cancellation` | 26 |
| `parallel_endpoint_violation` | 100 |
| `accepted_frontier` | 0 |

Parity + parallel-endpoint are order-independent and already close all 184 (22 + 162, per #839). The rectangle-trap / row-Ptolemy split above is natural-order-specific because those filters are fixed-order gates.

## Scope discipline

`REVIEW_PENDING_DIAGNOSTIC`. This does not re-derive the frontier, does not independently prove the n=9 finite case, does not prove Erdos Problem #97, exhibits no counterexample, and does not change official/global status.

## Verification

- `/Users/davidiach/Desktop/erdos97/.venv/bin/python scripts/check_n9_incidence_frontier.py --write --assert-expected`
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python -m pytest tests/test_n9_incidence_frontier.py tests/test_n9_parallel_endpoint_closure.py -q` (`19 passed, 1 deselected`)
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python scripts/check_n9_incidence_frontier.py --assert-expected --json`
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --summary-json`
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python -m ruff check src/erdos97/n9_incidence_frontier.py tests/test_n9_incidence_frontier.py scripts/check_n9_incidence_frontier.py src/erdos97/n9_turn_inequality_frontier.py`
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python scripts/check_text_clean.py`
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python scripts/check_status_consistency.py`
- `/Users/davidiach/Desktop/erdos97/.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `make verify-fast PYTHON=/Users/davidiach/Desktop/erdos97/.venv/bin/python` (`1413 passed, 663 deselected`)

https://claude.ai/code/session_01SX3J6id3SvYB7W8P37EufQ