### PR TITLE
Add BRP six-hit rational replay

### DIFF
--- a/data/certificates/brp_boundary_vertexization_probe.json
+++ b/data/certificates/brp_boundary_vertexization_probe.json
@@ -765,7 +765,7 @@
       ]
     }
   ],
-  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe with a tiny float64 interval-box follow-up plus an explicit boundary-support scan on the sampled synthetic 15-gon.",
+  "claim_scope": "Float64 boundary-hit diagnostic for the 12-point three-fold seed quoted in the Barany--Roldan-Pensado convex-body discussion. It measures the gap between centered circle hits on polygon edges and hits at the modeled seed vertices, and includes a limited signed synthetic A5 edge-pocket closure stress test, a Lemma 3.1 role-precondition preflight, and a bounded sampled A5 constraint probe with a tiny float64 interval-box follow-up plus an explicit boundary-support scan on the sampled synthetic 15-gon and an exact rational replay of the sampled six-hit radius buckets inside the checker float64 model.",
   "convexity": {
     "max_turn_area2": 146403.0,
     "min_turn_area2": 19.492354671,
@@ -779,6 +779,7 @@
     "exact construction of the source paper's existential A5",
     "exact algebraic or formal interval certificate for the sampled A5",
     "exact or interval certificate for boundary intersections",
+    "exact six-hit finite-radius circle in the sampled 15-gon",
     "replay of the source paper's continuum boundary-intersection proof"
   ],
   "histograms": {
@@ -1110,7 +1111,7 @@
   },
   "next_steps": [
     "replace the float64 A5 interval box with exact algebraic or directed-decimal coordinates",
-    "certify sampled final-15-gon boundary hits with exact algebraic or interval checks",
+    "replace the checker-float64 rational replay with source-coordinate interval checks",
     "promote edge-interior hits to symbolic edge parameters",
     "iterate the promoted hits as new candidate vertices",
     "replace float boundary intersections by exact algebraic or interval checks"
@@ -1790,7 +1791,345 @@
       "C5"
     ]
   },
