### PR TITLE
Enforce explicit artifact replay checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,23 +133,23 @@ verify-n9-review:
 	$(PYTHON) scripts/check_n9_t11_strict_cycle_minireplay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_vertex_circle_t12_strict_cycle_lemma_packet.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_t12_strict_cycle_minireplay.py --check --assert-expected --json
-	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
+	$(PYTHON) scripts/check_n9_row_ptolemy_product_cancellations.py --artifact data/certificates/n9_row_ptolemy_product_cancellations.json --check --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_family_signatures.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_sensitivity.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_order_admissible_census.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_admissible_gap_replay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_row_ptolemy_gap_self_edge_cores.py --check --assert-expected --json
-	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
-	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --check --json
-	$(PYTHON) scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
-	$(PYTHON) scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py --check --json
+	$(PYTHON) scripts/check_n9_base_apex_low_excess_ledgers.py --artifact data/certificates/n9_base_apex_low_excess_ledgers.json --check --json
+	$(PYTHON) scripts/check_n9_base_apex_escape_budget.py --artifact data/certificates/n9_base_apex_escape_budget_report.json --check --json
+	$(PYTHON) scripts/check_n9_selected_baseline_escape_budget_overlay.py --artifact data/certificates/n9_selected_baseline_escape_budget_overlay.json --check --json
+	$(PYTHON) scripts/check_n9_d3_escape_slice.py --artifact data/certificates/n9_base_apex_d3_escape_slice.json --check --json
+	$(PYTHON) scripts/check_n9_base_apex_d3_escape_frontier_packet.py --artifact data/certificates/n9_base_apex_d3_escape_frontier_packet.json --check --json
+	$(PYTHON) scripts/check_n9_base_apex_low_excess_escape_ladder.py --artifact data/certificates/n9_base_apex_low_excess_escape_ladder.json --check --json
+	$(PYTHON) scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json
+	$(PYTHON) scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py --artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json --check --json
 	$(PYTHON) scripts/check_n9_selected_baseline_d3_vertex_circle_template_join.py --check --json
-	$(PYTHON) scripts/check_n9_d3_escape_slice.py --check --json
-	$(PYTHON) scripts/check_n9_base_apex_d3_escape_frontier_packet.py --check --json
-	$(PYTHON) scripts/check_n9_base_apex_low_excess_escape_ladder.py --check --json
-	$(PYTHON) scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json
-	$(PYTHON) scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json
-	$(PYTHON) scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
+	$(PYTHON) scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --artifact data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json --check --json
+	$(PYTHON) scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --artifact data/certificates/n9_base_apex_d3_incidence_capacity_packet.json --check --json
 	$(PYTHON) scripts/check_n9_base_apex_d3_p19_degree_obstruction.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_base_apex_d3_p20_residue_obstruction.py --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_base_apex_d3_artifact_join.py --check --json
@@ -163,7 +163,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
 	$(PYTHON) scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json
 	$(PYTHON) scripts/check_brp_boundary_probe.py --check --assert-expected --json
-	$(PYTHON) scripts/check_quarter_cell_derivative_certificate.py --check --assert-expected --json
+	$(PYTHON) scripts/check_quarter_cell_derivative_certificate.py --artifact data/certificates/quarter_cell_derivative_certificate.json --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_core_crosswalk.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_vertex_circle_overlay.py --check --assert-expected --json
 	$(PYTHON) scripts/check_bootstrap_t12_forcing_targets.py --check --assert-expected --json

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -314,6 +314,8 @@ artifacts:
     kind: certificate_diagnostic_artifact
     generator: scripts/analyze_kalmanson_certificates.py
     command: python scripts/analyze_kalmanson_certificates.py --c19-compact-vs-legacy --assert-expected --out reports/c19_kalmanson_compact_vs_legacy.json
+    checker: scripts/analyze_kalmanson_certificates.py
+    check_command: python scripts/analyze_kalmanson_certificates.py --c19-compact-vs-legacy --assert-expected --check-artifact reports/c19_kalmanson_compact_vs_legacy.json
     direct_edit_allowed: false
     provenance_mode: manifest_only_legacy
     trust: EXACT_CERTIFICATE_DIAGNOSTIC
@@ -2713,7 +2715,7 @@ artifacts:
     generator: scripts/explore_n9_base_apex.py
     command: python scripts/explore_n9_base_apex.py --low-excess-report --out data/certificates/n9_base_apex_low_excess_ledgers.json
     checker: scripts/check_n9_base_apex_low_excess_ledgers.py
