### PR TITLE
Keep Kalmanson audit surfaces on full JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_vertex_circle_dynamic_mro_choices.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_mro_branching_replay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_frontier_coverage_crosswalk.py --check --assert-expected --json
-	$(PYTHON) scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json
-	$(PYTHON) scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json
+	$(PYTHON) scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_strict_edge_geometry.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_local_core_subset_audit.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -536,9 +536,9 @@ artifacts:
     generator: scripts/check_n9_kalmanson_selfedge.py
     command: python scripts/check_n9_kalmanson_selfedge.py --write --assert-expected --summary-only
     checker: scripts/check_n9_kalmanson_selfedge.py
-    check_command: python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --summary-json
+    check_command: python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json
     independent_replay: scripts/check_n9_kalmanson_selfedge_independent_replay.py
-    independent_replay_command: python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --summary-json
+    independent_replay_command: python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -327,7 +327,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--verify-certificate",
             "data/certificates/n9_kalmanson_selfedge.json",
             "--assert-expected",
-            "--summary-json",
+            "--json",
         ),
         claim_scope=(
             "Review-pending n=9 selected-witness Kalmanson self-edge "
@@ -342,7 +342,7 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "scripts/check_n9_kalmanson_selfedge_independent_replay.py",
             "--check",
             "--assert-expected",
-            "--summary-json",
+            "--json",
         ),
         claim_scope=(
             "Independent stored-input replay for the review-pending n=9 "


### PR DESCRIPTION
## Summary

- restore full `--json` for the Kalmanson self-edge commands in `verify-n9-review`
- restore full `--json` in generated artifact metadata for the Kalmanson checker and independent replay
- restore full `--json` in the scheduled artifact audit command registry so provenance captures the full replay surfaces

## Verification

- `.venv/bin/python scripts/check_n9_kalmanson_selfedge.py --verify-certificate data/certificates/n9_kalmanson_selfedge.json --assert-expected --json`
- `.venv/bin/python scripts/check_n9_kalmanson_selfedge_independent_replay.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `.venv/bin/python -m pytest tests/test_run_artifact_audit.py tests/test_makefile_targets.py -q`
- `.venv/bin/python -m ruff check scripts/run_artifact_audit.py`
- `.venv/bin/python scripts/run_artifact_audit.py --list-commands`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_text_clean.py`
- `git diff --check`
- `make verify-fast PYTHON=.venv/bin/python` (`1411 passed, 663 deselected`)

## Scope

This is audit/provenance plumbing only. It does not change the underlying Kalmanson certificates, does not promote `n=9`, and does not alter official/global status.