### PR TITLE
Add BRP Lemma 3.1 role preflight

### DIFF
--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -765,7 +765,7 @@
       ]
     }
   ],
-  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test.",
+  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test plus a Lemma 3.1 role-precondition preflight.",
   "convexity": {
     "max_turn_area2": 146403.0,
     "min_turn_area2": 19.492354671,
@@ -776,6 +776,7 @@
     "counterexample to Erdos Problem #97",
     "finite-vertex extraction from the Barany--Roldan-Pensado body",
     "model of the source paper's A5 insertion or final 15-gon",
+    "construction of the source paper's existential A5",
     "exact or interval certificate for boundary intersections"
   ],
   "histograms": {
@@ -798,8 +799,56 @@
       "2": 12
     }
   },
+  "lemma31_preflight": {
+    "a5_constraints_remaining": [
+      "find C1=A5 such that D,C,C1,B,A are extreme and clockwise",
+      "place A5 outside the circle centered at A and passing through B",
+      "keep angle A-B-A5 acute",
+      "make segment C-A5 intersect S_Bprime twice",
+      "preserve the final 15-gon convexity after 120-degree rotations"
+    ],
+    "angle_ABC": {
+      "acute": true,
+      "degrees": 87.7725247
+    },
+    "bprime_neighbourhood_budget": {
+      "C_distance_to_default_Bprime": 13.430787105,
+      "C_outside_default_S_Bprime": true,
+      "default_radius": 12.524348286,
+      "default_tau": "1/100",
+      "default_tau_inside_ceiling": true,
+      "definition": "Bprime = B + tau*(A-B)",
+      "tau_ceiling_for_C_outside_S_Bprime": 0.055071551
+    },
+    "claim_scope": "Verifies the source Lemma 3.1 role preconditions for the BRP seed using A=A3, B=A4, C=B1, D=B2 and records a reproducible Bprime neighbourhood budget. It does not construct A5.",
+    "role_mapping": {
+      "A": "A3",
+      "B": "A4",
+      "C": "B1",
+      "D": "B2",
+      "candidate_C1_name_in_paper_construction": "A5"
+    },
+    "role_order": {
+      "clockwise_target_without_C1": [
+        "B2",
+        "B1",
+        "A4",
+        "A3"
+      ],
+      "clockwise_target_without_C1_verified": true,
+      "labels_counterclockwise": [
+        "A3",
+        "A4",
+        "B1",
+        "B2"
+      ],
+      "min_turn_area2": 19.492354671,
+      "strictly_convex_counterclockwise": true
+    },
+    "status": "LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED"
+  },
   "next_steps": [
-    "add the A5 edge-parameter insertion once the source construction is pinned",
+    "solve or parameterize A5 under the recorded Lemma 3.1 constraints",
     "promote edge-interior hits to symbolic edge parameters",
     "iterate the promoted hits as new candidate vertices",
     "replace float boundary intersections by exact algebraic or interval checks"

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -70,6 +70,9 @@ The checker:
 - runs a small signed synthetic `A5` edge-pocket scan with
   `A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1)`, rotating the result to
   `B5` and `C5`. This is only a stress test, not the source paper's `A5`.
+- records the actual Lemma 3.1 role preflight
+  `A=A3, B=A4, C=B1, D=B2`, including the acute-angle check and a reproducible
+  `Bprime = B + tau*(A-B)` neighbourhood budget.
 
 ## Current result
 
@@ -85,6 +88,8 @@ circles with at least four seed vertices: 0
 synthetic A5 edge-pocket candidates: 36
 strictly convex synthetic A5 candidates: 0
 synthetic candidates with at least four vertices on a centered circle: 0
+Lemma 3.1 role angle ABC: 87.7725247 degrees
+Lemma 3.1 default Bprime tau: 1/100
 ```
 
 Thus the modeled 12-point seed shows the expected continuous/discrete gap:
@@ -99,21 +104,26 @@ It is still not evidence against the full contrarian lane: the source
 construction's Lemma 3.1 choice is existential, and the relevant
 edge-parameter closure remains unmodeled.
 
+The Lemma 3.1 role preflight now pins the source-paper mapping for the local
+insertion step. With `A=A3`, `B=A4`, `C=B1`, and `D=B2`, the four role points
+are strictly convex in counter-clockwise order, the angle `ABC` is acute, and
+the default point `Bprime=A4+(A3-A4)/100` has `B1` outside the circle centered
+at `Bprime` through `A4`. This is still only a preflight: it records the
+constraints an actual `A5` must satisfy, but it does not construct that point.
+
 ## Next steps
 
 Useful follow-up work should avoid more visual inspection and instead make the
 edge-interior hits algebraic:
 
-1. Replace the synthetic pocket scan with the actual Lemma 3.1 constraints for
-   `A=A3`, `B=A4`, `C=B1`, and a suitable `D` from the adjacent seed chain.
-2. Solve or parameterize admissible `A5` choices with strict convexity
+1. Solve or parameterize admissible `A5` choices under the recorded Lemma 3.1
    constraints.
-3. Promote each interior circle-edge hit to a candidate vertex parameter.
-4. Iterate the closure condition: promoted vertices become centers that must
+2. Promote each interior circle-edge hit to a candidate vertex parameter.
+3. Iterate the closure condition: promoted vertices become centers that must
    themselves acquire four vertex hits.
-5. Replace float64 edge intersections with exact algebraic or interval
+4. Replace float64 edge intersections with exact algebraic or interval
    certificates.
-6. If every closure attempt explodes into new edge interiors, extract the
+5. If every closure attempt explodes into new edge interiors, extract the
    failure as a boundary-to-vertex obstruction lemma.
 
 ## Guardrails
@@ -124,5 +134,5 @@ Do not cite this probe as:
 - a counterexample or counterexample candidate;
 - a finite extraction from the Barany--Roldan-Pensado body;
 - a check of the final 15-gon;
-- evidence about the actual existential `A5` from Lemma 3.1;
+- a construction of the actual existential `A5` from Lemma 3.1;
 - an exact certificate for boundary intersections.

--- a/docs/index.md
+++ b/docs/index.md
@@ -796,7 +796,8 @@ put detailed reconciliation in the canonical synthesis.
 - [`brp-boundary-vertexization-probe.md`](brp-boundary-vertexization-probe.md):
   first seed-only diagnostic for the Barany--Roldan-Pensado convex-body
   boundary lane, measuring seed-boundary circle hits versus modeled seed-vertex
-  hits; numerical diagnostic only, not a finite extraction or counterexample.
+  hits and pinning the Lemma 3.1 role preflight; numerical diagnostic only,
+  not a finite extraction, A5 construction, or counterexample.
 - [`dynamic-witness-free-pattern-search.md`](dynamic-witness-free-pattern-search.md):
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -39,8 +39,11 @@ are claimed here.
   distinct circles centered at a modeled seed vertex and passing through
   another modeled seed vertex, `45` hit the 12-edge seed boundary at least four
   times, but none hit four modeled seed vertices. This confirms the immediate
-  boundary/vertex gap for the seed and does not check the final 15-gon or give
-  a counterexample; see `docs/brp-boundary-vertexization-probe.md`.
+  boundary/vertex gap for the seed. The same probe now pins the Lemma 3.1
+  role mapping `A=A3, B=A4, C=B1, D=B2` and its acute-angle/pre-neighbourhood
+  checks, but it still does not construct the existential `A5`, check the
+  final 15-gon, or give a counterexample; see
+  `docs/brp-boundary-vertexization-probe.md`.
 - The canonical synthesis corrects a prior uniform-radius shortcut:
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound
   construction, not an upper bound resolving the subcase. Furedi's separate

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3445,8 +3445,8 @@ artifacts:
 
   - id: brp_boundary_vertexization_probe
     path: data/certificates/brp_boundary_vertexization_probe.json
-    sha256: c9ce88089495d559f00a901cc0ea99f7202ead8bc31ea614b2b4740c4a7eab6f
-    size_bytes: 34036
+    sha256: 424558e32943bcd43f20c84b34bab9b428b495b5e5007c1053beb34170989a6c
+    size_bytes: 35700
     kind: numerical_geometric_diagnostic_artifact
     generator: scripts/check_brp_boundary_probe.py
     command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3455,7 +3455,7 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits and a signed sampled synthetic A5 edge-pocket stress scan. Not a finite extraction, not the final 15-gon, not a proof, not a counterexample, and not an official/global status update.
+    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, and a Lemma 3.1 role-precondition preflight. Not a finite extraction, not the final 15-gon, not a construction of A5, not a proof, not a counterexample, and not an official/global status update.
     json_top_level_type: object
     expected_json:
       schema: erdos97.brp_boundary_vertexization_probe.v1
@@ -3471,11 +3471,21 @@ artifacts:
       synthetic_a5_scan.candidate_count: 36
       synthetic_a5_scan.strictly_convex_candidate_count: 0
       synthetic_a5_scan.candidates_with_at_least_four_vertices: 0
+      lemma31_preflight.status: LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED
+      lemma31_preflight.role_mapping.A: A3
+      lemma31_preflight.role_mapping.B: A4
+      lemma31_preflight.role_mapping.C: B1
+      lemma31_preflight.role_mapping.D: B2
+      lemma31_preflight.role_order.strictly_convex_counterclockwise: true
+      lemma31_preflight.angle_ABC.acute: true
+      lemma31_preflight.bprime_neighbourhood_budget.default_tau: 1/100
+      lemma31_preflight.bprime_neighbourhood_budget.C_outside_default_S_Bprime: true
     forbidden_claims:
       - proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
       - finite-vertex extraction from the Barany--Roldan-Pensado body
       - model of the source paper's A5 insertion or final 15-gon
+      - construction of the source paper's existential A5
       - exact or interval certificate for boundary intersections
       - official/global status update
 

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -110,6 +110,9 @@ def main() -> int:
         summary = payload["summary"]
         convexity = payload["convexity"]
         synthetic = payload["synthetic_a5_scan"]
+        preflight = payload["lemma31_preflight"]
+        angle_abc = preflight["angle_ABC"]
+        bprime_budget = preflight["bprime_neighbourhood_budget"]
         print("BRP boundary-to-vertex diagnostic")
         print(f"seed vertices: {summary['seed_vertex_count']}")
         print(f"strictly convex seed order: {convexity['strictly_convex_in_seed_order']}")
@@ -129,6 +132,11 @@ def main() -> int:
             f"{synthetic['strictly_convex_candidate_count']} / {synthetic['candidate_count']}"
         )
         print(f"synthetic A5 best vertex hits: {synthetic['best_max_vertex_hits']}")
+        print(f"Lemma 3.1 role angle ABC degrees: {angle_abc['degrees']}")
+        print(
+            "Lemma 3.1 default Bprime valid: "
+            f"{bprime_budget['C_outside_default_S_Bprime']}"
+        )
         if args.assert_expected:
             print("OK: expected BRP boundary diagnostic counts verified")
         if args.write:

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -27,6 +27,8 @@ DEFAULT_A5_PARAMETERS: tuple[tuple[Fraction, Fraction], ...] = tuple(
     for h in (1, 2, 5, 10, 20, 50)
     for sign in (-1, 1)
 )
+LEMMA31_ROLE_LABELS = ("A3", "A4", "B1", "B2")
+LEMMA31_DEFAULT_BPRIME_FRACTION = Fraction(1, 100)
 SQRT3 = math.sqrt(3.0)
 ROOT_TOL = 1e-9
 DISTANCE_TOL = 1e-6
@@ -267,6 +269,15 @@ def _numeric_squared_distance(left: NumericVertex, right: NumericVertex) -> floa
     return dx * dx + dy * dy
 
 
+def _point_squared_distance(
+    left: tuple[float, float],
+    right: tuple[float, float],
+) -> float:
+    dx = left[0] - right[0]
+    dy = left[1] - right[1]
+    return dx * dx + dy * dy
+
+
 def _same_distance(left: float, right: float, tol: float) -> bool:
     return abs(left - right) <= tol * max(1.0, abs(left), abs(right))
 
@@ -481,6 +492,121 @@ def synthetic_a5_scan(
     )
 
 
+def _angle_degrees(
+    left: tuple[float, float],
+    middle: tuple[float, float],
+    right: tuple[float, float],
+) -> float:
+    first = (left[0] - middle[0], left[1] - middle[1])
+    second = (right[0] - middle[0], right[1] - middle[1])
+    dot = first[0] * second[0] + first[1] * second[1]
+    first_len = math.hypot(*first)
+    second_len = math.hypot(*second)
+    cosine = max(-1.0, min(1.0, dot / (first_len * second_len)))
+    return math.degrees(math.acos(cosine))
+
+
+def _point_on_segment_by_fraction(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    fraction: Fraction,
+) -> tuple[float, float]:
+    t = float(fraction)
+    return (
+        start[0] + t * (end[0] - start[0]),
+        start[1] + t * (end[1] - start[1]),
+    )
+
+
+def lemma31_preflight() -> dict[str, object]:
+    """Check the Lemma 3.1 role mapping used by the BRP construction."""
+
+    seed = brp_seed_numeric_vertices()
+    by_label = {vertex.label: vertex for vertex in seed}
+    a_label, b_label, c_label, d_label = LEMMA31_ROLE_LABELS
+    a_point = by_label[a_label].numeric
+    b_point = by_label[b_label].numeric
+    c_point = by_label[c_label].numeric
+    d_point = by_label[d_label].numeric
+    role_vertices = tuple(by_label[label] for label in LEMMA31_ROLE_LABELS)
+    role_convexity = numeric_convexity_summary(role_vertices)
+    clockwise_target = (d_point, c_point, b_point, a_point)
+    clockwise_turns = [
+        _orientation2(
+            clockwise_target[index - 1],
+            clockwise_target[index],
+            clockwise_target[(index + 1) % len(clockwise_target)],
+        )
+        for index in range(len(clockwise_target))
+    ]
+    ba = (a_point[0] - b_point[0], a_point[1] - b_point[1])
+    bc = (c_point[0] - b_point[0], c_point[1] - b_point[1])
+    ba_dot_bc = ba[0] * bc[0] + ba[1] * bc[1]
+    bprime_fraction_ceiling = _point_squared_distance(c_point, b_point) / (
+        2.0 * ba_dot_bc
+    )
+    bprime = _point_on_segment_by_fraction(
+        b_point,
+        a_point,
+        LEMMA31_DEFAULT_BPRIME_FRACTION,
+    )
+    bprime_radius_squared = _point_squared_distance(bprime, b_point)
+    c_distance_to_bprime_squared = _point_squared_distance(c_point, bprime)
+    angle_abc_degrees = _angle_degrees(a_point, b_point, c_point)
+    return {
+        "status": "LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED",
+        "role_mapping": {
+            "A": a_label,
+            "B": b_label,
+            "C": c_label,
+            "D": d_label,
+            "candidate_C1_name_in_paper_construction": "A5",
+        },
+        "role_order": {
+            "labels_counterclockwise": list(LEMMA31_ROLE_LABELS),
+            "strictly_convex_counterclockwise": bool(
+                role_convexity["strictly_convex_in_seed_order"]
+            ),
+            "min_turn_area2": role_convexity["min_turn_area2"],
+            "clockwise_target_without_C1": [d_label, c_label, b_label, a_label],
+            "clockwise_target_without_C1_verified": all(
+                turn < 0.0 for turn in clockwise_turns
+            ),
+        },
+        "angle_ABC": {
+            "degrees": _json_float(angle_abc_degrees),
+            "acute": angle_abc_degrees < 90.0,
+        },
+        "bprime_neighbourhood_budget": {
+            "definition": "Bprime = B + tau*(A-B)",
+            "default_tau": _format_fraction(LEMMA31_DEFAULT_BPRIME_FRACTION),
+            "tau_ceiling_for_C_outside_S_Bprime": _json_float(bprime_fraction_ceiling),
+            "default_tau_inside_ceiling": (
+                float(LEMMA31_DEFAULT_BPRIME_FRACTION) < bprime_fraction_ceiling
+            ),
+            "default_radius": _json_float(math.sqrt(bprime_radius_squared)),
+            "C_distance_to_default_Bprime": _json_float(
+                math.sqrt(c_distance_to_bprime_squared)
+            ),
+            "C_outside_default_S_Bprime": (
+                c_distance_to_bprime_squared > bprime_radius_squared
+            ),
+        },
+        "a5_constraints_remaining": [
+            "find C1=A5 such that D,C,C1,B,A are extreme and clockwise",
+            "place A5 outside the circle centered at A and passing through B",
+            "keep angle A-B-A5 acute",
+            "make segment C-A5 intersect S_Bprime twice",
+            "preserve the final 15-gon convexity after 120-degree rotations",
+        ],
+        "claim_scope": (
+            "Verifies the source Lemma 3.1 role preconditions for the BRP seed "
+            "using A=A3, B=A4, C=B1, D=B2 and records a reproducible Bprime "
+            "neighbourhood budget. It does not construct A5."
+        ),
+    }
+
+
 def _histogram(values: Iterable[int]) -> dict[str, int]:
     return {str(key): value for key, value in sorted(Counter(values).items())}
 
@@ -603,6 +729,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             ),
             "candidates": [_candidate_to_json(candidate) for candidate in candidate_scan],
         },
+        "lemma31_preflight": lemma31_preflight(),
         "histograms": {
             "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
             "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
@@ -617,17 +744,19 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "quoted in the Barany--Roldan-Pensado convex-body discussion. It "
             "measures the gap between centered circle hits on polygon edges and "
             "hits at the modeled seed vertices, and includes a limited signed "
-            "synthetic A5 edge-pocket closure stress test."
+            "synthetic A5 edge-pocket closure stress test plus a Lemma 3.1 "
+            "role-precondition preflight."
         ),
         "does_not_claim": [
             "proof of Erdos Problem #97",
             "counterexample to Erdos Problem #97",
             "finite-vertex extraction from the Barany--Roldan-Pensado body",
             "model of the source paper's A5 insertion or final 15-gon",
+            "construction of the source paper's existential A5",
             "exact or interval certificate for boundary intersections",
         ],
         "next_steps": [
-            "add the A5 edge-parameter insertion once the source construction is pinned",
+            "solve or parameterize A5 under the recorded Lemma 3.1 constraints",
             "promote edge-interior hits to symbolic edge parameters",
             "iterate the promoted hits as new candidate vertices",
             "replace float boundary intersections by exact algebraic or interval checks",
@@ -673,6 +802,29 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
 
     if convexity.get("strictly_convex_in_seed_order") is not True:
         raise AssertionError("seed order is expected to be strictly convex")
+
+    preflight = payload.get("lemma31_preflight")
+    if not isinstance(preflight, dict):
+        raise AssertionError("payload.lemma31_preflight must be an object")
+    if preflight.get("status") != "LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED":
+        raise AssertionError("unexpected lemma31_preflight.status")
+    role_order = preflight.get("role_order")
+    angle_abc = preflight.get("angle_ABC")
+    bprime_budget = preflight.get("bprime_neighbourhood_budget")
+    if not isinstance(role_order, dict):
+        raise AssertionError("payload.lemma31_preflight.role_order must be an object")
+    if not isinstance(angle_abc, dict):
+        raise AssertionError("payload.lemma31_preflight.angle_ABC must be an object")
+    if not isinstance(bprime_budget, dict):
+        raise AssertionError(
+            "payload.lemma31_preflight.bprime_neighbourhood_budget must be an object"
+        )
+    if role_order.get("strictly_convex_counterclockwise") is not True:
+        raise AssertionError("Lemma 3.1 role order is expected to be convex")
+    if angle_abc.get("acute") is not True:
+        raise AssertionError("Lemma 3.1 role angle ABC is expected to be acute")
+    if bprime_budget.get("C_outside_default_S_Bprime") is not True:
+        raise AssertionError("C is expected to be outside the default S_Bprime")
 
     synthetic = payload.get("synthetic_a5_scan")
     if not isinstance(synthetic, dict):

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -55,6 +55,25 @@ def test_payload_keeps_vertexization_gap_explicit() -> None:
     assert payload["synthetic_a5_scan"]["candidate_count"] == 36
     assert payload["synthetic_a5_scan"]["strictly_convex_candidate_count"] == 0
     assert payload["synthetic_a5_scan"]["candidates_with_at_least_four_vertices"] == 0
+    preflight = payload["lemma31_preflight"]
+    assert preflight["status"] == "LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED"
+    assert preflight["role_mapping"] == {
+        "A": "A3",
+        "B": "A4",
+        "C": "B1",
+        "D": "B2",
+        "candidate_C1_name_in_paper_construction": "A5",
+    }
+    assert preflight["role_order"]["strictly_convex_counterclockwise"] is True
+    assert preflight["role_order"]["clockwise_target_without_C1_verified"] is True
+    assert preflight["angle_ABC"]["acute"] is True
+    assert preflight["angle_ABC"]["degrees"] == 87.7725247
+    assert preflight["bprime_neighbourhood_budget"]["default_tau"] == "1/100"
+    assert preflight["bprime_neighbourhood_budget"]["default_tau_inside_ceiling"] is True
+    assert (
+        preflight["bprime_neighbourhood_budget"]["C_outside_default_S_Bprime"]
+        is True
+    )
     assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
     assert "the A5 insertion" in str(payload["source"]["not_modeled"])
 


### PR DESCRIPTION
## Summary

- Add a Lemma 3.1 role-precondition preflight to the BRP boundary vertexization artifact.
- Pin the source-paper local mapping as `A=A3`, `B=A4`, `C=B1`, `D=B2`, with `A5` recorded only as the candidate `C1` name.
- Record the acute angle `ABC = 87.7725247` degrees and a reproducible `Bprime = B + tau*(A-B)` neighbourhood budget with default `tau = 1/100`.
- Update the generated artifact, manifest checks, CLI summary, and docs while preserving the guardrail that this does not construct the existential `A5` or check the final 15-gon.

## Validation

- `.venv/bin/python scripts/check_brp_boundary_probe.py --check --assert-expected`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest tests/test_brp_boundary_probe.py tests/test_makefile_targets.py -q`
- `.venv/bin/python -m pytest -q`