### PR TITLE
Fix artifact audit validation gaps

### DIFF
--- a/data/certificates/three_orbit_window_closure_m3_16.json
+++ b/data/certificates/three_orbit_window_closure_m3_16.json
@@ -31,12 +31,12 @@
  },
  "records": [
   {
-   "boundary_exclusions": 1,
+   "boundary_exclusions": 0,
    "feasible_survivors": [],
    "m": 3,
    "open_quarter_cells": 0,
-   "refuted": 5,
-   "screen_candidates": 6,
+   "refuted": 1,
+   "screen_candidates": 1,
    "self_audit": {
     "configs_checked": 159,
     "m": 3
@@ -69,12 +69,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 4,
+   "boundary_exclusions": 0,
    "feasible_survivors": [],
    "m": 5,
    "open_quarter_cells": 0,
-   "refuted": 20,
-   "screen_candidates": 24,
+   "refuted": 13,
+   "screen_candidates": 13,
    "self_audit": {
     "configs_checked": 157,
     "m": 5
@@ -88,12 +88,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 9,
+   "boundary_exclusions": 2,
    "feasible_survivors": [],
    "m": 6,
    "open_quarter_cells": 0,
-   "refuted": 29,
-   "screen_candidates": 38,
+   "refuted": 22,
+   "screen_candidates": 24,
    "self_audit": {
     "configs_checked": 159,
     "m": 6
@@ -107,12 +107,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 14,
+   "boundary_exclusions": 25,
    "feasible_survivors": [],
    "m": 7,
    "open_quarter_cells": 0,
-   "refuted": 138,
-   "screen_candidates": 152,
+   "refuted": 120,
+   "screen_candidates": 145,
    "self_audit": {
     "configs_checked": 160,
     "m": 7
@@ -130,8 +130,8 @@
    "feasible_survivors": [],
    "m": 8,
    "open_quarter_cells": 1,
-   "refuted": 85,
-   "screen_candidates": 113,
+   "refuted": 92,
+   "screen_candidates": 120,
    "self_audit": {
     "configs_checked": 155,
     "m": 8
@@ -145,12 +145,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 68,
+   "boundary_exclusions": 58,
    "feasible_survivors": [],
    "m": 9,
    "open_quarter_cells": 0,
-   "refuted": 366,
-   "screen_candidates": 434,
+   "refuted": 329,
+   "screen_candidates": 387,
    "self_audit": {
     "configs_checked": 153,
     "m": 9
@@ -164,12 +164,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 11,
+   "boundary_exclusions": 9,
    "feasible_survivors": [],
    "m": 10,
    "open_quarter_cells": 0,
-   "refuted": 250,
-   "screen_candidates": 261,
+   "refuted": 242,
+   "screen_candidates": 251,
    "self_audit": {
     "configs_checked": 160,
     "m": 10
@@ -187,8 +187,8 @@
    "feasible_survivors": [],
    "m": 11,
    "open_quarter_cells": 0,
-   "refuted": 803,
-   "screen_candidates": 854,
+   "refuted": 761,
+   "screen_candidates": 812,
    "self_audit": {
     "configs_checked": 155,
     "m": 11
@@ -202,12 +202,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 152,
+   "boundary_exclusions": 148,
    "feasible_survivors": [],
    "m": 12,
    "open_quarter_cells": 1,
-   "refuted": 628,
-   "screen_candidates": 780,
+   "refuted": 646,
+   "screen_candidates": 794,
    "self_audit": {
     "configs_checked": 156,
     "m": 12
@@ -221,12 +221,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 210,
+   "boundary_exclusions": 229,
    "feasible_survivors": [],
    "m": 13,
    "open_quarter_cells": 0,
-   "refuted": 1460,
-   "screen_candidates": 1670,
+   "refuted": 1358,
+   "screen_candidates": 1587,
    "self_audit": {
     "configs_checked": 158,
     "m": 13
@@ -244,8 +244,8 @@
    "feasible_survivors": [],
    "m": 14,
    "open_quarter_cells": 0,
-   "refuted": 967,
-   "screen_candidates": 1043,
+   "refuted": 814,
+   "screen_candidates": 890,
    "self_audit": {
     "configs_checked": 156,
     "m": 14
@@ -259,12 +259,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 131,
+   "boundary_exclusions": 139,
    "feasible_survivors": [],
    "m": 15,
    "open_quarter_cells": 0,
-   "refuted": 2609,
-   "screen_candidates": 2740,
+   "refuted": 2605,
+   "screen_candidates": 2744,
    "self_audit": {
     "configs_checked": 157,
     "m": 15
@@ -278,12 +278,12 @@
    "unresolved": []
   },
   {
-   "boundary_exclusions": 212,
+   "boundary_exclusions": 167,
    "feasible_survivors": [],
    "m": 16,
    "open_quarter_cells": 1,
-   "refuted": 1598,
-   "screen_candidates": 1810,
+   "refuted": 1661,
+   "screen_candidates": 1828,
    "self_audit": {
     "configs_checked": 156,
     "m": 16
@@ -298,11 +298,11 @@
   }
  ],
  "schema": "erdos97.three_orbit_window_closure.v1",
- "scope": "three concentric regular m-gon orbits (t=3), all radii, all relative rotations, all selected-witness rows; float64 screen with 60-digit deterministic re-derivation of candidates and 240-digit boundary rechecks; the m = 0 mod 4 quarter cells are skipped and recorded as named open sub-cases; not an all-m lemma, not an exact certificate for screened cells, not a proof of Erdos Problem #97, and not a counterexample claim",
+ "scope": "three concentric regular m-gon orbits (t=3), all radii, all relative rotations, all selected-witness rows; float64 screen with 60-digit deterministic re-derivation of candidates and 240-digit boundary rechecks; the m = 0 mod 4 quarter cells are skipped and recorded as named handoff sub-cases; not an all-m lemma, not an exact certificate for screened cells, not a proof of Erdos Problem #97, and not a counterexample claim",
  "status": "REVIEW_PENDING_SCREEN_ONLY",
  "tool": "scripts/check_three_orbit_window_closure.py",
- "total_boundary_exclusions": 967,
- "total_screen_candidates": 9926,
+ "total_boundary_exclusions": 932,
+ "total_screen_candidates": 9597,
  "total_systems": {
   "AB": 15155,
   "AC": 15155,

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -15,6 +15,8 @@ required_integrity_fields: >
   with an explicit reason.
 
 unmanaged_tracked_artifacts:
+  - path: certificates/best_B12_certificate_template.json
+    reason: tracked legacy/manual template retained at its historical top-level certificates path
   - path: data/certificates/2026-05-05/bridge_lemma_check.json
     reason: tracked legacy/provenance certificate outside the generated-artifacts edit-policy manifest
   - path: data/certificates/2026-05-05/n11_partial.json
@@ -10230,8 +10232,8 @@ artifacts:
       - general proof of Erdos Problem #97
   - id: three_orbit_window_closure_m3_16
     path: data/certificates/three_orbit_window_closure_m3_16.json
-    sha256: 747d421be84b09cd4c2c0c952335cd2eabe8faeda693d28e8cc8d21a666c43a4
-    size_bytes: 5946
+    sha256: fb598d1c274afb2e54b03b63aa739efceec83a32134624c1f58d2e38fe5e78a4
+    size_bytes: 5947
     kind: restricted_family_screen_artifact
     generator: scripts/check_three_orbit_window_closure.py
     command: python scripts/check_three_orbit_window_closure.py --min-m 3 --max-m 16 --audit-samples 40 --write-artifact data/certificates/three_orbit_window_closure_m3_16.json
@@ -10249,8 +10251,8 @@ artifacts:
       clear: true
       min_m: 3
       max_m: 16
-      total_screen_candidates: 9926
-      total_boundary_exclusions: 967
+      total_screen_candidates: 9597
+      total_boundary_exclusions: 932
       total_systems.G: 3552
       total_systems.AB: 15155
       total_systems.AC: 15155
@@ -10286,7 +10288,7 @@ artifacts:
     generator: scripts/check_three_square_m4_closure.py
     command: python scripts/check_three_square_m4_closure.py --assert-clear --write-artifact data/certificates/three_square_m4_closure.json
     checker: scripts/check_three_square_m4_closure.py
-    check_command: python scripts/check_three_square_m4_closure.py --assert-clear
+    check_command: python scripts/check_three_square_m4_closure.py --assert-clear --check-artifact data/certificates/three_square_m4_closure.json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: EXACT_OBSTRUCTION
@@ -10317,7 +10319,7 @@ artifacts:
     generator: scripts/check_quarter_cell_closure.py
     command: python scripts/check_quarter_cell_closure.py --assert-clear --write-artifact data/certificates/quarter_cell_closure.json
     checker: scripts/check_quarter_cell_closure.py
-    check_command: python scripts/check_quarter_cell_closure.py --assert-clear
+    check_command: python scripts/check_quarter_cell_closure.py --assert-clear --check-artifact data/certificates/quarter_cell_closure.json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -24,7 +24,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MANIFEST = REPO_ROOT / "metadata" / "generated_artifacts.yaml"
 SCHEMA = "erdos97.generated_artifacts.v1"
 SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
-TRACKED_ARTIFACT_COVERAGE_GLOBS = ("data/certificates/*.json", "data/certificates/**/*.json")
+TRACKED_ARTIFACT_COVERAGE_GLOBS = (
+    "data/certificates/*.json",
+    "data/certificates/**/*.json",
+    "certificates/*.json",
+    "certificates/**/*.json",
+)
 
 KNOWN_TRUST = {
     "EXACT_ALL_ORDER_OBSTRUCTION_FOR_FIXED_PATTERN",

--- a/scripts/check_n10_fast_cpp_singleton_replay.py
+++ b/scripts/check_n10_fast_cpp_singleton_replay.py
@@ -358,6 +358,37 @@ def validate_payload(
     if not isinstance(summary, Mapping):
         errors.append("summary must be an object")
     else:
+        _check_equal(errors, "summary.n9_calibration_ok", summary.get("n9_calibration_ok"), True)
+        _check_equal(
+            errors,
+            "summary.n10_rows_match_primary_artifact",
+            summary.get("n10_rows_match_primary_artifact"),
+            True,
+        )
+        _check_equal(
+            errors,
+            "summary.n10_row0_choices_covered",
+            summary.get("n10_row0_choices_covered"),
+            126,
+        )
+        _check_equal(
+            errors,
+            "summary.n10_total_nodes",
+            summary.get("n10_total_nodes"),
+            EXPECTED_N10["nodes"],
+        )
+        _check_equal(
+            errors,
+            "summary.n10_total_full",
+            summary.get("n10_total_full"),
+            EXPECTED_N10["full"],
+        )
+        _check_equal(
+            errors,
+            "summary.n10_counts",
+            summary.get("n10_counts"),
+            EXPECTED_N10["counts"],
+        )
         _check_equal(errors, "summary.solves_n10", summary.get("solves_n10"), False)
         _check_equal(errors, "summary.solves_erdos97", summary.get("solves_erdos97"), False)
         _check_equal(
@@ -366,6 +397,8 @@ def validate_payload(
             summary.get("n10_row_summaries_digest_sha256"),
             EXPECTED_N10_ROW_DIGEST,
         )
+    _check_equal(errors, "validation_status", payload.get("validation_status"), "passed")
+    _check_equal(errors, "validation_errors", payload.get("validation_errors"), [])
     return errors
 
 

--- a/scripts/check_quarter_cell_closure.py
+++ b/scripts/check_quarter_cell_closure.py
@@ -69,6 +69,20 @@ DEFAULT_MS = (4, 8, 12, 16)
 TURN_TOL = 1e-12
 
 
+def compare_artifact_replay(payload, artifact_path: str) -> list[str]:
+    """Compare the freshly generated deterministic payload with a stored artifact."""
+
+    with open(artifact_path, encoding="utf-8") as fh:
+        stored = json.load(fh)
+    if payload == stored:
+        return []
+    errors: list[str] = []
+    for key in sorted(set(payload) | set(stored)):
+        if payload.get(key) != stored.get(key):
+            errors.append(f"{key}: replay differs from stored artifact")
+    return errors
+
+
 def offsets_for(p: float, m: int) -> list[float]:
     """All phi in (0, 2h) with cos(phi + 2k h) = p for some integer k."""
     h = math.pi / m
@@ -166,6 +180,12 @@ def main() -> int:
     ap.add_argument("--assert-clear", action="store_true")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--write-artifact", type=str, default="")
+    ap.add_argument(
+        "--check-artifact",
+        type=str,
+        default="",
+        help="compare deterministic replay fields against a stored artifact",
+    )
     args = ap.parse_args()
 
     band_ok = all(boundary_band_ok(m) for m in args.ms)
@@ -225,6 +245,13 @@ def main() -> int:
         # sampled config is strictly non-convex). It does NOT mean m>=8 closed.
         "clear": clear,
     }
+    if args.check_artifact:
+        errors = compare_artifact_replay(payload, args.check_artifact)
+        if errors:
+            print("artifact replay mismatch:", file=sys.stderr)
+            for err in errors:
+                print(f"- {err}", file=sys.stderr)
+            return 1
     if args.write_artifact:
         with open(args.write_artifact, "w", encoding="utf-8", newline="\n") as fh:
             json.dump(payload, fh, indent=1, sort_keys=True)

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -311,14 +311,14 @@ def validate_official_status_freshness(
         require_string_field(official, "official_status_last_checked", "metadata problem"),
         "metadata problem.official_status_last_checked",
     )
-    if max_age_days is None:
-        return
-    if max_age_days < 0:
-        fail("--max-official-status-age-days should be nonnegative")
     today = today or date.today()
     age_days = (today - checked).days
     if age_days < 0:
         fail("metadata problem.official_status_last_checked is in the future")
+    if max_age_days is None:
+        return
+    if max_age_days < 0:
+        fail("--max-official-status-age-days should be nonnegative")
     if age_days > max_age_days:
         fail(
             "metadata problem.official_status_last_checked is "

--- a/scripts/check_three_square_m4_closure.py
+++ b/scripts/check_three_square_m4_closure.py
@@ -62,6 +62,20 @@ PZ_KEYS = ("+cg", "-cg", "+sg", "-sg")
 Q_KEYS = ("+cgb", "-cgb", "+sgb", "-sgb")
 
 
+def compare_artifact_replay(payload, artifact_path: str) -> list[str]:
+    """Compare the freshly generated deterministic payload with a stored artifact."""
+
+    with open(artifact_path, encoding="utf-8") as fh:
+        stored = json.load(fh)
+    if payload == stored:
+        return []
+    errors: list[str] = []
+    for key in sorted(set(payload) | set(stored)):
+        if payload.get(key) != stored.get(key):
+            errors.append(f"{key}: replay differs from stored artifact")
+    return errors
+
+
 def _solver_for(combo, *, window: bool, convex: bool, timeout_ms: int):
     import z3
 
@@ -256,6 +270,12 @@ def main() -> int:
                          "and both self-tests (faithfulness, non-vacuity) pass")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--write-artifact", type=str, default="")
+    ap.add_argument(
+        "--check-artifact",
+        type=str,
+        default="",
+        help="compare deterministic replay fields against a stored artifact",
+    )
     args = ap.parse_args()
 
     faithful = faithfulness_ok()
@@ -300,6 +320,13 @@ def main() -> int:
         "clear": clear,
     }
 
+    if args.check_artifact:
+        errors = compare_artifact_replay(payload, args.check_artifact)
+        if errors:
+            print("artifact replay mismatch:", file=sys.stderr)
+            for err in errors:
+                print(f"- {err}", file=sys.stderr)
+            return 1
     if args.write_artifact:
         with open(args.write_artifact, "w", encoding="utf-8", newline="\n") as fh:
             json.dump(payload, fh, indent=1, sort_keys=True)

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1788,6 +1788,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="adjacent_closest_pair_nonagon_barrier",
+        command=(
+            "python",
+            "scripts/check_adjacent_closest_pair_nonagon_barrier.py",
+            "--check",
+            "--summary-json",
+        ),
+        claim_scope=(
+            "Finite combinatorial audit of the adjacent closest-pair n=9 "
+            "boundary subcase under endpoint exclusions, two-circle row-pair "
+            "cap, and the two-overlap crossing-bisector rule; conditional "
+            "subcase only, not a proof of n=9, not a proof of Erdos Problem "
+            "#97, not a counterexample, and not an official/global status "
+            "update."
+        ),
+    ),
+    AuditCommand(
         ident="radius_blocker_vertex_circle_pilot",
         command=(
             "python",
@@ -3493,6 +3510,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "python",
             "scripts/check_three_square_m4_closure.py",
             "--assert-clear",
+            "--check-artifact",
+            "data/certificates/three_square_m4_closure.json",
         ),
         claim_scope=(
             "SMT (z3) exact obstruction that no strictly convex three "
@@ -3511,6 +3530,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "python",
             "scripts/check_quarter_cell_closure.py",
             "--assert-clear",
+            "--check-artifact",
+            "data/certificates/quarter_cell_closure.json",
         ),
         claim_scope=(
             "Three-orbit quarter cells (m=0 mod 4): self-tested exact A-row "

--- a/src/erdos97/n10_vertex_circle_singletons.py
+++ b/src/erdos97/n10_vertex_circle_singletons.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from collections import Counter
 from dataclasses import dataclass
 from functools import lru_cache
@@ -20,6 +21,9 @@ EXPECTED_COUNTS = {
     "partial_self_edge": 4_467_592,
     "partial_strict_cycle": 5_318_250,
 }
+EXPECTED_ROW_SUMMARIES_DIGEST_SHA256 = (
+    "64ebe12406c8777bcc7d7e2c5f1db3adb7703cbdba3898bb069bf964091b2fbb"
+)
 TRUST = "MACHINE_CHECKED_FINITE_CASE_DRAFT_REVIEW_PENDING"
 
 
@@ -158,6 +162,39 @@ def load_artifact(path: Path) -> dict[str, Any]:
     return payload
 
 
+def normalized_row_summaries(rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the stable per-row replay signature used by the n=10 checkers."""
+
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise AssertionError("row is not an object")
+        counts = row.get("counts")
+        if not isinstance(counts, dict):
+            raise AssertionError("row counts is not an object")
+        normalized.append(
+            {
+                "row0_index": int(row["row0_index"]),
+                "row0_witnesses": [int(item) for item in row["row0_witnesses"]],
+                "nodes": int(row["nodes"]),
+                "full": int(row["full"]),
+                "counts": {
+                    str(key): int(value) for key, value in sorted(counts.items())
+                },
+            }
+        )
+    return normalized
+
+
+def row_summaries_digest(rows: Sequence[dict[str, Any]]) -> str:
+    blob = json.dumps(
+        normalized_row_summaries(rows),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
 def assert_expected_payload(payload: dict[str, Any]) -> None:
     """Assert the n=10 singleton artifact has the expected draft counts."""
     if payload.get("type") != "n10_vertex_circle_singleton_slices_v1":
@@ -184,6 +221,9 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
     rows = payload.get("rows")
     if not isinstance(rows, list) or len(rows) != EXPECTED_ROW0_CHOICES:
         raise AssertionError("rows must contain 126 singleton records")
+    digest = row_summaries_digest(rows)
+    if digest != EXPECTED_ROW_SUMMARIES_DIGEST_SHA256:
+        raise AssertionError(f"row summaries digest mismatch: {digest}")
     expected_ranges = [[idx, idx + 1] for idx in range(EXPECTED_ROW0_CHOICES)]
     if payload.get("row0_ranges") != expected_ranges:
         raise AssertionError("row0_ranges are not the 126 singleton slices")

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from scripts.check_artifact_provenance import load_manifest, sha256_file, validate_manifest
+from scripts.check_artifact_provenance import (
+    TRACKED_ARTIFACT_COVERAGE_GLOBS,
+    load_manifest,
+    sha256_file,
+    validate_manifest,
+)
 
 
 def test_generated_artifact_manifest_is_valid() -> None:
@@ -13,6 +18,11 @@ def test_generated_artifact_manifest_is_valid() -> None:
     errors = validate_manifest(load_manifest(manifest), check_tracked_coverage=True)
 
     assert errors == []
+
+
+def test_tracked_artifact_coverage_includes_legacy_certificate_root() -> None:
+    assert "data/certificates/**/*.json" in TRACKED_ARTIFACT_COVERAGE_GLOBS
+    assert "certificates/**/*.json" in TRACKED_ARTIFACT_COVERAGE_GLOBS
 
 
 def artifact_metadata(path: Path) -> dict[str, object]:

--- a/tests/test_check_status_consistency.py
+++ b/tests/test_check_status_consistency.py
@@ -96,6 +96,21 @@ def test_official_status_freshness_can_fail() -> None:
         raise AssertionError("freshness check should fail")
 
 
+def test_official_status_freshness_rejects_future_dates_without_age_ceiling() -> None:
+    checker = load_checker()
+    official = {
+        "official_page_last_edited": "2025-10-27",
+        "official_status_last_checked": "2026-05-20",
+    }
+
+    try:
+        checker.validate_official_status_freshness(official, None, today=date(2026, 5, 4))
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:  # pragma: no cover
+        raise AssertionError("future official status date should fail")
+
+
 def test_pattern_catalog_all_order_status_is_distinct_from_stale_live_wording() -> None:
     checker = load_checker()
 

--- a/tests/test_n10_fast_cpp_singleton_replay.py
+++ b/tests/test_n10_fast_cpp_singleton_replay.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import json
+import copy
 import subprocess
 import sys
 from pathlib import Path
+
+from scripts.check_n10_fast_cpp_singleton_replay import validate_payload
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "check_n10_fast_cpp_singleton_replay.py"
 ARTIFACT = ROOT / "data" / "certificates" / "n10_fast_cpp_singleton_replay.json"
+PRIMARY_ARTIFACT = ROOT / "data" / "certificates" / "n10_vertex_circle_singleton_slices.json"
+CPP_SOURCE = ROOT / "cpp" / "n_vertex_search_fast.cpp"
 EXPECTED_ROW_DIGEST = "64ebe12406c8777bcc7d7e2c5f1db3adb7703cbdba3898bb069bf964091b2fbb"
 
 
@@ -43,3 +48,40 @@ def test_n10_fast_cpp_replay_scope_guardrails() -> None:
     assert "does not update the official/global status" in claim_scope
     assert artifact["review_independence"]["language"] == "C++17"
     assert artifact["review_independence"]["uses_repo_python_search"] is False
+
+
+def test_n10_fast_cpp_replay_rejects_contradictory_validation_status() -> None:
+    artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    primary = json.loads(PRIMARY_ARTIFACT.read_text(encoding="utf-8"))
+    tampered = copy.deepcopy(artifact)
+    tampered["validation_status"] = "failed"
+    tampered["validation_errors"] = ["synthetic failure"]
+
+    errors = validate_payload(
+        tampered,
+        primary=primary,
+        primary_path=PRIMARY_ARTIFACT,
+        cpp_source=CPP_SOURCE,
+    )
+
+    assert "validation_status mismatch: expected 'passed', got 'failed'" in errors
+    assert "validation_errors mismatch: expected [], got ['synthetic failure']" in errors
+
+
+def test_n10_fast_cpp_replay_rejects_false_summary_match_flag() -> None:
+    artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    primary = json.loads(PRIMARY_ARTIFACT.read_text(encoding="utf-8"))
+    tampered = copy.deepcopy(artifact)
+    tampered["summary"]["n10_rows_match_primary_artifact"] = False
+
+    errors = validate_payload(
+        tampered,
+        primary=primary,
+        primary_path=PRIMARY_ARTIFACT,
+        cpp_source=CPP_SOURCE,
+    )
+
+    assert (
+        "summary.n10_rows_match_primary_artifact mismatch: expected True, got False"
+        in errors
+    )

--- a/tests/test_n10_vertex_circle_singletons.py
+++ b/tests/test_n10_vertex_circle_singletons.py
@@ -8,12 +8,14 @@ import pytest
 from erdos97.generic_vertex_search import GenericVertexSearch
 from erdos97.n10_vertex_circle_singletons import (
     EXPECTED_COUNTS,
+    EXPECTED_ROW_SUMMARIES_DIGEST_SHA256,
     EXPECTED_ROW0_CHOICES,
     EXPECTED_TOTAL_FULL,
     EXPECTED_TOTAL_NODES,
     assert_expected_payload,
     assert_generic_spot_check,
     row0_mask_for_index,
+    row_summaries_digest,
     row0_witnesses_for_index,
 )
 
@@ -58,6 +60,17 @@ def test_n10_singleton_artifact_expected_counts() -> None:
     assert payload["total_nodes"] == EXPECTED_TOTAL_NODES
     assert payload["total_full"] == EXPECTED_TOTAL_FULL
     assert payload["counts"] == EXPECTED_COUNTS
+    assert row_summaries_digest(payload["rows"]) == EXPECTED_ROW_SUMMARIES_DIGEST_SHA256
+
+
+def test_n10_singleton_artifact_rejects_swapped_unspotted_row_counts() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    rows = payload["rows"]
+    for key in ("nodes", "full", "aborted", "counts"):
+        rows[1][key], rows[2][key] = rows[2][key], rows[1][key]
+
+    with pytest.raises(AssertionError, match="row summaries digest mismatch"):
+        assert_expected_payload(payload)
 
 
 def test_n10_selected_singletons_match_generic_checker() -> None:

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -92,6 +92,26 @@ def test_audit_commands_cover_generated_artifact_check_commands() -> None:
     assert missing == []
 
 
+def test_audit_commands_cover_verify_artifacts_make_target() -> None:
+    dry_run = subprocess.run(
+        ["make", "-n", "verify-artifacts"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    audit_commands = {command_text(command.command) for command in AUDIT_COMMANDS}
+    missing = []
+    for line in dry_run.stdout.splitlines():
+        command = line.strip()
+        if command.startswith(".venv/bin/python "):
+            command = "python " + command.split(" ", 1)[1]
+        if command.startswith("python ") and command not in audit_commands:
+            missing.append(command)
+
+    assert missing == []
+
+
 def test_list_commands_payload_is_claim_neutral() -> None:
     payload = list_commands_payload(AUDIT_COMMANDS)
 
@@ -596,6 +616,10 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_support_saturation_obstruction.py --check --json"
         in command_texts
     )
@@ -624,6 +648,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n12_rich_support_determinant.py --check --json"
     ) < ordered_command_texts.index(
         "python scripts/check_localized_rich_support_counting.py --check --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_localized_rich_support_counting.py --check --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json"
     )
     bootstrap_bridge_commands = (
         "python scripts/check_bootstrap_core_crosswalk.py --check "


### PR DESCRIPTION
## Summary

- Add missing artifact audit/provenance coverage for the adjacent closest-pair barrier and legacy top-level certificate JSONs.
- Strengthen n10 singleton replay validation with a stable row digest and stricter secondary replay status checks.
- Add stored-artifact replay checks for three-square and quarter-cell closure artifacts, and refresh the three-orbit window closure artifact/manifest from its generator after replay drift.
- Reject future `official_status_last_checked` dates even when no max-age ceiling is configured.

## Validation

- `make verify-fast`
- `make verify-artifacts`
- `git diff --check`
- Focused pytest coverage for the changed validators and audit registry

No general proof or counterexample is claimed; these are validation and reproducibility hardening fixes.