-    check_command: python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json
+    check_command: python scripts/check_n9_base_apex_low_excess_ledgers.py --artifact data/certificates/n9_base_apex_low_excess_ledgers.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -2746,7 +2748,7 @@ artifacts:
     generator: scripts/explore_n9_base_apex.py
     command: python scripts/explore_n9_base_apex.py --escape-budget-report --out data/certificates/n9_base_apex_escape_budget_report.json
     checker: scripts/check_n9_base_apex_escape_budget.py
-    check_command: python scripts/check_n9_base_apex_escape_budget.py --check --json
+    check_command: python scripts/check_n9_base_apex_escape_budget.py --artifact data/certificates/n9_base_apex_escape_budget_report.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -2776,7 +2778,7 @@ artifacts:
     generator: scripts/analyze_n9_selected_baseline_escape_budget_overlay.py
     command: python scripts/analyze_n9_selected_baseline_escape_budget_overlay.py --assert-expected --out data/certificates/n9_selected_baseline_escape_budget_overlay.json
     checker: scripts/check_n9_selected_baseline_escape_budget_overlay.py
-    check_command: python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json
+    check_command: python scripts/check_n9_selected_baseline_escape_budget_overlay.py --artifact data/certificates/n9_selected_baseline_escape_budget_overlay.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -2816,7 +2818,7 @@ artifacts:
     generator: scripts/analyze_n9_selected_baseline_d3_escape_class_crosswalk.py
     command: python scripts/analyze_n9_selected_baseline_d3_escape_class_crosswalk.py --assert-expected --out data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json
     checker: scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py
-    check_command: python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py --check --json
+    check_command: python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py --artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -2953,7 +2955,7 @@ artifacts:
     generator: scripts/analyze_n9_d3_escape_slice.py
     command: python scripts/analyze_n9_d3_escape_slice.py --assert-expected --out data/certificates/n9_base_apex_d3_escape_slice.json
     checker: scripts/check_n9_d3_escape_slice.py
-    check_command: python scripts/check_n9_d3_escape_slice.py --check --json
+    check_command: python scripts/check_n9_d3_escape_slice.py --artifact data/certificates/n9_base_apex_d3_escape_slice.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -2993,7 +2995,7 @@ artifacts:
     generator: scripts/analyze_n9_base_apex_d3_escape_frontier_packet.py
     command: python scripts/analyze_n9_base_apex_d3_escape_frontier_packet.py --assert-expected --out data/certificates/n9_base_apex_d3_escape_frontier_packet.json
     checker: scripts/check_n9_base_apex_d3_escape_frontier_packet.py
-    check_command: python scripts/check_n9_base_apex_d3_escape_frontier_packet.py --check --json
+    check_command: python scripts/check_n9_base_apex_d3_escape_frontier_packet.py --artifact data/certificates/n9_base_apex_d3_escape_frontier_packet.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -3034,7 +3036,7 @@ artifacts:
     generator: scripts/analyze_n9_base_apex_d3_p19_incidence_capacity_pilot.py
     command: python scripts/analyze_n9_base_apex_d3_p19_incidence_capacity_pilot.py --assert-expected --out data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json
     checker: scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py
-    check_command: python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json
+    check_command: python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --artifact data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -3098,7 +3100,7 @@ artifacts:
     generator: scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py
     command: python scripts/analyze_n9_base_apex_d3_incidence_capacity_packet.py --assert-expected --out data/certificates/n9_base_apex_d3_incidence_capacity_packet.json
     checker: scripts/check_n9_base_apex_d3_incidence_capacity_packet.py
-    check_command: python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json
+    check_command: python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --artifact data/certificates/n9_base_apex_d3_incidence_capacity_packet.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -3148,7 +3150,7 @@ artifacts:
     generator: scripts/analyze_n9_base_apex_low_excess_escape_ladder.py
     command: python scripts/analyze_n9_base_apex_low_excess_escape_ladder.py --assert-expected --out data/certificates/n9_base_apex_low_excess_escape_ladder.json
     checker: scripts/check_n9_base_apex_low_excess_escape_ladder.py
-    check_command: python scripts/check_n9_base_apex_low_excess_escape_ladder.py --check --json
+    check_command: python scripts/check_n9_base_apex_low_excess_escape_ladder.py --artifact data/certificates/n9_base_apex_low_excess_escape_ladder.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -3188,7 +3190,7 @@ artifacts:
     generator: scripts/analyze_n9_base_apex_low_excess_escape_crosswalk.py
     command: python scripts/analyze_n9_base_apex_low_excess_escape_crosswalk.py --assert-expected --out data/certificates/n9_base_apex_low_excess_escape_crosswalk.json
     checker: scripts/check_n9_base_apex_low_excess_escape_crosswalk.py
