### PR TITLE
[codex] fix audit reproducibility workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON ?= python
+PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python >/dev/null 2>&1; then printf '%s' python; else printf '%s' python3; fi)
 
 .PHONY: verify-lint verify-fast verify-lean verify-pytest-artifacts verify-pytest-all verify-n8 verify-kalmanson verify-n9-candidate verify-n9-review verify-bridge-frontier verify-n10-review verify-artifacts audit-artifacts verify-all
 
@@ -254,8 +254,6 @@ verify-n10-review:
 verify-artifacts: verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review
 
 audit-artifacts:
-	$(PYTHON) scripts/check_status_consistency.py --max-official-status-age-days 90
-	$(PYTHON) scripts/check_artifact_provenance.py
 	$(PYTHON) scripts/run_artifact_audit.py --output-dir artifact-audit-results
 
 verify-all: verify-fast verify-artifacts

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -3527,6 +3527,13 @@ def command_text(command: Sequence[str]) -> str:
     return " ".join(command)
 
 
+def subprocess_command(command: Sequence[str]) -> tuple[str, ...]:
+    """Return the executable argv for a stored audit command."""
+    if command and command[0] == "python":
+        return (sys.executable, *command[1:])
+    return tuple(command)
+
+
 def run_audit_command(command: AuditCommand, output_dir: Path) -> dict[str, Any]:
     command_dir = output_dir / "commands"
     command_dir.mkdir(parents=True, exist_ok=True)
@@ -3536,7 +3543,7 @@ def run_audit_command(command: AuditCommand, output_dir: Path) -> dict[str, Any]
     started_at = utc_now()
     start = time.perf_counter()
     result = subprocess.run(
-        command.command,
+        subprocess_command(command.command),
         cwd=REPO_ROOT,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -3566,9 +3573,15 @@ def run_audit_command(command: AuditCommand, output_dir: Path) -> dict[str, Any]
     }
 
 
-def build_summary(output_dir: Path, commands: Sequence[AuditCommand]) -> dict[str, Any]:
+def build_summary(
+    output_dir: Path,
+    commands: Sequence[AuditCommand],
+    *,
+    preflight_commands: Sequence[AuditCommand] = AUDIT_PREFLIGHT_COMMANDS,
+) -> dict[str, Any]:
     started_at = utc_now()
-    command_results = [run_audit_command(command, output_dir) for command in commands]
+    listed_commands = (*preflight_commands, *commands)
+    command_results = [run_audit_command(command, output_dir) for command in listed_commands]
     finished_at = utc_now()
     dependency_snapshot = REPO_ROOT / "requirements-lock.txt"
 
@@ -3587,6 +3600,9 @@ def build_summary(output_dir: Path, commands: Sequence[AuditCommand]) -> dict[st
         "started_at_utc": started_at,
         "finished_at_utc": finished_at,
         "verified": all(record["exit_code"] == 0 for record in command_results),
+        "preflight_command_count": len(preflight_commands),
+        "audit_command_count": len(commands),
+        "command_count": len(listed_commands),
         "repo": {
             "commit": run_git(("rev-parse", "HEAD")),
             "status_porcelain": run_git(("status", "--porcelain")),

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -11,6 +11,7 @@ from scripts.run_artifact_audit import (
     AUDIT_COMMANDS,
     AUDIT_PREFLIGHT_COMMANDS,
     AuditCommand,
+    build_summary,
     command_text,
     list_commands_payload,
     run_audit_command,
@@ -41,6 +42,41 @@ def test_run_audit_command_records_metadata(tmp_path: Path) -> None:
     assert (tmp_path / record["stdout_path"]).read_bytes() == b"ok\n"
     assert (tmp_path / record["stderr_path"]).read_bytes() == b""
     assert len(record["combined_output_sha256"]) == 64
+
+
+def test_run_audit_command_resolves_python_to_current_interpreter(tmp_path: Path) -> None:
+    command = AuditCommand(
+        ident="python_alias",
+        command=("python", "-c", "import sys; print(sys.executable)"),
+        claim_scope="test command only",
+    )
+
+    record = run_audit_command(command, tmp_path)
+
+    assert record["command"] == "python -c import sys; print(sys.executable)"
+    assert record["exit_code"] == 0
+    assert (tmp_path / record["stdout_path"]).read_text(encoding="utf-8").strip() == sys.executable
+
+
+def test_build_summary_runs_preflight_and_audit_commands(tmp_path: Path) -> None:
+    preflight = AuditCommand(
+        ident="preflight",
+        command=("python", "-c", "print('preflight')"),
+        claim_scope="test preflight only",
+    )
+    audit = AuditCommand(
+        ident="audit",
+        command=("python", "-c", "print('audit')"),
+        claim_scope="test audit only",
+    )
+
+    summary = build_summary(tmp_path, [audit], preflight_commands=[preflight])
+
+    assert summary["verified"] is True
+    assert summary["preflight_command_count"] == 1
+    assert summary["audit_command_count"] == 1
+    assert summary["command_count"] == 2
+    assert [record["id"] for record in summary["commands"]] == ["preflight", "audit"]
 
 
 def test_audit_commands_cover_generated_artifact_check_commands() -> None:


### PR DESCRIPTION
## Summary

- Make bare `make verify-fast` prefer the repo virtualenv when it exists, with fallback to `python`/`python3`.
- Resolve stored audit commands that begin with `python` to the interpreter running `scripts/run_artifact_audit.py`.
- Include audit preflight commands in actual audit run summaries, not only in `--list-commands` output.
- Add regression tests for interpreter resolution and preflight execution.

## Validation

- `make verify-lint`
- `.venv/bin/python -m pytest -q tests/test_run_artifact_audit.py`
- `make verify-fast` -> `1424 passed, 663 deselected`
- `.venv/bin/python scripts/run_artifact_audit.py --list-commands` -> `command_count: 223` including 2 preflight commands

## Notes

The untracked `stuff/` directory was left untouched and is not part of this PR.