### PR TITLE
Add BRP boundary vertexization probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_n12_rich_support_determinant.py --check --json
 	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
 	$(PYTHON) scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json
+	$(PYTHON) scripts/check_brp_boundary_probe.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected --json

--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -10,28 +10,28 @@
             "A3",
             "A4"
           ],
-          "t": 0.955030125243
+          "t": 0.955030125
         },
         {
           "edge": [
             "B2",
             "B3"
           ],
-          "t": 0.979925648445
+          "t": 0.979925648
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.868959625935
+          "t": 0.868959626
         },
         {
           "edge": [
             "C1",
             "C2"
           ],
-          "t": 0.399998621735
+          "t": 0.399998622
         }
       ],
       "radius_squared_exact": "2189906 + 359000*sqrt3",
@@ -51,28 +51,28 @@
             "A3",
             "A4"
           ],
-          "t": 0.973566915008
+          "t": 0.973566915
         },
         {
           "edge": [
             "B2",
             "B3"
           ],
-          "t": 0.479634499052
+          "t": 0.479634499
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.672516352848
+          "t": 0.672516353
         },
         {
           "edge": [
             "C2",
             "C3"
           ],
-          "t": 0.058306805156
+          "t": 0.058306805
         }
       ],
       "radius_squared_exact": "2004034 + 251724*sqrt3",
@@ -92,32 +92,32 @@
             "A3",
             "A4"
           ],
-          "t": 0.99982219509
+          "t": 0.999822195
         },
         {
           "edge": [
             "B1",
             "B2"
           ],
-          "t": 0.002955183549
+          "t": 0.002955184
         },
         {
           "edge": [
             "B2",
             "B3"
           ],
-          "t": 0.479634499052
+          "t": 0.479634499
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.022938552995
+          "t": 0.022938553
         }
       ],
       "radius_squared_exact": "2004034 - 251724*sqrt3",
-      "radius_squared_float": 1568035.2425155318,
+      "radius_squared_float": 1568035.242515532,
       "vertex_hit_count": 1,
       "vertex_hits": [
         "B2"
@@ -133,32 +133,32 @@
             "A1",
             "A2"
           ],
-          "t": 0.374759906134
+          "t": 0.374759906
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.954380149942
+          "t": 0.95438015
         },
         {
           "edge": [
             "C2",
             "C3"
           ],
-          "t": 0.99866030234
+          "t": 0.998660302
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.876202425305
+          "t": 0.876202425
         }
       ],
       "radius_squared_exact": "1543030 + 740577*sqrt3",
-      "radius_squared_float": 2825746.9909169367,
+      "radius_squared_float": 2825746.990916937,
       "vertex_hit_count": 1,
       "vertex_hits": [
         "C3"
@@ -174,28 +174,28 @@
             "A1",
             "A2"
           ],
-          "t": 0.399998621735
+          "t": 0.399998622
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.955030125243
+          "t": 0.955030125
         },
         {
           "edge": [
             "C2",
             "C3"
           ],
-          "t": 0.979925648445
+          "t": 0.979925648
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.868959625935
+          "t": 0.868959626
         }
       ],
       "radius_squared_exact": "2189906 + 359000*sqrt3",
@@ -215,28 +215,28 @@
             "A2",
             "A3"
           ],
-          "t": 0.058306805156
+          "t": 0.058306805
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.973566915008
+          "t": 0.973566915
         },
         {
           "edge": [
             "C2",
             "C3"
           ],
-          "t": 0.479634499052
+          "t": 0.479634499
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.672516352848
+          "t": 0.672516353
         }
       ],
       "radius_squared_exact": "2004034 + 251724*sqrt3",
@@ -256,32 +256,32 @@
             "A3",
             "A4"
           ],
-          "t": 0.022938552995
+          "t": 0.022938553
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.99982219509
+          "t": 0.999822195
         },
         {
           "edge": [
             "C1",
             "C2"
           ],
-          "t": 0.002955183549
+          "t": 0.002955184
         },
         {
           "edge": [
             "C2",
             "C3"
           ],
-          "t": 0.479634499052
+          "t": 0.479634499
         }
       ],
       "radius_squared_exact": "2004034 - 251724*sqrt3",
-      "radius_squared_float": 1568035.2425155318,
+      "radius_squared_float": 1568035.242515532,
       "vertex_hit_count": 1,
       "vertex_hits": [
         "C2"
@@ -297,32 +297,32 @@
             "A2",
             "A3"
           ],
-          "t": 0.998660302343
+          "t": 0.998660302
         },
         {
           "edge": [
             "A3",
             "A4"
           ],
-          "t": 0.876202425305
+          "t": 0.876202425
         },
         {
           "edge": [
             "B1",
             "B2"
           ],
-          "t": 0.374759906134
+          "t": 0.374759906
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.954380149942
+          "t": 0.95438015
         }
       ],
       "radius_squared_exact": "1543030 + 740577*sqrt3",
-      "radius_squared_float": 2825746.9909169367,
+      "radius_squared_float": 2825746.990916937,
       "vertex_hit_count": 1,
       "vertex_hits": [
         "A3"
@@ -338,28 +338,28 @@
             "A2",
             "A3"
           ],
-          "t": 0.979925648445
+          "t": 0.979925648
         },
         {
           "edge": [
             "A3",
             "A4"
           ],
-          "t": 0.868959625935
+          "t": 0.868959626
         },
         {
           "edge": [
             "B1",
             "B2"
           ],
-          "t": 0.399998621735
+          "t": 0.399998622
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.955030125243
+          "t": 0.955030125
         }
       ],
       "radius_squared_exact": "2189906 + 359000*sqrt3",
@@ -379,28 +379,28 @@
             "A2",
             "A3"
           ],
-          "t": 0.479634499052
+          "t": 0.479634499
         },
         {
           "edge": [
             "A3",
             "A4"
           ],
-          "t": 0.672516352848
+          "t": 0.672516353
         },
         {
           "edge": [
             "B2",
             "B3"
           ],
-          "t": 0.058306805156
+          "t": 0.058306805
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.973566915008
+          "t": 0.973566915
         }
       ],
       "radius_squared_exact": "2004034 + 251724*sqrt3",
@@ -420,32 +420,32 @@
             "A1",
             "A2"
           ],
-          "t": 0.002955183549
+          "t": 0.002955184
         },
         {
           "edge": [
             "A2",
             "A3"
           ],
-          "t": 0.479634499052
+          "t": 0.479634499
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.022938552995
+          "t": 0.022938553
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.99982219509
+          "t": 0.999822195
         }
       ],
       "radius_squared_exact": "2004034 - 251724*sqrt3",
-      "radius_squared_float": 1568035.2425155318,
+      "radius_squared_float": 1568035.242515532,
       "vertex_hit_count": 1,
       "vertex_hits": [
         "A2"
@@ -461,32 +461,32 @@
             "A3",
             "A4"
           ],
-          "t": 0.954380149942
+          "t": 0.95438015
         },
         {
           "edge": [
             "B2",
             "B3"
           ],
-          "t": 0.998660302343
+          "t": 0.998660302
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.876202425305
+          "t": 0.876202425
         },
         {
           "edge": [
             "C1",
             "C2"
           ],
-          "t": 0.374759906134
+          "t": 0.374759906
         }
       ],
       "radius_squared_exact": "1543030 + 740577*sqrt3",
-      "radius_squared_float": 2825746.9909169367,
+      "radius_squared_float": 2825746.990916937,
       "vertex_hit_count": 1,
       "vertex_hits": [
         "B3"
@@ -504,14 +504,14 @@
             "A3",
             "A4"
           ],
-          "t": 0.999387074654
+          "t": 0.999387075
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.990185482564
+          "t": 0.990185483
         }
       ],
       "radius_squared_exact": "3000000",
@@ -532,14 +532,14 @@
             "A3",
             "A4"
           ],
-          "t": 0.989220990074
+          "t": 0.98922099
         },
         {
           "edge": [
             "B3",
             "B4"
           ],
-          "t": 0.726454587078
+          "t": 0.726454587
         }
       ],
       "radius_squared_exact": "2501496",
@@ -560,7 +560,7 @@
             "B3",
             "B4"
           ],
-          "t": 0.240702342216
+          "t": 0.240702342
         }
       ],
       "radius_squared_exact": "1634718",
@@ -594,14 +594,14 @@
             "B3",
             "B4"
           ],
-          "t": 0.999387074654
+          "t": 0.999387075
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.990185482564
+          "t": 0.990185483
         }
       ],
       "radius_squared_exact": "3000000",
@@ -622,14 +622,14 @@
             "B3",
             "B4"
           ],
-          "t": 0.989220990074
+          "t": 0.98922099
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.726454587078
+          "t": 0.726454587
         }
       ],
       "radius_squared_exact": "2501496",
@@ -650,7 +650,7 @@
             "C3",
             "C4"
           ],
-          "t": 0.240702342216
+          "t": 0.240702342
         }
       ],
       "radius_squared_exact": "1634718",
@@ -684,14 +684,14 @@
             "A3",
             "A4"
           ],
-          "t": 0.990185482564
+          "t": 0.990185483
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.999387074654
+          "t": 0.999387075
         }
       ],
       "radius_squared_exact": "3000000",
@@ -712,14 +712,14 @@
             "A3",
             "A4"
           ],
-          "t": 0.726454587078
+          "t": 0.726454587
         },
         {
           "edge": [
             "C3",
             "C4"
           ],
-          "t": 0.989220990074
+          "t": 0.98922099
         }
       ],
       "radius_squared_exact": "2501496",
@@ -740,7 +740,7 @@
             "A3",
             "A4"
           ],
-          "t": 0.240702342216
+          "t": 0.240702342
         }
       ],
       "radius_squared_exact": "1634718",