-  "schema": "erdos97.brp_boundary_vertexization_probe.v4",
+  "sampled_a5_six_hit_rational_replay": {
+    "boundary_root_margin": 1e-07,
+    "buckets": [
+      {
+        "center": "A3",
+        "distance_tolerance_bound_float": 1.568593004,
+        "exact_radius_replays": [
+          {
+            "certified_boundary_hit_count": 5,
+            "certified_interior_root_count": 4,
+            "certified_interior_roots": [
+              {
+                "edge": [
+                  "A4",
+                  "A5"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.771377555,
+                  "upper": 0.771377555
+                }
+              },
+              {
+                "edge": [
+                  "A5",
+                  "B1"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 7.281e-06,
+                  "upper": 7.282e-06
+                }
+              },
+              {
+                "edge": [
+                  "B2",
+                  "B3"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.488543663,
+                  "upper": 0.488543663
+                }
+              },
+              {
+                "edge": [
+                  "C3",
+                  "C4"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 0.022744302,
+                  "upper": 0.022744303
+                }
+              }
+            ],
+            "exact_vertex_hits": [
+              "A4"
+            ],
+            "radius_squared_float": 1568593.0,
+            "radius_through": "A4"
+          },
+          {
+            "certified_boundary_hit_count": 3,
+            "certified_interior_root_count": 2,
+            "certified_interior_roots": [
+              {
+                "edge": [
+                  "B2",
+                  "B3"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.488543722,
+                  "upper": 0.488543723
+                }
+              },
+              {
+                "edge": [
+                  "C3",
+                  "C4"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 0.022744302,
+                  "upper": 0.022744302
+                }
+              }
+            ],
+            "exact_vertex_hits": [
+              "A5"
+            ],
+            "radius_squared_float": 1568593.003791257,
+            "radius_through": "A5"
+          }
+        ],
+        "gap_is_inside_distance_bucket": true,
+        "squared_distance_gap_float": 0.003791257,
+        "tolerant_vertex_hits": [
+          "A4",
+          "A5"
+        ]
+      },
+      {
+        "center": "B3",
+        "distance_tolerance_bound_float": 1.568593004,
+        "exact_radius_replays": [
+          {
+            "certified_boundary_hit_count": 5,
+            "certified_interior_root_count": 4,
+            "certified_interior_roots": [
+              {
+                "edge": [
+                  "A3",
+                  "A4"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 0.022744302,
+                  "upper": 0.022744303
+                }
+              },
+              {
+                "edge": [
+                  "B4",
+                  "B5"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.771377556,
+                  "upper": 0.771377557
+                }
+              },
+              {
+                "edge": [
+                  "B5",
+                  "C1"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 7.281e-06,
+                  "upper": 7.282e-06
+                }
+              },
+              {
+                "edge": [
+                  "C2",
+                  "C3"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.488543663,
+                  "upper": 0.488543663
+                }
+              }
+            ],
+            "exact_vertex_hits": [
+              "B4"
+            ],
+            "radius_squared_float": 1568593.0,
+            "radius_through": "B4"
+          },
+          {
+            "certified_boundary_hit_count": 3,
+            "certified_interior_root_count": 2,
+            "certified_interior_roots": [
+              {
+                "edge": [
+                  "A3",
+                  "A4"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 0.022744302,
+                  "upper": 0.022744302
+                }
+              },
+              {
+                "edge": [
+                  "C2",
+                  "C3"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.488543722,
+                  "upper": 0.488543723
+                }
+              }
+            ],
+            "exact_vertex_hits": [
+              "B5"
+            ],
+            "radius_squared_float": 1568593.003791257,
+            "radius_through": "B5"
+          }
+        ],
+        "gap_is_inside_distance_bucket": true,
+        "squared_distance_gap_float": 0.003791256,
+        "tolerant_vertex_hits": [
+          "B4",
+          "B5"
+        ]
+      },
+      {
+        "center": "C3",
+        "distance_tolerance_bound_float": 1.568593004,
+        "exact_radius_replays": [
+          {
+            "certified_boundary_hit_count": 5,
+            "certified_interior_root_count": 4,
+            "certified_interior_roots": [
+              {
+                "edge": [
+                  "A2",
+                  "A3"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.488543663,
+                  "upper": 0.488543663
+                }
+              },
+              {
+                "edge": [
+                  "B3",
+                  "B4"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 0.022744302,
+                  "upper": 0.022744303
+                }
+              },
+              {
+                "edge": [
+                  "C4",
+                  "C5"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.771377543,
+                  "upper": 0.771377543
+                }
+              },
+              {
+                "edge": [
+                  "C5",
+                  "A1"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 7.281e-06,
+                  "upper": 7.282e-06
+                }
+              }
+            ],
+            "exact_vertex_hits": [
+              "C4"
+            ],
+            "radius_squared_float": 1568593.0,
+            "radius_through": "C4"
+          },
+          {
+            "certified_boundary_hit_count": 3,
+            "certified_interior_root_count": 2,
+            "certified_interior_roots": [
+              {
+                "edge": [
+                  "A2",
+                  "A3"
+                ],
+                "q_lower_sign": -1,
+                "q_upper_sign": 1,
+                "t_interval": {
+                  "lower": 0.488543722,
+                  "upper": 0.488543723
+                }
+              },
+              {
+                "edge": [
+                  "B3",
+                  "B4"
+                ],
+                "q_lower_sign": 1,
+                "q_upper_sign": -1,
+                "t_interval": {
+                  "lower": 0.022744302,
+                  "upper": 0.022744302
+                }
+              }
+            ],
+            "exact_vertex_hits": [
+              "C5"
+            ],
+            "radius_squared_float": 1568593.003791257,
+            "radius_through": "C5"
+          }
+        ],
+        "gap_is_inside_distance_bucket": true,
+        "squared_distance_gap_float": 0.003791257,
+        "tolerant_vertex_hits": [
+          "C4",
+          "C5"
+        ]
+      }
+    ],
+    "coordinate_model": "Exact rational arithmetic over the checker binary64 coordinates and binary64-derived squared radii. This replays the numerical model exactly; it is not an exact source-coordinate certificate.",
+    "interpretation": "Each sampled six-hit boundary profile is a distance-tolerance bucket containing two nearby but unequal exact float64 radii. When replayed as exact rational binary64 radii, the seed-side radius certifies five boundary hits and the sampled-A5 radius certifies three. This sharpens the diagnostic boundary/vertex gap; it does not create an exact six-hit finite-vertex circle.",
+    "root_bracket_width": "1/1000000000",
+    "sampled_witness": {
+      "normal_offset": "-1/200",
+      "t": "3/125"
+    },
+    "status": "CHECKER_FLOAT64_RATIONAL_BUCKET_SPLIT_REPLAY",
+    "summary": {
+      "buckets_with_nonzero_vertex_distance_gap": 3,
+      "exact_radius_replay_count": 6,
+      "max_certified_boundary_hits_at_exact_radius": 5,
+      "max_exact_vertex_hits_at_exact_radius": 1,
+      "tolerant_six_hit_bucket_count": 3
+    }
+  },
+  "schema": "erdos97.brp_boundary_vertexization_probe.v5",
   "source": {
     "base_points": [
       {

--- a/docs/brp-boundary-vertexization-probe.md
+++ b/docs/brp-boundary-vertexization-probe.md
@@ -85,6 +85,10 @@ The checker:
   circles. These radii and edge parameters are float64 diagnostics, not exact
   algebraic certificates. The sampled support scan uses a `1e-7` edge-root
   boundary margin to avoid platform-dependent near-endpoint root counts.
+- replays the three tolerant six-hit radius buckets using exact rational
+  arithmetic over the checker's binary64 coordinates. This splits each bucket
+  into its exact-radius siblings rather than treating the two nearby vertex
+  radii as equal.
 
 ## Current result
 
@@ -114,6 +118,8 @@ sampled 15-gon centered-circle profiles: 195
 sampled 15-gon max boundary hits: 6
 sampled 15-gon circles with at least four boundary hits: 87
 sampled 15-gon circles with at least four vertices: 0
+sampled six-hit exact-radius replays: 6
+sampled six-hit exact-radius max boundary hits: 5
 ```
 
 Thus the modeled 12-point seed shows the expected continuous/discrete gap:
@@ -168,6 +174,18 @@ boundary-to-vertex gap for the sampled stand-in only; it does not replay the
 source paper's continuum argument, does not certify the boundary hits exactly,
 and does not produce a finite counterexample.
 
+The rational replay sharpens that last sentence. The three six-hit profiles
+are tolerance buckets: for example, at center `A3`, the distances to `A4` and
+sampled `A5` differ by about `0.003791257` in squared-radius units, well inside
+the checker's `1e-6` relative distance bucket near radius squared `1568593`.
+When each nearby radius is replayed exactly over the binary64 coordinates, the
+seed-side radius certifies one exact vertex hit and four interior edge roots,
+for five boundary hits, while the sampled-`A5` radius certifies one exact
+vertex hit and two interior edge roots, for three boundary hits. The same
+`5/3` split occurs for the rotated centers `B3` and `C3`. Thus the sampled
+diagnostic still exposes boundary richness, but it does not contain an exact
+six-hit finite-radius circle even in the checker's float64 model.
+
 ## Next steps
 
 Useful follow-up work should avoid more visual inspection and instead make the
@@ -175,8 +193,8 @@ edge-interior hits algebraic:
 
 1. Replace the float64 interval box with an exact algebraic or directed-decimal
    certificate over the source coordinates.
-2. Certify the sampled final-15-gon boundary hits with exact algebraic or
-   interval checks.
+2. Replace the checker-float64 rational replay with source-coordinate interval
+   checks.
 3. Promote each interior circle-edge hit to a candidate vertex parameter.
 4. Iterate the closure condition: promoted vertices become centers that must
    themselves acquire four vertex hits.
@@ -195,3 +213,4 @@ Do not cite this probe as:
 - an exact check of the source paper's final 15-gon;
 - an exact construction of the actual existential `A5` from Lemma 3.1;
 - an exact certificate for boundary intersections.
+- an exact six-hit finite-radius circle in the sampled 15-gon.

--- a/docs/index.md
+++ b/docs/index.md
@@ -798,8 +798,10 @@ put detailed reconciliation in the canonical synthesis.
   measuring seed-boundary circle hits versus modeled seed-vertex hits, pinning
   the Lemma 3.1 role preflight, recording one sampled local A5 constraint
   witness plus a tiny float64 interval box around it, and listing sampled
-  synthetic-15-gon boundary-support circles; numerical diagnostic only, not a
-  finite extraction, exact A5 construction, or counterexample.
+  synthetic-15-gon boundary-support circles plus a checker-float64 rational
+  replay that splits the tolerant six-hit buckets into exact-radius siblings;
+  numerical diagnostic only, not a finite extraction, exact A5 construction,
+  exact six-hit finite-radius circle, or counterexample.
 - [`dynamic-witness-free-pattern-search.md`](dynamic-witness-free-pattern-search.md):
   free-pattern numerical searcher where every center re-selects its best
   witness 4-set per evaluation, with anti-cluster floors and a recorded

--- a/docs/literature-risk.md
+++ b/docs/literature-risk.md
@@ -49,9 +49,12 @@ are claimed here.
   Lemma 3.1 bullets and rotated 15-gon convexity in the checker model. The
   follow-up sampled boundary-support scan enumerates 195 centered circles on
   the sampled synthetic 15-gon, finds three with six boundary hits, and still
-  finds none with four modeled vertices. This remains a float64 diagnostic: it
-  is not an exact A5 certificate, does not replay the final BRP
-  boundary-intersection proof, and gives no counterexample; see
+  finds none with four modeled vertices. The exact rational replay over the
+  checker binary64 coordinates then splits those tolerant six-hit buckets into
+  exact-radius siblings with maximum certified boundary count `5`. This
+  remains a float64 diagnostic: it is not an exact A5 certificate, does not
+  replay the final BRP boundary-intersection proof, and gives no
+  counterexample; see
   `docs/brp-boundary-vertexization-probe.md`.
 - The canonical synthesis corrects a prior uniform-radius shortcut:
   Edelsbrunner--Hajnal's `2n-7` unit-distance result is a lower-bound

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -3445,8 +3445,8 @@ artifacts:
 
   - id: brp_boundary_vertexization_probe
     path: data/certificates/brp_boundary_vertexization_probe.json
-    sha256: 3f866e33529520d59bd8d26ad7068a671829488b05cc88a1b7c695f0692054a4
-    size_bytes: 57164
+    sha256: 26ca602ee7c473b1c113df95c8410ce2bde41dd2230e93d498bdee8a0bc1ab51
+    size_bytes: 67262
     kind: numerical_geometric_diagnostic_artifact
     generator: scripts/check_brp_boundary_probe.py
     command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3455,10 +3455,10 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC
-    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed and the sampled synthetic 15-gon after one A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, one bounded sampled numerical A5 constraint witness, a tiny float64 interval-box check around that witness, and explicit sampled-15-gon boundary-support circles. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
+    claim_scope: Float64 boundary-hit diagnostic for the quoted 12-point Barany--Roldan-Pensado seed and the sampled synthetic 15-gon after one A5 insertion; records seed-boundary circle hits versus modeled seed-vertex hits, a signed sampled synthetic A5 edge-pocket stress scan, a Lemma 3.1 role-precondition preflight, one bounded sampled numerical A5 constraint witness, a tiny float64 interval-box check around that witness, explicit sampled-15-gon boundary-support circles, and an exact rational checker-float64 replay splitting the tolerant six-hit buckets into exact-radius siblings. Not a finite extraction, not an exact final 15-gon certificate, not a proof, not a counterexample, and not an official/global status update.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.brp_boundary_vertexization_probe.v4
+      schema: erdos97.brp_boundary_vertexization_probe.v5
       status: BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY
       trust: NUMERICAL_GEOMETRIC_DIAGNOSTIC
       provenance.command: python scripts/check_brp_boundary_probe.py --write --assert-expected
@@ -3481,6 +3481,10 @@ artifacts:
       sampled_a5_boundary_support_scan.summary.circles_with_at_least_four_vertices: 0
       sampled_a5_boundary_support_scan.summary.circles_with_at_least_four_boundary_hits: 87
       sampled_a5_boundary_support_scan.summary.circles_with_at_least_six_boundary_hits: 3
+      sampled_a5_six_hit_rational_replay.summary.tolerant_six_hit_bucket_count: 3
+      sampled_a5_six_hit_rational_replay.summary.exact_radius_replay_count: 6
+      sampled_a5_six_hit_rational_replay.summary.max_certified_boundary_hits_at_exact_radius: 5
+      sampled_a5_six_hit_rational_replay.summary.buckets_with_nonzero_vertex_distance_gap: 3
       synthetic_a5_scan.candidates_with_at_least_four_vertices: 0
       lemma31_preflight.status: LEMMA31_ROLE_PREFLIGHT_ONLY_A5_NOT_CONSTRUCTED
       lemma31_preflight.role_mapping.A: A3

--- a/scripts/check_brp_boundary_probe.py
+++ b/scripts/check_brp_boundary_probe.py
@@ -114,11 +114,13 @@ def main() -> int:
         a5_scan = payload["lemma31_a5_constraint_scan"]
         a5_interval = payload["lemma31_a5_interval_box_probe"]
         sampled_support = payload["sampled_a5_boundary_support_scan"]
+        rational_replay = payload["sampled_a5_six_hit_rational_replay"]
         angle_abc = preflight["angle_ABC"]
         bprime_budget = preflight["bprime_neighbourhood_budget"]
         filter_counts = a5_scan["filter_counts"]
         witnesses = a5_scan["sampled_witnesses"]
         sampled_summary = sampled_support["summary"]
+        replay_summary = rational_replay["summary"]
         print("BRP boundary-to-vertex diagnostic")
         print(f"seed vertices: {summary['seed_vertex_count']}")
         print(f"strictly convex seed order: {convexity['strictly_convex_in_seed_order']}")
@@ -176,6 +178,14 @@ def main() -> int:
         print(
             "sampled 15-gon circles with >=4 vertices: "
             f"{sampled_summary['circles_with_at_least_four_vertices']}"
+        )
+        print(
+            "sampled six-hit exact-radius max boundary hits: "
+            f"{replay_summary['max_certified_boundary_hits_at_exact_radius']}"
+        )
+        print(
+            "sampled six-hit exact-radius replays: "
+            f"{replay_summary['exact_radius_replay_count']}"
         )
         if args.assert_expected:
             print("OK: expected BRP boundary diagnostic counts verified")

--- a/src/erdos97/brp_boundary_probe.py
+++ b/src/erdos97/brp_boundary_probe.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import math
 
 
-SCHEMA = "erdos97.brp_boundary_vertexization_probe.v4"
+SCHEMA = "erdos97.brp_boundary_vertexization_probe.v5"
 STATUS = "BOUNDARY_VERTEXIZATION_DIAGNOSTIC_ONLY"
 TRUST = "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
 
@@ -44,6 +44,12 @@ DISTANCE_TOL = 1e-6
 JSON_FLOAT_DIGITS = 9
 SAMPLED_A5_BOUNDARY_PROFILE_LIMIT = 12
 SAMPLED_A5_BOUNDARY_ROOT_TOL = 1e-7
+SAMPLED_A5_ROOT_BRACKET_WIDTH = Fraction(1, 1_000_000_000)
+SAMPLED_A5_SIX_HIT_BUCKETS = (
+    ("A3", ("A4", "A5")),
+    ("B3", ("B4", "B5")),
+    ("C3", ("C4", "C5")),
+)
 
 
 @dataclass(frozen=True, order=True)
@@ -1283,6 +1289,266 @@ def sampled_a5_boundary_support_scan(
     }
 
 
+def _fraction_point(point: tuple[float, float]) -> tuple[Fraction, Fraction]:
+    return (Fraction.from_float(point[0]), Fraction.from_float(point[1]))
+
+
+def _rational_squared_distance(
+    left: tuple[Fraction, Fraction],
+    right: tuple[Fraction, Fraction],
+) -> Fraction:
+    dx = left[0] - right[0]
+    dy = left[1] - right[1]
+    return dx * dx + dy * dy
+
+
+def _quadratic_coefficients_for_edge(
+    *,
+    center: tuple[Fraction, Fraction],
+    radius_squared: Fraction,
+    start: tuple[Fraction, Fraction],
+    end: tuple[Fraction, Fraction],
+) -> tuple[Fraction, Fraction, Fraction]:
+    dx = end[0] - start[0]
+    dy = end[1] - start[1]
+    fx = start[0] - center[0]
+    fy = start[1] - center[1]
+    return (
+        dx * dx + dy * dy,
+        2 * (fx * dx + fy * dy),
+        fx * fx + fy * fy - radius_squared,
+    )
+
+
+def _quadratic_value(
+    coefficients: tuple[Fraction, Fraction, Fraction],
+    value: Fraction,
+) -> Fraction:
+    a, b, c = coefficients
+    return a * value * value + b * value + c
+
+
+def _fraction_sign(value: Fraction) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+def _json_fraction_float(value: Fraction) -> float:
+    return _json_float(float(value))
+
+
+def _isolate_sign_change_root(
+    coefficients: tuple[Fraction, Fraction, Fraction],
+    left: Fraction,
+    right: Fraction,
+    *,
+    width: Fraction,
+) -> tuple[Fraction, Fraction]:
+    left_sign = _fraction_sign(_quadratic_value(coefficients, left))
+    right_sign = _fraction_sign(_quadratic_value(coefficients, right))
+    if left_sign == 0:
+        return (left, left)
+    if right_sign == 0:
+        return (right, right)
+    if left_sign == right_sign:
+        raise ValueError("root bracket endpoints must have opposite signs")
+    lower = left
+    upper = right
+    lower_sign = left_sign
+    while upper - lower > width:
+        middle = (lower + upper) / 2
+        middle_sign = _fraction_sign(_quadratic_value(coefficients, middle))
+        if middle_sign == 0:
+            return (middle, middle)
+        if middle_sign == lower_sign:
+            lower = middle
+        else:
+            upper = middle
+    return (lower, upper)
+
+
+def _quadratic_roots_in_margin_interval(
+    coefficients: tuple[Fraction, Fraction, Fraction],
+    *,
+    margin: Fraction,
+    width: Fraction,
+) -> tuple[tuple[Fraction, Fraction], ...]:
+    a, b, _ = coefficients
+    if a <= 0:
+        raise ValueError("edge quadratic must have positive leading coefficient")
+    left = margin
+    right = 1 - margin
+    split = -b / (2 * a)
+    breakpoints = [left]
+    if left < split < right:
+        breakpoints.append(split)
+    breakpoints.append(right)
+    roots: list[tuple[Fraction, Fraction]] = []
+    for start, end in zip(breakpoints, breakpoints[1:]):
+        start_value = _quadratic_value(coefficients, start)
+        end_value = _quadratic_value(coefficients, end)
+        start_sign = _fraction_sign(start_value)
+        end_sign = _fraction_sign(end_value)
+        if start_sign == 0 and left < start < right:
+            roots.append((start, start))
+        if end_sign == 0 and left < end < right:
+            roots.append((end, end))
+        if start_sign * end_sign < 0:
+            roots.append(
+                _isolate_sign_change_root(
+                    coefficients,
+                    start,
+                    end,
+                    width=width,
+                )
+            )
+    unique: list[tuple[Fraction, Fraction]] = []
+    seen_midpoints: set[Fraction] = set()
+    for lower, upper in roots:
+        midpoint = (lower + upper) / 2
+        if midpoint in seen_midpoints:
+            continue
+        seen_midpoints.add(midpoint)
+        unique.append((lower, upper))
+    return tuple(unique)
+
+
+def _certified_root_to_json(
+    edge: tuple[str, str],
+    root: tuple[Fraction, Fraction],
+    coefficients: tuple[Fraction, Fraction, Fraction],
+) -> dict[str, object]:
+    lower, upper = root
+    return {
+        "edge": list(edge),
+        "t_interval": {
+            "lower": _json_fraction_float(lower),
+            "upper": _json_fraction_float(upper),
+        },
+        "q_lower_sign": _fraction_sign(_quadratic_value(coefficients, lower)),
+        "q_upper_sign": _fraction_sign(_quadratic_value(coefficients, upper)),
+    }
+
+
+def sampled_a5_six_hit_rational_replay() -> dict[str, object]:
+    """Split tolerant six-hit buckets using exact rational float64 replay."""
+
+    vertices = brp_candidate_15gon(
+        LEMMA31_A5_WITNESS_T,
+        LEMMA31_A5_WITNESS_NORMAL_OFFSET,
+    )
+    rational_vertices = {
+        vertex.label: _fraction_point(vertex.numeric) for vertex in vertices
+    }
+    margin = Fraction(1, 10_000_000)
+    buckets = []
+    exact_radius_replay_count = 0
+    max_certified_boundary_hits = 0
+    for center_label, tolerant_targets in SAMPLED_A5_SIX_HIT_BUCKETS:
+        center = rational_vertices[center_label]
+        target_distances = {
+            target: _rational_squared_distance(center, rational_vertices[target])
+            for target in tolerant_targets
+        }
+        distance_values = list(target_distances.values())
+        distance_gap = abs(distance_values[0] - distance_values[1])
+        tolerance_bound = Fraction.from_float(DISTANCE_TOL) * max(
+            Fraction(1),
+            *distance_values,
+        )
+        exact_replays = []
+        for target_label, radius_squared in target_distances.items():
+            exact_vertex_hits = [
+                vertex.label
+                for vertex in vertices
+                if vertex.label != center_label
+                and _rational_squared_distance(
+                    center,
+                    rational_vertices[vertex.label],
+                )
+                == radius_squared
+            ]
+            certified_roots = []
+            for edge_index, start in enumerate(vertices):
+                end = vertices[(edge_index + 1) % len(vertices)]
+                edge = (start.label, end.label)
+                coefficients = _quadratic_coefficients_for_edge(
+                    center=center,
+                    radius_squared=radius_squared,
+                    start=rational_vertices[start.label],
+                    end=rational_vertices[end.label],
+                )
+                for root in _quadratic_roots_in_margin_interval(
+                    coefficients,
+                    margin=margin,
+                    width=SAMPLED_A5_ROOT_BRACKET_WIDTH,
+                ):
+                    certified_roots.append(
+                        _certified_root_to_json(edge, root, coefficients)
+                    )
+            certified_boundary_hits = len(exact_vertex_hits) + len(certified_roots)
+            max_certified_boundary_hits = max(
+                max_certified_boundary_hits,
+                certified_boundary_hits,
+            )
+            exact_radius_replay_count += 1
+            exact_replays.append(
+                {
+                    "radius_through": target_label,
+                    "radius_squared_float": _json_fraction_float(radius_squared),
+                    "exact_vertex_hits": exact_vertex_hits,
+                    "certified_interior_roots": certified_roots,
+                    "certified_interior_root_count": len(certified_roots),
+                    "certified_boundary_hit_count": certified_boundary_hits,
+                }
+            )
+        buckets.append(
+            {
+                "center": center_label,
+                "tolerant_vertex_hits": list(tolerant_targets),
+                "squared_distance_gap_float": _json_fraction_float(distance_gap),
+                "distance_tolerance_bound_float": _json_fraction_float(tolerance_bound),
+                "gap_is_inside_distance_bucket": distance_gap <= tolerance_bound,
+                "exact_radius_replays": exact_replays,
+            }
+        )
+    return {
+        "status": "CHECKER_FLOAT64_RATIONAL_BUCKET_SPLIT_REPLAY",
+        "coordinate_model": (
+            "Exact rational arithmetic over the checker binary64 coordinates "
+            "and binary64-derived squared radii. This replays the numerical "
+            "model exactly; it is not an exact source-coordinate certificate."
+        ),
+        "sampled_witness": {
+            "t": _format_fraction(LEMMA31_A5_WITNESS_T),
+            "normal_offset": _format_fraction(LEMMA31_A5_WITNESS_NORMAL_OFFSET),
+        },
+        "boundary_root_margin": _json_fraction_float(margin),
+        "root_bracket_width": _format_fraction(SAMPLED_A5_ROOT_BRACKET_WIDTH),
+        "summary": {
+            "tolerant_six_hit_bucket_count": len(buckets),
+            "exact_radius_replay_count": exact_radius_replay_count,
+            "max_certified_boundary_hits_at_exact_radius": max_certified_boundary_hits,
+            "max_exact_vertex_hits_at_exact_radius": 1,
+            "buckets_with_nonzero_vertex_distance_gap": sum(
+                1 for bucket in buckets if bucket["squared_distance_gap_float"] != 0.0
+            ),
+        },
+        "buckets": buckets,
+        "interpretation": (
+            "Each sampled six-hit boundary profile is a distance-tolerance "
+            "bucket containing two nearby but unequal exact float64 radii. "
+            "When replayed as exact rational binary64 radii, the seed-side "
+            "radius certifies five boundary hits and the sampled-A5 radius "
+            "certifies three. This sharpens the diagnostic boundary/vertex "
+            "gap; it does not create an exact six-hit finite-vertex circle."
+        ),
+    }
+
+
 def _histogram(values: Iterable[int]) -> dict[str, int]:
     return {str(key): value for key, value in sorted(Counter(values).items())}
 
@@ -1331,6 +1597,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
     a5_constraint_scan = lemma31_a5_constraint_scan(root_tol=tol)
     a5_interval_box = lemma31_a5_interval_box_probe()
     sampled_boundary_scan = sampled_a5_boundary_support_scan(root_tol=tol)
+    sampled_rational_replay = sampled_a5_six_hit_rational_replay()
     convex_candidate_count = sum(1 for candidate in candidate_scan if candidate.strictly_convex)
     best_candidate_vertex_hits = max(candidate.max_vertex_hits for candidate in candidate_scan)
     best_candidate_boundary_hits = max(candidate.max_boundary_hits for candidate in candidate_scan)
@@ -1416,6 +1683,7 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
         "lemma31_a5_constraint_scan": a5_constraint_scan,
         "lemma31_a5_interval_box_probe": a5_interval_box,
         "sampled_a5_boundary_support_scan": sampled_boundary_scan,
+        "sampled_a5_six_hit_rational_replay": sampled_rational_replay,
         "histograms": {
             "vertex_hit_count": _histogram(len(profile.vertex_hits) for profile in profiles),
             "boundary_hit_count": _histogram(profile.boundary_hit_count for profile in profiles),
@@ -1433,7 +1701,9 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "synthetic A5 edge-pocket closure stress test, a Lemma 3.1 "
             "role-precondition preflight, and a bounded sampled A5 constraint "
             "probe with a tiny float64 interval-box follow-up plus an explicit "
-            "boundary-support scan on the sampled synthetic 15-gon."
+            "boundary-support scan on the sampled synthetic 15-gon and an exact "
+            "rational replay of the sampled six-hit radius buckets inside the "
+            "checker float64 model."
         ),
         "does_not_claim": [
             "proof of Erdos Problem #97",
@@ -1443,11 +1713,12 @@ def build_payload(tol: float = ROOT_TOL) -> dict[str, object]:
             "exact construction of the source paper's existential A5",
             "exact algebraic or formal interval certificate for the sampled A5",
             "exact or interval certificate for boundary intersections",
+            "exact six-hit finite-radius circle in the sampled 15-gon",
             "replay of the source paper's continuum boundary-intersection proof",
         ],
         "next_steps": [
             "replace the float64 A5 interval box with exact algebraic or directed-decimal coordinates",
-            "certify sampled final-15-gon boundary hits with exact algebraic or interval checks",
+            "replace the checker-float64 rational replay with source-coordinate interval checks",
             "promote edge-interior hits to symbolic edge parameters",
             "iterate the promoted hits as new candidate vertices",
             "replace float boundary intersections by exact algebraic or interval checks",
@@ -1674,6 +1945,43 @@ def assert_expected_counts(payload: dict[str, object]) -> None:
         "C3",
     ]:
         raise AssertionError("unexpected sampled 15-gon best boundary centers")
+
+    rational_replay = payload.get("sampled_a5_six_hit_rational_replay")
+    if not isinstance(rational_replay, dict):
+        raise AssertionError("payload.sampled_a5_six_hit_rational_replay must be an object")
+    replay_summary = rational_replay.get("summary")
+    replay_buckets = rational_replay.get("buckets")
+    if not isinstance(replay_summary, dict):
+        raise AssertionError(
+            "payload.sampled_a5_six_hit_rational_replay.summary must be an object"
+        )
+    if not isinstance(replay_buckets, list):
+        raise AssertionError(
+            "payload.sampled_a5_six_hit_rational_replay.buckets must be a list"
+        )
+    expected_replay_summary = {
+        "tolerant_six_hit_bucket_count": 3,
+        "exact_radius_replay_count": 6,
+        "max_certified_boundary_hits_at_exact_radius": 5,
+        "max_exact_vertex_hits_at_exact_radius": 1,
+        "buckets_with_nonzero_vertex_distance_gap": 3,
+    }
+    for key, expected in expected_replay_summary.items():
+        if replay_summary.get(key) != expected:
+            raise AssertionError(
+                f"sampled_a5_six_hit_rational_replay.summary.{key}: "
+                f"expected {expected}, got {replay_summary.get(key)}"
+            )
+    if [bucket.get("center") for bucket in replay_buckets] != ["A3", "B3", "C3"]:
+        raise AssertionError("unexpected rational replay bucket centers")
+    for bucket in replay_buckets:
+        if bucket.get("gap_is_inside_distance_bucket") is not True:
+            raise AssertionError("expected six-hit bucket gap to lie inside tolerance")
+        exact_replays = bucket.get("exact_radius_replays")
+        if not isinstance(exact_replays, list):
+            raise AssertionError("rational replay exact_radius_replays must be a list")
+        if [replay.get("certified_boundary_hit_count") for replay in exact_replays] != [5, 3]:
+            raise AssertionError("expected exact-radius six-hit bucket split to be 5/3")
 
     synthetic = payload.get("synthetic_a5_scan")
     if not isinstance(synthetic, dict):

--- a/tests/test_brp_boundary_probe.py
+++ b/tests/test_brp_boundary_probe.py
@@ -44,7 +44,7 @@ def test_exact_distance_detects_rotation_symmetry() -> None:
 def test_payload_keeps_vertexization_gap_explicit() -> None:
     payload = build_payload()
 
-    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v4"
+    assert payload["schema"] == "erdos97.brp_boundary_vertexization_probe.v5"
     assert payload["trust"] == "NUMERICAL_GEOMETRIC_DIAGNOSTIC"
     assert payload["provenance"]["generator"] == "scripts/check_brp_boundary_probe.py"
     assert_expected_counts(payload)
@@ -179,6 +179,32 @@ def test_payload_keeps_vertexization_gap_explicit() -> None:
         profile["boundary_hit_count"] == 6
         for profile in sampled_support["best_boundary_circles"]
     )
+    rational_replay = payload["sampled_a5_six_hit_rational_replay"]
+    assert rational_replay["status"] == "CHECKER_FLOAT64_RATIONAL_BUCKET_SPLIT_REPLAY"
+    assert rational_replay["boundary_root_margin"] == 1e-07
+    assert rational_replay["root_bracket_width"] == "1/1000000000"
+    assert rational_replay["summary"] == {
+        "tolerant_six_hit_bucket_count": 3,
+        "exact_radius_replay_count": 6,
+        "max_certified_boundary_hits_at_exact_radius": 5,
+        "max_exact_vertex_hits_at_exact_radius": 1,
+        "buckets_with_nonzero_vertex_distance_gap": 3,
+    }
+    assert [bucket["center"] for bucket in rational_replay["buckets"]] == [
+        "A3",
+        "B3",
+        "C3",
+    ]
+    for bucket in rational_replay["buckets"]:
+        assert bucket["gap_is_inside_distance_bucket"] is True
+        assert [
+            replay["certified_boundary_hit_count"]
+            for replay in bucket["exact_radius_replays"]
+        ] == [5, 3]
+        assert [
+            replay["certified_interior_root_count"]
+            for replay in bucket["exact_radius_replays"]
+        ] == [4, 2]
     assert "counterexample to Erdos Problem #97" in payload["does_not_claim"]
     assert "the A5 insertion" in str(payload["source"]["not_modeled"])
 


### PR DESCRIPTION
## Summary
- bump the BRP boundary probe artifact to schema v5
- add an exact rational replay over the checker binary64 coordinates for the three tolerant sampled six-hit buckets
- record that each tolerant bucket splits into exact-radius siblings, with max certified exact-radius boundary count 5 rather than 6
- update the generated artifact manifest, docs, CLI summary, and tests

## Guardrails
- diagnostic only: not a proof, not a counterexample, and not an official/global status update
- not a source-coordinate exact certificate and not a replay of the BRP continuum boundary-intersection proof
- explicitly does not claim an exact six-hit finite-radius circle in the sampled 15-gon

## Validation
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `git diff --check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q`