-    check_command: python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json
+    check_command: python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -3221,7 +3223,7 @@ artifacts:
     generator: scripts/analyze_n9_row_ptolemy_product_cancellations.py
     command: python scripts/analyze_n9_row_ptolemy_product_cancellations.py --assert-expected --out data/certificates/n9_row_ptolemy_product_cancellations.json
     checker: scripts/check_n9_row_ptolemy_product_cancellations.py
-    check_command: python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json
+    check_command: python scripts/check_n9_row_ptolemy_product_cancellations.py --artifact data/certificates/n9_row_ptolemy_product_cancellations.json --check --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: FINITE_BOOKKEEPING_NOT_A_PROOF
@@ -10382,7 +10384,7 @@ artifacts:
     generator: scripts/check_quarter_cell_derivative_certificate.py
     command: python scripts/check_quarter_cell_derivative_certificate.py --m-values 8,12,16 --assert-expected --write data/certificates/quarter_cell_derivative_certificate.json
     checker: scripts/check_quarter_cell_derivative_certificate.py
-    check_command: python scripts/check_quarter_cell_derivative_certificate.py --check --assert-expected --json
+    check_command: python scripts/check_quarter_cell_derivative_certificate.py --artifact data/certificates/quarter_cell_derivative_certificate.json --check --assert-expected --json
     direct_edit_allowed: false
     provenance_mode: embedded
     trust: REVIEW_PENDING_DIAGNOSTIC

--- a/scripts/analyze_kalmanson_certificates.py
+++ b/scripts/analyze_kalmanson_certificates.py
@@ -44,6 +44,16 @@ def _relative_path(path: Path) -> str:
         return str(path)
 
 
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check_artifact(path: Path, payload: Mapping[str, object]) -> None:
+    artifact = load_json(path)
+    if artifact != payload:
+        raise AssertionError(f"{_relative_path(path)} does not match regenerated diagnostic payload")
+
+
 def _normalise_cycle(values: Sequence[int]) -> tuple[int, ...]:
     vals = tuple(int(value) for value in values)
     rotations = [vals[idx:] + vals[:idx] for idx in range(len(vals))]
@@ -521,6 +531,7 @@ def main() -> int:
     )
     parser.add_argument("--top", type=int, default=12, help="number of top diagnostic rows to retain")
     parser.add_argument("--out", type=Path, help="write JSON payload to this path")