@@ -767,8 +767,8 @@
   ],
   "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test.",
   "convexity": {
-    "max_turn_area2": 146403.00000000003,
-    "min_turn_area2": 19.492354670772542,
+    "max_turn_area2": 146403.0,
+    "min_turn_area2": 19.492354671,
     "strictly_convex_in_seed_order": true
   },
   "does_not_claim": [
@@ -876,7 +876,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -133.09255722860885,
+        "min_turn_area2": -133.092557229,
         "normal_offset": "-1",
         "normal_side": "right",
         "strictly_convex": false,
@@ -887,7 +887,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -5.361586286528747,
+        "min_turn_area2": -5.361586287,
         "normal_offset": "1",
         "normal_side": "left",
         "strictly_convex": false,
@@ -898,7 +898,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -280.80438046029644,
+        "min_turn_area2": -280.80438046,
         "normal_offset": "-2",
         "normal_side": "right",
         "strictly_convex": false,
@@ -909,7 +909,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -10.723172573056504,
+        "min_turn_area2": -10.723172573,
         "normal_offset": "2",
         "normal_side": "left",
         "strictly_convex": false,
@@ -920,7 +920,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -723.9398501553841,
+        "min_turn_area2": -723.939850155,
         "normal_offset": "-5",
         "normal_side": "right",
         "strictly_convex": false,
@@ -931,7 +931,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -26.807931432639,
+        "min_turn_area2": -26.807931433,
         "normal_offset": "5",
         "normal_side": "left",
         "strictly_convex": false,
@@ -942,7 +942,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -1462.4989663138301,
+        "min_turn_area2": -1462.498966314,
         "normal_offset": "-10",
         "normal_side": "right",
         "strictly_convex": false,
@@ -953,7 +953,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -53.61586286527786,
+        "min_turn_area2": -53.615862865,
         "normal_offset": "10",
         "normal_side": "left",
         "strictly_convex": false,
@@ -964,7 +964,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -2939.6171986307545,
+        "min_turn_area2": -2939.617198631,
         "normal_offset": "-20",
         "normal_side": "right",
         "strictly_convex": false,
@@ -975,7 +975,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -107.23172573055501,
+        "min_turn_area2": -107.231725731,
         "normal_offset": "20",
         "normal_side": "left",
         "strictly_convex": false,
@@ -986,7 +986,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -7370.971895581516,
+        "min_turn_area2": -7370.971895582,
         "normal_offset": "-50",
         "normal_side": "right",
         "strictly_convex": false,
@@ -997,7 +997,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -756.4274572486756,
+        "min_turn_area2": -756.427457249,
         "normal_offset": "50",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1008,7 +1008,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -137.96564589631924,
+        "min_turn_area2": -137.965645896,
         "normal_offset": "-1",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1019,7 +1019,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -5.36158628652926,
+        "min_turn_area2": -5.361586287,
         "normal_offset": "1",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1030,7 +1030,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -285.67746912799305,
+        "min_turn_area2": -285.677469128,
         "normal_offset": "-2",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1041,7 +1041,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -10.723172573056827,
+        "min_turn_area2": -10.723172573,
         "normal_offset": "2",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1052,7 +1052,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -728.812938823078,
+        "min_turn_area2": -728.812938823,
         "normal_offset": "-5",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1063,7 +1063,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -26.80793143263999,
+        "min_turn_area2": -26.807931433,
         "normal_offset": "5",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1074,7 +1074,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -1467.3720549815225,
+        "min_turn_area2": -1467.372054982,
         "normal_offset": "-10",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1085,7 +1085,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -53.61586286527819,
+        "min_turn_area2": -53.615862865,
         "normal_offset": "10",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1096,7 +1096,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -2944.4902872984467,
+        "min_turn_area2": -2944.490287298,
         "normal_offset": "-20",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1107,7 +1107,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -107.23172573055552,
+        "min_turn_area2": -107.231725731,
         "normal_offset": "20",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1118,7 +1118,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -7375.844984249208,
+        "min_turn_area2": -7375.844984249,
         "normal_offset": "-50",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1129,7 +1129,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 8,
         "max_vertex_hits": 2,
-        "min_turn_area2": -268.07931432638725,
+        "min_turn_area2": -268.079314326,
         "normal_offset": "50",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1140,7 +1140,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -142.8387345639993,
+        "min_turn_area2": -142.838734564,
         "normal_offset": "-1",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1151,7 +1151,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -5.361586286529688,
+        "min_turn_area2": -5.361586287,
         "normal_offset": "1",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1162,7 +1162,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -290.5505577956896,
+        "min_turn_area2": -290.550557796,
         "normal_offset": "-2",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1173,7 +1173,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -10.723172573057443,
+        "min_turn_area2": -10.723172573,
         "normal_offset": "2",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1184,7 +1184,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -733.6860274907744,
+        "min_turn_area2": -733.686027491,
         "normal_offset": "-5",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1195,7 +1195,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -26.807931432640608,
+        "min_turn_area2": -26.807931433,
         "normal_offset": "5",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1206,7 +1206,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -1472.245143649222,
+        "min_turn_area2": -1472.245143649,
         "normal_offset": "-10",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1217,7 +1217,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -53.6158628652788,
+        "min_turn_area2": -53.615862865,
         "normal_offset": "10",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1228,7 +1228,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -2949.3633759661434,
+        "min_turn_area2": -2949.363375966,
         "normal_offset": "-20",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1239,7 +1239,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 7,
         "max_vertex_hits": 2,
-        "min_turn_area2": -107.23172573055615,
+        "min_turn_area2": -107.231725731,
         "normal_offset": "20",
         "normal_side": "left",
         "strictly_convex": false,
@@ -1250,7 +1250,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 5,
         "max_vertex_hits": 2,
-        "min_turn_area2": -7380.718072916897,
+        "min_turn_area2": -7380.718072917,
         "normal_offset": "-50",
         "normal_side": "right",
         "strictly_convex": false,
@@ -1261,7 +1261,7 @@
         "circles_with_at_least_four_vertices": 0,
         "max_boundary_hits": 8,
         "max_vertex_hits": 2,
-        "min_turn_area2": -268.07931432638793,
+        "min_turn_area2": -268.079314326,
         "normal_offset": "50",
         "normal_side": "left",
         "strictly_convex": false,

--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -1,0 +1,1459 @@
+{
+  "best_boundary_circles": [
+    {
+      "boundary_hit_count": 5,
+      "center": "A1",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.955030125243
+        },
+        {
+          "edge": [
+            "B2",
+            "B3"
+          ],
+          "t": 0.979925648445
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.868959625935
+        },
+        {
+          "edge": [
+            "C1",
+            "C2"
+          ],
+          "t": 0.399998621735
+        }
+      ],
+      "radius_squared_exact": "2189906 + 359000*sqrt3",
+      "radius_squared_float": 2811712.239917227,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "B3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "A2",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.973566915008
+        },
+        {
+          "edge": [
+            "B2",
+            "B3"
+          ],
+          "t": 0.479634499052
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.672516352848
+        },
+        {
+          "edge": [
+            "C2",
+            "C3"
+          ],
+          "t": 0.058306805156
+        }
+      ],
+      "radius_squared_exact": "2004034 + 251724*sqrt3",
+      "radius_squared_float": 2440032.757484468,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "B3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "A3",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.99982219509
+        },
+        {
+          "edge": [
+            "B1",
+            "B2"
+          ],
+          "t": 0.002955183549
+        },
+        {
+          "edge": [
+            "B2",
+            "B3"
+          ],
+          "t": 0.479634499052
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.022938552995
+        }
+      ],
+      "radius_squared_exact": "2004034 - 251724*sqrt3",
+      "radius_squared_float": 1568035.2425155318,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "B2"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "A4",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A1",
+            "A2"
+          ],
+          "t": 0.374759906134
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.954380149942
+        },
+        {
+          "edge": [
+            "C2",
+            "C3"
+          ],
+          "t": 0.99866030234
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.876202425305
+        }
+      ],
+      "radius_squared_exact": "1543030 + 740577*sqrt3",
+      "radius_squared_float": 2825746.9909169367,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "C3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "B1",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A1",
+            "A2"
+          ],
+          "t": 0.399998621735
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.955030125243
+        },
+        {
+          "edge": [
+            "C2",
+            "C3"
+          ],
+          "t": 0.979925648445
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.868959625935
+        }
+      ],
+      "radius_squared_exact": "2189906 + 359000*sqrt3",
+      "radius_squared_float": 2811712.239917227,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "C3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "B2",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A2",
+            "A3"
+          ],
+          "t": 0.058306805156
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.973566915008
+        },
+        {
+          "edge": [
+            "C2",
+            "C3"
+          ],
+          "t": 0.479634499052
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.672516352848
+        }
+      ],
+      "radius_squared_exact": "2004034 + 251724*sqrt3",
+      "radius_squared_float": 2440032.757484468,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "C3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "B3",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.022938552995
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.99982219509
+        },
+        {
+          "edge": [
+            "C1",
+            "C2"
+          ],
+          "t": 0.002955183549
+        },
+        {
+          "edge": [
+            "C2",
+            "C3"
+          ],
+          "t": 0.479634499052
+        }
+      ],
+      "radius_squared_exact": "2004034 - 251724*sqrt3",
+      "radius_squared_float": 1568035.2425155318,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "C2"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "B4",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A2",
+            "A3"
+          ],
+          "t": 0.998660302343
+        },
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.876202425305
+        },
+        {
+          "edge": [
+            "B1",
+            "B2"
+          ],
+          "t": 0.374759906134
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.954380149942
+        }
+      ],
+      "radius_squared_exact": "1543030 + 740577*sqrt3",
+      "radius_squared_float": 2825746.9909169367,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "A3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "C1",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A2",
+            "A3"
+          ],
+          "t": 0.979925648445
+        },
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.868959625935
+        },
+        {
+          "edge": [
+            "B1",
+            "B2"
+          ],
+          "t": 0.399998621735
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.955030125243
+        }
+      ],
+      "radius_squared_exact": "2189906 + 359000*sqrt3",
+      "radius_squared_float": 2811712.239917227,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "A3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "C2",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A2",
+            "A3"
+          ],
+          "t": 0.479634499052
+        },
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.672516352848
+        },
+        {
+          "edge": [
+            "B2",
+            "B3"
+          ],
+          "t": 0.058306805156
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.973566915008
+        }
+      ],
+      "radius_squared_exact": "2004034 + 251724*sqrt3",
+      "radius_squared_float": 2440032.757484468,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "A3"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "C3",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A1",
+            "A2"
+          ],
+          "t": 0.002955183549
+        },
+        {
+          "edge": [
+            "A2",
+            "A3"
+          ],
+          "t": 0.479634499052
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.022938552995
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.99982219509
+        }
+      ],
+      "radius_squared_exact": "2004034 - 251724*sqrt3",
+      "radius_squared_float": 1568035.2425155318,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "A2"
+      ]
+    },
+    {
+      "boundary_hit_count": 5,
+      "center": "C4",
+      "interior_hit_count": 4,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.954380149942
+        },
+        {
+          "edge": [
+            "B2",
+            "B3"
+          ],
+          "t": 0.998660302343
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.876202425305
+        },
+        {
+          "edge": [
+            "C1",
+            "C2"
+          ],
+          "t": 0.374759906134
+        }
+      ],
+      "radius_squared_exact": "1543030 + 740577*sqrt3",
+      "radius_squared_float": 2825746.9909169367,
+      "vertex_hit_count": 1,
+      "vertex_hits": [
+        "B3"
+      ]
+    }
+  ],
+  "best_vertex_circles": [
+    {
+      "boundary_hit_count": 4,
+      "center": "A1",
+      "interior_hit_count": 2,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.999387074654
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.990185482564
+        }
+      ],
+      "radius_squared_exact": "3000000",
+      "radius_squared_float": 3000000.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "B1",
+        "C1"
+      ]
+    },
+    {
+      "boundary_hit_count": 4,
+      "center": "A2",
+      "interior_hit_count": 2,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.989220990074
+        },
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.726454587078
+        }
+      ],
+      "radius_squared_exact": "2501496",
+      "radius_squared_float": 2501496.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "B2",
+        "C2"
+      ]
+    },
+    {
+      "boundary_hit_count": 3,
+      "center": "A3",
+      "interior_hit_count": 1,
+      "interior_hits": [
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.240702342216
+        }
+      ],
+      "radius_squared_exact": "1634718",
+      "radius_squared_float": 1634718.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "B3",
+        "C3"
+      ]
+    },
+    {
+      "boundary_hit_count": 2,
+      "center": "A4",
+      "interior_hit_count": 0,
+      "interior_hits": [],
+      "radius_squared_exact": "3019935",
+      "radius_squared_float": 3019935.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "B4",
+        "C4"
+      ]
+    },
+    {
+      "boundary_hit_count": 4,
+      "center": "B1",
+      "interior_hit_count": 2,
+      "interior_hits": [
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.999387074654
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.990185482564
+        }
+      ],
+      "radius_squared_exact": "3000000",
+      "radius_squared_float": 3000000.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A1",
+        "C1"
+      ]
+    },
+    {
+      "boundary_hit_count": 4,
+      "center": "B2",
+      "interior_hit_count": 2,
+      "interior_hits": [
+        {
+          "edge": [
+            "B3",
+            "B4"
+          ],
+          "t": 0.989220990074
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.726454587078
+        }
+      ],
+      "radius_squared_exact": "2501496",
+      "radius_squared_float": 2501496.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A2",
+        "C2"
+      ]
+    },
+    {
+      "boundary_hit_count": 3,
+      "center": "B3",
+      "interior_hit_count": 1,
+      "interior_hits": [
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.240702342216
+        }
+      ],
+      "radius_squared_exact": "1634718",
+      "radius_squared_float": 1634718.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A3",
+        "C3"
+      ]
+    },
+    {
+      "boundary_hit_count": 2,
+      "center": "B4",
+      "interior_hit_count": 0,
+      "interior_hits": [],
+      "radius_squared_exact": "3019935",
+      "radius_squared_float": 3019935.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A4",
+        "C4"
+      ]
+    },
+    {
+      "boundary_hit_count": 4,
+      "center": "C1",
+      "interior_hit_count": 2,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.990185482564
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.999387074654
+        }
+      ],
+      "radius_squared_exact": "3000000",
+      "radius_squared_float": 3000000.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A1",
+        "B1"
+      ]
+    },
+    {
+      "boundary_hit_count": 4,
+      "center": "C2",
+      "interior_hit_count": 2,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.726454587078
+        },
+        {
+          "edge": [
+            "C3",
+            "C4"
+          ],
+          "t": 0.989220990074
+        }
+      ],
+      "radius_squared_exact": "2501496",
+      "radius_squared_float": 2501496.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A2",
+        "B2"
+      ]
+    },
+    {
+      "boundary_hit_count": 3,
+      "center": "C3",
+      "interior_hit_count": 1,
+      "interior_hits": [
+        {
+          "edge": [
+            "A3",
+            "A4"
+          ],
+          "t": 0.240702342216
+        }
+      ],
+      "radius_squared_exact": "1634718",
+      "radius_squared_float": 1634718.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A3",
+        "B3"
+      ]
+    },
+    {
+      "boundary_hit_count": 2,
+      "center": "C4",
+      "interior_hit_count": 0,
+      "interior_hits": [],
+      "radius_squared_exact": "3019935",
+      "radius_squared_float": 3019935.0,
+      "vertex_hit_count": 2,
+      "vertex_hits": [
+        "A4",
+        "B4"
+      ]
+    }
+  ],
+  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test.",
+  "convexity": {
+    "max_turn_area2": 146403.00000000003,
+    "min_turn_area2": 19.492354670772542,
+    "strictly_convex_in_seed_order": true
+  },
+  "does_not_claim": [
+    "proof of Erdos Problem #97",
+    "counterexample to Erdos Problem #97",
+    "finite-vertex extraction from the Barany--Roldan-Pensado body",
+    "model of the source paper's A5 insertion or final 15-gon",
+    "exact or interval certificate for boundary intersections"
+  ],
+  "histograms": {
+    "boundary_hit_count": {
+      "1": 9,
+      "2": 45,
+      "3": 21,
+      "4": 33,
+      "5": 12
+    },
+    "interior_hit_count": {
+      "0": 12,
+      "1": 45,
+      "2": 24,
+      "3": 27,
+      "4": 12
+    },
+    "vertex_hit_count": {
+      "1": 108,
+      "2": 12
+    }
+  },
+  "next_steps": [
+    "add the A5 edge-parameter insertion once the source construction is pinned",
+    "promote edge-interior hits to symbolic edge parameters",
+    "iterate the promoted hits as new candidate vertices",
+    "replace float boundary intersections by exact algebraic or interval checks"
+  ],
+  "provenance": {
+    "command": "python scripts/check_brp_boundary_probe.py --write --assert-expected",
+    "generator": "scripts/check_brp_boundary_probe.py",
+    "notes": "Float64 boundary-intersection diagnostic for the quoted Barany--Roldan-Pensado 12-point seed before A5 insertion."
+  },
+  "schema": "erdos97.brp_boundary_vertexization_probe.v1",
+  "source": {
+    "base_points": [
+      {
+        "label": "A1",
+        "x": 1000,
+        "y": 0
+      },
+      {
+        "label": "A2",
+        "x": 906,
+        "y": 114
+      },
+      {
+        "label": "A3",
+        "x": 645,
+        "y": 359
+      },
+      {
+        "label": "A4",
+        "x": -498,
+        "y": 871
+      }
+    ],
+    "construction": "Barany--Roldan-Pensado 3-fold seed before A5 insertion",
+    "modeled_vertices": [
+      "A1",
+      "A2",
+      "A3",
+      "A4",
+      "B1",
+      "B2",
+      "B3",
+      "B4",
+      "C1",
+      "C2",
+      "C3",
+      "C4"
+    ],
+    "not_modeled": "the A5 insertion and the final 15-gon edge-parameter closure",
+    "rotations_degrees": [
+      0,
+      120,
+      240
+    ]
+  },
+  "status": "BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY",
+  "summary": {
+    "circles_with_at_least_four_boundary_hits": 45,
+    "circles_with_at_least_four_seed_vertices": 0,
+    "distinct_centered_vertex_radii": 120,
+    "max_boundary_hits_on_seed_edges": 5,
+    "max_interior_hits_on_one_seed_circle": 4,
+    "max_vertex_hits_on_seed": 2,
+    "seed_edge_count": 12,
+    "seed_vertex_count": 12
+  },
+  "synthetic_a5_scan": {
+    "best_max_boundary_hits": 8,
+    "best_max_vertex_hits": 2,
+    "candidate_count": 36,
+    "candidates": [
+      {
+        "circles_with_at_least_four_boundary_hits": 78,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -133.09255722860885,
+        "normal_offset": "-1",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -5.361586286528747,
+        "normal_offset": "1",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 78,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -280.80438046029644,
+        "normal_offset": "-2",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -10.723172573056504,
+        "normal_offset": "2",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -723.9398501553841,
+        "normal_offset": "-5",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -26.807931432639,
+        "normal_offset": "5",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 90,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -1462.4989663138301,
+        "normal_offset": "-10",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -53.61586286527786,
+        "normal_offset": "10",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 96,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -2939.6171986307545,
+        "normal_offset": "-20",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -107.23172573055501,
+        "normal_offset": "20",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 96,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -7370.971895581516,
+        "normal_offset": "-50",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -756.4274572486756,
+        "normal_offset": "50",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 78,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -137.96564589631924,
+        "normal_offset": "-1",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -5.36158628652926,
+        "normal_offset": "1",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 78,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -285.67746912799305,
+        "normal_offset": "-2",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -10.723172573056827,
+        "normal_offset": "2",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -728.812938823078,
+        "normal_offset": "-5",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -26.80793143263999,
+        "normal_offset": "5",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 90,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -1467.3720549815225,
+        "normal_offset": "-10",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -53.61586286527819,
+        "normal_offset": "10",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 93,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -2944.4902872984467,
+        "normal_offset": "-20",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -107.23172573055552,
+        "normal_offset": "20",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 96,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -7375.844984249208,
+        "normal_offset": "-50",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 8,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -268.07931432638725,
+        "normal_offset": "50",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "1/2"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 78,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -142.8387345639993,
+        "normal_offset": "-1",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -5.361586286529688,
+        "normal_offset": "1",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 81,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -290.5505577956896,
+        "normal_offset": "-2",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 84,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -10.723172573057443,
+        "normal_offset": "2",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 84,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -733.6860274907744,
+        "normal_offset": "-5",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -26.807931432640608,
+        "normal_offset": "5",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 90,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -1472.245143649222,
+        "normal_offset": "-10",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 90,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -53.6158628652788,
+        "normal_offset": "10",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 93,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -2949.3633759661434,
+        "normal_offset": "-20",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 90,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 7,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -107.23172573055615,
+        "normal_offset": "20",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 96,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 5,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -7380.718072916897,
+        "normal_offset": "-50",
+        "normal_side": "right",
+        "strictly_convex": false,
+        "t": "3/4"
+      },
+      {
+        "circles_with_at_least_four_boundary_hits": 93,
+        "circles_with_at_least_four_vertices": 0,
+        "max_boundary_hits": 8,
+        "max_vertex_hits": 2,
+        "min_turn_area2": -268.07931432638793,
+        "normal_offset": "50",
+        "normal_side": "left",
+        "strictly_convex": false,
+        "t": "3/4"
+      }
+    ],
+    "candidates_with_at_least_four_vertices": 0,
+    "description": "A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1), with signed h and rotations to B5/C5; diagnostic stand-in only, not the source paper's A5.",
+    "interpretation": "This signed normal-offset scan is a diagnostic stress test only. It samples nearby synthetic A5 placements but does not model the source paper's existential A5 constraints.",
+    "parameters": [
+      {
+        "normal_offset": "-1",
+        "normal_side": "right",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "1",
+        "normal_side": "left",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "-2",
+        "normal_side": "right",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "2",
+        "normal_side": "left",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "-5",
+        "normal_side": "right",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "5",
+        "normal_side": "left",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "-10",
+        "normal_side": "right",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "10",
+        "normal_side": "left",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "-20",
+        "normal_side": "right",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "20",
+        "normal_side": "left",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "-50",
+        "normal_side": "right",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "50",
+        "normal_side": "left",
+        "t": "1/4"
+      },
+      {
+        "normal_offset": "-1",
+        "normal_side": "right",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "1",
+        "normal_side": "left",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "-2",
+        "normal_side": "right",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "2",
+        "normal_side": "left",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "-5",
+        "normal_side": "right",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "5",
+        "normal_side": "left",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "-10",
+        "normal_side": "right",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "10",
+        "normal_side": "left",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "-20",
+        "normal_side": "right",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "20",
+        "normal_side": "left",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "-50",
+        "normal_side": "right",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "50",
+        "normal_side": "left",
+        "t": "1/2"
+      },
+      {
+        "normal_offset": "-1",
+        "normal_side": "right",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "1",
+        "normal_side": "left",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "-2",
+        "normal_side": "right",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "2",
+        "normal_side": "left",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "-5",
+        "normal_side": "right",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "5",
+        "normal_side": "left",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "-10",
+        "normal_side": "right",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "10",
+        "normal_side": "left",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "-20",
+        "normal_side": "right",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "20",
+        "normal_side": "left",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "-50",
+        "normal_side": "right",
+        "t": "3/4"
+      },
+      {
+        "normal_offset": "50",
+        "normal_side": "left",
+        "t": "3/4"
+      }
+    ],
+    "strictly_convex_candidate_count": 0
+  },
+  "trust": "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
+}

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -51,6 +51,14 @@ Run:
 python3 scripts/check_brp_boundary_probe.py --assert-expected
 ```
 
+The checked artifact is
+`data/certificates/brp_boundary_vertexization_probe.json`, managed by
+`metadata/generated_artifacts.yaml`. Replay the artifact check with:
+
+```bash
+python3 scripts/check_brp_boundary_probe.py --check --assert-expected --json
+```
+
 The checker:
 
 - represents vertex-to-vertex squared distances exactly in `Q(sqrt(3))` for
@@ -58,10 +66,10 @@ The checker:
 - enumerates every distinct circle centered at a seed vertex and passing
   through another seed vertex;
 - intersects each such circle numerically with the 12 seed boundary edges;
-- separates hits at modeled vertices from hits in edge interiors.
-- runs a small synthetic `A5` edge-pocket scan with
-  `A5(t,h)=A4+t*(B1-A4)+h*unit_normal(A4B1)`, rotating the result to `B5`
-  and `C5`. This is only a stress test, not the source paper's `A5`.
+- separates hits at modeled vertices from hits in edge interiors;
+- runs a small signed synthetic `A5` edge-pocket scan with
+  `A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1)`, rotating the result to
+  `B5` and `C5`. This is only a stress test, not the source paper's `A5`.
 
 ## Current result
 
@@ -74,7 +82,7 @@ max seed-vertex hits on one centered circle: 2
 max seed-boundary hits on one centered circle: 5
 circles with at least four boundary hits: 45
 circles with at least four seed vertices: 0
-synthetic A5 edge-pocket candidates: 18
+synthetic A5 edge-pocket candidates: 36
 strictly convex synthetic A5 candidates: 0
 synthetic candidates with at least four vertices on a centered circle: 0
 ```
