### PR TITLE
Check n8 SMT artifact replay

### DIFF
--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -10417,7 +10417,7 @@ artifacts:
     generator: scripts/check_n8_survivors_smt.py
     command: python scripts/check_n8_survivors_smt.py --assert-clear --write-artifact data/certificates/n8_survivors_smt.json
     checker: scripts/check_n8_survivors_smt.py
-    check_command: python scripts/check_n8_survivors_smt.py --assert-clear
+    check_command: python scripts/check_n8_survivors_smt.py --assert-clear --check-artifact data/certificates/n8_survivors_smt.json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: EXACT_OBSTRUCTION

--- a/scripts/check_n8_survivors_smt.py
+++ b/scripts/check_n8_survivors_smt.py
@@ -174,29 +174,22 @@ def decide_class(rows, timeout_ms: int) -> dict:
     }
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--timeout-ms", type=int, default=60000)
-    ap.add_argument("--assert-clear", action="store_true",
-                    help="exit nonzero unless all 15 classes are UNSAT")
-    ap.add_argument("--json", action="store_true")
-    ap.add_argument("--write-artifact", type=str, default="")
-    args = ap.parse_args()
-
+def build_payload(timeout_ms: int) -> dict[str, object]:
     root = repo_root()
     survivors = load_survivors(root)
     records = []
     for rec in survivors:
         cid = int(rec["id"])
-        d = decide_class(rec["rows"], args.timeout_ms)
+        d = decide_class(rec["rows"], timeout_ms)
         records.append({"class": cid, **d})
     # main result: no strictly convex octagon (any order) realizes any class
     not_convex_unsat = [r["class"] for r in records if r["strict_convex"] != "unsat"]
     # bonus: classes killed with no convexity assumption at all
-    order_independent = [r["class"] for r in records
-                         if r["without_convexity"] == "unsat"]
+    order_independent = [
+        r["class"] for r in records if r["without_convexity"] == "unsat"
+    ]
     clear = len(records) == 15 and not not_convex_unsat
-    payload = {
+    return {
         "schema": "erdos97.n8_survivors_smt.v1",
         "status": "EXACT_OBSTRUCTION_SMT" if clear else "INCOMPLETE",
         "trust": "EXACT_OBSTRUCTION",
@@ -234,6 +227,53 @@ def main() -> int:
         "order_independent_unsat_classes": order_independent,
         "clear": clear,
     }
+
+
+def compare_artifact_replay(payload: dict[str, object], artifact_path: str) -> list[str]:
+    path = Path(artifact_path)
+    if not path.is_absolute():
+        path = repo_root() / path
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    if stored == payload:
+        return []
+    errors = [f"stored artifact replay mismatch: {path}"]
+    for key in (
+        "schema",
+        "status",
+        "trust",
+        "clear",
+        "classes_total",
+        "not_strictly_convex_unsat_failures",
+        "order_independent_unsat_classes",
+        "records",
+    ):
+        if stored.get(key) != payload.get(key):
+            errors.append(f"field {key!r} differs")
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--timeout-ms", type=int, default=60000)
+    ap.add_argument("--assert-clear", action="store_true",
+                    help="exit nonzero unless all 15 classes are UNSAT")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--write-artifact", type=str, default="")
+    ap.add_argument(
+        "--check-artifact",
+        type=str,
+        default="",
+        help="compare regenerated payload to a stored JSON artifact",
+    )
+    args = ap.parse_args()
+
+    payload = build_payload(args.timeout_ms)
+    clear = bool(payload["clear"])
+    artifact_errors = (
+        compare_artifact_replay(payload, args.check_artifact)
+        if args.check_artifact
+        else []
+    )
     if args.write_artifact:
         with open(args.write_artifact, "w", encoding="utf-8", newline="\n") as fh:
             json.dump(payload, fh, indent=1, sort_keys=True)
@@ -241,13 +281,18 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, indent=1, sort_keys=True))
     else:
-        for r in records:
+        for r in payload["records"]:
             print(f"class {r['class']:2d}: strict_convex={r['strict_convex']:7s} "
                   f"without_convexity={r['without_convexity']:7s} "
                   f"({r['equations']} eqs)")
         print(f"all 15 not-strictly-convex (UNSAT): {clear}")
         print(f"order-independent (UNSAT w/o convexity): "
-              f"{len(order_independent)}/15 classes {order_independent}")
+              f"{len(payload['order_independent_unsat_classes'])}/15 classes "
+              f"{payload['order_independent_unsat_classes']}")
+        for error in artifact_errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+    if artifact_errors:
+        return 1
     if args.assert_clear and not clear:
         return 1
     return 0

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -3590,6 +3590,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "python",
             "scripts/check_n8_survivors_smt.py",
             "--assert-clear",
+            "--check-artifact",
+            "data/certificates/n8_survivors_smt.json",
         ),
         claim_scope=(
             "Independent z3 (NRA) second source for the n=8 exact-survivor "

--- a/tests/test_n8_survivors_smt.py
+++ b/tests/test_n8_survivors_smt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import pathlib
 import sys
 
@@ -61,6 +62,31 @@ def test_each_center_has_four_witnesses():
         rows = rec["rows"]
         for i in range(MOD.N):
             assert len(MOD.witnesses(rows, i)) == 4, (rec["id"], i)
+
+
+def test_compare_artifact_replay_detects_stale_payload(tmp_path):
+    payload = {
+        "schema": "erdos97.n8_survivors_smt.v1",
+        "status": "EXACT_OBSTRUCTION_SMT",
+        "trust": "EXACT_OBSTRUCTION",
+        "clear": True,
+        "classes_total": 15,
+        "not_strictly_convex_unsat_failures": [],
+        "order_independent_unsat_classes": list(range(14)),
+        "records": [{"class": 0, "strict_convex": "unsat"}],
+    }
+    artifact = tmp_path / "n8_survivors_smt.json"
+    artifact.write_text(
+        json.dumps({**payload, "clear": False}, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    errors = MOD.compare_artifact_replay(payload, str(artifact))
+
+    assert errors == [
+        f"stored artifact replay mismatch: {artifact}",
+        "field 'clear' differs",
+    ]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- Add `--check-artifact` support to `scripts/check_n8_survivors_smt.py` so regenerated SMT results are compared against `data/certificates/n8_survivors_smt.json`.
- Register the stored-artifact replay in `metadata/generated_artifacts.yaml` and `scripts/run_artifact_audit.py`.
- Add a regression test proving stale stored payload fields are reported as replay mismatches.

## Validation

- `.venv/bin/python -m pytest -q tests/test_n8_survivors_smt.py tests/test_run_artifact_audit.py`
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `.venv/bin/python scripts/run_artifact_audit.py --list-commands`
- `.venv/bin/python scripts/check_n8_survivors_smt.py --assert-clear --check-artifact data/certificates/n8_survivors_smt.json`
- `git diff --check`
- `make verify-fast`

No general proof or counterexample is claimed; this only hardens stored-artifact replay validation.