+    parser.add_argument("--check-artifact", type=Path, help="compare generated JSON to this stored artifact")
     parser.add_argument("--json", action="store_true", help="print JSON payload")
     parser.add_argument("--assert-expected", action="store_true")
     parser.add_argument(
@@ -543,6 +554,9 @@ def main() -> int:
         data = payload(paths, top=args.top)
         if args.assert_expected:
             assert_expected(data)
+    if args.check_artifact:
+        artifact = args.check_artifact if args.check_artifact.is_absolute() else ROOT / args.check_artifact
+        check_artifact(artifact, data)
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -556,10 +570,14 @@ def main() -> int:
         print(f"support overlap: {comparison['support_signature_overlap_count']}")  # type: ignore[index]
         if args.assert_expected:
             print("OK: C19 compact-vs-legacy diagnostic matches expected values")
+        if args.check_artifact:
+            print(f"OK: {_relative_path(args.check_artifact)} matches regenerated payload")
     else:
         print_table(data)
         if args.assert_expected:
             print("OK: Kalmanson certificate diagnostics match expected fixed-order certificates")
+        if args.check_artifact:
+            print(f"OK: {_relative_path(args.check_artifact)} matches regenerated payload")
     return 0
 
 

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -53,6 +54,19 @@ JSON_TOP_LEVEL_TYPES = {
 AMBIGUOUS_FORBIDDEN_CLAIMS = {
     "external independent review",
     "independent external review",
+}
+PATH_REPLAY_FLAGS = {
+    "--artifact",
+    "--certificate",
+    "--check-artifact",
+    "--check-compatible-orders-data",
+    "--check-exact-analysis-data",
+}
+PATH_OUTPUT_FLAGS = {
+    "--out",
+    "--output",
+    "--write",
+    "--write-artifact",
 }
 
 
@@ -177,6 +191,7 @@ def validate_artifact(
         not isinstance(check_command, str) or not check_command.strip()
     ):
         errors.append(f"{label}.check_command must be a nonempty string when present")
+    errors.extend(validate_check_command_replays_explicit_artifact_path(artifact, label))
 
     if artifact.get("direct_edit_allowed") is not False:
         errors.append(f"{label}.direct_edit_allowed must be false for generated artifacts")
@@ -206,6 +221,135 @@ def validate_artifact(
     if payload is not None:
         errors.extend(validate_json_payload(artifact, payload, label))
     return errors
+
+
+def command_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def path_variants(raw_path: str) -> set[str]:
+    normalized = raw_path.replace("\\", "/")
+    stripped = normalized
+    while stripped.startswith("./"):
+        stripped = stripped[2:]
+    variants = {normalized, stripped, repo_path(raw_path).resolve().as_posix()}
+    if stripped and not Path(stripped).is_absolute():
+        variants.add(f"./{stripped}")
+    return variants
+
+
+def token_matches_path(token: str, variants: set[str]) -> bool:
+    normalized = token.replace("\\", "/")
+    return normalized in variants
+
+
+def token_value_matches_path(token: str, variants: set[str]) -> bool:
+    if "=" not in token:
+        return False
+    return token_matches_path(token.split("=", 1)[1], variants)
+
+
+def redirection_value(token: str) -> str | None:
+    match = re.fullmatch(r"\d?>{1,2}(.+)", token)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def command_mentions_path(command: str, raw_path: str) -> bool:
+    variants = path_variants(raw_path)
+    previous: str | None = None
+    for token in command_tokens(command):
+        redirect_target = redirection_value(token)
+        if (
+            token_matches_path(token, variants)
+            or token_value_matches_path(token, variants)
+            or (
+                previous is not None
+                and re.fullmatch(r"\d?>{1,2}", previous)
+                and token_matches_path(token, variants)
+            )
+            or (
+                redirect_target is not None
+                and token_matches_path(redirect_target, variants)
+            )
+        ):
+            return True
+        previous = token
+    return False
+
+
+def command_outputs_path(command: str, raw_path: str) -> bool:
+    tokens = command_tokens(command)
+    variants = path_variants(raw_path)
+    previous: str | None = None
+    for token in tokens:
+        redirect_target = redirection_value(token)
+        if token_matches_path(token, variants):
+            return previous in PATH_OUTPUT_FLAGS
+        if any(
+            token.startswith(f"{flag}=")
+            and token_matches_path(token.split("=", 1)[1], variants)
+            for flag in PATH_OUTPUT_FLAGS
+        ):
+            return True
+        if (
+            previous is not None
+            and re.fullmatch(r"\d?>{1,2}", previous)
+            and token_matches_path(token, variants)
+        ):
+            return True
+        if redirect_target is not None and token_matches_path(redirect_target, variants):
+            return True
+        previous = token
+    return False
+
+
+def command_replays_path(command: str, raw_path: str) -> bool:
+    tokens = command_tokens(command)
+    variants = path_variants(raw_path)
+    previous: str | None = None
+    for token in tokens:
+        if token_matches_path(token, variants):
+            return previous in PATH_REPLAY_FLAGS
+        if any(
+            token.startswith(f"{flag}=")
+            and token_matches_path(token.split("=", 1)[1], variants)
+            for flag in PATH_REPLAY_FLAGS
+        ):
+            return True
+        previous = token
+    return False
+
+
+def validate_check_command_replays_explicit_artifact_path(
+    artifact: dict[str, Any],
+    label: str,
+) -> list[str]:
+    raw_path = artifact.get("path")
+    command = artifact.get("command")
+    check_command = artifact.get("check_command")
+    if not (
+        isinstance(raw_path, str)
+        and isinstance(command, str)
+    ):
+        return []
+    if not command_outputs_path(command, raw_path):
+        return []
+    if not isinstance(check_command, str) or not check_command.strip():
+        return [
+            f"{label}.check_command must replay explicitly generated artifact path "
+            f"{raw_path!r}"
+        ]
+    if command_replays_path(check_command, raw_path):
+        return []
+    return [
+        f"{label}.check_command must replay explicitly generated artifact path "
+        f"{raw_path!r}"
+    ]
 
 
 def validate_file_metadata(artifact: dict[str, Any], path: Path, label: str) -> list[str]:

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -163,6 +163,22 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="c19_compact_vs_legacy_diagnostic",
+        command=(
+            "python",
+            "scripts/analyze_kalmanson_certificates.py",
+            "--c19-compact-vs-legacy",
+            "--assert-expected",
+            "--check-artifact",
+            "reports/c19_kalmanson_compact_vs_legacy.json",
+        ),
+        claim_scope=(
+            "Fixed-order C19_skew compact-vs-legacy certificate support "
+            "diagnostic only; not an all-order obstruction or proof of "
+            "Erdos Problem #97."
+        ),
+    ),
+    AuditCommand(
         ident="c19_proof_tooling_preflight",
         command=(
             "python",
@@ -1392,7 +1408,14 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
     ),
     AuditCommand(
         ident="n9_base_apex_low_excess_ledgers",
-        command=("python", "scripts/check_n9_base_apex_low_excess_ledgers.py", "--check", "--json"),
+        command=(
+            "python",
+            "scripts/check_n9_base_apex_low_excess_ledgers.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_low_excess_ledgers.json",
+            "--check",
+            "--json",
+        ),
         claim_scope=(
             "Focused n=9 base-apex low-excess bookkeeping; "
             "not a proof of n=9, not a counterexample, "
@@ -1401,7 +1424,14 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
     ),
     AuditCommand(
         ident="n9_base_apex_escape_budget",
-        command=("python", "scripts/check_n9_base_apex_escape_budget.py", "--check", "--json"),
+        command=(
+            "python",
+            "scripts/check_n9_base_apex_escape_budget.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_escape_budget_report.json",
+            "--check",
+            "--json",
+        ),
         claim_scope=(
             "Focused n=9 base-apex escape-budget bookkeeping; "
             "not a proof of n=9, not a counterexample, and not a global status update."
@@ -1412,6 +1442,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_selected_baseline_escape_budget_overlay.py",
+            "--artifact",
+            "data/certificates/n9_selected_baseline_escape_budget_overlay.json",
             "--check",
             "--json",
         ),
@@ -1423,7 +1455,14 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
     ),
     AuditCommand(
         ident="n9_base_apex_d3_escape_slice",
-        command=("python", "scripts/check_n9_d3_escape_slice.py", "--check", "--json"),
+        command=(
+            "python",
+            "scripts/check_n9_d3_escape_slice.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_d3_escape_slice.json",
+            "--check",
+            "--json",
+        ),
         claim_scope=(
             "Focused n=9 base-apex D=3,r=3 coupled escape-slice bookkeeping; "
             "not a proof of n=9, not a counterexample, not a geometric "
@@ -1435,6 +1474,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_base_apex_d3_escape_frontier_packet.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_d3_escape_frontier_packet.json",
             "--check",
             "--json",
         ),
@@ -1449,6 +1490,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_base_apex_low_excess_escape_ladder.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_low_excess_escape_ladder.json",
             "--check",
             "--json",
         ),
@@ -1463,6 +1506,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_base_apex_low_excess_escape_crosswalk.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_low_excess_escape_crosswalk.json",
             "--check",
             "--json",
         ),
@@ -1477,6 +1522,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py",
+            "--artifact",
+            "data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json",
             "--check",
             "--json",
         ),
@@ -1508,6 +1555,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json",
             "--check",
             "--json",
         ),
@@ -1523,6 +1572,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_base_apex_d3_incidence_capacity_packet.py",
+            "--artifact",
+            "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json",
             "--check",
             "--json",
         ),
