### PR TITLE
Tighten artifact audit command contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,8 @@ verify-n10-review:
 	$(PYTHON) scripts/check_n10_fast_cpp_singleton_replay.py --check --json
 	$(PYTHON) scripts/check_n10_secondary_singleton_replay.py --check --assert-expected --json
 
-verify-artifacts: verify-n8 verify-kalmanson verify-n9-review verify-bridge-frontier verify-n10-review
+verify-artifacts:
+	$(PYTHON) scripts/run_artifact_audit.py --verify-only
 
 audit-artifacts:
 	$(PYTHON) scripts/run_artifact_audit.py --output-dir artifact-audit-results

--- a/README.md
+++ b/README.md
@@ -380,10 +380,12 @@ For CI-style metadata capture, run:
 make audit-artifacts
 ```
 
-If `make` is unavailable, treat [`Makefile`](Makefile),
-[`scripts/run_artifact_audit.py`](scripts/run_artifact_audit.py), and
-[`docs/reviewer-guide.md`](docs/reviewer-guide.md) as the source of truth for
-the current raw artifact command set.
+Both targets use the command registry in
+[`scripts/run_artifact_audit.py`](scripts/run_artifact_audit.py): `verify-artifacts`
+runs the registry without metadata capture, while `audit-artifacts` records
+per-command stdout/stderr and environment metadata. If `make` is unavailable,
+use `python scripts/run_artifact_audit.py --verify-only` for the same raw
+artifact command set.
 
 Useful exploratory commands:
 

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -53,13 +53,16 @@ For CI-style audit metadata, run:
 make audit-artifacts
 ```
 
-The `audit-artifacts` target includes the dated official-status consistency
-check, so this audit path is stricter than the default fast tier.
+Both artifact targets use the command registry in
+`scripts/run_artifact_audit.py`: `verify-artifacts` runs the registered
+artifact commands without metadata capture, while `audit-artifacts` also runs
+the two audit preflights and records per-command stdout/stderr plus environment
+metadata.
 