@@ -84,10 +92,11 @@ many centered circles hit the polygonal boundary four or five times, but none
 hits four modeled seed vertices.
 
 The synthetic `A5` pocket scan is also a useful failed route: the sampled
-normal-offset candidates do not remain strictly convex. This says the missing
-`A5` step cannot be replaced by a naive point inserted around the tiny
-`A4B1` edge pocket. It is still not evidence against the full contrarian lane:
-the source construction's Lemma 3.1 choice is existential, and the relevant
+signed normal-offset stand-ins do not remain strictly convex. This only
+rejects those 36 sampled edge-pocket candidates; it does not rule out other
+naive edge-pocket placements or the source construction's existential `A5`.
+It is still not evidence against the full contrarian lane: the source
+construction's Lemma 3.1 choice is existential, and the relevant
 edge-parameter closure remains unmodeled.
 
 ## Next steps

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -1,0 +1,119 @@
+# Barany--Roldan-Pensado boundary vertexization probe
+
+Status: `NUMERICAL_GEOMETRIC_DIAGNOSTIC`.
+
+This note records a first contrarian probe of the convex-body boundary
+construction lane. It does not prove Erdos Problem #97, does not give a
+counterexample, and does not model the full Barany--Roldan-Pensado 15-gon.
+
+## Question
+
+Barany--Roldan-Pensado construct convex bodies whose boundary has high
+centered-circle intersection multiplicity. The obstruction for Erdos #97 is
+that those extra circle intersections may lie in edge interiors rather than at
+vertices.
+
+The first finite-vertex question is deliberately smaller:
+
+```text
+For the recorded 3-fold seed points, do centered circles already convert
+boundary richness into vertex richness?
+```
+
+## Modeled seed
+
+The checker uses the four quoted source points
+
+```text
+A1 = (1000, 0)
+A2 = (906, 114)
+A3 = (645, 359)
+A4 = (-498, 871)
+```
+
+and their rotations by `2*pi/3` and `4*pi/3`, giving the 12 modeled vertices
+
+```text
+A1,A2,A3,A4,B1,B2,B3,B4,C1,C2,C3,C4.
+```
+
+The seed order is strictly convex in the float64 check. The source paper then
+uses Lemma 3.1 to prove the existence of a point `A5` in a neighborhood of the
+broken line `A4B1B2B3`, but it does not give coordinates for `A5`. The checker
+therefore keeps the explicit 12-point seed separate from any synthetic `A5`
+stress test.
+
+## Checker
+
+Run:
+
+```bash
+python3 scripts/check_brp_boundary_probe.py --assert-expected
+```
+
+The checker:
+
+- represents vertex-to-vertex squared distances exactly in `Q(sqrt(3))` for
+  the 120-degree rotated seed;
+- enumerates every distinct circle centered at a seed vertex and passing
+  through another seed vertex;
+- intersects each such circle numerically with the 12 seed boundary edges;
+- separates hits at modeled vertices from hits in edge interiors.
+- runs a small synthetic `A5` edge-pocket scan with
+  `A5(t,h)=A4+t*(B1-A4)+h*unit_normal(A4B1)`, rotating the result to `B5`
+  and `C5`. This is only a stress test, not the source paper's `A5`.
+
+## Current result
+
+The stable checked summary is:
+
+```text
+seed vertices: 12
+distinct centered vertex radii: 120
+max seed-vertex hits on one centered circle: 2
+max seed-boundary hits on one centered circle: 5
+circles with at least four boundary hits: 45
+circles with at least four seed vertices: 0
+synthetic A5 edge-pocket candidates: 18
+strictly convex synthetic A5 candidates: 0
+synthetic candidates with at least four vertices on a centered circle: 0
+```
+
+Thus the modeled 12-point seed shows the expected continuous/discrete gap:
+many centered circles hit the polygonal boundary four or five times, but none
+hits four modeled seed vertices.
+
+The synthetic `A5` pocket scan is also a useful failed route: the sampled
+normal-offset candidates do not remain strictly convex. This says the missing
+`A5` step cannot be replaced by a naive point inserted around the tiny
+`A4B1` edge pocket. It is still not evidence against the full contrarian lane:
+the source construction's Lemma 3.1 choice is existential, and the relevant
+edge-parameter closure remains unmodeled.
+
+## Next steps
+
+Useful follow-up work should avoid more visual inspection and instead make the
+edge-interior hits algebraic:
+
+1. Replace the synthetic pocket scan with the actual Lemma 3.1 constraints for
+   `A=A3`, `B=A4`, `C=B1`, and a suitable `D` from the adjacent seed chain.
+2. Solve or parameterize admissible `A5` choices with strict convexity
+   constraints.
+3. Promote each interior circle-edge hit to a candidate vertex parameter.
+4. Iterate the closure condition: promoted vertices become centers that must
+   themselves acquire four vertex hits.
+5. Replace float64 edge intersections with exact algebraic or interval
+   certificates.
+6. If every closure attempt explodes into new edge interiors, extract the
+   failure as a boundary-to-vertex obstruction lemma.
+
+## Guardrails
+
+Do not cite this probe as:
+
+- a proof of Erdos Problem #97;
+- a counterexample or counterexample candidate;
+- a finite extraction from the Barany--Roldan-Pensado body;
+- a check of the final 15-gon;
+- evidence about the actual existential `A5` from Lemma 3.1;
+- an exact certificate for boundary intersections.