@@ -1603,6 +1654,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_n9_row_ptolemy_product_cancellations.py",
+            "--artifact",
+            "data/certificates/n9_row_ptolemy_product_cancellations.json",
             "--check",
             "--json",
         ),
@@ -3569,6 +3622,8 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         command=(
             "python",
             "scripts/check_quarter_cell_derivative_certificate.py",
+            "--artifact",
+            "data/certificates/quarter_cell_derivative_certificate.json",
             "--check",
             "--assert-expected",
             "--json",

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -5,15 +5,19 @@ from pathlib import Path
 
 from scripts.check_artifact_provenance import (
     TRACKED_ARTIFACT_COVERAGE_GLOBS,
+    command_mentions_path,
+    command_outputs_path,
+    command_replays_path,
     load_manifest,
     sha256_file,
     validate_manifest,
 )
 
+ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_generated_artifact_manifest_is_valid() -> None:
-    repo = Path(__file__).resolve().parents[1]
-    manifest = repo / "metadata" / "generated_artifacts.yaml"
+    manifest = ROOT / "metadata" / "generated_artifacts.yaml"
 
     errors = validate_manifest(load_manifest(manifest), check_tracked_coverage=True)
 
@@ -27,6 +31,44 @@ def test_tracked_artifact_coverage_includes_legacy_certificate_root() -> None:
 
 def artifact_metadata(path: Path) -> dict[str, object]:
     return {"sha256": sha256_file(path), "size_bytes": path.stat().st_size}
+
+
+def replay_manifest(
+    tmp_path: Path,
+    *,
+    command: str,
+    check_command: str | None,
+) -> dict[str, object]:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    checker = tmp_path / "checker.py"
+    artifact.write_text(json.dumps({"status": "GOOD"}) + "\n", encoding="utf-8")
+    generator.write_text("print('ok')\n", encoding="utf-8")
+    checker.write_text("print('ok')\n", encoding="utf-8")
+    entry = {
+        "id": "sample",
+        "path": str(artifact),
+        "kind": "test",
+        "generator": str(generator),
+        "command": command,
+        "checker": str(checker),
+        "direct_edit_allowed": False,
+        "provenance_mode": "manifest_only_legacy",
+        "trust": "EXACT_OBSTRUCTION",
+        "claim_scope": "test artifact only",
+        "json_top_level_type": "object",
+        "sha256": sha256_file(artifact),
+        "size_bytes": artifact.stat().st_size,
+        "expected_json": {"status": "GOOD"},
+        "forbidden_claims": ["general proof"],
+    }
+    if check_command is not None:
+        entry["check_command"] = check_command
+    return {
+        "schema": "erdos97.generated_artifacts.v1",
+        "claim_scope": "test manifest only",
+        "artifacts": [entry],
+    }
 
 
 def test_manifest_rejects_mismatched_expected_json(tmp_path: Path) -> None:
@@ -123,6 +165,121 @@ def test_manifest_rejects_missing_optional_checker(tmp_path: Path) -> None:
     errors = validate_manifest(manifest)
 
     assert any("checker does not exist" in error for error in errors)
+
+
+def test_manifest_rejects_explicit_write_path_without_check_replay(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    checker = tmp_path / "checker.py"
+    manifest = replay_manifest(
+        tmp_path,
+        command=f"python {generator} --out {artifact}",
+        check_command=f"python {checker} --check",
+    )
+
+    errors = validate_manifest(manifest)
+
+    assert any("must replay explicitly generated artifact path" in error for error in errors)
+
+
+def test_manifest_rejects_equals_write_path_without_check_replay(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    checker = tmp_path / "checker.py"
+    manifest = replay_manifest(
+        tmp_path,
+        command=f"python {generator} --out={artifact}",
+        check_command=f"python {checker} --check",
+    )
+
+    errors = validate_manifest(manifest)
+
+    assert any("must replay explicitly generated artifact path" in error for error in errors)
+
+
+def test_manifest_rejects_explicit_write_path_without_check_command(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    manifest = replay_manifest(
+        tmp_path,
+        command=f"python {generator} --out {artifact}",
+        check_command=None,
+    )
+
+    errors = validate_manifest(manifest)
+
+    assert any("must replay explicitly generated artifact path" in error for error in errors)
+
+
+def test_manifest_rejects_check_path_without_replay_flag(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    checker = tmp_path / "checker.py"
+    manifest = replay_manifest(
+        tmp_path,
+        command=f"python {generator} --out {artifact}",
+        check_command=f"python {checker} --baseline {artifact} --check",
+    )
+
+    errors = validate_manifest(manifest)
+
+    assert any("must replay explicitly generated artifact path" in error for error in errors)
+
+
+def test_manifest_accepts_explicit_write_path_with_check_replay(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    generator = tmp_path / "generator.py"
+    checker = tmp_path / "checker.py"
+    manifest = replay_manifest(
+        tmp_path,
+        command=f"python {generator} --out {artifact}",
+        check_command=f"python {checker} --artifact={artifact} --check",
+    )
+
+    errors = validate_manifest(manifest)
+
+    assert errors == []
+
+
+def test_command_path_detection_accepts_common_artifact_path_forms() -> None:
+    artifact = ROOT / "data/certificates/example.json"
+
+    assert command_mentions_path(
+        "python generator.py --out=data/certificates/example.json",
+        "data/certificates/example.json",
+    )
+    assert command_outputs_path(
+        "python generator.py --out=data/certificates/example.json",
+        "data/certificates/example.json",
+    )
+    assert command_outputs_path(
+        "python generator.py --out ./data/certificates/example.json",
+        "data/certificates/example.json",
+    )
+    assert command_outputs_path(
+        f"python generator.py --out {artifact}",
+        "data/certificates/example.json",
+    )
+    assert command_outputs_path(
+        "python generator.py >data/certificates/example.json",
+        "data/certificates/example.json",
+    )
+    assert not command_outputs_path(
+        "python checker.py --artifact data/certificates/example.json --check",
+        "data/certificates/example.json",
+    )
+    assert command_replays_path(
+        "python checker.py --artifact=./data/certificates/example.json --check",
+        "data/certificates/example.json",
+    )
+    assert command_replays_path(
+        f"python checker.py --artifact {artifact} --check",
+        "data/certificates/example.json",
+    )
+    assert not command_replays_path(
+        "python checker.py --baseline data/certificates/example.json --check",
+        "data/certificates/example.json",
+    )
 
 
 def test_manifest_accepts_exact_certificate_diagnostic_trust(tmp_path: Path) -> None:

--- a/tests/test_kalmanson_certificate_diagnostics.py
+++ b/tests/test_kalmanson_certificate_diagnostics.py
@@ -82,3 +82,20 @@ def test_c19_compact_vs_legacy_diagnostic_matches_artifact() -> None:
     assert payload["comparison"]["same_cyclic_order"] is True
     assert payload["comparison"]["support_signature_overlap_count"] == 0
     assert payload["comparison"]["compact_support_subset_of_legacy"] is False
+
+
+def test_c19_compact_vs_legacy_check_artifact_replays_stored_payload() -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--c19-compact-vs-legacy",
+            "--assert-expected",
+            "--check-artifact",
+            str(C19_COMPACT_VS_LEGACY),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -100,16 +100,40 @@ def test_audit_commands_cover_verify_artifacts_make_target() -> None:
         text=True,
         stdout=subprocess.PIPE,
     )
-    audit_commands = {command_text(command.command) for command in AUDIT_COMMANDS}
+    audit_order = {
+        command_text(command.command): index for index, command in enumerate(AUDIT_COMMANDS)
+    }
+    make_commands = []
     missing = []
     for line in dry_run.stdout.splitlines():
         command = line.strip()
         if command.startswith(".venv/bin/python "):
             command = "python " + command.split(" ", 1)[1]
-        if command.startswith("python ") and command not in audit_commands:
-            missing.append(command)
+        if command.startswith("python "):
+            make_commands.append(command)
+            if command not in audit_order:
+                missing.append(command)
 
     assert missing == []
+    d3_dependency_order = [
+        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --artifact "
+        "data/certificates/n9_selected_baseline_escape_budget_overlay.json --check --json",
+        "python scripts/check_n9_d3_escape_slice.py --artifact "
+        "data/certificates/n9_base_apex_d3_escape_slice.json --check --json",
+        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact "
+        "data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json",
+        "python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py "
+        "--artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json "
+        "--check --json",
+        "python scripts/check_n9_selected_baseline_d3_vertex_circle_template_join.py "
+        "--check --json",
+        "python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --artifact "
+        "data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json "
+        "--check --json",
+    ]
+    assert [
+        command for command in make_commands if command in d3_dependency_order
+    ] == d3_dependency_order
 
 
 def test_list_commands_payload_is_claim_neutral() -> None:
@@ -233,16 +257,23 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/probe_c19_proof_tooling.py --check-c19-cnf-summary --json"
     )
     assert (
-        "python scripts/check_n9_base_apex_low_excess_ledgers.py --check --json"
+        "python scripts/check_n9_base_apex_low_excess_ledgers.py --artifact "
+        "data/certificates/n9_base_apex_low_excess_ledgers.json --check --json"
         in command_texts
     )
-    assert "python scripts/check_n9_base_apex_escape_budget.py --check --json" in command_texts
     assert (
-        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
+        "python scripts/check_n9_base_apex_escape_budget.py --artifact "
+        "data/certificates/n9_base_apex_escape_budget_report.json --check --json"
+        in command_texts
+    )
+    assert (
+        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --artifact "
+        "data/certificates/n9_selected_baseline_escape_budget_overlay.json --check --json"
         in command_texts
     )
     assert (
         "python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py "
+        "--artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json "
         "--check --json"
         in command_texts
     )
@@ -251,17 +282,25 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --json"
         in command_texts
     )
-    assert "python scripts/check_n9_d3_escape_slice.py --check --json" in command_texts
     assert (
-        "python scripts/check_n9_base_apex_d3_escape_frontier_packet.py --check --json"
+        "python scripts/check_n9_d3_escape_slice.py --artifact "
+        "data/certificates/n9_base_apex_d3_escape_slice.json --check --json"
         in command_texts
     )
     assert (
-        "python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json"
+        "python scripts/check_n9_base_apex_d3_escape_frontier_packet.py --artifact "
+        "data/certificates/n9_base_apex_d3_escape_frontier_packet.json --check --json"
         in command_texts
     )
     assert (
-        "python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json"
+        "python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --artifact "
+        "data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json "
+        "--check --json"
+        in command_texts
+    )
+    assert (
+        "python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --artifact "
+        "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json --check --json"
         in command_texts
     )
     assert (
@@ -283,11 +322,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
-        "python scripts/check_n9_base_apex_low_excess_escape_ladder.py --check --json"
+        "python scripts/check_n9_base_apex_low_excess_escape_ladder.py --artifact "
+        "data/certificates/n9_base_apex_low_excess_escape_ladder.json --check --json"
         in command_texts
     )
     assert (
-        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json"
+        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact "
+        "data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json"
         in command_texts
     )
     assert (
@@ -519,24 +560,31 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "--check --assert-expected --json"
     )
     assert ordered_command_texts.index(
-        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --check --json"
+        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --artifact "
+        "data/certificates/n9_selected_baseline_escape_budget_overlay.json --check --json"
     ) < ordered_command_texts.index(
-        "python scripts/check_n9_d3_escape_slice.py --check --json"
+        "python scripts/check_n9_d3_escape_slice.py --artifact "
+        "data/certificates/n9_base_apex_d3_escape_slice.json --check --json"
     )
     assert ordered_command_texts.index(
-        "python scripts/check_n9_d3_escape_slice.py --check --json"
+        "python scripts/check_n9_d3_escape_slice.py --artifact "
+        "data/certificates/n9_base_apex_d3_escape_slice.json --check --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py "
+        "--artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json "
         "--check --json"
     )
     assert ordered_command_texts.index(
-        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json"
+        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact "
+        "data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py "
+        "--artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json "
         "--check --json"
     )
     assert ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py "
+        "--artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json "
         "--check --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_selected_baseline_d3_vertex_circle_template_join.py "
@@ -546,15 +594,20 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n9_selected_baseline_d3_vertex_circle_template_join.py "
         "--check --json"
     ) < ordered_command_texts.index(
-        "python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --check --json"
+        "python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --artifact "
+        "data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json "
+        "--check --json"
     )
     assert ordered_command_texts.index(
-        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --check --json"
+        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact "
+        "data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json"
     ) < ordered_command_texts.index(
-        "python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json"
+        "python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --artifact "
+        "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json --check --json"
     )
     assert ordered_command_texts.index(
-        "python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --check --json"
+        "python scripts/check_n9_base_apex_d3_incidence_capacity_packet.py --artifact "
+        "data/certificates/n9_base_apex_d3_incidence_capacity_packet.json --check --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n9_base_apex_d3_p19_degree_obstruction.py --check "
         "--assert-expected --json"
@@ -578,7 +631,8 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         "python scripts/check_n9_base_apex_audit_path.py --check --json"
     )
     assert (
-        "python scripts/check_n9_row_ptolemy_product_cancellations.py --check --json"
+        "python scripts/check_n9_row_ptolemy_product_cancellations.py --artifact "
+        "data/certificates/n9_row_ptolemy_product_cancellations.json --check --json"
         in command_texts
     )
     assert (


### PR DESCRIPTION
## Summary
- add a provenance-manifest guard for generated artifacts whose command writes an explicit output path: their `check_command` must replay that same path through a recognized checker argument
- wire explicit `--artifact` replay paths through the affected generated-artifact manifest entries, audit registry, and Makefile commands
- add `--check-artifact` replay support for the C19 compact-vs-legacy diagnostic and register it in the artifact audit
- align the D3 cluster order between `verify-artifacts` and the audit registry, with regression coverage

## Validation
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `.venv/bin/python -m pytest -q tests/test_artifact_provenance.py tests/test_run_artifact_audit.py tests/test_kalmanson_certificate_diagnostics.py`
- `.venv/bin/python scripts/analyze_kalmanson_certificates.py --c19-compact-vs-legacy --assert-expected --check-artifact reports/c19_kalmanson_compact_vs_legacy.json`
- `.venv/bin/python scripts/run_artifact_audit.py --list-commands`
- `git diff --check`
- `.venv/bin/python -m ruff check scripts/check_artifact_provenance.py scripts/analyze_kalmanson_certificates.py tests/test_artifact_provenance.py tests/test_run_artifact_audit.py tests/test_kalmanson_certificate_diagnostics.py`
- `make verify-fast` (`1443 passed, 668 deselected`)

No general proof or counterexample is claimed.