### PR TITLE
[codex] Add BRP A5 interval box probe

### DIFF
--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -765,7 +765,7 @@
       ]
     }
   ],
-  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe.",
+  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe with a tiny float64 interval-box follow-up.",
   "convexity": {
     "max_turn_area2": 146403.0,
     "min_turn_area2": 19.492354671,
@@ -777,6 +777,7 @@
     "finite-vertex extraction from the Barany--Roldan-Pensado body",
     "exact model of the source paper's A5 insertion or final 15-gon",
     "exact construction of the source paper's existential A5",
+    "exact algebraic or formal interval certificate for the sampled A5",
     "exact or interval certificate for boundary intersections"
   ],
   "histograms": {
@@ -879,6 +880,186 @@
     "source_lemma_scope": "N=1 specialization of Lemma 3.1 with A=A3, B=A4, C=B1, D=B2, C1=A5, and default Bprime fraction 1/100.",
     "status": "SAMPLED_NUMERICAL_A5_CONSTRAINT_PROBE"
   },
+  "lemma31_a5_interval_box_probe": {
+    "a5_coordinate_interval": {
+      "x": {
+        "lower": -498.052639401,
+        "upper": -498.052638816
+      },
+      "y": {
+        "lower": 870.882474276,
+        "upper": 870.882475345
+      }
+    },
+    "all_interval_checks_pass": true,
+    "box": {
+      "normal_offset": {
+        "center": "-1/200",
+        "lower": "-50001/10000000",
+        "radius": "1/10000000",
+        "upper": "-49999/10000000"
+      },
+      "sampled_witness_center": {
+        "normal_offset": "-1/200",
+        "t": "3/125"
+      },
+      "t": {
+        "center": "3/125",
+        "lower": "239999/10000000",
+        "radius": "1/10000000",
+        "upper": "240001/10000000"
+      }
+    },
+    "coordinate_model": "Outward-rounded interval arithmetic over the checker float64 coordinate model. This is not an exact algebraic certificate for the source Q(sqrt(3)) coordinates.",
+    "interpretation": "Certifies a small float64-model box around the sampled A5 witness for the local Lemma 3.1 bullets and rotated 15-gon strict convexity. It does not certify BRP boundary-intersection counts, finite-vertex multiplicities throughout the box, or exact source-paper coordinates.",
+    "lemma31_N1_interval_checks": {
+      "A5_outside_S_A": true,
+      "D_C_A5_B_A_extreme_clockwise": true,
+      "S_Bprime_quadratic": {
+        "a": {
+          "lower": 27.383347058,
+          "upper": 27.383359728
+        },
+        "b": {
+          "lower": -50.893648546,
+          "upper": -50.893632506
+        },
+        "c": {
+          "lower": 23.526742261,
+          "upper": 23.526742261
+        },
+        "discriminant": {
+          "lower": 13.196843444,
+          "upper": 13.199668391
+        }
+      },
+      "S_Bprime_root_intervals_on_segment_C_A5": [
+        {
+          "lower": 0.862941914,
+          "upper": 0.862949705
+        },
+        {
+          "lower": 0.995611551,
+          "upper": 0.995619404
+        }
+      ],
+      "acute_dot_interval": {
+        "lower": 0.005787446,
+        "upper": 0.007004343
+      },
+      "angle_A_B_A5_acute": true,
+      "local_turn_intervals": [
+        {
+          "lower": -184702.16455617,
+          "upper": -184702.164556167
+        },
+        {
+          "lower": -18.286047227,
+          "upper": -18.285910858
+        },
+        {
+          "lower": -0.026810457,
+          "upper": -0.026805405
+        },
+        {
+          "lower": -161.283276412,
+          "upper": -161.281754023
+        },
+        {
+          "lower": -191392.635675885,
+          "upper": -191392.635675884
+        }
+      ],
+      "max_local_turn_upper_bound": -0.026805405,
+      "outside_S_A_margin_interval": {
+        "lower": 0.002574451,
+        "upper": 0.005008062
+      },
+      "segment_C_A5_intersects_default_S_Bprime_twice": true
+    },
+    "rotated_15gon_interval_checks": {
+      "min_turn_lower_bound": 0.026803636,
+      "strictly_convex": true,
+      "turn_intervals": [
+        {
+          "label": "A1",
+          "lower": 18.285852206,
+          "upper": 18.286105879
+        },
+        {
+          "label": "A2",
+          "lower": 6724.0,
+          "upper": 6724.0
+        },
+        {
+          "label": "A3",
+          "lower": 146402.999999999,
+          "upper": 146403.000000001
+        },
+        {
+          "label": "A4",
+          "lower": 161.281754079,
+          "upper": 161.283276357
+        },
+        {
+          "label": "A5",
+          "lower": 0.026805405,
+          "upper": 0.026810457
+        },
+        {
+          "label": "B1",
+          "lower": 18.285905931,
+          "upper": 18.286052154
+        },
+        {
+          "label": "B2",
+          "lower": 6723.999999999,
+          "upper": 6724.000000001
+        },
+        {
+          "label": "B3",
+          "lower": 146402.999999998,
+          "upper": 146403.000000001
+        },
+        {
+          "label": "B4",
+          "lower": 161.281689119,
+          "upper": 161.283341317
+        },
+        {
+          "label": "B5",
+          "lower": 0.026804706,
+          "upper": 0.026811157
+        },
+        {
+          "label": "C1",
+          "lower": 18.28588195,
+          "upper": 18.286076135
+        },
+        {
+          "label": "C2",
+          "lower": 6723.999999999,
+          "upper": 6724.000000001
+        },
+        {
+          "label": "C3",
+          "lower": 146402.999999997,
+          "upper": 146403.000000002
+        },
+        {
+          "label": "C4",
+          "lower": 161.281539213,
+          "upper": 161.283491223
+        },
+        {
+          "label": "C5",
+          "lower": 0.026803636,
+          "upper": 0.026812226
+        }
+      ]
+    },
+    "status": "FLOAT64_INTERVAL_BOX_DIAGNOSTIC"
+  },
   "lemma31_preflight": {
     "a5_constraints_remaining_after_sampled_scan": [
       "upgrade the sampled C1=A5 witness to exact or interval coordinates",
@@ -927,8 +1108,8 @@
     "status": "LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED"
   },
   "next_steps": [
-    "upgrade the sampled A5 witness to exact algebraic or interval coordinates",
-    "prove an admissible neighbourhood around the sampled A5 witness",
+    "replace the float64 A5 interval box with exact algebraic or directed-decimal coordinates",
+    "certify BRP boundary-intersection counts for the sampled final 15-gon",
     "promote edge-interior hits to symbolic edge parameters",
     "iterate the promoted hits as new candidate vertices",
     "replace float boundary intersections by exact algebraic or interval checks"
@@ -938,7 +1119,7 @@
     "generator": "scripts/check_brp_boundary_probe.py",
     "notes": "Float64 boundary-intersection diagnostic for the quoted Barany--Roldan-Pensado 12-point seed before A5 insertion."
   },
-  "schema": "erdos97.brp_boundary_vertexization_probe.v2",
+  "schema": "erdos97.brp_boundary_vertexization_probe.v3",
   "source": {
     "base_points": [
       {

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -76,6 +76,10 @@ The checker:
 - runs a bounded `N=1` Lemma 3.1 A5 constraint scan near `A4`, using the
   parameterization
   `A5(t,h)=A4+t*(B1-A4)+h*unit_left_normal(A4B1)`.
+- checks a tiny outward-rounded float64 interval box around the sampled
+  witness:
+  `t in [239999/10000000, 240001/10000000]` and
+  `h in [-50001/10000000, -49999/10000000]`.
 
 ## Current result
 
@@ -98,6 +102,9 @@ sampled Lemma 3.1 A5 witnesses: 1
 first sampled witness: t=3/125, h=-1/200
 rotated 15-gon convex for sampled witness: yes
 sampled-witness centered circles with four vertices: 0
+float64 A5 interval box checks pass: yes
+interval max local turn upper bound: -0.026805405
+interval rotated 15-gon min turn lower bound: 0.026803636
 ```
 
 Thus the modeled 12-point seed shows the expected continuous/discrete gap:
@@ -132,13 +139,23 @@ exact certificate. The sampled `A5` remains a float64 point in a bounded search
 family, the final BRP boundary-intersection proof is not replayed, and the
 boundary-hit/finite-vertex gap remains open.
 
+The interval-box follow-up makes the sampled point less brittle inside the
+checker's own numeric model. With outward-rounded float64 interval arithmetic,
+the whole box above keeps `B2,B1,A5,A4,A3` clockwise, keeps `A5` outside the
+circle centered at `A3` through `A4`, keeps the angle `A3 A4 A5` acute, keeps
+the default `S_Bprime` intersection roots inside `(0,1)`, and keeps the
+rotated synthetic 15-gon strictly convex. This is still not an exact algebraic
+certificate for the source `Q(sqrt(3))` coordinates and it does not certify
+the BRP boundary-intersection count throughout the box.
+
 ## Next steps
 
 Useful follow-up work should avoid more visual inspection and instead make the
 edge-interior hits algebraic:
 
-1. Upgrade the sampled `A5` witness to exact algebraic or interval coordinates.
-2. Prove a neighbourhood of admissible `A5` choices around the sampled point.
+1. Replace the float64 interval box with an exact algebraic or directed-decimal
+   certificate over the source coordinates.
+2. Certify the BRP boundary-intersection counts for the sampled final 15-gon.
 3. Promote each interior circle-edge hit to a candidate vertex parameter.
 4. Iterate the closure condition: promoted vertices become centers that must
    themselves acquire four vertex hits.

--- a/docs/index.md
+++ b/docs/index.md
@@ -797,8 +797,9 @@ put detailed reconciliation in the canonical synthesis.
   first seed-only diagnostic for the Barany--Roldan-Pensado convex-body
   boundary lane, measuring seed-boundary circle hits versus modeled seed-vertex
   hits, pinning the Lemma 3.1 role preflight, and recording one sampled local
-  A5 constraint witness; numerical diagnostic only, not a finite extraction,
-  exact A5 construction, or counterexample.
+  A5 constraint witness plus a tiny float64 interval box around it; numerical
+  diagnostic only, not a finite extraction, exact A5 construction, or
+  counterexample.
 - [`dynamic-witness-free-pattern-search.md`](dynamic-witness-free-pattern-search.md):
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -44,10 +44,12 @@ are claimed here.
   checks, and records one sampled local A5 constraint witness
   `t=3/125, h=-1/200` in the `A4->B1` edge-pocket parameterization. Rotating
   that sampled point gives a strictly convex numerical 15-gon with maximum
-  centered vertex multiplicity still `2`. This remains a float64 diagnostic:
-  it is not an exact A5 certificate, does not replay the final BRP
-  boundary-intersection proof, and gives no counterexample; see
-  `docs/brp-boundary-vertexization-probe.md`.
+  centered vertex multiplicity still `2`. A tiny outward-rounded float64
+  interval box around the same sampled witness also preserves the local
+  Lemma 3.1 bullets and rotated 15-gon convexity in the checker model. This
+  remains a float64 diagnostic: it is not an exact A5 certificate, does not
+  replay the final BRP boundary-intersection proof, and gives no
+  counterexample; see `docs/brp-boundary-vertexization-probe.md`.
 - The canonical synthesis corrects a prior uniform-radius shortcut:
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound
   construction, not an upper bound resolving the subcase. Furedi's separate

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3445,8 +3445,8 @@ artifacts:
 
   - id: brp_boundary_vertexization_probe
     path: data/certificates/brp_boundary_vertexization_probe.json
-    sha256: f564df4c160756e75e245fcb0737f9e9a60f1787a007fe9ae3b9905da6f3fce5
-    size_bytes: 38330
+    sha256: 8573aa4fb4e669365d5e336a307073b4ea269e171ce0f0efee1e862943021592
+    size_bytes: 43167
     kind: numerical_geometric_diagnostic_artifact
     generator: scripts/check_brp_boundary_probe.py
     command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3455,10 +3455,10 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, and one bounded sampled numerical A5 constraint witness. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
+    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, one bounded sampled numerical A5 constraint witness, and a tiny float64 interval-box check around that witness. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.brp_boundary_vertexization_probe.v2
+      schema: erdos97.brp_boundary_vertexization_probe.v3
       status: BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY
       trust: NUMERICAL_GEOMETRIC_DIAGNOSTIC
       provenance.command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3473,6 +3473,9 @@ artifacts:
       lemma31_a5_constraint_scan.parameterization.sample_count: 2000
       lemma31_a5_constraint_scan.filter_counts.plus_segment_C_A5_intersects_default_S_Bprime_twice: 1
       lemma31_a5_constraint_scan.filter_counts.plus_rotated_15gon_strictly_convex: 1
+      lemma31_a5_interval_box_probe.all_interval_checks_pass: true
+      lemma31_a5_interval_box_probe.lemma31_N1_interval_checks.max_local_turn_upper_bound: -0.026805405
+      lemma31_a5_interval_box_probe.rotated_15gon_interval_checks.min_turn_lower_bound: 0.026803636
       synthetic_a5_scan.candidates_with_at_least_four_vertices: 0
       lemma31_preflight.status: LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED
       lemma31_preflight.role_mapping.A: A3

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -112,6 +112,7 @@ def main() -> int:
         synthetic = payload["synthetic_a5_scan"]
         preflight = payload["lemma31_preflight"]
         a5_scan = payload["lemma31_a5_constraint_scan"]
+        a5_interval = payload["lemma31_a5_interval_box_probe"]
         angle_abc = preflight["angle_ABC"]
         bprime_budget = preflight["bprime_neighbourhood_budget"]
         filter_counts = a5_scan["filter_counts"]
@@ -154,6 +155,14 @@ def main() -> int:
                 "Lemma 3.1 first sampled A5: "
                 f"t={witness['t']}, h={witness['normal_offset']}"
             )
+        print(
+            "Lemma 3.1 A5 interval box valid: "
+            f"{a5_interval['all_interval_checks_pass']}"
+        )
+        print(
+            "Lemma 3.1 A5 interval max local turn upper: "
+            f"{a5_interval['lemma31_N1_interval_checks']['max_local_turn_upper_bound']}"
+        )
         if args.assert_expected:
             print("OK: expected BRP boundary diagnostic counts verified")
         if args.write:

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import math
 
 
-SCHEMA = "erdos97.brp_boundary_vertexization_probe.v2"
+SCHEMA = "erdos97.brp_boundary_vertexization_probe.v3"
 STATUS = "BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY"
 TRUST = "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
 
@@ -35,6 +35,9 @@ LEMMA31_A5_EDGE_NORMAL_OFFSETS = tuple(
     for denominator in (1000, 500, 200, 100, 50, 20, 10, 5, 2, 1)
     for offset in (Fraction(1, denominator), Fraction(-1, denominator))
 )
+LEMMA31_A5_WITNESS_T = Fraction(3, 125)
+LEMMA31_A5_WITNESS_NORMAL_OFFSET = Fraction(-1, 200)
+LEMMA31_A5_INTERVAL_RADIUS = Fraction(1, 10_000_000)
 SQRT3 = math.sqrt(3.0)
 ROOT_TOL = 1e-9
 DISTANCE_TOL = 1e-6
@@ -125,6 +128,117 @@ class Lemma31A5ScanSample:
     final_15gon: Candidate15Summary | None
 
 
+@dataclass(frozen=True)
+class FloatInterval:
+    """Small outward-rounded interval over the checker float64 model."""
+
+    lower: float
+    upper: float
+
+    @staticmethod
+    def point(value: float) -> FloatInterval:
+        return FloatInterval(
+            math.nextafter(float(value), -math.inf),
+            math.nextafter(float(value), math.inf),
+        )
+
+    def __add__(self, other: FloatInterval | float) -> FloatInterval:
+        other = _as_interval(other)
+        return FloatInterval(
+            math.nextafter(self.lower + other.lower, -math.inf),
+            math.nextafter(self.upper + other.upper, math.inf),
+        )
+
+    __radd__ = __add__
+
+    def __sub__(self, other: FloatInterval | float) -> FloatInterval:
+        other = _as_interval(other)
+        return FloatInterval(
+            math.nextafter(self.lower - other.upper, -math.inf),
+            math.nextafter(self.upper - other.lower, math.inf),
+        )
+
+    def __rsub__(self, other: FloatInterval | float) -> FloatInterval:
+        return _as_interval(other) - self
+
+    def __neg__(self) -> FloatInterval:
+        return FloatInterval(
+            math.nextafter(-self.upper, -math.inf),
+            math.nextafter(-self.lower, math.inf),
+        )
+
+    def __mul__(self, other: FloatInterval | float) -> FloatInterval:
+        other = _as_interval(other)
+        products = (
+            self.lower * other.lower,
+            self.lower * other.upper,
+            self.upper * other.lower,
+            self.upper * other.upper,
+        )
+        return FloatInterval(
+            math.nextafter(min(products), -math.inf),
+            math.nextafter(max(products), math.inf),
+        )
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, other: FloatInterval | float) -> FloatInterval:
+        other = _as_interval(other)
+        if other.lower <= 0.0 <= other.upper:
+            raise ZeroDivisionError("interval division by range containing zero")
+        reciprocals = (1.0 / other.lower, 1.0 / other.upper)
+        return self * FloatInterval(
+            math.nextafter(min(reciprocals), -math.inf),
+            math.nextafter(max(reciprocals), math.inf),
+        )
+
+    def sqrt(self) -> FloatInterval:
+        if self.lower < 0.0:
+            raise ValueError("cannot take interval sqrt of a negative lower bound")
+        return FloatInterval(
+            math.nextafter(math.sqrt(self.lower), -math.inf),
+            math.nextafter(math.sqrt(self.upper), math.inf),
+        )
+
+
+def _as_interval(value: FloatInterval | float) -> FloatInterval:
+    if isinstance(value, FloatInterval):
+        return value
+    return FloatInterval.point(float(value))
+
+
+def _interval_to_json(value: FloatInterval) -> dict[str, float]:
+    return {
+        "lower": _json_float(value.lower),
+        "upper": _json_float(value.upper),
+    }
+
+
+def _interval_square(value: FloatInterval) -> FloatInterval:
+    return value * value
+
+
+def _interval_point(point: tuple[float, float]) -> tuple[FloatInterval, FloatInterval]:
+    return (FloatInterval.point(point[0]), FloatInterval.point(point[1]))
+
+
+def _interval_orientation2(
+    left: tuple[FloatInterval, FloatInterval],
+    middle: tuple[FloatInterval, FloatInterval],
+    right: tuple[FloatInterval, FloatInterval],
+) -> FloatInterval:
+    return (middle[0] - left[0]) * (right[1] - left[1]) - (
+        middle[1] - left[1]
+    ) * (right[0] - left[0])
+
+
+def _interval_squared_distance(
+    left: tuple[FloatInterval, FloatInterval],
+    right: tuple[FloatInterval, FloatInterval],
+) -> FloatInterval:
+    return _interval_square(left[0] - right[0]) + _interval_square(left[1] - right[1])
+
+
 def _q(value: int | Fraction, sqrt3: int | Fraction = 0) -> Quad:
     return Quad(Fraction(value), Fraction(sqrt3))
 
@@ -179,6 +293,21 @@ def _rotate_numeric_point(point: tuple[float, float], orbit: int) -> tuple[float
     return (
         x * math.cos(angle) - y * math.sin(angle),
         x * math.sin(angle) + y * math.cos(angle),
+    )
+
+
+def _rotate_interval_point(
+    point: tuple[FloatInterval, FloatInterval],
+    orbit: int,
+) -> tuple[FloatInterval, FloatInterval]:
+    if orbit == 0:
+        return point
+    angle = 2.0 * math.pi * orbit / 3.0
+    cosine = FloatInterval.point(math.cos(angle))
+    sine = FloatInterval.point(math.sin(angle))
+    return (
+        point[0] * cosine - point[1] * sine,
+        point[0] * sine + point[1] * cosine,
     )
 
 
@@ -256,6 +385,29 @@ def _a5_edge_pocket_point(
     return (
         a4[0] + t * edge[0] + h * normal_unit[0],
         a4[1] + t * edge[1] + h * normal_unit[1],
+    )
+
+
+def _a5_edge_pocket_interval_point(
+    t_value: FloatInterval,
+    normal_offset: FloatInterval,
+    *,
+    by_label: dict[str, tuple[FloatInterval, FloatInterval]],
+) -> tuple[FloatInterval, FloatInterval]:
+    a4 = by_label["A4"]
+    b1 = by_label["B1"]
+    edge = (b1[0] - a4[0], b1[1] - a4[1])
+    normal = (-edge[1], edge[0])
+    normal_length = (
+        _interval_square(normal[0]) + _interval_square(normal[1])
+    ).sqrt()
+    normal_unit = (
+        normal[0] / normal_length,
+        normal[1] / normal_length,
+    )
+    return (
+        a4[0] + t_value * edge[0] + normal_offset * normal_unit[0],
+        a4[1] + t_value * edge[1] + normal_offset * normal_unit[1],
     )
 
 
@@ -831,6 +983,189 @@ def lemma31_a5_constraint_scan(
     }
 
 
+def _interval_box_endpoints(
+    center: Fraction,
+    radius: Fraction,
+) -> dict[str, str]:
+    return {
+        "lower": _format_fraction(center - radius),
+        "center": _format_fraction(center),
+        "upper": _format_fraction(center + radius),
+        "radius": _format_fraction(radius),
+    }
+
+
+def lemma31_a5_interval_box_probe() -> dict[str, object]:
+    """Certify a tiny A5 neighbourhood in the checker float64 interval model."""
+
+    seed = brp_seed_numeric_vertices()
+    by_label = {vertex.label: _interval_point(vertex.numeric) for vertex in seed}
+    t_center = LEMMA31_A5_WITNESS_T
+    h_center = LEMMA31_A5_WITNESS_NORMAL_OFFSET
+    radius = LEMMA31_A5_INTERVAL_RADIUS
+    t_interval = FloatInterval(
+        math.nextafter(float(t_center - radius), -math.inf),
+        math.nextafter(float(t_center + radius), math.inf),
+    )
+    h_interval = FloatInterval(
+        math.nextafter(float(h_center - radius), -math.inf),
+        math.nextafter(float(h_center + radius), math.inf),
+    )
+    a5 = _a5_edge_pocket_interval_point(
+        t_interval,
+        h_interval,
+        by_label=by_label,
+    )
+    a_label, b_label, c_label, d_label = LEMMA31_ROLE_LABELS
+    a_point = by_label[a_label]
+    b_point = by_label[b_label]
+    c_point = by_label[c_label]
+    d_point = by_label[d_label]
+    local_order = (d_point, c_point, a5, b_point, a_point)
+    local_turns = tuple(
+        _interval_orientation2(
+            local_order[index - 1],
+            local_order[index],
+            local_order[(index + 1) % len(local_order)],
+        )
+        for index in range(len(local_order))
+    )
+    outside_margin = _interval_squared_distance(
+        a_point,
+        a5,
+    ) - _interval_squared_distance(a_point, b_point)
+    ba = (a_point[0] - b_point[0], a_point[1] - b_point[1])
+    ba5 = (a5[0] - b_point[0], a5[1] - b_point[1])
+    acute_dot = ba[0] * ba5[0] + ba[1] * ba5[1]
+    tau = FloatInterval.point(float(LEMMA31_DEFAULT_BPRIME_FRACTION))
+    bprime = (
+        b_point[0] + tau * (a_point[0] - b_point[0]),
+        b_point[1] + tau * (a_point[1] - b_point[1]),
+    )
+    bprime_radius_squared = _interval_squared_distance(bprime, b_point)
+    dx = a5[0] - c_point[0]
+    dy = a5[1] - c_point[1]
+    fx = c_point[0] - bprime[0]
+    fy = c_point[1] - bprime[1]
+    quadratic_a = _interval_square(dx) + _interval_square(dy)
+    quadratic_b = FloatInterval.point(2.0) * (fx * dx + fy * dy)
+    quadratic_c = (
+        _interval_square(fx) + _interval_square(fy) - bprime_radius_squared
+    )
+    discriminant = (
+        quadratic_b * quadratic_b
+        - FloatInterval.point(4.0) * quadratic_a * quadratic_c
+    )
+    sqrt_discriminant = discriminant.sqrt()
+    denominator = FloatInterval.point(2.0) * quadratic_a
+    first_root = (-quadratic_b - sqrt_discriminant) / denominator
+    second_root = (-quadratic_b + sqrt_discriminant) / denominator
+    root_intervals = (first_root, second_root)
+
+    base_vertices = {f"A{suffix}": by_label[f"A{suffix}"] for suffix in ("1", "2", "3", "4")}
+    interval_15gon: list[tuple[str, tuple[FloatInterval, FloatInterval]]] = []
+    for orbit, prefix in enumerate(ORBIT_PREFIXES):
+        for suffix in ("1", "2", "3", "4"):
+            source = base_vertices[f"A{suffix}"]
+            interval_15gon.append(
+                (
+                    f"{prefix}{suffix}",
+                    source if orbit == 0 else _rotate_interval_point(source, orbit),
+                )
+            )
+        interval_15gon.append((f"{prefix}5", _rotate_interval_point(a5, orbit)))
+    rotated_turns = tuple(
+        (
+            label,
+            _interval_orientation2(
+                interval_15gon[index - 1][1],
+                point,
+                interval_15gon[(index + 1) % len(interval_15gon)][1],
+            ),
+        )
+        for index, (label, point) in enumerate(interval_15gon)
+    )
+    local_clockwise = max(turn.upper for turn in local_turns) < 0.0
+    outside_s_a = outside_margin.lower > 0.0
+    acute_angle = acute_dot.lower > 0.0
+    crosses_twice = (
+        discriminant.lower > 0.0
+        and first_root.lower > 0.0
+        and first_root.upper < 1.0
+        and second_root.lower > 0.0
+        and second_root.upper < 1.0
+        and first_root.upper < second_root.lower
+    )
+    rotated_strictly_convex = min(turn.lower for _, turn in rotated_turns) > 0.0
+    return {
+        "status": "FLOAT64_INTERVAL_BOX_DIAGNOSTIC",
+        "coordinate_model": (
+            "Outward-rounded interval arithmetic over the checker float64 "
+            "coordinate model. This is not an exact algebraic certificate for "
+            "the source Q(sqrt(3)) coordinates."
+        ),
+        "box": {
+            "t": _interval_box_endpoints(t_center, radius),
+            "normal_offset": _interval_box_endpoints(h_center, radius),
+            "sampled_witness_center": {
+                "t": _format_fraction(t_center),
+                "normal_offset": _format_fraction(h_center),
+            },
+        },
+        "a5_coordinate_interval": {
+            "x": _interval_to_json(a5[0]),
+            "y": _interval_to_json(a5[1]),
+        },
+        "lemma31_N1_interval_checks": {
+            "D_C_A5_B_A_extreme_clockwise": local_clockwise,
+            "local_turn_intervals": [
+                _interval_to_json(turn) for turn in local_turns
+            ],
+            "max_local_turn_upper_bound": _json_float(
+                max(turn.upper for turn in local_turns)
+            ),
+            "A5_outside_S_A": outside_s_a,
+            "outside_S_A_margin_interval": _interval_to_json(outside_margin),
+            "angle_A_B_A5_acute": acute_angle,
+            "acute_dot_interval": _interval_to_json(acute_dot),
+            "segment_C_A5_intersects_default_S_Bprime_twice": crosses_twice,
+            "S_Bprime_quadratic": {
+                "a": _interval_to_json(quadratic_a),
+                "b": _interval_to_json(quadratic_b),
+                "c": _interval_to_json(quadratic_c),
+                "discriminant": _interval_to_json(discriminant),
+            },
+            "S_Bprime_root_intervals_on_segment_C_A5": [
+                _interval_to_json(root) for root in root_intervals
+            ],
+        },
+        "rotated_15gon_interval_checks": {
+            "strictly_convex": rotated_strictly_convex,
+            "min_turn_lower_bound": _json_float(
+                min(turn.lower for _, turn in rotated_turns)
+            ),
+            "turn_intervals": [
+                {"label": label, **_interval_to_json(turn)}
+                for label, turn in rotated_turns
+            ],
+        },
+        "all_interval_checks_pass": (
+            local_clockwise
+            and outside_s_a
+            and acute_angle
+            and crosses_twice
+            and rotated_strictly_convex
+        ),
+        "interpretation": (
+            "Certifies a small float64-model box around the sampled A5 "
+            "witness for the local Lemma 3.1 bullets and rotated 15-gon "
+            "strict convexity. It does not certify BRP boundary-intersection "
+            "counts, finite-vertex multiplicities throughout the box, or exact "
+            "source-paper coordinates."
+        ),
+    }
+
+
 def _histogram(values: Iterable[int]) -> dict[str, int]:
     return {str(key): value for key, value in sorted(Counter(values).items())}
 
@@ -877,6 +1212,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
     profiles = all_circle_profiles(tol=tol)
     candidate_scan = synthetic_a5_scan(root_tol=tol)
     a5_constraint_scan = lemma31_a5_constraint_scan(root_tol=tol)
+    a5_interval_box = lemma31_a5_interval_box_probe()
     convex_candidate_count = sum(1 for candidate in candidate_scan if candidate.strictly_convex)
     best_candidate_vertex_hits = max(candidate.max_vertex_hits for candidate in candidate_scan)
     best_candidate_boundary_hits = max(candidate.max_boundary_hits for candidate in candidate_scan)
@@ -956,6 +1292,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
         },
         "lemma31_preflight": lemma31_preflight(),
         "lemma31_a5_constraint_scan": a5_constraint_scan,
+        "lemma31_a5_interval_box_probe": a5_interval_box,
         "histograms": {
             "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
             "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
@@ -972,7 +1309,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "hits at the modeled seed vertices, and includes a limited signed "
             "synthetic A5 edge-pocket closure stress test, a Lemma 3.1 "
             "role-precondition preflight, and a bounded sampled A5 constraint "
-            "probe."
+            "probe with a tiny float64 interval-box follow-up."
         ),
         "does_not_claim": [
             "proof of Erdos Problem #97",
@@ -980,11 +1317,12 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "finite-vertex extraction from the Barany--Roldan-Pensado body",
             "exact model of the source paper's A5 insertion or final 15-gon",
             "exact construction of the source paper's existential A5",
+            "exact algebraic or formal interval certificate for the sampled A5",
             "exact or interval certificate for boundary intersections",
         ],
         "next_steps": [
-            "upgrade the sampled A5 witness to exact algebraic or interval coordinates",
-            "prove an admissible neighbourhood around the sampled A5 witness",
+            "replace the float64 A5 interval box with exact algebraic or directed-decimal coordinates",
+            "certify BRP boundary-intersection counts for the sampled final 15-gon",
             "promote edge-interior hits to symbolic edge parameters",
             "iterate the promoted hits as new candidate vertices",
             "replace float boundary intersections by exact algebraic or interval checks",
@@ -1112,6 +1450,53 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
         raise AssertionError("sampled A5 witness should keep the rotated 15-gon convex")
     if rotated_15gon.get("circles_with_at_least_four_vertices") != 0:
         raise AssertionError("sampled A5 witness should not create four-vertex circles")
+
+    interval_box = payload.get("lemma31_a5_interval_box_probe")
+    if not isinstance(interval_box, dict):
+        raise AssertionError("payload.lemma31_a5_interval_box_probe must be an object")
+    box = interval_box.get("box")
+    interval_checks = interval_box.get("lemma31_N1_interval_checks")
+    rotated_interval_checks = interval_box.get("rotated_15gon_interval_checks")
+    if not isinstance(box, dict):
+        raise AssertionError("payload.lemma31_a5_interval_box_probe.box must be an object")
+    if not isinstance(interval_checks, dict):
+        raise AssertionError(
+            "payload.lemma31_a5_interval_box_probe.lemma31_N1_interval_checks must be an object"
+        )
+    if not isinstance(rotated_interval_checks, dict):
+        raise AssertionError(
+            "payload.lemma31_a5_interval_box_probe.rotated_15gon_interval_checks must be an object"
+        )
+    if interval_box.get("all_interval_checks_pass") is not True:
+        raise AssertionError("sampled A5 interval box should pass all interval checks")
+    if box.get("t") != {
+        "lower": "239999/10000000",
+        "center": "3/125",
+        "upper": "240001/10000000",
+        "radius": "1/10000000",
+    }:
+        raise AssertionError("unexpected A5 interval t box")
+    if box.get("normal_offset") != {
+        "lower": "-50001/10000000",
+        "center": "-1/200",
+        "upper": "-49999/10000000",
+        "radius": "1/10000000",
+    }:
+        raise AssertionError("unexpected A5 interval normal-offset box")
+    if interval_checks.get("D_C_A5_B_A_extreme_clockwise") is not True:
+        raise AssertionError("A5 interval box should certify local clockwise order")
+    if interval_checks.get("A5_outside_S_A") is not True:
+        raise AssertionError("A5 interval box should stay outside S_A")
+    if interval_checks.get("angle_A_B_A5_acute") is not True:
+        raise AssertionError("A5 interval box should keep angle A-B-A5 acute")
+    if interval_checks.get("segment_C_A5_intersects_default_S_Bprime_twice") is not True:
+        raise AssertionError("A5 interval box should keep two S_Bprime crossings")
+    if rotated_interval_checks.get("strictly_convex") is not True:
+        raise AssertionError("A5 interval box should keep the rotated 15-gon convex")
+    if interval_checks.get("max_local_turn_upper_bound") != -0.026805405:
+        raise AssertionError("unexpected A5 interval local-turn bound")
+    if rotated_interval_checks.get("min_turn_lower_bound") != 0.026803636:
+        raise AssertionError("unexpected A5 interval 15-gon turn bound")
 
     synthetic = payload.get("synthetic_a5_scan")
     if not isinstance(synthetic, dict):

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -44,7 +44,7 @@ def test_exact_distance_detects_rotation_symmetry() -> None:
 def test_payload_keeps_vertexization_gap_explicit() -> None:
     payload = build_payload()
 
-    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v2"
+    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v3"
     assert payload["trust"] == "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
     assert payload["provenance"]["generator"] == "scripts/check_brp_boundary_probe.py"
     assert_expected_counts(payload)
@@ -111,6 +111,41 @@ def test_payload_keeps_vertexization_gap_explicit() -> None:
         "circles_with_at_least_four_vertices": 0,
         "circles_with_at_least_four_boundary_hits": 87,
     }
+    interval_box = payload["lemma31_a5_interval_box_probe"]
+    assert interval_box["status"] == "FLOAT64_INTERVAL_BOX_DIAGNOSTIC"
+    assert interval_box["all_interval_checks_pass"] is True
+    assert interval_box["box"]["t"] == {
+        "lower": "239999/10000000",
+        "center": "3/125",
+        "upper": "240001/10000000",
+        "radius": "1/10000000",
+    }
+    assert interval_box["box"]["normal_offset"] == {
+        "lower": "-50001/10000000",
+        "center": "-1/200",
+        "upper": "-49999/10000000",
+        "radius": "1/10000000",
+    }
+    interval_checks = interval_box["lemma31_N1_interval_checks"]
+    assert interval_checks["D_C_A5_B_A_extreme_clockwise"] is True
+    assert interval_checks["max_local_turn_upper_bound"] == -0.026805405
+    assert interval_checks["A5_outside_S_A"] is True
+    assert interval_checks["outside_S_A_margin_interval"]["lower"] == 0.002574451
+    assert interval_checks["angle_A_B_A5_acute"] is True
+    assert interval_checks["acute_dot_interval"]["lower"] == 0.005787446
+    assert (
+        interval_checks["segment_C_A5_intersects_default_S_Bprime_twice"]
+        is True
+    )
+    assert interval_checks["S_Bprime_root_intervals_on_segment_C_A5"] == [
+        {"lower": 0.862941914, "upper": 0.862949705},
+        {"lower": 0.995611551, "upper": 0.995619404},
+    ]
+    assert interval_box["rotated_15gon_interval_checks"]["strictly_convex"] is True
+    assert (
+        interval_box["rotated_15gon_interval_checks"]["min_turn_lower_bound"]
+        == 0.026803636
+    )
     assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
     assert "the A5 insertion" in str(payload["source"]["not_modeled"])
 


### PR DESCRIPTION
## Summary

Adds a tiny outward-rounded float64 interval-box follow-up around the sampled BRP Lemma 3.1 `A5` witness.

- bumps the BRP boundary vertexization artifact schema to v3
- adds interval arithmetic over the existing checker float64 coordinate model
- certifies the box `t in [239999/10000000, 240001/10000000]`, `h in [-50001/10000000, -49999/10000000]` for the local `N=1` Lemma 3.1 bullets
- records strict interval margins for local clockwise turns, outside-circle margin, acute-angle dot product, default `S_Bprime` roots, and rotated 15-gon convexity
- regenerates the JSON artifact and updates docs, manifest, CLI output, and tests

## Guardrails

This is still a numerical diagnostic in the checker float64 model. It is not an exact algebraic certificate for the source `Q(sqrt(3))` coordinates, not a BRP boundary-intersection proof replay, not a finite-vertex extraction, and not a counterexample.

## Validation

- `.venv/bin/python scripts/check_brp_boundary_probe.py --check --assert-expected --json`
- `.venv/bin/python -m pytest tests/test_brp_boundary_probe.py -q`
- `.venv/bin/python -m ruff check src/erdos97/brp_boundary_probe.py scripts/check_brp_boundary_probe.py tests/test_brp_boundary_probe.py`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q` (`1422 passed, 663 deselected`)