--- a/docs/index.md
+++ b/docs/index.md
@@ -793,6 +793,10 @@ put detailed reconciliation in the canonical synthesis.
   opposite-chain parabolic-lens closure equations for a possible future exact
   search, plus a bounded rational-grid negative-control artifact; search
   scaffold only, not counterexample evidence.
+- [`brp-boundary-vertexization-probe.md`](brp-boundary-vertexization-probe.md):
+  first seed-only diagnostic for the Barany--Roldan-Pensado convex-body
+  boundary lane, measuring seed-boundary circle hits versus modeled seed-vertex
+  hits; numerical diagnostic only, not a finite extraction or counterexample.
 - [`dynamic-witness-free-pattern-search.md`](dynamic-witness-free-pattern-search.md):
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -34,6 +34,13 @@ are claimed here.
   vertex problem at the `N=2` level: Barany--Roldan-Pensado note that for any
   boundary point of an acute triangle, some centered circle meets the boundary
   four times. This also does not imply a finite selected-vertex example.[^barany-roldan]
+- A first seed-only vertexization probe now checks the quoted 3-fold
+  Barany--Roldan-Pensado seed before the `A5` insertion. Among the `120`
+  distinct circles centered at a modeled seed vertex and passing through
+  another modeled seed vertex, `45` hit the 12-edge seed boundary at least four
+  times, but none hit four modeled seed vertices. This confirms the immediate
+  boundary/vertex gap for the seed and does not check the final 15-gon or give
+  a counterexample; see `docs/brp-boundary-vertexization-probe.md`.
 - The canonical synthesis corrects a prior uniform-radius shortcut:
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound
   construction, not an upper bound resolving the subcase. Furedi's separate

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3443,6 +3443,42 @@ artifacts:
       - source-of-truth strongest result
       - general proof of Erdos Problem #97
 
+  - id: brp_boundary_vertexization_probe
+    path: data/certificates/brp_boundary_vertexization_probe.json
+    sha256: 158434c458b6616d9f9fd1bf90958e6b3434ec5c84520e0b257c9a6c5b785aa8
+    size_bytes: 34413
+    kind: numerical_geometric_diagnostic_artifact
+    generator: scripts/check_brp_boundary_probe.py
+    command: python scripts/check_brp_boundary_probe.py --write --assert-expected
+    checker: scripts/check_brp_boundary_probe.py
+    check_command: python scripts/check_brp_boundary_probe.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits and a signed sampled synthetic A5 edge-pocket stress scan. Not a finite extraction, not the final 15-gon, not a proof, not a counterexample, and not an official/global status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.brp_boundary_vertexization_probe.v1
+      status: BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY
+      trust: NUMERICAL_GEOMETRIC_DIAGNOSTIC
+      provenance.command: python scripts/check_brp_boundary_probe.py --write --assert-expected
+      summary.seed_vertex_count: 12
+      summary.distinct_centered_vertex_radii: 120
+      summary.max_vertex_hits_on_seed: 2
+      summary.max_boundary_hits_on_seed_edges: 5
+      summary.circles_with_at_least_four_seed_vertices: 0
+      summary.circles_with_at_least_four_boundary_hits: 45
+      synthetic_a5_scan.candidate_count: 36
+      synthetic_a5_scan.strictly_convex_candidate_count: 0
+      synthetic_a5_scan.candidates_with_at_least_four_vertices: 0
+    forbidden_claims:
+      - proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+      - finite-vertex extraction from the Barany--Roldan-Pensado body
+      - model of the source paper's A5 insertion or final 15-gon
+      - exact or interval certificate for boundary intersections
+      - official/global status update
+
   - id: two_parabola_lens_grid_search
     path: data/certificates/two_parabola_lens_grid_search.json
     sha256: b514282e4d5a6ebc096551e6e61ab354d6fc90fda592f1f8e494993fb03e5c18

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3445,8 +3445,8 @@ artifacts:
 
   - id: brp_boundary_vertexization_probe
     path: data/certificates/brp_boundary_vertexization_probe.json
-    sha256: 158434c458b6616d9f9fd1bf90958e6b3434ec5c84520e0b257c9a6c5b785aa8
-    size_bytes: 34413
+    sha256: c9ce88089495d559f00a901cc0ea99f7202ead8bc31ea614b2b4740c4a7eab6f
+    size_bytes: 34036
     kind: numerical_geometric_diagnostic_artifact
     generator: scripts/check_brp_boundary_probe.py
     command: python scripts/check_brp_boundary_probe.py --write --assert-expected

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -31,6 +32,52 @@ def _load_json(path: Path) -> dict[str, object]:
     return payload
 
 
+def _assert_payload_current(
+    stored: object,
+    current: object,
+    *,
+    tol: float,
+    path: str = "$",
+) -> None:
+    if isinstance(stored, float) or isinstance(current, float):
+        if not isinstance(stored, (int, float)) or not isinstance(current, (int, float)):
+            raise AssertionError(f"{path}: numeric type mismatch")
+        if not math.isclose(float(stored), float(current), rel_tol=tol, abs_tol=tol):
+            raise AssertionError(f"{path}: expected {current!r}, got {stored!r}")
+        return
+
+    if isinstance(stored, dict) and isinstance(current, dict):
+        stored_keys = set(stored)
+        current_keys = set(current)
+        if stored_keys != current_keys:
+            missing = sorted(current_keys - stored_keys)
+            extra = sorted(stored_keys - current_keys)
+            raise AssertionError(f"{path}: key mismatch; missing={missing}, extra={extra}")
+        for key in sorted(stored):
+            _assert_payload_current(
+                stored[key],
+                current[key],
+                tol=tol,
+                path=f"{path}.{key}",
+            )
+        return
+
+    if isinstance(stored, list) and isinstance(current, list):
+        if len(stored) != len(current):
+            raise AssertionError(f"{path}: expected length {len(current)}, got {len(stored)}")
+        for index, (stored_item, current_item) in enumerate(zip(stored, current, strict=True)):
+            _assert_payload_current(
+                stored_item,
+                current_item,
+                tol=tol,
+                path=f"{path}[{index}]",
+            )
+        return
+
+    if stored != current:
+        raise AssertionError(f"{path}: expected {current!r}, got {stored!r}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print stable JSON")
@@ -46,8 +93,7 @@ def main() -> int:
     if args.check:
         payload = _load_json(artifact)
         current = build_payload(tol=args.tol)
