### PR TITLE
Add sampled BRP boundary support scan

### DIFF
--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -765,7 +765,7 @@
       ]
     }
   ],
-  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe with a tiny float64 interval-box follow-up.",
+  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe with a tiny float64 interval-box follow-up plus an explicit boundary-support scan on the sampled synthetic 15-gon.",
   "convexity": {
     "max_turn_area2": 146403.0,
     "min_turn_area2": 19.492354671,
@@ -778,7 +778,8 @@
     "exact model of the source paper's A5 insertion or final 15-gon",
     "exact construction of the source paper's existential A5",
     "exact algebraic or formal interval certificate for the sampled A5",
-    "exact or interval certificate for boundary intersections"
+    "exact or interval certificate for boundary intersections",
+    "replay of the source paper's continuum boundary-intersection proof"
   ],
   "histograms": {
     "boundary_hit_count": {
@@ -1109,7 +1110,7 @@
   },
   "next_steps": [
     "replace the float64 A5 interval box with exact algebraic or directed-decimal coordinates",
-    "certify BRP boundary-intersection counts for the sampled final 15-gon",
+    "certify sampled final-15-gon boundary hits with exact algebraic or interval checks",
     "promote edge-interior hits to symbolic edge parameters",
     "iterate the promoted hits as new candidate vertices",
     "replace float boundary intersections by exact algebraic or interval checks"
@@ -1117,9 +1118,679 @@
   "provenance": {
     "command": "python scripts/check_brp_boundary_probe.py --write --assert-expected",
     "generator": "scripts/check_brp_boundary_probe.py",
-    "notes": "Float64 boundary-intersection diagnostic for the quoted Barany--Roldan-Pensado 12-point seed before A5 insertion."
+    "notes": "Float64 boundary-intersection diagnostic for the quoted Barany--Roldan-Pensado 12-point seed and sampled synthetic 15-gon after one A5 insertion."
   },
-  "schema": "erdos97.brp_boundary_vertexization_probe.v3",
+  "sampled_a5_boundary_support_scan": {
+    "best_boundary_circles": [
+      {
+        "boundary_hit_count": 6,
+        "center": "A3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A4",
+              "A5"
+            ],
+            "t": 0.771377555
+          },
+          {
+            "edge": [
+              "A5",
+              "B1"
+            ],
+            "t": 7.282e-06
+          },
+          {
+            "edge": [
+              "B2",
+              "B3"
+            ],
+            "t": 0.488543663
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.022744303
+          }
+        ],
+        "radius_squared_float": 1568593.0,
+        "vertex_hit_count": 2,
+        "vertex_hits": [
+          "A4",
+          "A5"
+        ]
+      },
+      {
+        "boundary_hit_count": 6,
+        "center": "B3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.022744303
+          },
+          {
+            "edge": [
+              "B4",
+              "B5"
+            ],
+            "t": 0.771377556
+          },
+          {
+            "edge": [
+              "B5",
+              "C1"
+            ],
+            "t": 7.282e-06
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.488543663
+          }
+        ],
+        "radius_squared_float": 1568593.0,
+        "vertex_hit_count": 2,
+        "vertex_hits": [
+          "B4",
+          "B5"
+        ]
+      },
+      {
+        "boundary_hit_count": 6,
+        "center": "C3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A2",
+              "A3"
+            ],
+            "t": 0.488543663
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.022744303
+          },
+          {
+            "edge": [
+              "C4",
+              "C5"
+            ],
+            "t": 0.771377543
+          },
+          {
+            "edge": [
+              "C5",
+              "A1"
+            ],
+            "t": 7.282e-06
+          }
+        ],
+        "radius_squared_float": 1568593.0,
+        "vertex_hit_count": 2,
+        "vertex_hits": [
+          "C4",
+          "C5"
+        ]
+      }
+    ],
+    "boundary_root_tol": 1e-07,
+    "coordinate_model": "Float64 sampled synthetic 15-gon from the recorded Lemma 3.1 A5 witness. The serialized radii and edge parameters are diagnostic approximations, not exact algebraic certificates.",
+    "histograms": {
+      "boundary_hit_count": {
+        "1": 12,
+        "2": 75,
+        "3": 21,
+        "4": 69,
+        "5": 15,
+        "6": 3
+      },
+      "interior_hit_count": {
+        "0": 15,
+        "1": 75,
+        "2": 30,
+        "3": 57,
+        "4": 18
+      },
+      "vertex_hit_count": {
+        "1": 174,
+        "2": 21
+      }
+    },
+    "interpretation": "The sampled final 15-gon keeps the BRP-style boundary richness visible at edge interiors: centered circles can hit six boundary points, while no centered circle hits four modeled vertices. This does not replay the source paper's continuum proof and does not turn the sampled polygon into a finite counterexample.",
+    "sampled_witness": {
+      "normal_offset": "-1/200",
+      "normal_side": "right",
+      "t": "3/125"
+    },
+    "status": "SAMPLED_A5_BOUNDARY_SUPPORT_DIAGNOSTIC",
+    "summary": {
+      "circles_with_at_least_four_boundary_hits": 87,
+      "circles_with_at_least_four_vertices": 0,
+      "circles_with_at_least_six_boundary_hits": 3,
+      "max_boundary_hits": 6,
+      "max_interior_hits": 4,
+      "max_vertex_hits": 2,
+      "min_turn_area2": 0.026807931,
+      "profile_count": 195,
+      "strictly_convex": true
+    },
+    "top_boundary_circles": [
+      {
+        "boundary_hit_count": 6,
+        "center": "A3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A4",
+              "A5"
+            ],
+            "t": 0.771377555
+          },
+          {
+            "edge": [
+              "A5",
+              "B1"
+            ],
+            "t": 7.282e-06
+          },
+          {
+            "edge": [
+              "B2",
+              "B3"
+            ],
+            "t": 0.488543663
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.022744303
+          }
+        ],
+        "radius_squared_float": 1568593.0,
+        "vertex_hit_count": 2,
+        "vertex_hits": [
+          "A4",
+          "A5"
+        ]
+      },
+      {
+        "boundary_hit_count": 6,
+        "center": "B3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.022744303
+          },
+          {
+            "edge": [
+              "B4",
+              "B5"
+            ],
+            "t": 0.771377556
+          },
+          {
+            "edge": [
+              "B5",
+              "C1"
+            ],
+            "t": 7.282e-06
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.488543663
+          }
+        ],
+        "radius_squared_float": 1568593.0,
+        "vertex_hit_count": 2,
+        "vertex_hits": [
+          "B4",
+          "B5"
+        ]
+      },
+      {
+        "boundary_hit_count": 6,
+        "center": "C3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A2",
+              "A3"
+            ],
+            "t": 0.488543663
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.022744303
+          },
+          {
+            "edge": [
+              "C4",
+              "C5"
+            ],
+            "t": 0.771377543
+          },
+          {
+            "edge": [
+              "C5",
+              "A1"
+            ],
+            "t": 7.282e-06
+          }
+        ],
+        "radius_squared_float": 1568593.0,
+        "vertex_hit_count": 2,
+        "vertex_hits": [
+          "C4",
+          "C5"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "A1",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.955030125
+          },
+          {
+            "edge": [
+              "B2",
+              "B3"
+            ],
+            "t": 0.979925648
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.868959626
+          },
+          {
+            "edge": [
+              "C1",
+              "C2"
+            ],
+            "t": 0.399998622
+          }
+        ],
+        "radius_squared_float": 2811712.239917227,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "B3"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "A2",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.973566915
+          },
+          {
+            "edge": [
+              "B2",
+              "B3"
+            ],
+            "t": 0.479634499
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.672516353
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.058306805
+          }
+        ],
+        "radius_squared_float": 2440032.757484468,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "B3"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "A3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.999822195
+          },
+          {
+            "edge": [
+              "B1",
+              "B2"
+            ],
+            "t": 0.002955184
+          },
+          {
+            "edge": [
+              "B2",
+              "B3"
+            ],
+            "t": 0.479634499
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.022938553
+          }
+        ],
+        "radius_squared_float": 1568035.242515532,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "B2"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "A4",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A1",
+              "A2"
+            ],
+            "t": 0.374759906
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.95438015
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.998660302
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.876202425
+          }
+        ],
+        "radius_squared_float": 2825746.990916936,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "C3"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "A5",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A1",
+              "A2"
+            ],
+            "t": 0.375377217
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.954396753
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.998188873
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.87602434
+          }
+        ],
+        "radius_squared_float": 2825419.998788516,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "C3"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "B1",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A1",
+              "A2"
+            ],
+            "t": 0.399998622
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.955030125
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.979925648
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.868959626
+          }
+        ],
+        "radius_squared_float": 2811712.239917226,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "C3"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "B2",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A2",
+              "A3"
+            ],
+            "t": 0.058306805
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.973566915
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.479634499
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.672516353
+          }
+        ],
+        "radius_squared_float": 2440032.757484468,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "C3"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "B3",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.022938553
+          },
+          {
+            "edge": [
+              "B3",
+              "B4"
+            ],
+            "t": 0.999822195
+          },
+          {
+            "edge": [
+              "C1",
+              "C2"
+            ],
+            "t": 0.002955184
+          },
+          {
+            "edge": [
+              "C2",
+              "C3"
+            ],
+            "t": 0.479634499
+          }
+        ],
+        "radius_squared_float": 1568035.242515531,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "C2"
+        ]
+      },
+      {
+        "boundary_hit_count": 5,
+        "center": "B4",
+        "interior_hit_count": 4,
+        "interior_hits": [
+          {
+            "edge": [
+              "A2",
+              "A3"
+            ],
+            "t": 0.998660302
+          },
+          {
+            "edge": [
+              "A3",
+              "A4"
+            ],
+            "t": 0.876202425
+          },
+          {
+            "edge": [
+              "B1",
+              "B2"
+            ],
+            "t": 0.374759906
+          },
+          {
+            "edge": [
+              "C3",
+              "C4"
+            ],
+            "t": 0.95438015
+          }
+        ],
+        "radius_squared_float": 2825746.990916937,
+        "vertex_hit_count": 1,
+        "vertex_hits": [
+          "A3"
+        ]
+      }
+    ],
+    "vertex_order": [
+      "A1",
+      "A2",
+      "A3",
+      "A4",
+      "A5",
+      "B1",
+      "B2",
+      "B3",
+      "B4",
+      "B5",
+      "C1",
+      "C2",
+      "C3",
+      "C4",
+      "C5"
+    ]
+  },
+  "schema": "erdos97.brp_boundary_vertexization_probe.v4",
   "source": {
     "base_points": [
       {
@@ -1158,7 +1829,7 @@
       "C3",
       "C4"
     ],
-    "not_modeled": "the A5 insertion and the final 15-gon edge-parameter closure",
+    "not_modeled": "the A5 insertion from the source paper as exact coordinates and the final 15-gon edge-parameter closure",
     "rotations_degrees": [
       0,
       120,

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -80,6 +80,11 @@ The checker:
   witness:
   `t in [239999/10000000, 240001/10000000]` and
   `h in [-50001/10000000, -49999/10000000]`.
+- records the centered-circle boundary support profiles for the sampled
+  synthetic 15-gon from `t=3/125, h=-1/200`, including the best boundary-rich
+  circles. These radii and edge parameters are float64 diagnostics, not exact
+  algebraic certificates. The sampled support scan uses a `1e-7` edge-root
+  boundary margin to avoid platform-dependent near-endpoint root counts.
 
 ## Current result
 
@@ -105,6 +110,10 @@ sampled-witness centered circles with four vertices: 0
 float64 A5 interval box checks pass: yes
 interval max local turn upper bound: -0.026805405
 interval rotated 15-gon min turn lower bound: 0.026803636
+sampled 15-gon centered-circle profiles: 195
+sampled 15-gon max boundary hits: 6
+sampled 15-gon circles with at least four boundary hits: 87
+sampled 15-gon circles with at least four vertices: 0
 ```
 
 Thus the modeled 12-point seed shows the expected continuous/discrete gap:
@@ -148,6 +157,17 @@ rotated synthetic 15-gon strictly convex. This is still not an exact algebraic
 certificate for the source `Q(sqrt(3))` coordinates and it does not certify
 the BRP boundary-intersection count throughout the box.
 
+The sampled boundary-support scan makes the final-polygon diagnostic more
+concrete. For the same sampled synthetic 15-gon, the checker enumerates 195
+centered circles through modeled vertices, finds three circles with six
+boundary hits, and records the best profiles centered at `A3`, `B3`, and `C3`.
+Each of those circles hits two modeled vertices and four edge-interior points.
+Across the sampled 15-gon, 87 centered circles have at least four boundary
+hits, while no centered circle has four modeled vertices. This sharpens the
+boundary-to-vertex gap for the sampled stand-in only; it does not replay the
+source paper's continuum argument, does not certify the boundary hits exactly,
+and does not produce a finite counterexample.
+
 ## Next steps
 
 Useful follow-up work should avoid more visual inspection and instead make the
@@ -155,7 +175,8 @@ edge-interior hits algebraic:
 
 1. Replace the float64 interval box with an exact algebraic or directed-decimal
    certificate over the source coordinates.
-2. Certify the BRP boundary-intersection counts for the sampled final 15-gon.
+2. Certify the sampled final-15-gon boundary hits with exact algebraic or
+   interval checks.
 3. Promote each interior circle-edge hit to a candidate vertex parameter.
 4. Iterate the closure condition: promoted vertices become centers that must
    themselves acquire four vertex hits.
@@ -171,6 +192,6 @@ Do not cite this probe as:
 - a proof of Erdos Problem #97;
 - a counterexample or counterexample candidate;
 - a finite extraction from the Barany--Roldan-Pensado body;
-- a check of the final 15-gon;
+- an exact check of the source paper's final 15-gon;
 - an exact construction of the actual existential `A5` from Lemma 3.1;
 - an exact certificate for boundary intersections.

--- a/docs/index.md
+++ b/docs/index.md
@@ -794,12 +794,12 @@ put detailed reconciliation in the canonical synthesis.
   search, plus a bounded rational-grid negative-control artifact; search
   scaffold only, not counterexample evidence.
 - [`brp-boundary-vertexization-probe.md`](brp-boundary-vertexization-probe.md):
-  first seed-only diagnostic for the Barany--Roldan-Pensado convex-body
-  boundary lane, measuring seed-boundary circle hits versus modeled seed-vertex
-  hits, pinning the Lemma 3.1 role preflight, and recording one sampled local
-  A5 constraint witness plus a tiny float64 interval box around it; numerical
-  diagnostic only, not a finite extraction, exact A5 construction, or
-  counterexample.
+  diagnostic for the Barany--Roldan-Pensado convex-body boundary lane,
+  measuring seed-boundary circle hits versus modeled seed-vertex hits, pinning
+  the Lemma 3.1 role preflight, recording one sampled local A5 constraint
+  witness plus a tiny float64 interval box around it, and listing sampled
+  synthetic-15-gon boundary-support circles; numerical diagnostic only, not a
+  finite extraction, exact A5 construction, or counterexample.
 - [`dynamic-witness-free-pattern-search.md`](dynamic-witness-free-pattern-search.md):
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -46,10 +46,13 @@ are claimed here.
   that sampled point gives a strictly convex numerical 15-gon with maximum
   centered vertex multiplicity still `2`. A tiny outward-rounded float64
   interval box around the same sampled witness also preserves the local
-  Lemma 3.1 bullets and rotated 15-gon convexity in the checker model. This
-  remains a float64 diagnostic: it is not an exact A5 certificate, does not
-  replay the final BRP boundary-intersection proof, and gives no
-  counterexample; see `docs/brp-boundary-vertexization-probe.md`.
+  Lemma 3.1 bullets and rotated 15-gon convexity in the checker model. The
+  follow-up sampled boundary-support scan enumerates 195 centered circles on
+  the sampled synthetic 15-gon, finds three with six boundary hits, and still
+  finds none with four modeled vertices. This remains a float64 diagnostic: it
+  is not an exact A5 certificate, does not replay the final BRP
+  boundary-intersection proof, and gives no counterexample; see
+  `docs/brp-boundary-vertexization-probe.md`.
 - The canonical synthesis corrects a prior uniform-radius shortcut:
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound
   construction, not an upper bound resolving the subcase. Furedi's separate

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3445,8 +3445,8 @@ artifacts:
 
   - id: brp_boundary_vertexization_probe
     path: data/certificates/brp_boundary_vertexization_probe.json
-    sha256: 8573aa4fb4e669365d5e336a307073b4ea269e171ce0f0efee1e862943021592
-    size_bytes: 43167
+    sha256: 3f866e33529520d59bd8d26ad7068a671829488b05cc88a1b7c695f0692054a4
+    size_bytes: 57164
     kind: numerical_geometric_diagnostic_artifact
     generator: scripts/check_brp_boundary_probe.py
     command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3455,10 +3455,10 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed before A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, one bounded sampled numerical A5 constraint witness, and a tiny float64 interval-box check around that witness. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
+    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed and the sampled synthetic 15-gon after one A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, one bounded sampled numerical A5 constraint witness, a tiny float64 interval-box check around that witness, and explicit sampled-15-gon boundary-support circles. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.brp_boundary_vertexization_probe.v3
+      schema: erdos97.brp_boundary_vertexization_probe.v4
       status: BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY
       trust: NUMERICAL_GEOMETRIC_DIAGNOSTIC
       provenance.command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3476,6 +3476,11 @@ artifacts:
       lemma31_a5_interval_box_probe.all_interval_checks_pass: true
       lemma31_a5_interval_box_probe.lemma31_N1_interval_checks.max_local_turn_upper_bound: -0.026805405
       lemma31_a5_interval_box_probe.rotated_15gon_interval_checks.min_turn_lower_bound: 0.026803636
+      sampled_a5_boundary_support_scan.summary.max_vertex_hits: 2
+      sampled_a5_boundary_support_scan.summary.max_boundary_hits: 6
+      sampled_a5_boundary_support_scan.summary.circles_with_at_least_four_vertices: 0
+      sampled_a5_boundary_support_scan.summary.circles_with_at_least_four_boundary_hits: 87
+      sampled_a5_boundary_support_scan.summary.circles_with_at_least_six_boundary_hits: 3
       synthetic_a5_scan.candidates_with_at_least_four_vertices: 0
       lemma31_preflight.status: LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED
       lemma31_preflight.role_mapping.A: A3

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -113,10 +113,12 @@ def main() -> int:
         preflight = payload["lemma31_preflight"]
         a5_scan = payload["lemma31_a5_constraint_scan"]
         a5_interval = payload["lemma31_a5_interval_box_probe"]
+        sampled_support = payload["sampled_a5_boundary_support_scan"]
         angle_abc = preflight["angle_ABC"]
         bprime_budget = preflight["bprime_neighbourhood_budget"]
         filter_counts = a5_scan["filter_counts"]
         witnesses = a5_scan["sampled_witnesses"]
+        sampled_summary = sampled_support["summary"]
         print("BRP boundary-to-vertex diagnostic")
         print(f"seed vertices: {summary['seed_vertex_count']}")
         print(f"strictly convex seed order: {convexity['strictly_convex_in_seed_order']}")
@@ -162,6 +164,18 @@ def main() -> int:
         print(
             "Lemma 3.1 A5 interval max local turn upper: "
             f"{a5_interval['lemma31_N1_interval_checks']['max_local_turn_upper_bound']}"
+        )
+        print(
+            "sampled 15-gon max boundary hits: "
+            f"{sampled_summary['max_boundary_hits']}"
+        )
+        print(
+            "sampled 15-gon circles with >=4 boundary hits: "
+            f"{sampled_summary['circles_with_at_least_four_boundary_hits']}"
+        )
+        print(
+            "sampled 15-gon circles with >=4 vertices: "
+            f"{sampled_summary['circles_with_at_least_four_vertices']}"
         )
         if args.assert_expected:
             print("OK: expected BRP boundary diagnostic counts verified")

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import math
 
 
-SCHEMA = "erdos97.brp_boundary_vertexization_probe.v3"
+SCHEMA = "erdos97.brp_boundary_vertexization_probe.v4"
 STATUS = "BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY"
 TRUST = "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
 
@@ -42,6 +42,8 @@ SQRT3 = math.sqrt(3.0)
 ROOT_TOL = 1e-9
 DISTANCE_TOL = 1e-6
 JSON_FLOAT_DIGITS = 9
+SAMPLED_A5_BOUNDARY_PROFILE_LIMIT = 12
+SAMPLED_A5_BOUNDARY_ROOT_TOL = 1e-7
 
 
 @dataclass(frozen=True, order=True)
@@ -1166,6 +1168,121 @@ def lemma31_a5_interval_box_probe() -> dict[str, object]:
     }
 
 
+def _sampled_profile_sort_key(profile: CircleProfile) -> tuple[object, ...]:
+    return (
+        -profile.boundary_hit_count,
+        -len(profile.vertex_hits),
+        -len(profile.interior_hits),
+        profile.center,
+        _json_float(profile.radius_squared),
+        profile.vertex_hits,
+        tuple((hit.edge, hit.t) for hit in profile.interior_hits),
+    )
+
+
+def _sampled_profile_to_json(profile: CircleProfile) -> dict[str, object]:
+    return {
+        "center": profile.center,
+        "radius_squared_float": _json_float(profile.radius_squared),
+        "vertex_hit_count": len(profile.vertex_hits),
+        "boundary_hit_count": profile.boundary_hit_count,
+        "interior_hit_count": len(profile.interior_hits),
+        "vertex_hits": list(profile.vertex_hits),
+        "interior_hits": [
+            {
+                "edge": list(hit.edge),
+                "t": _json_float(hit.t),
+            }
+            for hit in profile.interior_hits
+        ],
+    }
+
+
+def sampled_a5_boundary_support_scan(
+    *,
+    root_tol: float = ROOT_TOL,
+    distance_tol: float = DISTANCE_TOL,
+    profile_limit: int = SAMPLED_A5_BOUNDARY_PROFILE_LIMIT,
+) -> dict[str, object]:
+    """Record boundary-rich centered circles for the sampled synthetic 15-gon."""
+
+    if profile_limit <= 0:
+        raise ValueError("profile_limit must be positive")
+    effective_root_tol = max(root_tol, SAMPLED_A5_BOUNDARY_ROOT_TOL)
+    vertices = brp_candidate_15gon(
+        LEMMA31_A5_WITNESS_T,
+        LEMMA31_A5_WITNESS_NORMAL_OFFSET,
+    )
+    profiles = _numeric_circle_profiles(
+        vertices,
+        root_tol=effective_root_tol,
+        distance_tol=distance_tol,
+    )
+    convexity = numeric_convexity_summary(vertices)
+    max_vertex_hits = max(len(profile.vertex_hits) for profile in profiles)
+    max_boundary_hits = max(profile.boundary_hit_count for profile in profiles)
+    max_interior_hits = max(len(profile.interior_hits) for profile in profiles)
+    best_boundary_profiles = sorted(
+        (profile for profile in profiles if profile.boundary_hit_count == max_boundary_hits),
+        key=_sampled_profile_sort_key,
+    )
+    rich_boundary_profiles = sorted(
+        (profile for profile in profiles if profile.boundary_hit_count >= 4),
+        key=_sampled_profile_sort_key,
+    )
+    return {
+        "status": "SAMPLED_A5_BOUNDARY_SUPPORT_DIAGNOSTIC",
+        "coordinate_model": (
+            "Float64 sampled synthetic 15-gon from the recorded Lemma 3.1 "
+            "A5 witness. The serialized radii and edge parameters are "
+            "diagnostic approximations, not exact algebraic certificates."
+        ),
+        "boundary_root_tol": _json_float(effective_root_tol),
+        "sampled_witness": {
+            "t": _format_fraction(LEMMA31_A5_WITNESS_T),
+            "normal_offset": _format_fraction(LEMMA31_A5_WITNESS_NORMAL_OFFSET),
+            "normal_side": "right",
+        },
+        "vertex_order": [vertex.label for vertex in vertices],
+        "summary": {
+            "profile_count": len(profiles),
+            "strictly_convex": bool(convexity["strictly_convex_in_seed_order"]),
+            "min_turn_area2": convexity["min_turn_area2"],
+            "max_vertex_hits": max_vertex_hits,
+            "max_boundary_hits": max_boundary_hits,
+            "max_interior_hits": max_interior_hits,
+            "circles_with_at_least_four_vertices": sum(
+                1 for profile in profiles if len(profile.vertex_hits) >= 4
+            ),
+            "circles_with_at_least_four_boundary_hits": sum(
+                1 for profile in profiles if profile.boundary_hit_count >= 4
+            ),
+            "circles_with_at_least_six_boundary_hits": sum(
+                1 for profile in profiles if profile.boundary_hit_count >= 6
+            ),
+        },
+        "histograms": {
+            "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
+            "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
+            "interior_hit_count": _histogram(len(profile.interior_hits) for profile in profiles),
+        },
+        "best_boundary_circles": [
+            _sampled_profile_to_json(profile) for profile in best_boundary_profiles
+        ],
+        "top_boundary_circles": [
+            _sampled_profile_to_json(profile)
+            for profile in rich_boundary_profiles[:profile_limit]
+        ],
+        "interpretation": (
+            "The sampled final 15-gon keeps the BRP-style boundary richness "
+            "visible at edge interiors: centered circles can hit six boundary "
+            "points, while no centered circle hits four modeled vertices. This "
+            "does not replay the source paper's continuum proof and does not "
+            "turn the sampled polygon into a finite counterexample."
+        ),
+    }
+
+
 def _histogram(values: Iterable[int]) -> dict[str, int]:
     return {str(key): value for key, value in sorted(Counter(values).items())}
 
@@ -1213,6 +1330,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
     candidate_scan = synthetic_a5_scan(root_tol=tol)
     a5_constraint_scan = lemma31_a5_constraint_scan(root_tol=tol)
     a5_interval_box = lemma31_a5_interval_box_probe()
+    sampled_boundary_scan = sampled_a5_boundary_support_scan(root_tol=tol)
     convex_candidate_count = sum(1 for candidate in candidate_scan if candidate.strictly_convex)
     best_candidate_vertex_hits = max(candidate.max_vertex_hits for candidate in candidate_scan)
     best_candidate_boundary_hits = max(candidate.max_boundary_hits for candidate in candidate_scan)
@@ -1234,7 +1352,8 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "command": "python scripts/check_brp_boundary_probe.py --write --assert-expected",
             "notes": (
                 "Float64 boundary-intersection diagnostic for the quoted "
-                "Barany--Roldan-Pensado 12-point seed before A5 insertion."
+                "Barany--Roldan-Pensado 12-point seed and sampled synthetic "
+                "15-gon after one A5 insertion."
             ),
         },
         "source": {
@@ -1245,7 +1364,10 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             ],
             "rotations_degrees": [0, 120, 240],
             "modeled_vertices": [vertex.label for vertex in vertices],
-            "not_modeled": "the A5 insertion and the final 15-gon edge-parameter closure",
+            "not_modeled": (
+                "the A5 insertion from the source paper as exact coordinates "
+                "and the final 15-gon edge-parameter closure"
+            ),
         },
         "convexity": seed_convexity_summary(vertices),
         "summary": {
@@ -1293,6 +1415,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
         "lemma31_preflight": lemma31_preflight(),
         "lemma31_a5_constraint_scan": a5_constraint_scan,
         "lemma31_a5_interval_box_probe": a5_interval_box,
+        "sampled_a5_boundary_support_scan": sampled_boundary_scan,
         "histograms": {
             "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
             "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
@@ -1309,7 +1432,8 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "hits at the modeled seed vertices, and includes a limited signed "
             "synthetic A5 edge-pocket closure stress test, a Lemma 3.1 "
             "role-precondition preflight, and a bounded sampled A5 constraint "
-            "probe with a tiny float64 interval-box follow-up."
+            "probe with a tiny float64 interval-box follow-up plus an explicit "
+            "boundary-support scan on the sampled synthetic 15-gon."
         ),
         "does_not_claim": [
             "proof of Erdos Problem #97",
@@ -1319,10 +1443,11 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "exact construction of the source paper's existential A5",
             "exact algebraic or formal interval certificate for the sampled A5",
             "exact or interval certificate for boundary intersections",
+            "replay of the source paper's continuum boundary-intersection proof",
         ],
         "next_steps": [
             "replace the float64 A5 interval box with exact algebraic or directed-decimal coordinates",
-            "certify BRP boundary-intersection counts for the sampled final 15-gon",
+            "certify sampled final-15-gon boundary hits with exact algebraic or interval checks",
             "promote edge-interior hits to symbolic edge parameters",
             "iterate the promoted hits as new candidate vertices",
             "replace float boundary intersections by exact algebraic or interval checks",
@@ -1497,6 +1622,58 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
         raise AssertionError("unexpected A5 interval local-turn bound")
     if rotated_interval_checks.get("min_turn_lower_bound") != 0.026803636:
         raise AssertionError("unexpected A5 interval 15-gon turn bound")
+
+    sampled_support = payload.get("sampled_a5_boundary_support_scan")
+    if not isinstance(sampled_support, dict):
+        raise AssertionError("payload.sampled_a5_boundary_support_scan must be an object")
+    sampled_summary = sampled_support.get("summary")
+    sampled_histograms = sampled_support.get("histograms")
+    best_sampled_boundary = sampled_support.get("best_boundary_circles")
+    if not isinstance(sampled_summary, dict):
+        raise AssertionError(
+            "payload.sampled_a5_boundary_support_scan.summary must be an object"
+        )
+    if not isinstance(sampled_histograms, dict):
+        raise AssertionError(
+            "payload.sampled_a5_boundary_support_scan.histograms must be an object"
+        )
+    if not isinstance(best_sampled_boundary, list):
+        raise AssertionError(
+            "payload.sampled_a5_boundary_support_scan.best_boundary_circles must be a list"
+        )
+    expected_sampled_summary = {
+        "profile_count": 195,
+        "strictly_convex": True,
+        "max_vertex_hits": 2,
+        "max_boundary_hits": 6,
+        "max_interior_hits": 4,
+        "circles_with_at_least_four_vertices": 0,
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_six_boundary_hits": 3,
+    }
+    for key, expected in expected_sampled_summary.items():
+        if sampled_summary.get(key) != expected:
+            raise AssertionError(
+                f"sampled_a5_boundary_support_scan.summary.{key}: "
+                f"expected {expected}, got {sampled_summary.get(key)}"
+            )
+    expected_sampled_histograms = {
+        "vertex_hit_count": {"1": 174, "2": 21},
+        "boundary_hit_count": {"1": 12, "2": 75, "3": 21, "4": 69, "5": 15, "6": 3},
+        "interior_hit_count": {"0": 15, "1": 75, "2": 30, "3": 57, "4": 18},
+    }
+    for key, expected in expected_sampled_histograms.items():
+        if sampled_histograms.get(key) != expected:
+            raise AssertionError(
+                f"sampled_a5_boundary_support_scan.histograms.{key}: "
+                f"expected {expected}, got {sampled_histograms.get(key)}"
+            )
+    if [profile.get("center") for profile in best_sampled_boundary] != [
+        "A3",
+        "B3",
+        "C3",
+    ]:
+        raise AssertionError("unexpected sampled 15-gon best boundary centers")
 
     synthetic = payload.get("synthetic_a5_scan")
     if not isinstance(synthetic, dict):

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -44,7 +44,7 @@ def test_exact_distance_detects_rotation_symmetry() -> None:
 def test_payload_keeps_vertexization_gap_explicit() -> None:
     payload = build_payload()
 
-    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v3"
+    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v4"
     assert payload["trust"] == "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
     assert payload["provenance"]["generator"] == "scripts/check_brp_boundary_probe.py"
     assert_expected_counts(payload)
@@ -145,6 +145,39 @@ def test_payload_keeps_vertexization_gap_explicit() -> None:
     assert (
         interval_box["rotated_15gon_interval_checks"]["min_turn_lower_bound"]
         == 0.026803636
+    )
+    sampled_support = payload["sampled_a5_boundary_support_scan"]
+    assert sampled_support["status"] == "SAMPLED_A5_BOUNDARY_SUPPORT_DIAGNOSTIC"
+    assert sampled_support["boundary_root_tol"] == 1e-07
+    assert sampled_support["sampled_witness"] == {
+        "t": "3/125",
+        "normal_offset": "-1/200",
+        "normal_side": "right",
+    }
+    assert sampled_support["summary"] == {
+        "profile_count": 195,
+        "strictly_convex": True,
+        "min_turn_area2": 0.026807931,
+        "max_vertex_hits": 2,
+        "max_boundary_hits": 6,
+        "max_interior_hits": 4,
+        "circles_with_at_least_four_vertices": 0,
+        "circles_with_at_least_four_boundary_hits": 87,
+        "circles_with_at_least_six_boundary_hits": 3,
+    }
+    assert sampled_support["histograms"] == {
+        "vertex_hit_count": {"1": 174, "2": 21},
+        "boundary_hit_count": {"1": 12, "2": 75, "3": 21, "4": 69, "5": 15, "6": 3},
+        "interior_hit_count": {"0": 15, "1": 75, "2": 30, "3": 57, "4": 18},
+    }
+    assert [profile["center"] for profile in sampled_support["best_boundary_circles"]] == [
+        "A3",
+        "B3",
+        "C3",
+    ]
+    assert all(
+        profile["boundary_hit_count"] == 6
+        for profile in sampled_support["best_boundary_circles"]
     )
     assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
     assert "the A5 insertion" in str(payload["source"]["not_modeled"])


### PR DESCRIPTION
## Summary
- add a schema-v4 sampled boundary-support scan for the synthetic BRP 15-gon at `t=3/125, h=-1/200`
- record the three six-boundary-hit centered circles and keep the zero four-vertex-hit gap explicit
- regenerate the managed BRP certificate, manifest metadata, checker output, tests, and docs

## Validation
- `.venv/bin/python scripts/check_brp_boundary_probe.py --check --assert-expected --json`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `.venv/bin/python -m pytest tests/test_brp_boundary_probe.py -q`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q` (`1422 passed, 663 deselected`)