-If `make` is unavailable, treat `Makefile` and
-`scripts/run_artifact_audit.py` as the source of truth for the current raw
-command set. To print the registered artifact-audit command list without
-running the audit, including the two `audit-artifacts` preflight checks, use:
+If `make` is unavailable, use `python scripts/run_artifact_audit.py --verify-only`
+for the current raw artifact command set. To print the registered artifact-audit
+command list without running the audit, including the two `audit-artifacts`
+preflight checks, use:
 
 ```bash
 python scripts/run_artifact_audit.py --list-commands

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -61,10 +61,18 @@ PATH_REPLAY_FLAGS = {
     "--check-artifact",
     "--check-compatible-orders-data",
     "--check-exact-analysis-data",
+    "--verify-certificate",
 }
 PATH_OUTPUT_FLAGS = {
     "--out",
     "--output",
+    "--write",
+    "--write-artifact",
+}
+PATH_OUTPUT_SWITCHES_WITH_TARGET_FLAGS = {
+    "--write-artifact": {"--artifact"},
+}
+PATH_DEFAULT_OUTPUT_SWITCHES = {
     "--write",
     "--write-artifact",
 }
@@ -191,7 +199,7 @@ def validate_artifact(
         not isinstance(check_command, str) or not check_command.strip()
     ):
         errors.append(f"{label}.check_command must be a nonempty string when present")
-    errors.extend(validate_check_command_replays_explicit_artifact_path(artifact, label))
+    errors.extend(validate_check_command_for_generated_write(artifact, label))
 
     if artifact.get("direct_edit_allowed") is not False:
         errors.append(f"{label}.direct_edit_allowed must be false for generated artifacts")
@@ -285,15 +293,23 @@ def command_mentions_path(command: str, raw_path: str) -> bool:
 def command_outputs_path(command: str, raw_path: str) -> bool:
     tokens = command_tokens(command)
     variants = path_variants(raw_path)
+    output_target_flags: set[str] = set()
     previous: str | None = None
     for token in tokens:
         redirect_target = redirection_value(token)
+        output_target_flags.update(PATH_OUTPUT_SWITCHES_WITH_TARGET_FLAGS.get(token, set()))
         if token_matches_path(token, variants):
-            return previous in PATH_OUTPUT_FLAGS
+            return previous in PATH_OUTPUT_FLAGS or previous in output_target_flags
         if any(
             token.startswith(f"{flag}=")
             and token_matches_path(token.split("=", 1)[1], variants)
             for flag in PATH_OUTPUT_FLAGS
+        ):
+            return True
+        if any(
+            token.startswith(f"{flag}=")
+            and token_matches_path(token.split("=", 1)[1], variants)
+            for flag in output_target_flags
         ):
             return True
         if (
@@ -306,6 +322,12 @@ def command_outputs_path(command: str, raw_path: str) -> bool:
             return True
         previous = token
     return False
+
+
+def command_uses_default_output_path(command: str, raw_path: str) -> bool:
+    if command_outputs_path(command, raw_path):
+        return False
+    return any(token in PATH_DEFAULT_OUTPUT_SWITCHES for token in command_tokens(command))
 
 
 def command_replays_path(command: str, raw_path: str) -> bool:
@@ -325,7 +347,7 @@ def command_replays_path(command: str, raw_path: str) -> bool:
     return False
 
 
-def validate_check_command_replays_explicit_artifact_path(
+def validate_check_command_for_generated_write(
     artifact: dict[str, Any],
     label: str,
 ) -> list[str]:
@@ -337,6 +359,13 @@ def validate_check_command_replays_explicit_artifact_path(
         and isinstance(command, str)
     ):
         return []
+    if command_uses_default_output_path(command, raw_path) and (
+        not isinstance(check_command, str) or not check_command.strip()
+    ):
+        return [
+            f"{label}.check_command must be present for default-path artifact write "
+            f"command {raw_path!r}"
+        ]
     if not command_outputs_path(command, raw_path):
         return []
     if not isinstance(check_command, str) or not check_command.strip():

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -3744,6 +3744,18 @@ def run_audit_command(command: AuditCommand, output_dir: Path) -> dict[str, Any]
     }
 
 
+def run_verify_commands(commands: Sequence[AuditCommand]) -> int:
+    for index, command in enumerate(commands, start=1):
+        print(
+            f"[{index}/{len(commands)}] {command.ident}: {command_text(command.command)}",
+            flush=True,
+        )
+        result = subprocess.run(subprocess_command(command.command), cwd=REPO_ROOT)
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
 def build_summary(
     output_dir: Path,
     commands: Sequence[AuditCommand],
@@ -3829,10 +3841,16 @@ def list_commands_payload(
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--list-commands",
         action="store_true",
         help="Print the registered audit command list as JSON without running it.",
+    )
+    mode.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Run registered artifact audit commands without writing metadata.",
     )
     parser.add_argument(
         "--output-dir",
@@ -3848,6 +3866,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.list_commands:
         print(json.dumps(list_commands_payload(AUDIT_COMMANDS), indent=2, sort_keys=True))
         return 0
+    if args.verify_only:
+        return run_verify_commands(AUDIT_COMMANDS)
 
     output_dir = args.output_dir
     if not output_dir.is_absolute():

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -8,6 +8,7 @@ from scripts.check_artifact_provenance import (
     command_mentions_path,
     command_outputs_path,
     command_replays_path,
+    command_uses_default_output_path,
     load_manifest,
     sha256_file,
     validate_manifest,
@@ -211,6 +212,19 @@ def test_manifest_rejects_explicit_write_path_without_check_command(tmp_path: Pa
     assert any("must replay explicitly generated artifact path" in error for error in errors)
 
 
+def test_manifest_rejects_default_write_without_check_command(tmp_path: Path) -> None:
+    generator = tmp_path / "generator.py"
+    manifest = replay_manifest(
+        tmp_path,
+        command=f"python {generator} --write --assert-expected",
+        check_command=None,
+    )
+
+    errors = validate_manifest(manifest)
+
+    assert any("must be present for default-path artifact write command" in error for error in errors)
+
+
 def test_manifest_rejects_check_path_without_replay_flag(tmp_path: Path) -> None:
     artifact = tmp_path / "artifact.json"
     generator = tmp_path / "generator.py"
@@ -264,8 +278,20 @@ def test_command_path_detection_accepts_common_artifact_path_forms() -> None:
         "python generator.py >data/certificates/example.json",
         "data/certificates/example.json",
     )
+    assert command_outputs_path(
+        "python generator.py --write-artifact --artifact data/certificates/example.json --check",
+        "data/certificates/example.json",
+    )
     assert not command_outputs_path(
         "python checker.py --artifact data/certificates/example.json --check",
+        "data/certificates/example.json",
+    )
+    assert command_uses_default_output_path(
+        "python generator.py --write --assert-expected",
+        "data/certificates/example.json",
+    )
+    assert not command_uses_default_output_path(
+        "python generator.py --out data/certificates/example.json",
         "data/certificates/example.json",
     )
     assert command_replays_path(
@@ -274,6 +300,11 @@ def test_command_path_detection_accepts_common_artifact_path_forms() -> None:
     )
     assert command_replays_path(
         f"python checker.py --artifact {artifact} --check",
+        "data/certificates/example.json",
+    )
+    assert command_replays_path(
+        "python checker.py --verify-certificate data/certificates/example.json "
+        "--assert-expected --json",
         "data/certificates/example.json",
     )
     assert not command_replays_path(

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -15,6 +15,7 @@ from scripts.run_artifact_audit import (
     command_text,
     list_commands_payload,
     run_audit_command,
+    run_verify_commands,
     sha256_bytes,
 )
 
@@ -56,6 +57,43 @@ def test_run_audit_command_resolves_python_to_current_interpreter(tmp_path: Path
     assert record["command"] == "python -c import sys; print(sys.executable)"
     assert record["exit_code"] == 0
     assert (tmp_path / record["stdout_path"]).read_text(encoding="utf-8").strip() == sys.executable
+
+
+def test_run_verify_commands_resolves_python_to_current_interpreter(capfd) -> None:
+    command = AuditCommand(
+        ident="python_alias",
+        command=("python", "-c", "import sys; print(sys.executable)"),
+        claim_scope="test command only",
+    )
+
+    exit_code = run_verify_commands([command])
+
+    assert exit_code == 0
+    captured = capfd.readouterr()
+    assert sys.executable in captured.out
+
+
+def test_run_verify_commands_stops_on_first_failure(capfd) -> None:
+    commands = [
+        AuditCommand(
+            ident="fail",
+            command=("python", "-c", "import sys; sys.exit(7)"),
+            claim_scope="test command only",
+        ),
+        AuditCommand(
+            ident="skip",
+            command=("python", "-c", "print('should not run')"),
+            claim_scope="test command only",
+        ),
+    ]
+
+    exit_code = run_verify_commands(commands)
+
+    assert exit_code == 7
+    captured = capfd.readouterr()
+    assert "fail" in captured.out
+    assert "skip" not in captured.out
+    assert "should not run" not in captured.out
 
 
 def test_build_summary_runs_preflight_and_audit_commands(tmp_path: Path) -> None:
@@ -100,40 +138,16 @@ def test_audit_commands_cover_verify_artifacts_make_target() -> None:
         text=True,
         stdout=subprocess.PIPE,
     )
-    audit_order = {
-        command_text(command.command): index for index, command in enumerate(AUDIT_COMMANDS)
-    }
-    make_commands = []
-    missing = []
-    for line in dry_run.stdout.splitlines():
-        command = line.strip()
-        if command.startswith(".venv/bin/python "):
-            command = "python " + command.split(" ", 1)[1]
-        if command.startswith("python "):
-            make_commands.append(command)
-            if command not in audit_order:
-                missing.append(command)
-
-    assert missing == []
-    d3_dependency_order = [
-        "python scripts/check_n9_selected_baseline_escape_budget_overlay.py --artifact "
-        "data/certificates/n9_selected_baseline_escape_budget_overlay.json --check --json",
-        "python scripts/check_n9_d3_escape_slice.py --artifact "
-        "data/certificates/n9_base_apex_d3_escape_slice.json --check --json",
-        "python scripts/check_n9_base_apex_low_excess_escape_crosswalk.py --artifact "
-        "data/certificates/n9_base_apex_low_excess_escape_crosswalk.json --check --json",
-        "python scripts/check_n9_selected_baseline_d3_escape_class_crosswalk.py "
-        "--artifact data/certificates/n9_selected_baseline_d3_escape_class_crosswalk.json "
-        "--check --json",
-        "python scripts/check_n9_selected_baseline_d3_vertex_circle_template_join.py "
-        "--check --json",
-        "python scripts/check_n9_base_apex_d3_p19_incidence_capacity_pilot.py --artifact "
-        "data/certificates/n9_base_apex_d3_p19_incidence_capacity_pilot.json "
-        "--check --json",
+    command_lines = [
+        line.strip()
+        for line in dry_run.stdout.splitlines()
+        if line.strip() and not line.startswith("make[")
     ]
-    assert [
-        command for command in make_commands if command in d3_dependency_order
-    ] == d3_dependency_order
+    assert len(command_lines) == 1
+    command = command_lines[0]
+    if command.startswith(".venv/bin/python "):
+        command = "python " + command.split(" ", 1)[1]
+    assert command == "python scripts/run_artifact_audit.py --verify-only"
 
 
 def test_list_commands_payload_is_claim_neutral() -> None:


### PR DESCRIPTION
## Summary
- teach provenance validation about the local `--write-artifact --artifact <path>` output pattern and `--verify-certificate <path>` replay pattern
- require default-path artifact write commands to keep a `check_command`, so default-output writers cannot silently lose checker coverage
- add `run_artifact_audit.py --verify-only` and make `make verify-artifacts` delegate to the audit registry, removing the 200-vs-228 command-list drift
- update reviewer docs to describe the shared artifact command registry

## Validation
- `.venv/bin/python scripts/check_artifact_provenance.py`
- `.venv/bin/python -m pytest -q tests/test_artifact_provenance.py tests/test_run_artifact_audit.py`
- `.venv/bin/python scripts/run_artifact_audit.py --list-commands`
- `make -n verify-artifacts`
- `.venv/bin/python scripts/check_text_clean.py`
- `.venv/bin/python scripts/check_status_consistency.py`
- `git diff --check`
- `.venv/bin/python -m ruff check scripts/check_artifact_provenance.py scripts/run_artifact_audit.py tests/test_artifact_provenance.py tests/test_run_artifact_audit.py`
- `make verify-fast` (`1446 passed, 668 deselected`)

Not run locally: full `make verify-artifacts` / `scripts/run_artifact_audit.py --verify-only` 228-command artifact tier.

No general proof or counterexample is claimed.