-        if payload != current:
-            raise AssertionError("BRP boundary vertexization probe artifact is not current")
+        _assert_payload_current(payload, current, tol=args.tol)
     else:
         payload = build_payload(tol=args.tol)
 

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Run the Barany--Roldan-Pensado boundary-to-vertex diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.brp_boundary_probe import (  # noqa: E402
+    ROOT_TOL,
+    assert_expected_counts,
+    build_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "brp_boundary_vertexization_probe.json"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} does not contain a JSON object")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print stable JSON")
+    parser.add_argument("--write", action="store_true", help="write the JSON payload")
+    parser.add_argument("--check", action="store_true", help="check an existing JSON payload")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--tol", type=float, default=ROOT_TOL)
+    parser.add_argument("--artifact", default=str(DEFAULT_ARTIFACT))
+    args = parser.parse_args()
+
+    artifact = Path(args.artifact)
+    if args.check:
+        payload = _load_json(artifact)
+        current = build_payload(tol=args.tol)
+        if payload != current:
+            raise AssertionError("BRP boundary vertexization probe artifact is not current")
+    else:
+        payload = build_payload(tol=args.tol)
+
+    if args.assert_expected:
+        assert_expected_counts(payload)
+
+    if args.write and not args.check:
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        convexity = payload["convexity"]
+        synthetic = payload["synthetic_a5_scan"]
+        print("BRP boundary-to-vertex diagnostic")
+        print(f"seed vertices: {summary['seed_vertex_count']}")
+        print(f"strictly convex seed order: {convexity['strictly_convex_in_seed_order']}")
+        print(f"distinct centered vertex radii: {summary['distinct_centered_vertex_radii']}")
+        print(f"max seed-vertex hits: {summary['max_vertex_hits_on_seed']}")
+        print(f"max seed-boundary hits: {summary['max_boundary_hits_on_seed_edges']}")
+        print(
+            "circles with >=4 boundary hits: "
+            f"{summary['circles_with_at_least_four_boundary_hits']}"
+        )
+        print(
+            "circles with >=4 seed vertices: "
+            f"{summary['circles_with_at_least_four_seed_vertices']}"
+        )
+        print(
+            "synthetic A5 convex candidates: "
+            f"{synthetic['strictly_convex_candidate_count']} / {synthetic['candidate_count']}"
+        )
+        print(f"synthetic A5 best vertex hits: {synthetic['best_max_vertex_hits']}")
+        if args.assert_expected:
+            print("OK: expected BRP boundary diagnostic counts verified")
+        if args.write and not args.check:
+            print(f"wrote {display_path(artifact, ROOT)}")
+        if args.check:
+            print(f"OK: {display_path(artifact, ROOT)} is current")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -34,8 +34,9 @@ def _load_json(path: Path) -> dict[str, object]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="print stable JSON")
-    parser.add_argument("--write", action="store_true", help="write the JSON payload")
-    parser.add_argument("--check", action="store_true", help="check an existing JSON payload")
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument("--write", action="store_true", help="write the JSON payload")
+    mode_group.add_argument("--check", action="store_true", help="check an existing JSON payload")
     parser.add_argument("--assert-expected", action="store_true")
     parser.add_argument("--tol", type=float, default=ROOT_TOL)
     parser.add_argument("--artifact", default=str(DEFAULT_ARTIFACT))
@@ -53,7 +54,7 @@ def main() -> int:
     if args.assert_expected:
         assert_expected_counts(payload)
 
-    if args.write and not args.check:
+    if args.write:
         artifact.parent.mkdir(parents=True, exist_ok=True)
         artifact.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -84,7 +85,7 @@ def main() -> int:
         print(f"synthetic A5 best vertex hits: {synthetic['best_max_vertex_hits']}")
         if args.assert_expected:
             print("OK: expected BRP boundary diagnostic counts verified")
