### PR TITLE
[codex] Add BRP A5 constraint probe

### DIFF
--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -765,7 +765,7 @@
       ]
     }
   ],
-  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test plus a Lemma 3.1 role-precondition preflight.",
+  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe.",
   "convexity": {
     "max_turn_area2": 146403.0,
     "min_turn_area2": 19.492354671,
@@ -775,8 +775,8 @@
     "proof of Erdos Problem #97",
     "counterexample to Erdos Problem #97",
     "finite-vertex extraction from the Barany--Roldan-Pensado body",
-    "model of the source paper's A5 insertion or final 15-gon",
-    "construction of the source paper's existential A5",
+    "exact model of the source paper's A5 insertion or final 15-gon",
+    "exact construction of the source paper's existential A5",
     "exact or interval certificate for boundary intersections"
   ],
   "histograms": {
@@ -799,13 +799,92 @@
       "2": 12
     }
   },
+  "lemma31_a5_constraint_scan": {
+    "filter_counts": {
+      "D_C_A5_B_A_extreme_clockwise": 700,
+      "plus_A5_outside_S_A": 290,
+      "plus_angle_A_B_A5_acute": 3,
+      "plus_rotated_15gon_strictly_convex": 1,
+      "plus_segment_C_A5_intersects_default_S_Bprime_twice": 1
+    },
+    "individual_condition_counts": {
+      "A5_outside_S_A": 590,
+      "D_C_A5_B_A_extreme_clockwise": 700,
+      "angle_A_B_A5_acute": 1413,
+      "segment_C_A5_intersects_default_S_Bprime_twice": 41
+    },
+    "interpretation": "This is a bounded float64 sample of the local Lemma 3.1 A5 constraints, not an exact coordinate certificate and not a finite-vertex extraction from the BRP convex-body construction.",
+    "parameterization": {
+      "formula": "A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1)",
+      "normal_offsets": [
+        "1/1000",
+        "-1/1000",
+        "1/500",
+        "-1/500",
+        "1/200",
+        "-1/200",
+        "1/100",
+        "-1/100",
+        "1/50",
+        "-1/50",
+        "1/20",
+        "-1/20",
+        "1/10",
+        "-1/10",
+        "1/5",
+        "-1/5",
+        "1/2",
+        "-1/2",
+        "1",
+        "-1"
+      ],
+      "sample_count": 2000,
+      "t_values": {
+        "count": 100,
+        "formula": "i/500 for 1 <= i <= 100",
+        "max": "1/5",
+        "min": "1/500"
+      }
+    },
+    "sampled_witnesses": [
+      {
+        "lemma31_N1_bullets": {
+          "A5_outside_S_A": true,
+          "D_C_A5_B_A_extreme_clockwise": true,
+          "S_Bprime_roots_on_segment_C_A5": [
+            0.86294581,
+            0.995615477
+          ],
+          "angle_A_B_A5_acute": true,
+          "largest_clockwise_turn_area2": -0.026807931,
+          "segment_C_A5_intersects_default_S_Bprime_twice": true
+        },
+        "normal_offset": "-1/200",
+        "normal_side": "right",
+        "point_float": {
+          "x": -498.052639109,
+          "y": 870.88247481
+        },
+        "rotated_15gon": {
+          "circles_with_at_least_four_boundary_hits": 87,
+          "circles_with_at_least_four_vertices": 0,
+          "max_boundary_hits": 6,
+          "max_vertex_hits": 2,
+          "min_turn_area2": 0.026807931,
+          "strictly_convex": true
+        },
+        "t": "3/125"
+      }
+    ],
+    "source_lemma_scope": "N=1 specialization of Lemma 3.1 with A=A3, B=A4, C=B1, D=B2, C1=A5, and default Bprime fraction 1/100.",
+    "status": "SAMPLED_NUMERICAL_A5_CONSTRAINT_PROBE"
+  },
   "lemma31_preflight": {
-    "a5_constraints_remaining": [
-      "find C1=A5 such that D,C,C1,B,A are extreme and clockwise",
-      "place A5 outside the circle centered at A and passing through B",
-      "keep angle A-B-A5 acute",
-      "make segment C-A5 intersect S_Bprime twice",
-      "preserve the final 15-gon convexity after 120-degree rotations"
+    "a5_constraints_remaining_after_sampled_scan": [
+      "upgrade the sampled C1=A5 witness to exact or interval coordinates",
+      "prove a neighbourhood of admissible A5 choices, not only one sample",
+      "certify all source-paper boundary-intersection counts for the final 15-gon",
+      "separate boundary hits from finite selected-vertex hits"
     ],
     "angle_ABC": {
       "acute": true,
@@ -820,7 +899,7 @@
       "definition": "Bprime = B + tau*(A-B)",
       "tau_ceiling_for_C_outside_S_Bprime": 0.055071551
     },
-    "claim_scope": "Verifies the source Lemma 3.1 role preconditions for the BRP seed using A=A3, B=A4, C=B1, D=B2 and records a reproducible Bprime neighbourhood budget. It does not construct A5.",
+    "claim_scope": "Verifies the source Lemma 3.1 role preconditions for the BRP seed using A=A3, B=A4, C=B1, D=B2 and records a reproducible Bprime neighbourhood budget. The companion scan records only sampled float64 A5 candidates.",
     "role_mapping": {
       "A": "A3",
       "B": "A4",
@@ -848,7 +927,8 @@
     "status": "LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED"
   },
   "next_steps": [
-    "solve or parameterize A5 under the recorded Lemma 3.1 constraints",
+    "upgrade the sampled A5 witness to exact algebraic or interval coordinates",
+    "prove an admissible neighbourhood around the sampled A5 witness",
     "promote edge-interior hits to symbolic edge parameters",
     "iterate the promoted hits as new candidate vertices",
     "replace float boundary intersections by exact algebraic or interval checks"
@@ -858,7 +938,7 @@
     "generator": "scripts/check_brp_boundary_probe.py",
     "notes": "Float64 boundary-intersection diagnostic for the quoted Barany--Roldan-Pensado 12-point seed before A5 insertion."
   },
-  "schema": "erdos97.brp_boundary_vertexization_probe.v1",
+  "schema": "erdos97.brp_boundary_vertexization_probe.v2",
   "source": {
     "base_points": [
       {

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -73,6 +73,9 @@ The checker:
 - records the actual Lemma 3.1 role preflight
   `A=A3, B=A4, C=B1, D=B2`, including the acute-angle check and a reproducible
   `Bprime = B + tau*(A-B)` neighbourhood budget.
+- runs a bounded `N=1` Lemma 3.1 A5 constraint scan near `A4`, using the
+  parameterization
+  `A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1)`.
 
 ## Current result
 
@@ -90,6 +93,11 @@ strictly convex synthetic A5 candidates: 0
 synthetic candidates with at least four vertices on a centered circle: 0
 Lemma 3.1 role angle ABC: 87.7725247 degrees
 Lemma 3.1 default Bprime tau: 1/100
+Lemma 3.1 A5 constraint samples: 2000
+sampled Lemma 3.1 A5 witnesses: 1
+first sampled witness: t=3/125, h=-1/200
+rotated 15-gon convex for sampled witness: yes
+sampled-witness centered circles with four vertices: 0
 ```
 
 Thus the modeled 12-point seed shows the expected continuous/discrete gap:
@@ -104,26 +112,39 @@ It is still not evidence against the full contrarian lane: the source
 construction's Lemma 3.1 choice is existential, and the relevant
 edge-parameter closure remains unmodeled.
 
-The Lemma 3.1 role preflight now pins the source-paper mapping for the local
+The Lemma 3.1 role preflight pins the source-paper mapping for the local
 insertion step. With `A=A3`, `B=A4`, `C=B1`, and `D=B2`, the four role points
 are strictly convex in counter-clockwise order, the angle `ABC` is acute, and
 the default point `Bprime=A4+(A3-A4)/100` has `B1` outside the circle centered
-at `Bprime` through `A4`. This is still only a preflight: it records the
-constraints an actual `A5` must satisfy, but it does not construct that point.
+at `Bprime` through `A4`.
+
+The follow-up A5 constraint scan samples 100 rational positions close to `A4`
+along `A4->B1` and 20 signed normal offsets. Exactly one sampled point,
+`t=3/125, h=-1/200`, satisfies the `N=1` Lemma 3.1 local bullets in float64:
+`B2,B1,A5,A4,A3` is extreme and clockwise, `A5` is outside the circle centered
+at `A3` through `A4`, the angle `A3 A4 A5` is acute, and the segment `B1A5`
+intersects the default `S_Bprime` twice. Rotating this sampled point gives a
+strictly convex synthetic 15-gon, but its centered vertex circles still have
+maximum vertex multiplicity `2`; no centered circle hits four modeled vertices.
+
+This is a useful next-step witness for the source construction lane, not an
+exact certificate. The sampled `A5` remains a float64 point in a bounded search
+family, the final BRP boundary-intersection proof is not replayed, and the
+boundary-hit/finite-vertex gap remains open.
 
 ## Next steps
 
 Useful follow-up work should avoid more visual inspection and instead make the
 edge-interior hits algebraic:
 
-1. Solve or parameterize admissible `A5` choices under the recorded Lemma 3.1
-   constraints.
-2. Promote each interior circle-edge hit to a candidate vertex parameter.
-3. Iterate the closure condition: promoted vertices become centers that must
+1. Upgrade the sampled `A5` witness to exact algebraic or interval coordinates.
+2. Prove a neighbourhood of admissible `A5` choices around the sampled point.
+3. Promote each interior circle-edge hit to a candidate vertex parameter.
+4. Iterate the closure condition: promoted vertices become centers that must
    themselves acquire four vertex hits.
-4. Replace float64 edge intersections with exact algebraic or interval
+5. Replace float64 edge intersections with exact algebraic or interval
    certificates.
-5. If every closure attempt explodes into new edge interiors, extract the
+6. If every closure attempt explodes into new edge interiors, extract the
    failure as a boundary-to-vertex obstruction lemma.
 
 ## Guardrails
@@ -134,5 +155,5 @@ Do not cite this probe as:
 - a counterexample or counterexample candidate;
 - a finite extraction from the Barany--Roldan-Pensado body;
 - a check of the final 15-gon;
-- a construction of the actual existential `A5` from Lemma 3.1;
+- an exact construction of the actual existential `A5` from Lemma 3.1;
 - an exact certificate for boundary intersections.

--- a/docs/index.md
+++ b/docs/index.md
@@ -796,8 +796,9 @@ put detailed reconciliation in the canonical synthesis.
 - [`brp-boundary-vertexization-probe.md`](brp-boundary-vertexization-probe.md):
   first seed-only diagnostic for the Barany--Roldan-Pensado convex-body
   boundary lane, measuring seed-boundary circle hits versus modeled seed-vertex
-  hits and pinning the Lemma 3.1 role preflight; numerical diagnostic only,
-  not a finite extraction, A5 construction, or counterexample.
+  hits, pinning the Lemma 3.1 role preflight, and recording one sampled local
+  A5 constraint witness; numerical diagnostic only, not a finite extraction,
+  exact A5 construction, or counterexample.
 - [`dynamic-witness-free-pattern-search.md`](dynamic-witness-free-pattern-search.md):
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -41,8 +41,12 @@ are claimed here.
   times, but none hit four modeled seed vertices. This confirms the immediate
   boundary/vertex gap for the seed. The same probe now pins the Lemma 3.1
   role mapping `A=A3, B=A4, C=B1, D=B2` and its acute-angle/pre-neighbourhood
-  checks, but it still does not construct the existential `A5`, check the
-  final 15-gon, or give a counterexample; see
+  checks, and records one sampled local A5 constraint witness
+  `t=3/125, h=-1/200` in the `A4->B1` edge-pocket parameterization. Rotating
+  that sampled point gives a strictly convex numerical 15-gon with maximum
+  centered vertex multiplicity still `2`. This remains a float64 diagnostic:
+  it is not an exact A5 certificate, does not replay the final BRP
+  boundary-intersection proof, and gives no counterexample; see
   `docs/brp-boundary-vertexization-probe.md`.
 - The canonical synthesis corrects a prior uniform-radius shortcut:
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3445,8 +3445,8 @@ artifacts:
 
   - id: brp_boundary_vertexization_probe
     path: data/certificates/brp_boundary_vertexization_probe.json
-    sha256: 424558e32943bcd43f20c84b34bab9b428b495b5e5007c1053beb34170989a6c
-    size_bytes: 35700
+    sha256: f564df4c160756e75e245fcb0737f9e9a60f1787a007fe9ae3b9905da6f3fce5
+    size_bytes: 38330
     kind: numerical_geometric_diagnostic_artifact
     generator: scripts/check_brp_boundary_probe.py
     command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3455,10 +3455,10 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, and a Lemma 3.1 role-precondition preflight. Not a finite extraction, not the final 15-gon, not a construction of A5, not a proof, not a counterexample, and not an official/global status update.
+    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, and one bounded sampled numerical A5 constraint witness. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.brp_boundary_vertexization_probe.v1
+      schema: erdos97.brp_boundary_vertexization_probe.v2
       status: BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY
       trust: NUMERICAL_GEOMETRIC_DIAGNOSTIC
       provenance.command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3470,6 +3470,9 @@ artifacts:
       summary.circles_with_at_least_four_boundary_hits: 45
       synthetic_a5_scan.candidate_count: 36
       synthetic_a5_scan.strictly_convex_candidate_count: 0
+      lemma31_a5_constraint_scan.parameterization.sample_count: 2000
+      lemma31_a5_constraint_scan.filter_counts.plus_segment_C_A5_intersects_default_S_Bprime_twice: 1
+      lemma31_a5_constraint_scan.filter_counts.plus_rotated_15gon_strictly_convex: 1
       synthetic_a5_scan.candidates_with_at_least_four_vertices: 0
       lemma31_preflight.status: LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED
       lemma31_preflight.role_mapping.A: A3

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -111,8 +111,11 @@ def main() -> int:
         convexity = payload["convexity"]
         synthetic = payload["synthetic_a5_scan"]
         preflight = payload["lemma31_preflight"]
+        a5_scan = payload["lemma31_a5_constraint_scan"]
         angle_abc = preflight["angle_ABC"]
         bprime_budget = preflight["bprime_neighbourhood_budget"]
+        filter_counts = a5_scan["filter_counts"]
+        witnesses = a5_scan["sampled_witnesses"]
         print("BRP boundary-to-vertex diagnostic")
         print(f"seed vertices: {summary['seed_vertex_count']}")
         print(f"strictly convex seed order: {convexity['strictly_convex_in_seed_order']}")
@@ -137,6 +140,20 @@ def main() -> int:
             "Lemma 3.1 default Bprime valid: "
             f"{bprime_budget['C_outside_default_S_Bprime']}"
         )
+        print(
+            "Lemma 3.1 sampled A5 witnesses: "
+            f"{len(witnesses)} / {a5_scan['parameterization']['sample_count']}"
+        )
+        print(
+            "Lemma 3.1 final convex sampled witnesses: "
+            f"{filter_counts['plus_rotated_15gon_strictly_convex']}"
+        )
+        if witnesses:
+            witness = witnesses[0]
+            print(
+                "Lemma 3.1 first sampled A5: "
+                f"t={witness['t']}, h={witness['normal_offset']}"
+            )
         if args.assert_expected:
             print("OK: expected BRP boundary diagnostic counts verified")
         if args.write:

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import math
 
 
-SCHEMA = "erdos97.brp_boundary_vertexization_probe.v1"
+SCHEMA = "erdos97.brp_boundary_vertexization_probe.v2"
 STATUS = "BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY"
 TRUST = "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
 
@@ -29,6 +29,12 @@ DEFAULT_A5_PARAMETERS: tuple[tuple[Fraction, Fraction], ...] = tuple(
 )
 LEMMA31_ROLE_LABELS = ("A3", "A4", "B1", "B2")
 LEMMA31_DEFAULT_BPRIME_FRACTION = Fraction(1, 100)
+LEMMA31_A5_EDGE_T_VALUES = tuple(Fraction(index, 500) for index in range(1, 101))
+LEMMA31_A5_EDGE_NORMAL_OFFSETS = tuple(
+    offset
+    for denominator in (1000, 500, 200, 100, 50, 20, 10, 5, 2, 1)
+    for offset in (Fraction(1, denominator), Fraction(-1, denominator))
+)
 SQRT3 = math.sqrt(3.0)
 ROOT_TOL = 1e-9
 DISTANCE_TOL = 1e-6
@@ -103,6 +109,20 @@ class Candidate15Summary:
     max_boundary_hits: int
     circles_with_at_least_four_vertices: int
     circles_with_at_least_four_boundary_hits: int
+
+
+@dataclass(frozen=True)
+class Lemma31A5ScanSample:
+    t_value: Fraction
+    normal_offset: Fraction
+    point: tuple[float, float]
+    local_clockwise: bool
+    outside_s_a: bool
+    acute_angle: bool
+    segment_crosses_s_bprime_twice: bool
+    s_bprime_roots: tuple[float, ...]
+    local_clockwise_turns: tuple[float, ...]
+    final_15gon: Candidate15Summary | None
 
 
 def _q(value: int | Fraction, sqrt3: int | Fraction = 0) -> Quad:
@@ -197,21 +217,7 @@ def brp_candidate_15gon(t_value: Fraction, normal_offset: Fraction) -> tuple[Num
         raise ValueError("normal_offset must be nonzero")
     seed = brp_seed_numeric_vertices()
     by_label = {vertex.label: vertex.numeric for vertex in seed}
-    a4 = by_label["A4"]
-    b1 = by_label["B1"]
-    edge = (b1[0] - a4[0], b1[1] - a4[1])
-    normal = (-edge[1], edge[0])
-    normal_length = math.hypot(*normal)
-    normal_unit = (
-        normal[0] / normal_length,
-        normal[1] / normal_length,
-    )
-    t = float(t_value)
-    h = float(normal_offset)
-    a5 = (
-        a4[0] + t * edge[0] + h * normal_unit[0],
-        a4[1] + t * edge[1] + h * normal_unit[1],
-    )
+    a5 = _a5_edge_pocket_point(t_value, normal_offset, by_label=by_label)
     vertices: list[NumericVertex] = []
     for orbit, prefix in enumerate(ORBIT_PREFIXES):
         for suffix in ("1", "2", "3", "4"):
@@ -226,6 +232,31 @@ def brp_candidate_15gon(t_value: Fraction, normal_offset: Fraction) -> tuple[Num
             NumericVertex(label=f"{prefix}5", numeric=_rotate_numeric_point(a5, orbit))
         )
     return tuple(vertices)
+
+
+def _a5_edge_pocket_point(
+    t_value: Fraction,
+    normal_offset: Fraction,
+    *,
+    by_label: dict[str, tuple[float, float]],
+) -> tuple[float, float]:
+    """Place A5 near the directed edge A4->B1 with a signed normal offset."""
+
+    a4 = by_label["A4"]
+    b1 = by_label["B1"]
+    edge = (b1[0] - a4[0], b1[1] - a4[1])
+    normal = (-edge[1], edge[0])
+    normal_length = math.hypot(*normal)
+    normal_unit = (
+        normal[0] / normal_length,
+        normal[1] / normal_length,
+    )
+    t = float(t_value)
+    h = float(normal_offset)
+    return (
+        a4[0] + t * edge[0] + h * normal_unit[0],
+        a4[1] + t * edge[1] + h * normal_unit[1],
+    )
 
 
 def exact_squared_distance(left: SeedVertex, right: SeedVertex) -> Quad:
@@ -592,17 +623,210 @@ def lemma31_preflight() -> dict[str, object]:
                 c_distance_to_bprime_squared > bprime_radius_squared
             ),
         },
-        "a5_constraints_remaining": [
-            "find C1=A5 such that D,C,C1,B,A are extreme and clockwise",
-            "place A5 outside the circle centered at A and passing through B",
-            "keep angle A-B-A5 acute",
-            "make segment C-A5 intersect S_Bprime twice",
-            "preserve the final 15-gon convexity after 120-degree rotations",
+        "a5_constraints_remaining_after_sampled_scan": [
+            "upgrade the sampled C1=A5 witness to exact or interval coordinates",
+            "prove a neighbourhood of admissible A5 choices, not only one sample",
+            "certify all source-paper boundary-intersection counts for the final 15-gon",
+            "separate boundary hits from finite selected-vertex hits",
         ],
         "claim_scope": (
             "Verifies the source Lemma 3.1 role preconditions for the BRP seed "
             "using A=A3, B=A4, C=B1, D=B2 and records a reproducible Bprime "
-            "neighbourhood budget. It does not construct A5."
+            "neighbourhood budget. The companion scan records only sampled "
+            "float64 A5 candidates."
+        ),
+    }
+
+
+def _lemma31_a5_sample(
+    t_value: Fraction,
+    normal_offset: Fraction,
+    *,
+    root_tol: float,
+    by_label: dict[str, tuple[float, float]],
+) -> Lemma31A5ScanSample:
+    a_label, b_label, c_label, d_label = LEMMA31_ROLE_LABELS
+    a_point = by_label[a_label]
+    b_point = by_label[b_label]
+    c_point = by_label[c_label]
+    d_point = by_label[d_label]
+    a5 = _a5_edge_pocket_point(t_value, normal_offset, by_label=by_label)
+    local_order = (d_point, c_point, a5, b_point, a_point)
+    local_turns = tuple(
+        _orientation2(
+            local_order[index - 1],
+            local_order[index],
+            local_order[(index + 1) % len(local_order)],
+        )
+        for index in range(len(local_order))
+    )
+    local_clockwise = all(turn < 0.0 for turn in local_turns)
+    outside_s_a = _point_squared_distance(a_point, a5) > _point_squared_distance(
+        a_point,
+        b_point,
+    )
+    ba = (a_point[0] - b_point[0], a_point[1] - b_point[1])
+    ba5 = (a5[0] - b_point[0], a5[1] - b_point[1])
+    acute_angle = ba[0] * ba5[0] + ba[1] * ba5[1] > 0.0
+    bprime = _point_on_segment_by_fraction(
+        b_point,
+        a_point,
+        LEMMA31_DEFAULT_BPRIME_FRACTION,
+    )
+    bprime_radius_squared = _point_squared_distance(bprime, b_point)
+    roots = _edge_roots(
+        center=bprime,
+        radius_squared=bprime_radius_squared,
+        start=c_point,
+        end=a5,
+        tol=root_tol,
+    )
+    segment_crosses_twice = (
+        sum(1 for root in roots if root_tol < root < 1.0 - root_tol) == 2
+    )
+    final_15gon = None
+    if local_clockwise and outside_s_a and acute_angle and segment_crosses_twice:
+        final_15gon = summarize_candidate_15gon(
+            t_value,
+            normal_offset,
+            root_tol=root_tol,
+        )
+    return Lemma31A5ScanSample(
+        t_value=t_value,
+        normal_offset=normal_offset,
+        point=a5,
+        local_clockwise=local_clockwise,
+        outside_s_a=outside_s_a,
+        acute_angle=acute_angle,
+        segment_crosses_s_bprime_twice=segment_crosses_twice,
+        s_bprime_roots=roots,
+        local_clockwise_turns=local_turns,
+        final_15gon=final_15gon,
+    )
+
+
+def _a5_sample_to_json(sample: Lemma31A5ScanSample) -> dict[str, object]:
+    final = sample.final_15gon
+    return {
+        "t": _format_fraction(sample.t_value),
+        "normal_offset": _format_fraction(sample.normal_offset),
+        "normal_side": "left" if sample.normal_offset > 0 else "right",
+        "point_float": {
+            "x": _json_float(sample.point[0]),
+            "y": _json_float(sample.point[1]),
+        },
+        "lemma31_N1_bullets": {
+            "D_C_A5_B_A_extreme_clockwise": sample.local_clockwise,
+            "A5_outside_S_A": sample.outside_s_a,
+            "angle_A_B_A5_acute": sample.acute_angle,
+            "segment_C_A5_intersects_default_S_Bprime_twice": (
+                sample.segment_crosses_s_bprime_twice
+            ),
+            "S_Bprime_roots_on_segment_C_A5": [
+                _json_float(root) for root in sample.s_bprime_roots
+            ],
+            "largest_clockwise_turn_area2": _json_float(
+                max(sample.local_clockwise_turns)
+            ),
+        },
+        "rotated_15gon": None
+        if final is None
+        else {
+            "strictly_convex": final.strictly_convex,
+            "min_turn_area2": _json_float(final.min_turn_area2),
+            "max_vertex_hits": final.max_vertex_hits,
+            "max_boundary_hits": final.max_boundary_hits,
+            "circles_with_at_least_four_vertices": (
+                final.circles_with_at_least_four_vertices
+            ),
+            "circles_with_at_least_four_boundary_hits": (
+                final.circles_with_at_least_four_boundary_hits
+            ),
+        },
+    }
+
+
+def lemma31_a5_constraint_scan(
+    parameters: Iterable[tuple[Fraction, Fraction]] | None = None,
+    *,
+    root_tol: float = ROOT_TOL,
+) -> dict[str, object]:
+    """Sample A5 candidates against the N=1 Lemma 3.1 construction bullets."""
+
+    seed = brp_seed_numeric_vertices()
+    by_label = {vertex.label: vertex.numeric for vertex in seed}
+    if parameters is None:
+        parameters = (
+            (t_value, normal_offset)
+            for t_value in LEMMA31_A5_EDGE_T_VALUES
+            for normal_offset in LEMMA31_A5_EDGE_NORMAL_OFFSETS
+        )
+    samples = [
+        _lemma31_a5_sample(
+            t_value,
+            normal_offset,
+            root_tol=root_tol,
+            by_label=by_label,
+        )
+        for t_value, normal_offset in parameters
+    ]
+    local_clockwise = [sample for sample in samples if sample.local_clockwise]
+    local_outside = [sample for sample in local_clockwise if sample.outside_s_a]
+    local_outside_acute = [sample for sample in local_outside if sample.acute_angle]
+    lemma31_samples = [
+        sample
+        for sample in local_outside_acute
+        if sample.segment_crosses_s_bprime_twice
+    ]
+    final_convex_samples = [
+        sample
+        for sample in lemma31_samples
+        if sample.final_15gon is not None and sample.final_15gon.strictly_convex
+    ]
+    return {
+        "status": "SAMPLED_NUMERICAL_A5_CONSTRAINT_PROBE",
+        "source_lemma_scope": (
+            "N=1 specialization of Lemma 3.1 with "
+            "A=A3, B=A4, C=B1, D=B2, C1=A5, and default "
+            f"Bprime fraction {_format_fraction(LEMMA31_DEFAULT_BPRIME_FRACTION)}."
+        ),
+        "parameterization": {
+            "formula": "A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1)",
+            "t_values": {
+                "formula": "i/500 for 1 <= i <= 100",
+                "count": len(LEMMA31_A5_EDGE_T_VALUES),
+                "min": _format_fraction(LEMMA31_A5_EDGE_T_VALUES[0]),
+                "max": _format_fraction(LEMMA31_A5_EDGE_T_VALUES[-1]),
+            },
+            "normal_offsets": [
+                _format_fraction(offset) for offset in LEMMA31_A5_EDGE_NORMAL_OFFSETS
+            ],
+            "sample_count": len(samples),
+        },
+        "filter_counts": {
+            "D_C_A5_B_A_extreme_clockwise": len(local_clockwise),
+            "plus_A5_outside_S_A": len(local_outside),
+            "plus_angle_A_B_A5_acute": len(local_outside_acute),
+            "plus_segment_C_A5_intersects_default_S_Bprime_twice": len(
+                lemma31_samples
+            ),
+            "plus_rotated_15gon_strictly_convex": len(final_convex_samples),
+        },
+        "individual_condition_counts": {
+            "D_C_A5_B_A_extreme_clockwise": sum(
+                1 for sample in samples if sample.local_clockwise
+            ),
+            "A5_outside_S_A": sum(1 for sample in samples if sample.outside_s_a),
+            "angle_A_B_A5_acute": sum(1 for sample in samples if sample.acute_angle),
+            "segment_C_A5_intersects_default_S_Bprime_twice": sum(
+                1 for sample in samples if sample.segment_crosses_s_bprime_twice
+            ),
+        },
+        "sampled_witnesses": [_a5_sample_to_json(sample) for sample in lemma31_samples],
+        "interpretation": (
+            "This is a bounded float64 sample of the local Lemma 3.1 A5 "
+            "constraints, not an exact coordinate certificate and not a "
+            "finite-vertex extraction from the BRP convex-body construction."
         ),
     }
 
@@ -652,6 +876,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
     vertices = brp_seed_vertices()
     profiles = all_circle_profiles(tol=tol)
     candidate_scan = synthetic_a5_scan(root_tol=tol)
+    a5_constraint_scan = lemma31_a5_constraint_scan(root_tol=tol)
     convex_candidate_count = sum(1 for candidate in candidate_scan if candidate.strictly_convex)
     best_candidate_vertex_hits = max(candidate.max_vertex_hits for candidate in candidate_scan)
     best_candidate_boundary_hits = max(candidate.max_boundary_hits for candidate in candidate_scan)
@@ -730,6 +955,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "candidates": [_candidate_to_json(candidate) for candidate in candidate_scan],
         },
         "lemma31_preflight": lemma31_preflight(),
+        "lemma31_a5_constraint_scan": a5_constraint_scan,
         "histograms": {
             "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
             "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
@@ -744,19 +970,21 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "quoted in the Barany--Roldan-Pensado convex-body discussion. It "
             "measures the gap between centered circle hits on polygon edges and "
             "hits at the modeled seed vertices, and includes a limited signed "
-            "synthetic A5 edge-pocket closure stress test plus a Lemma 3.1 "
-            "role-precondition preflight."
+            "synthetic A5 edge-pocket closure stress test, a Lemma 3.1 "
+            "role-precondition preflight, and a bounded sampled A5 constraint "
+            "probe."
         ),
         "does_not_claim": [
             "proof of Erdos Problem #97",
             "counterexample to Erdos Problem #97",
             "finite-vertex extraction from the Barany--Roldan-Pensado body",
-            "model of the source paper's A5 insertion or final 15-gon",
-            "construction of the source paper's existential A5",
+            "exact model of the source paper's A5 insertion or final 15-gon",
+            "exact construction of the source paper's existential A5",
             "exact or interval certificate for boundary intersections",
         ],
         "next_steps": [
-            "solve or parameterize A5 under the recorded Lemma 3.1 constraints",
+            "upgrade the sampled A5 witness to exact algebraic or interval coordinates",
+            "prove an admissible neighbourhood around the sampled A5 witness",
             "promote edge-interior hits to symbolic edge parameters",
             "iterate the promoted hits as new candidate vertices",
             "replace float boundary intersections by exact algebraic or interval checks",
@@ -825,6 +1053,65 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
         raise AssertionError("Lemma 3.1 role angle ABC is expected to be acute")
     if bprime_budget.get("C_outside_default_S_Bprime") is not True:
         raise AssertionError("C is expected to be outside the default S_Bprime")
+
+    a5_scan = payload.get("lemma31_a5_constraint_scan")
+    if not isinstance(a5_scan, dict):
+        raise AssertionError("payload.lemma31_a5_constraint_scan must be an object")
+    parameterization = a5_scan.get("parameterization")
+    filter_counts = a5_scan.get("filter_counts")
+    individual_condition_counts = a5_scan.get("individual_condition_counts")
+    witnesses = a5_scan.get("sampled_witnesses")
+    if not isinstance(parameterization, dict):
+        raise AssertionError("payload.lemma31_a5_constraint_scan.parameterization must be an object")
+    if not isinstance(filter_counts, dict):
+        raise AssertionError("payload.lemma31_a5_constraint_scan.filter_counts must be an object")
+    if not isinstance(individual_condition_counts, dict):
+        raise AssertionError(
+            "payload.lemma31_a5_constraint_scan.individual_condition_counts must be an object"
+        )
+    if not isinstance(witnesses, list):
+        raise AssertionError("payload.lemma31_a5_constraint_scan.sampled_witnesses must be a list")
+    if parameterization.get("sample_count") != 2000:
+        raise AssertionError("expected 2000 sampled A5 parameters")
+    expected_filter_counts = {
+        "D_C_A5_B_A_extreme_clockwise": 700,
+        "plus_A5_outside_S_A": 290,
+        "plus_angle_A_B_A5_acute": 3,
+        "plus_segment_C_A5_intersects_default_S_Bprime_twice": 1,
+        "plus_rotated_15gon_strictly_convex": 1,
+    }
+    for key, expected in expected_filter_counts.items():
+        if filter_counts.get(key) != expected:
+            raise AssertionError(
+                f"lemma31_a5_constraint_scan.filter_counts.{key}: "
+                f"expected {expected}, got {filter_counts.get(key)}"
+            )
+    expected_individual_counts = {
+        "D_C_A5_B_A_extreme_clockwise": 700,
+        "A5_outside_S_A": 590,
+        "angle_A_B_A5_acute": 1413,
+        "segment_C_A5_intersects_default_S_Bprime_twice": 41,
+    }
+    for key, expected in expected_individual_counts.items():
+        if individual_condition_counts.get(key) != expected:
+            raise AssertionError(
+                f"lemma31_a5_constraint_scan.individual_condition_counts.{key}: "
+                f"expected {expected}, got {individual_condition_counts.get(key)}"
+            )
+    if len(witnesses) != 1:
+        raise AssertionError(f"expected 1 sampled A5 witness, got {len(witnesses)}")
+    witness = witnesses[0]
+    if not isinstance(witness, dict):
+        raise AssertionError("sampled A5 witness must be an object")
+    if witness.get("t") != "3/125" or witness.get("normal_offset") != "-1/200":
+        raise AssertionError("unexpected sampled A5 witness parameters")
+    rotated_15gon = witness.get("rotated_15gon")
+    if not isinstance(rotated_15gon, dict):
+        raise AssertionError("sampled A5 witness must include rotated_15gon summary")
+    if rotated_15gon.get("strictly_convex") is not True:
+        raise AssertionError("sampled A5 witness should keep the rotated 15-gon convex")
+    if rotated_15gon.get("circles_with_at_least_four_vertices") != 0:
+        raise AssertionError("sampled A5 witness should not create four-vertex circles")
 
     synthetic = payload.get("synthetic_a5_scan")
     if not isinstance(synthetic, dict):

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -44,7 +44,7 @@ def test_exact_distance_detects_rotation_symmetry() -> None:
 def test_payload_keeps_vertexization_gap_explicit() -> None:
     payload = build_payload()
 
-    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v1"
+    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v2"
     assert payload["trust"] == "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
     assert payload["provenance"]["generator"] == "scripts/check_brp_boundary_probe.py"
     assert_expected_counts(payload)
@@ -74,6 +74,43 @@ def test_payload_keeps_vertexization_gap_explicit() -> None:
         preflight["bprime_neighbourhood_budget"]["C_outside_default_S_Bprime"]
         is True
     )
+    a5_scan = payload["lemma31_a5_constraint_scan"]
+    assert a5_scan["status"] == "SAMPLED_NUMERICAL_A5_CONSTRAINT_PROBE"
+    assert a5_scan["parameterization"]["sample_count"] == 2000
+    assert a5_scan["filter_counts"] == {
+        "D_C_A5_B_A_extreme_clockwise": 700,
+        "plus_A5_outside_S_A": 290,
+        "plus_angle_A_B_A5_acute": 3,
+        "plus_segment_C_A5_intersects_default_S_Bprime_twice": 1,
+        "plus_rotated_15gon_strictly_convex": 1,
+    }
+    assert a5_scan["individual_condition_counts"] == {
+        "D_C_A5_B_A_extreme_clockwise": 700,
+        "A5_outside_S_A": 590,
+        "angle_A_B_A5_acute": 1413,
+        "segment_C_A5_intersects_default_S_Bprime_twice": 41,
+    }
+    assert len(a5_scan["sampled_witnesses"]) == 1
+    witness = a5_scan["sampled_witnesses"][0]
+    assert witness["t"] == "3/125"
+    assert witness["normal_offset"] == "-1/200"
+    assert witness["normal_side"] == "right"
+    assert witness["lemma31_N1_bullets"] == {
+        "D_C_A5_B_A_extreme_clockwise": True,
+        "A5_outside_S_A": True,
+        "angle_A_B_A5_acute": True,
+        "segment_C_A5_intersects_default_S_Bprime_twice": True,
+        "S_Bprime_roots_on_segment_C_A5": [0.86294581, 0.995615477],
+        "largest_clockwise_turn_area2": -0.026807931,
+    }
+    assert witness["rotated_15gon"] == {
+        "strictly_convex": True,
+        "min_turn_area2": 0.026807931,
+        "max_vertex_hits": 2,
+        "max_boundary_hits": 6,
+        "circles_with_at_least_four_vertices": 0,
+        "circles_with_at_least_four_boundary_hits": 87,
+    }
     assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
     assert "the A5 insertion" in str(payload["source"]["not_modeled"])
 


### PR DESCRIPTION
## Summary

Adds a bounded sampled `A5` constraint probe to the Barany--Roldan-Pensado boundary vertexization diagnostic.

- encodes the `N=1` Lemma 3.1 local bullets for `A=A3`, `B=A4`, `C=B1`, `D=B2`, `C1=A5`
- scans 2,000 near-`A4` edge-pocket samples and records the single sampled witness `t=3/125`, `h=-1/200`
- confirms the rotated sampled 15-gon is strictly convex but still has maximum centered vertex multiplicity `2`, preserving the boundary/finite-vertex gap
- regenerates the JSON artifact and updates the manifest, docs, and tests

## Guardrails

This remains a float64 numerical diagnostic. It is not an exact A5 coordinate certificate, not a finite extraction from the BRP convex-body construction, not a proof, and not a counterexample.

## Validation

- `.venv/bin/python scripts/check_brp_boundary_probe.py --check --assert-expected --json`
- `.venv/bin/python -m pytest tests/test_brp_boundary_probe.py -q`
- `.venv/bin/python -m ruff check src/erdos97/brp_boundary_probe.py scripts/check_brp_boundary_probe.py tests/test_brp_boundary_probe.py`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q` (`1422 passed, 663 deselected`)