-        if args.write and not args.check:
+        if args.write:
             print(f"wrote {display_path(artifact, ROOT)}")
         if args.check:
             print(f"OK: {display_path(artifact, ROOT)} is current")

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1674,6 +1674,24 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="brp_boundary_vertexization_probe",
+        command=(
+            "python",
+            "scripts/check_brp_boundary_probe.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Float64 boundary-hit diagnostic for the quoted 12-point "
+            "Barany--Roldan-Pensado seed before A5 insertion with a signed "
+            "synthetic A5 edge-pocket stress scan; not a finite extraction "
+            "from the body, not the final 15-gon, not a proof of Erdos "
+            "Problem #97, not a counterexample, and not an official/global "
+            "status update."
+        ),
+    ),
+    AuditCommand(
         ident="rich_support_counting_bound",
         command=(
             "python",

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -22,9 +22,10 @@ BASE_POINTS: tuple[tuple[str, int, int], ...] = (
 )
 ORBIT_PREFIXES = ("A", "B", "C")
 DEFAULT_A5_PARAMETERS: tuple[tuple[Fraction, Fraction], ...] = tuple(
-    (Fraction(t, 4), Fraction(h))
+    (Fraction(t, 4), Fraction(sign * h))
     for t in (1, 2, 3)
     for h in (1, 2, 5, 10, 20, 50)
+    for sign in (-1, 1)
 )
 SQRT3 = math.sqrt(3.0)
 ROOT_TOL = 1e-9
@@ -176,14 +177,14 @@ def brp_candidate_15gon(t_value: Fraction, normal_offset: Fraction) -> tuple[Num
 
     The source paper proves existence of an A5 near A4 using Lemma 3.1 but does
     not give coordinates. This two-parameter family is a diagnostic stand-in:
-    it inserts A5 between A4 and B1, offset on one normal side of that edge,
+    it inserts A5 between A4 and B1, offset on either normal side of that edge,
     then rotates it to B5/C5. It is not claimed to be the paper's chosen point.
     """
 
     if not Fraction(0) < t_value < Fraction(1):
         raise ValueError("t_value must lie strictly between 0 and 1")
-    if normal_offset <= 0:
-        raise ValueError("normal_offset must be positive")
+    if normal_offset == 0:
+        raise ValueError("normal_offset must be nonzero")
     seed = brp_seed_numeric_vertices()
     by_label = {vertex.label: vertex.numeric for vertex in seed}
     a4 = by_label["A4"]
@@ -499,6 +500,7 @@ def _candidate_to_json(candidate: Candidate15Summary) -> dict[str, object]:
     return {
         "t": _format_fraction(candidate.t_value),
         "normal_offset": _format_fraction(candidate.normal_offset),
+        "normal_side": "left" if candidate.normal_offset > 0 else "right",
         "strictly_convex": candidate.strictly_convex,
         "min_turn_area2": candidate.min_turn_area2,
         "max_vertex_hits": candidate.max_vertex_hits,
@@ -532,6 +534,14 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
         "schema": SCHEMA,
         "status": STATUS,
         "trust": TRUST,
+        "provenance": {
+            "generator": "scripts/check_brp_boundary_probe.py",
+            "command": "python scripts/check_brp_boundary_probe.py --write --assert-expected",
+            "notes": (
+                "Float64 boundary-intersection diagnostic for the quoted "
+                "Barany--Roldan-Pensado 12-point seed before A5 insertion."
+            ),
+        },
         "source": {
             "construction": "Barany--Roldan-Pensado 3-fold seed before A5 insertion",
             "base_points": [
@@ -559,16 +569,17 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
         },
         "synthetic_a5_scan": {
             "description": (
-                "A5(t,h)=A4+t*(B1-A4)+h*unit_normal(A4B1), "
-                "then rotated to B5/C5; diagnostic stand-in only, not the "
-                "source paper's A5."
+                "A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1), "
+                "with signed h and rotations to B5/C5; diagnostic stand-in "
+                "only, not the source paper's A5."
             ),
             "parameters": [
                 {
                     "t": _format_fraction(t_value),
-                    "normal_offset": _format_fraction(outward_offset),
+                    "normal_offset": _format_fraction(normal_offset),
+                    "normal_side": "left" if normal_offset > 0 else "right",
                 }
-                for t_value, outward_offset in DEFAULT_A5_PARAMETERS
+                for t_value, normal_offset in DEFAULT_A5_PARAMETERS
             ],
             "candidate_count": len(candidate_scan),
             "strictly_convex_candidate_count": convex_candidate_count,
@@ -578,9 +589,9 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
                 1 for candidate in candidate_scan if candidate.circles_with_at_least_four_vertices
             ),
             "interpretation": (
-                "No sampled synthetic pocket candidate is strictly convex; "
-                "boundary-hit counts in this subscan are therefore nonconvex "
-                "stress diagnostics only."
+                "This signed normal-offset scan is a diagnostic stress test "
+                "only. It samples nearby synthetic A5 placements but does not "
+                "model the source paper's existential A5 constraints."
             ),
             "candidates": [_candidate_to_json(candidate) for candidate in candidate_scan],
         },
@@ -597,8 +608,8 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "Float64 boundary-hit diagnostic for the 12-point three-fold seed "
             "quoted in the Barany--Roldan-Pensado convex-body discussion. It "
             "measures the gap between centered circle hits on polygon edges and "
-            "hits at the modeled seed vertices, and includes a synthetic A5 "
-            "edge-pocket scan as a failed first closure stress test."
+            "hits at the modeled seed vertices, and includes a limited signed "
+            "synthetic A5 edge-pocket closure stress test."
         ),
         "does_not_claim": [
             "proof of Erdos Problem #97",
@@ -659,7 +670,7 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
     if not isinstance(synthetic, dict):
         raise AssertionError("payload.synthetic_a5_scan must be an object")
     expected_synthetic = {
-        "candidate_count": 18,
+        "candidate_count": 36,
         "strictly_convex_candidate_count": 0,
         "best_max_vertex_hits": 2,
         "best_max_boundary_hits": 8,

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -1,0 +1,670 @@
+"""Boundary-to-vertex diagnostic for the Barany--Roldan-Pensado seed."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Iterable
+
+import math
+
+
+SCHEMA = "erdos97.brp_boundary_vertexization_probe.v1"
+STATUS = "BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY"
+TRUST = "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
+
+BASE_POINTS: tuple[tuple[str, int, int], ...] = (
+    ("1", 1000, 0),
+    ("2", 906, 114),
+    ("3", 645, 359),
+    ("4", -498, 871),
+)
+ORBIT_PREFIXES = ("A", "B", "C")
+DEFAULT_A5_PARAMETERS: tuple[tuple[Fraction, Fraction], ...] = tuple(
+    (Fraction(t, 4), Fraction(h))
+    for t in (1, 2, 3)
+    for h in (1, 2, 5, 10, 20, 50)
+)
+SQRT3 = math.sqrt(3.0)
+ROOT_TOL = 1e-9
+DISTANCE_TOL = 1e-6
+
+
+@dataclass(frozen=True, order=True)
+class Quad:
+    """Number of the form `a + b*sqrt(3)` with rational coefficients."""
+
+    a: Fraction
+    b: Fraction = Fraction(0)
+
+    def __add__(self, other: Quad) -> Quad:
+        return Quad(self.a + other.a, self.b + other.b)
+
+    def __sub__(self, other: Quad) -> Quad:
+        return Quad(self.a - other.a, self.b - other.b)
+
+    def __neg__(self) -> Quad:
+        return Quad(-self.a, -self.b)
+
+    def __mul__(self, other: Quad) -> Quad:
+        return Quad(
+            self.a * other.a + 3 * self.b * other.b,
+            self.a * other.b + self.b * other.a,
+        )
+
+    def to_float(self) -> float:
+        return float(self.a) + float(self.b) * SQRT3
+
+
+@dataclass(frozen=True)
+class SeedVertex:
+    label: str
+    exact: tuple[Quad, Quad]
+    numeric: tuple[float, float]
+
+
+@dataclass(frozen=True)
+class NumericVertex:
+    label: str
+    numeric: tuple[float, float]
+
+
+@dataclass(frozen=True)
+class InteriorHit:
+    edge: tuple[str, str]
+    t: float
+
+
+@dataclass(frozen=True)
+class CircleProfile:
+    center: str
+    radius_key: Quad
+    radius_squared: float
+    vertex_hits: tuple[str, ...]
+    interior_hits: tuple[InteriorHit, ...]
+
+    @property
+    def boundary_hit_count(self) -> int:
+        return len(self.vertex_hits) + len(self.interior_hits)
+
+
+@dataclass(frozen=True)
+class Candidate15Summary:
+    t_value: Fraction
+    normal_offset: Fraction
+    strictly_convex: bool
+    min_turn_area2: float
+    max_vertex_hits: int
+    max_boundary_hits: int
+    circles_with_at_least_four_vertices: int
+    circles_with_at_least_four_boundary_hits: int
+
+
+def _q(value: int | Fraction, sqrt3: int | Fraction = 0) -> Quad:
+    return Quad(Fraction(value), Fraction(sqrt3))
+
+
+def _format_fraction(value: Fraction) -> str:
+    if value.denominator == 1:
+        return str(value.numerator)
+    return f"{value.numerator}/{value.denominator}"
+
+
+def quad_to_json(value: Quad) -> str:
+    """Stable compact display for `a + b*sqrt(3)`."""
+
+    if value.b == 0:
+        return _format_fraction(value.a)
+    if value.a == 0:
+        return f"{_format_fraction(value.b)}*sqrt3"
+    sign = "+" if value.b > 0 else "-"
+    return f"{_format_fraction(value.a)} {sign} {_format_fraction(abs(value.b))}*sqrt3"
+
+
+def _rotate_exact(x: int, y: int, orbit: int) -> tuple[Quad, Quad]:
+    if orbit == 0:
+        return (_q(x), _q(y))
+    if orbit == 1:
+        return (
+            _q(Fraction(-x, 2), Fraction(-y, 2)),
+            _q(Fraction(-y, 2), Fraction(x, 2)),
+        )
+    if orbit == 2:
+        return (
+            _q(Fraction(-x, 2), Fraction(y, 2)),
+            _q(Fraction(-y, 2), Fraction(-x, 2)),
+        )
+    raise ValueError(f"unknown orbit: {orbit}")
+
+
+def _rotate_numeric(x: int, y: int, orbit: int) -> tuple[float, float]:
+    return _rotate_numeric_point((float(x), float(y)), orbit)
+
+
+def _rotate_numeric_point(point: tuple[float, float], orbit: int) -> tuple[float, float]:
+    x, y = point
+    angle = 2.0 * math.pi * orbit / 3.0
+    return (
+        x * math.cos(angle) - y * math.sin(angle),
+        x * math.sin(angle) + y * math.cos(angle),
+    )
+
+
+def brp_seed_vertices() -> tuple[SeedVertex, ...]:
+    """Return the 12-point 3-fold seed before the paper's A5 insertion."""
+
+    vertices: list[SeedVertex] = []
+    for orbit, prefix in enumerate(ORBIT_PREFIXES):
+        for suffix, x, y in BASE_POINTS:
+            vertices.append(
+                SeedVertex(
+                    label=f"{prefix}{suffix}",
+                    exact=_rotate_exact(x, y, orbit),
+                    numeric=_rotate_numeric(x, y, orbit),
+                )
+            )
+    return tuple(vertices)
+
+
+def brp_seed_numeric_vertices() -> tuple[NumericVertex, ...]:
+    return tuple(NumericVertex(label=vertex.label, numeric=vertex.numeric) for vertex in brp_seed_vertices())
+
+
+def brp_candidate_15gon(t_value: Fraction, normal_offset: Fraction) -> tuple[NumericVertex, ...]:
+    """Return a synthetic 15-gon by placing A5 in the A4-B1 edge pocket.
+
+    The source paper proves existence of an A5 near A4 using Lemma 3.1 but does
+    not give coordinates. This two-parameter family is a diagnostic stand-in:
+    it inserts A5 between A4 and B1, offset on one normal side of that edge,
+    then rotates it to B5/C5. It is not claimed to be the paper's chosen point.
+    """
+
+    if not Fraction(0) < t_value < Fraction(1):
+        raise ValueError("t_value must lie strictly between 0 and 1")
+    if normal_offset <= 0:
+        raise ValueError("normal_offset must be positive")
+    seed = brp_seed_numeric_vertices()
+    by_label = {vertex.label: vertex.numeric for vertex in seed}
+    a4 = by_label["A4"]
+    b1 = by_label["B1"]
+    edge = (b1[0] - a4[0], b1[1] - a4[1])
+    normal = (-edge[1], edge[0])
+    normal_length = math.hypot(*normal)
+    normal_unit = (
+        normal[0] / normal_length,
+        normal[1] / normal_length,
+    )
+    t = float(t_value)
+    h = float(normal_offset)
+    a5 = (
+        a4[0] + t * edge[0] + h * normal_unit[0],
+        a4[1] + t * edge[1] + h * normal_unit[1],
+    )
+    vertices: list[NumericVertex] = []
+    for orbit, prefix in enumerate(ORBIT_PREFIXES):
+        for suffix in ("1", "2", "3", "4"):
+            label = f"{prefix}{suffix}"
+            if prefix == "A":
+                point = by_label[label]
+            else:
+                source = by_label[f"A{suffix}"]
+                point = _rotate_numeric_point(source, orbit)
+            vertices.append(NumericVertex(label=label, numeric=point))
+        vertices.append(
+            NumericVertex(label=f"{prefix}5", numeric=_rotate_numeric_point(a5, orbit))
+        )
+    return tuple(vertices)
+
+
+def exact_squared_distance(left: SeedVertex, right: SeedVertex) -> Quad:
+    dx = left.exact[0] - right.exact[0]
+    dy = left.exact[1] - right.exact[1]
+    return dx * dx + dy * dy
+
+
+def _orientation2(
+    left: tuple[float, float],
+    middle: tuple[float, float],
+    right: tuple[float, float],
+) -> float:
+    return (middle[0] - left[0]) * (right[1] - left[1]) - (
+        middle[1] - left[1]
+    ) * (right[0] - left[0])
+
+
+def seed_convexity_summary(vertices: tuple[SeedVertex, ...]) -> dict[str, object]:
+    return numeric_convexity_summary(
+        tuple(NumericVertex(label=vertex.label, numeric=vertex.numeric) for vertex in vertices)
+    )
+
+
+def numeric_convexity_summary(vertices: tuple[NumericVertex, ...]) -> dict[str, object]:
+    turns = []
+    for index, vertex in enumerate(vertices):
+        previous = vertices[index - 1]
+        following = vertices[(index + 1) % len(vertices)]
+        turns.append(_orientation2(previous.numeric, vertex.numeric, following.numeric))
+    return {
+        "strictly_convex_in_seed_order": all(turn > 0.0 for turn in turns),
+        "min_turn_area2": min(turns),
+        "max_turn_area2": max(turns),
+    }
+
+
+def _numeric_squared_distance(left: NumericVertex, right: NumericVertex) -> float:
+    dx = left.numeric[0] - right.numeric[0]
+    dy = left.numeric[1] - right.numeric[1]
+    return dx * dx + dy * dy
+
+
+def _same_distance(left: float, right: float, tol: float) -> bool:
+    return abs(left - right) <= tol * max(1.0, abs(left), abs(right))
+
+
+def _edge_roots(
+    *,
+    center: tuple[float, float],
+    radius_squared: float,
+    start: tuple[float, float],
+    end: tuple[float, float],
+    tol: float,
+) -> tuple[float, ...]:
+    dx = end[0] - start[0]
+    dy = end[1] - start[1]
+    fx = start[0] - center[0]
+    fy = start[1] - center[1]
+    a = dx * dx + dy * dy
+    b = 2.0 * (fx * dx + fy * dy)
+    c = fx * fx + fy * fy - radius_squared
+    discriminant = b * b - 4.0 * a * c
+    if discriminant < -tol:
+        return ()
+    if abs(discriminant) <= tol:
+        roots = (-b / (2.0 * a),)
+    else:
+        sqrt_disc = math.sqrt(discriminant)
+        roots = ((-b - sqrt_disc) / (2.0 * a), (-b + sqrt_disc) / (2.0 * a))
+    accepted = []
+    for root in roots:
+        if -tol <= root <= 1.0 + tol:
+            accepted.append(min(1.0, max(0.0, root)))
+    return tuple(sorted(set(round(root, 12) for root in accepted)))
+
+
+def _numeric_circle_profiles(
+    vertices: tuple[NumericVertex, ...],
+    *,
+    root_tol: float,
+    distance_tol: float,
+) -> tuple[CircleProfile, ...]:
+    profiles: list[CircleProfile] = []
+    seen: set[tuple[str, int]] = set()
+    for center_index, center in enumerate(vertices):
+        target_radii = [
+            _numeric_squared_distance(center, target)
+            for target_index, target in enumerate(vertices)
+            if target_index != center_index
+        ]
+        for radius_squared in target_radii:
+            radius_bucket = round(radius_squared / distance_tol)
+            key = (center.label, radius_bucket)
+            if key in seen:
+                continue
+            seen.add(key)
+            vertex_hits = tuple(
+                target.label
+                for target_index, target in enumerate(vertices)
+                if target_index != center_index
+                and _same_distance(
+                    _numeric_squared_distance(center, target),
+                    radius_squared,
+                    distance_tol,
+                )
+            )
+            interior_hits: list[InteriorHit] = []
+            for edge_index, start in enumerate(vertices):
+                end = vertices[(edge_index + 1) % len(vertices)]
+                for root in _edge_roots(
+                    center=center.numeric,
+                    radius_squared=radius_squared,
+                    start=start.numeric,
+                    end=end.numeric,
+                    tol=root_tol,
+                ):
+                    if root_tol < root < 1.0 - root_tol:
+                        interior_hits.append(
+                            InteriorHit(edge=(start.label, end.label), t=root)
+                        )
+            profiles.append(
+                CircleProfile(
+                    center=center.label,
+                    radius_key=Quad(Fraction.from_float(radius_squared).limit_denominator()),
+                    radius_squared=radius_squared,
+                    vertex_hits=vertex_hits,
+                    interior_hits=tuple(interior_hits),
+                )
+            )
+    return tuple(profiles)
+
+
+def _unique_radii_by_center(vertices: tuple[SeedVertex, ...]) -> dict[int, tuple[Quad, ...]]:
+    radii: dict[int, set[Quad]] = defaultdict(set)
+    for center_index, center in enumerate(vertices):
+        for target_index, target in enumerate(vertices):
+            if center_index == target_index:
+                continue
+            radii[center_index].add(exact_squared_distance(center, target))
+    return {
+        center_index: tuple(sorted(center_radii))
+        for center_index, center_radii in radii.items()
+    }
+
+
+def circle_profile(
+    vertices: tuple[SeedVertex, ...],
+    *,
+    center_index: int,
+    radius_key: Quad,
+    tol: float = ROOT_TOL,
+) -> CircleProfile:
+    center = vertices[center_index]
+    radius_squared = radius_key.to_float()
+    vertex_hits = tuple(
+        vertex.label
+        for vertex_index, vertex in enumerate(vertices)
+        if vertex_index != center_index
+        and exact_squared_distance(center, vertex) == radius_key
+    )
+    interior_hits: list[InteriorHit] = []
+    for edge_index, start in enumerate(vertices):
+        end = vertices[(edge_index + 1) % len(vertices)]
+        for root in _edge_roots(
+            center=center.numeric,
+            radius_squared=radius_squared,
+            start=start.numeric,
+            end=end.numeric,
+            tol=tol,
+        ):
+            if tol < root < 1.0 - tol:
+                interior_hits.append(
+                    InteriorHit(edge=(start.label, end.label), t=root)
+                )
+    return CircleProfile(
+        center=center.label,
+        radius_key=radius_key,
+        radius_squared=radius_squared,
+        vertex_hits=vertex_hits,
+        interior_hits=tuple(interior_hits),
+    )
+
+
+def all_circle_profiles(tol: float = ROOT_TOL) -> tuple[CircleProfile, ...]:
+    vertices = brp_seed_vertices()
+    profiles: list[CircleProfile] = []
+    for center_index, radii in _unique_radii_by_center(vertices).items():
+        for radius_key in radii:
+            profiles.append(
+                circle_profile(
+                    vertices,
+                    center_index=center_index,
+                    radius_key=radius_key,
+                    tol=tol,
+                )
+            )
+    return tuple(
+        sorted(
+            profiles,
+            key=lambda profile: (
+                profile.center,
+                profile.boundary_hit_count,
+                len(profile.vertex_hits),
+                quad_to_json(profile.radius_key),
+            ),
+        )
+    )
+
+
+def summarize_candidate_15gon(
+    t_value: Fraction,
+    normal_offset: Fraction,
+    *,
+    root_tol: float = ROOT_TOL,
+    distance_tol: float = DISTANCE_TOL,
+) -> Candidate15Summary:
+    vertices = brp_candidate_15gon(t_value, normal_offset)
+    convexity = numeric_convexity_summary(vertices)
+    profiles = _numeric_circle_profiles(
+        vertices,
+        root_tol=root_tol,
+        distance_tol=distance_tol,
+    )
+    return Candidate15Summary(
+        t_value=t_value,
+        normal_offset=normal_offset,
+        strictly_convex=bool(convexity["strictly_convex_in_seed_order"]),
+        min_turn_area2=float(convexity["min_turn_area2"]),
+        max_vertex_hits=max(len(profile.vertex_hits) for profile in profiles),
+        max_boundary_hits=max(profile.boundary_hit_count for profile in profiles),
+        circles_with_at_least_four_vertices=sum(
+            1 for profile in profiles if len(profile.vertex_hits) >= 4
+        ),
+        circles_with_at_least_four_boundary_hits=sum(
+            1 for profile in profiles if profile.boundary_hit_count >= 4
+        ),
+    )
+
+
+def synthetic_a5_scan(
+    parameters: Iterable[tuple[Fraction, Fraction]] = DEFAULT_A5_PARAMETERS,
+    *,
+    root_tol: float = ROOT_TOL,
+    distance_tol: float = DISTANCE_TOL,
+) -> tuple[Candidate15Summary, ...]:
+    return tuple(
+        summarize_candidate_15gon(
+            t_value,
+            normal_offset,
+            root_tol=root_tol,
+            distance_tol=distance_tol,
+        )
+        for t_value, normal_offset in parameters
+    )
+
+
+def _histogram(values: Iterable[int]) -> dict[str, int]:
+    return {str(key): value for key, value in sorted(Counter(values).items())}
+
+
+def _profile_to_json(profile: CircleProfile) -> dict[str, object]:
+    return {
+        "center": profile.center,
+        "radius_squared_exact": quad_to_json(profile.radius_key),
+        "radius_squared_float": profile.radius_squared,
+        "vertex_hit_count": len(profile.vertex_hits),
+        "boundary_hit_count": profile.boundary_hit_count,
+        "interior_hit_count": len(profile.interior_hits),
+        "vertex_hits": list(profile.vertex_hits),
+        "interior_hits": [
+            {
+                "edge": list(hit.edge),
+                "t": hit.t,
+            }
+            for hit in profile.interior_hits
+        ],
+    }
+
+
+def _candidate_to_json(candidate: Candidate15Summary) -> dict[str, object]:
+    return {
+        "t": _format_fraction(candidate.t_value),
+        "normal_offset": _format_fraction(candidate.normal_offset),
+        "strictly_convex": candidate.strictly_convex,
+        "min_turn_area2": candidate.min_turn_area2,
+        "max_vertex_hits": candidate.max_vertex_hits,
+        "max_boundary_hits": candidate.max_boundary_hits,
+        "circles_with_at_least_four_vertices": candidate.circles_with_at_least_four_vertices,
+        "circles_with_at_least_four_boundary_hits": (
+            candidate.circles_with_at_least_four_boundary_hits
+        ),
+    }
+
+
+def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
+    if tol <= 0.0:
+        raise ValueError("tol must be positive")
+    vertices = brp_seed_vertices()
+    profiles = all_circle_profiles(tol=tol)
+    candidate_scan = synthetic_a5_scan(root_tol=tol)
+    convex_candidate_count = sum(1 for candidate in candidate_scan if candidate.strictly_convex)
+    best_candidate_vertex_hits = max(candidate.max_vertex_hits for candidate in candidate_scan)
+    best_candidate_boundary_hits = max(candidate.max_boundary_hits for candidate in candidate_scan)
+    max_vertex_hits = max(len(profile.vertex_hits) for profile in profiles)
+    max_boundary_hits = max(profile.boundary_hit_count for profile in profiles)
+    max_interior_hits = max(len(profile.interior_hits) for profile in profiles)
+    best_vertex_profiles = [
+        profile for profile in profiles if len(profile.vertex_hits) == max_vertex_hits
+    ]
+    best_boundary_profiles = [
+        profile for profile in profiles if profile.boundary_hit_count == max_boundary_hits
+    ]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "source": {
+            "construction": "Barany--Roldan-Pensado 3-fold seed before A5 insertion",
+            "base_points": [
+                {"label": f"A{suffix}", "x": x, "y": y}
+                for suffix, x, y in BASE_POINTS
+            ],
+            "rotations_degrees": [0, 120, 240],
+            "modeled_vertices": [vertex.label for vertex in vertices],
+            "not_modeled": "the A5 insertion and the final 15-gon edge-parameter closure",
+        },
+        "convexity": seed_convexity_summary(vertices),
+        "summary": {
+            "seed_vertex_count": len(vertices),
+            "seed_edge_count": len(vertices),
+            "distinct_centered_vertex_radii": len(profiles),
+            "max_vertex_hits_on_seed": max_vertex_hits,
+            "max_boundary_hits_on_seed_edges": max_boundary_hits,
+            "max_interior_hits_on_one_seed_circle": max_interior_hits,
+            "circles_with_at_least_four_seed_vertices": sum(
+                1 for profile in profiles if len(profile.vertex_hits) >= 4
+            ),
+            "circles_with_at_least_four_boundary_hits": sum(
+                1 for profile in profiles if profile.boundary_hit_count >= 4
+            ),
+        },
+        "synthetic_a5_scan": {
+            "description": (
+                "A5(t,h)=A4+t*(B1-A4)+h*unit_normal(A4B1), "
+                "then rotated to B5/C5; diagnostic stand-in only, not the "
+                "source paper's A5."
+            ),
+            "parameters": [
+                {
+                    "t": _format_fraction(t_value),
+                    "normal_offset": _format_fraction(outward_offset),
+                }
+                for t_value, outward_offset in DEFAULT_A5_PARAMETERS
+            ],
+            "candidate_count": len(candidate_scan),
+            "strictly_convex_candidate_count": convex_candidate_count,
+            "best_max_vertex_hits": best_candidate_vertex_hits,
+            "best_max_boundary_hits": best_candidate_boundary_hits,
+            "candidates_with_at_least_four_vertices": sum(
+                1 for candidate in candidate_scan if candidate.circles_with_at_least_four_vertices
+            ),
+            "interpretation": (
+                "No sampled synthetic pocket candidate is strictly convex; "
+                "boundary-hit counts in this subscan are therefore nonconvex "
+                "stress diagnostics only."
+            ),
+            "candidates": [_candidate_to_json(candidate) for candidate in candidate_scan],
+        },
+        "histograms": {
+            "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
+            "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
+            "interior_hit_count": _histogram(len(profile.interior_hits) for profile in profiles),
+        },
+        "best_vertex_circles": [_profile_to_json(profile) for profile in best_vertex_profiles],
+        "best_boundary_circles": [
+            _profile_to_json(profile) for profile in best_boundary_profiles
+        ],
+        "claim_scope": (
+            "Float64 boundary-hit diagnostic for the 12-point three-fold seed "
+            "quoted in the Barany--Roldan-Pensado convex-body discussion. It "
+            "measures the gap between centered circle hits on polygon edges and "
+            "hits at the modeled seed vertices, and includes a synthetic A5 "
+            "edge-pocket scan as a failed first closure stress test."
+        ),
+        "does_not_claim": [
+            "proof of Erdos Problem #97",
+            "counterexample to Erdos Problem #97",
+            "finite-vertex extraction from the Barany--Roldan-Pensado body",
+            "model of the source paper's A5 insertion or final 15-gon",
+            "exact or interval certificate for boundary intersections",
+        ],
+        "next_steps": [
+            "add the A5 edge-parameter insertion once the source construction is pinned",
+            "promote edge-interior hits to symbolic edge parameters",
+            "iterate the promoted hits as new candidate vertices",
+            "replace float boundary intersections by exact algebraic or interval checks",
+        ],
+    }
+
+
+def assert_expected_counts(payload: dict[str, object]) -> None:
+    summary = payload.get("summary")
+    histograms = payload.get("histograms")
+    convexity = payload.get("convexity")
+    if not isinstance(summary, dict):
+        raise AssertionError("payload.summary must be an object")
+    if not isinstance(histograms, dict):
+        raise AssertionError("payload.histograms must be an object")
+    if not isinstance(convexity, dict):
+        raise AssertionError("payload.convexity must be an object")
+
+    expected_summary = {
+        "seed_vertex_count": 12,
+        "seed_edge_count": 12,
+        "distinct_centered_vertex_radii": 120,
+        "max_vertex_hits_on_seed": 2,
+        "max_boundary_hits_on_seed_edges": 5,
+        "max_interior_hits_on_one_seed_circle": 4,
+        "circles_with_at_least_four_seed_vertices": 0,
+        "circles_with_at_least_four_boundary_hits": 45,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            raise AssertionError(f"summary.{key}: expected {expected}, got {summary.get(key)}")
+
+    expected_histograms = {
+        "vertex_hit_count": {"1": 108, "2": 12},
+        "boundary_hit_count": {"1": 9, "2": 45, "3": 21, "4": 33, "5": 12},
+        "interior_hit_count": {"0": 12, "1": 45, "2": 24, "3": 27, "4": 12},
+    }
+    for key, expected in expected_histograms.items():
+        if histograms.get(key) != expected:
+            raise AssertionError(
+                f"histograms.{key}: expected {expected}, got {histograms.get(key)}"
+            )
+
+    if convexity.get("strictly_convex_in_seed_order") is not True:
+        raise AssertionError("seed order is expected to be strictly convex")
+
+    synthetic = payload.get("synthetic_a5_scan")
+    if not isinstance(synthetic, dict):
+        raise AssertionError("payload.synthetic_a5_scan must be an object")
+    expected_synthetic = {
+        "candidate_count": 18,
+        "strictly_convex_candidate_count": 0,
+        "best_max_vertex_hits": 2,
+        "best_max_boundary_hits": 8,
+        "candidates_with_at_least_four_vertices": 0,
+    }
+    for key, expected in expected_synthetic.items():
+        if synthetic.get(key) != expected:
+            raise AssertionError(f"synthetic_a5_scan.{key}: expected {expected}, got {synthetic.get(key)}")

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -30,6 +30,7 @@ DEFAULT_A5_PARAMETERS: tuple[tuple[Fraction, Fraction], ...] = tuple(
 SQRT3 = math.sqrt(3.0)
 ROOT_TOL = 1e-9
 DISTANCE_TOL = 1e-6
+JSON_FLOAT_DIGITS = 9
 
 
 @dataclass(frozen=True, order=True)
@@ -110,6 +111,13 @@ def _format_fraction(value: Fraction) -> str:
     if value.denominator == 1:
         return str(value.numerator)
     return f"{value.numerator}/{value.denominator}"
+
+
+def _json_float(value: float) -> float:
+    rounded = round(value, JSON_FLOAT_DIGITS)
+    if rounded == 0.0:
+        return 0.0
+    return rounded
 
 
 def quad_to_json(value: Quad) -> str:
@@ -248,8 +256,8 @@ def numeric_convexity_summary(vertices: tuple[NumericVertex, ...]) -> dict[str, 
         turns.append(_orientation2(previous.numeric, vertex.numeric, following.numeric))
     return {
         "strictly_convex_in_seed_order": all(turn > 0.0 for turn in turns),
-        "min_turn_area2": min(turns),
-        "max_turn_area2": max(turns),
+        "min_turn_area2": _json_float(min(turns)),
+        "max_turn_area2": _json_float(max(turns)),
     }
 
 
@@ -481,7 +489,7 @@ def _profile_to_json(profile: CircleProfile) -> dict[str, object]:
     return {
         "center": profile.center,
         "radius_squared_exact": quad_to_json(profile.radius_key),
-        "radius_squared_float": profile.radius_squared,
+        "radius_squared_float": _json_float(profile.radius_squared),
         "vertex_hit_count": len(profile.vertex_hits),
         "boundary_hit_count": profile.boundary_hit_count,
         "interior_hit_count": len(profile.interior_hits),
@@ -489,7 +497,7 @@ def _profile_to_json(profile: CircleProfile) -> dict[str, object]:
         "interior_hits": [
             {
                 "edge": list(hit.edge),
-                "t": hit.t,
+                "t": _json_float(hit.t),
             }
             for hit in profile.interior_hits
         ],
@@ -502,7 +510,7 @@ def _candidate_to_json(candidate: Candidate15Summary) -> dict[str, object]:
         "normal_offset": _format_fraction(candidate.normal_offset),
         "normal_side": "left" if candidate.normal_offset > 0 else "right",
         "strictly_convex": candidate.strictly_convex,
-        "min_turn_area2": candidate.min_turn_area2,
+        "min_turn_area2": _json_float(candidate.min_turn_area2),
         "max_vertex_hits": candidate.max_vertex_hits,
         "max_boundary_hits": candidate.max_boundary_hits,
         "circles_with_at_least_four_vertices": candidate.circles_with_at_least_four_vertices,

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+from erdos97.brp_boundary_probe import (
+    Quad,
+    assert_expected_counts,
+    brp_seed_vertices,
+    build_payload,
+    exact_squared_distance,
+    quad_to_json,
+    seed_convexity_summary,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_seed_vertices_are_three_rotated_copies() -> None:
+    vertices = brp_seed_vertices()
+
+    assert [vertex.label for vertex in vertices[:4]] == ["A1", "A2", "A3", "A4"]
+    assert [vertex.label for vertex in vertices[4:8]] == ["B1", "B2", "B3", "B4"]
+    assert [vertex.label for vertex in vertices[8:]] == ["C1", "C2", "C3", "C4"]
+    assert seed_convexity_summary(vertices)["strictly_convex_in_seed_order"] is True
+
+
+def test_exact_distance_detects_rotation_symmetry() -> None:
+    vertices = brp_seed_vertices()
+    by_label = {vertex.label: vertex for vertex in vertices}
+
+    assert exact_squared_distance(by_label["A1"], by_label["A2"]) == exact_squared_distance(
+        by_label["B1"], by_label["B2"]
+    )
+    assert exact_squared_distance(by_label["A1"], by_label["B1"]) == Quad(
+        Fraction(3000000)
+    )
+
+
+def test_payload_keeps_vertexization_gap_explicit() -> None:
+    payload = build_payload()
+
+    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v1"
+    assert payload["trust"] == "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
+    assert_expected_counts(payload)
+    assert payload["summary"]["max_boundary_hits_on_seed_edges"] >= 4
+    assert payload["summary"]["circles_with_at_least_four_seed_vertices"] == 0
+    assert payload["synthetic_a5_scan"]["strictly_convex_candidate_count"] == 0
+    assert payload["synthetic_a5_scan"]["candidates_with_at_least_four_vertices"] == 0
+    assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
+    assert "the A5 insertion" in str(payload["source"]["not_modeled"])
+
+
+def test_quad_display_is_stable() -> None:
+    assert quad_to_json(Quad(Fraction(3))) == "3"
+    assert quad_to_json(Quad(Fraction(0), Fraction(-2, 3))) == "-2/3*sqrt3"
+    assert quad_to_json(Quad(Fraction(5, 2), Fraction(7, 3))) == "5/2 + 7/3*sqrt3"
+
+
+def test_cli_write_check_roundtrip(tmp_path: Path) -> None:
+    artifact = tmp_path / "brp_probe.json"
+
+    write = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_brp_boundary_probe.py",
+            "--artifact",
+            str(artifact),
+            "--write",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert write.returncode == 0, write.stderr
+    stored = json.loads(artifact.read_text(encoding="utf-8"))
+    assert stored["summary"]["seed_vertex_count"] == 12
+
+    check = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_brp_boundary_probe.py",
+            "--artifact",
+            str(artifact),
+            "--check",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert check.returncode == 0, check.stderr

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -46,9 +46,13 @@ def test_payload_keeps_vertexization_gap_explicit() -> None:
 
     assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v1"
     assert payload["trust"] == "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
+    assert payload["provenance"]["generator"] == "scripts/check_brp_boundary_probe.py"
     assert_expected_counts(payload)
     assert payload["summary"]["max_boundary_hits_on_seed_edges"] >= 4
     assert payload["summary"]["circles_with_at_least_four_seed_vertices"] == 0
+    candidates = payload["synthetic_a5_scan"]["candidates"]
+    assert {candidate["normal_side"] for candidate in candidates} == {"left", "right"}
+    assert payload["synthetic_a5_scan"]["candidate_count"] == 36
     assert payload["synthetic_a5_scan"]["strictly_convex_candidate_count"] == 0
     assert payload["synthetic_a5_scan"]["candidates_with_at_least_four_vertices"] == 0
     assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
@@ -97,3 +101,40 @@ def test_cli_write_check_roundtrip(tmp_path: Path) -> None:
         stderr=subprocess.PIPE,
     )
     assert check.returncode == 0, check.stderr
+
+
+def test_cli_default_artifact_check_is_reproducible() -> None:
+    check = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_brp_boundary_probe.py",
+            "--check",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert check.returncode == 0, check.stderr
+
+
+def test_cli_write_check_modes_are_exclusive(tmp_path: Path) -> None:
+    artifact = tmp_path / "brp_probe.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_brp_boundary_probe.py",
+            "--artifact",
+            str(artifact),
+            "--write",
+            "--check",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode != 0
+    assert "not allowed with argument" in result.stderr

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -119,6 +119,53 @@ def test_cli_default_artifact_check_is_reproducible() -> None:
     assert check.returncode == 0, check.stderr
 
 
+def test_cli_check_tolerates_tiny_float_drift(tmp_path: Path) -> None:
+    artifact = tmp_path / "brp_probe.json"
+    payload = build_payload()
+    payload["convexity"]["min_turn_area2"] += 1e-12
+    artifact.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    check = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_brp_boundary_probe.py",
+            "--artifact",
+            str(artifact),
+            "--check",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert check.returncode == 0, check.stderr
+
+
+def test_cli_check_rejects_material_float_drift(tmp_path: Path) -> None:
+    artifact = tmp_path / "brp_probe.json"
+    payload = build_payload()
+    payload["convexity"]["min_turn_area2"] += 1e-4
+    artifact.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    check = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_brp_boundary_probe.py",
+            "--artifact",
+            str(artifact),
+            "--check",
+            "--assert-expected",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert check.returncode != 0
+    assert "$.convexity.min_turn_area2" in check.stderr
+
+
 def test_cli_write_check_modes_are_exclusive(tmp_path: Path) -> None:
     artifact = tmp_path / "brp_probe.json"
 

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -217,6 +217,7 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
             "python scripts/check_adjacent_closest_pair_nonagon_barrier.py "
             "--check --summary-json"
         ),
+        "python scripts/check_brp_boundary_probe.py --check --assert-expected --json",
         (
             "python scripts/check_bootstrap_core_crosswalk.py "
             "--check --assert-expected --json"


### PR DESCRIPTION
## Summary

- Add a Barany--Roldan-Pensado boundary-to-vertex diagnostic for the quoted 12-point seed before the existential A5 insertion.
- Record the seed gap: 45 centered seed circles hit the polygonal seed boundary at least four times, while none hit four modeled seed vertices.
- Add and register `data/certificates/brp_boundary_vertexization_probe.json` as the checked diagnostic artifact.
- Fix the synthetic A5 edge-pocket stress scan to sample signed normal offsets on both sides, and document it as a limited failed/nonconvex diagnostic route, not the source paper's A5.
- Link the diagnostic into artifact audit plumbing while preserving the repo's no-proof/no-counterexample guardrails.

## Validation

- `.venv/bin/python scripts/check_brp_boundary_probe.py --write --assert-expected`
- `.venv/bin/python scripts/check_brp_boundary_probe.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `.venv/bin/python -m pytest tests/test_brp_boundary_probe.py tests/test_run_artifact_audit.py tests/test_makefile_targets.py -q`
- `.venv/bin/python -m ruff check src/erdos97/brp_boundary_probe.py scripts/check_brp_boundary_probe.py tests/test_brp_boundary_probe.py scripts/run_artifact_audit.py tests/test_makefile_targets.py`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `make verify-fast PYTHON=.venv/bin/python` (1422 passed, 663 deselected)

## Review Notes

- Addressed review feedback that the first synthetic A5 scan was sign-forced to fail local convexity by adding signed offsets and recording `normal_side` in the artifact.
- Addressed clean-checkout reproducibility by adding the default checked artifact and a default `--check` regression test.
- Stabilized float fields in the diagnostic JSON and made `--check` tolerant of tiny float representation drift, while still requiring exact object/list structure and non-float values.
- Made `--write` and `--check` mutually exclusive for this checker so the CLI no longer silently ignores `--write`.