### PR TITLE
Add n=9 route decision template

### DIFF
--- a/docs/n9-vertex-circle-route-decision-preflight.md
+++ b/docs/n9-vertex-circle-route-decision-preflight.md
@@ -42,6 +42,18 @@ The preflight checks that:
 - a schema-only draft shape for `accepted_vertex_circle_route` validates as a
   decision record shape, without recording or implying a real decision.
 
+To print the fillable accepted-route template that carries this exact gate
+partition into decision intake, run:
+
+```bash
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --accepted-route-template
+```
+
+That output is only a template. It is emitted as a final decision record with
+blank required reviewer/provenance fields, so it does not validate until an
+independent reviewer fills the reviewer identity, review date, reviewed
+checkout, run-bundle digest, and any review notes.
+
 ## Decision Boundary
 
 The next required external artifact remains a filled decision record checked by:

--- a/docs/n9-vertex-circle-route-decision-request.md
+++ b/docs/n9-vertex-circle-route-decision-request.md
@@ -53,10 +53,10 @@ Capture a live run digest for the checkout under review:
 python scripts/check_n9_review_run_bundle.py --check --run --summary-json
 ```
 
-Print the decision template:
+Print the accepted-route decision draft:
 
 ```bash
-python scripts/check_n9_review_decision_intake.py --template
+python scripts/check_n9_vertex_circle_route_decision_preflight.py --accepted-route-template
 ```
 
 Validate a filled written decision:
@@ -64,6 +64,10 @@ Validate a filled written decision:
 ```bash
 python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
 ```
+
+The generic intake template remains available from
+`python scripts/check_n9_review_decision_intake.py --template` when a reviewer
+needs a different outcome shape, such as a precise gap record.
 
 ## Boundary
 

--- a/metadata/n9_vertex_circle_route_decision_request.yaml
+++ b/metadata/n9_vertex_circle_route_decision_request.yaml
@@ -12,7 +12,7 @@ canonical_command: python scripts/check_n9_vertex_circle_route_decision_request.
 markdown_command: python scripts/check_n9_vertex_circle_route_decision_request.py --markdown
 preflight_command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json
 run_capture_command: python scripts/check_n9_review_run_bundle.py --check --run --summary-json
-decision_template_command: python scripts/check_n9_review_decision_intake.py --template
+decision_template_command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --accepted-route-template
 decision_validation_command: python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
 claim_scope: >
   Machine-readable request packet for asking an external reviewer to decide
@@ -94,9 +94,10 @@ reviewer_steps:
       Capture command-output digests for the checkout being reviewed. This is
       execution provenance only.
   - id: template
-    command: python scripts/check_n9_review_decision_intake.py --template
+    command: python scripts/check_n9_vertex_circle_route_decision_preflight.py --accepted-route-template
     purpose: >
-      Print the fillable decision record schema.
+      Print the fillable accepted-route decision template with the requested
+      gate partition and boundary acknowledgements.
   - id: filled_decision_validation
     command: python scripts/check_n9_review_decision_intake.py --decision path/to/decision.yaml --check --summary-json
     purpose: >

--- a/scripts/check_n9_vertex_circle_route_decision_preflight.py
+++ b/scripts/check_n9_vertex_circle_route_decision_preflight.py
@@ -39,6 +39,10 @@ CANONICAL_COMMAND = (
     "python scripts/check_n9_vertex_circle_route_decision_preflight.py "
     "--check --summary-json"
 )
+ACCEPTED_ROUTE_TEMPLATE_COMMAND = (
+    "python scripts/check_n9_vertex_circle_route_decision_preflight.py "
+    "--accepted-route-template"
+)
 ACCEPTED_VERTEX_CIRCLE_ROUTE = "accepted_vertex_circle_route"
 VERTEX_CIRCLE_ROUTE_GATES = (
     "frontier_enumeration",
@@ -176,31 +180,38 @@ def _gate_list(
 
 
 def _decision_template_gate_ids(intake: dict[str, Any]) -> set[str]:
+    return set(_decision_template_gate_order(intake))
+
+
+def _decision_template_gate_order(intake: dict[str, Any]) -> tuple[str, ...]:
     template = intake.get("decision_template", {})
     if not isinstance(template, dict):
-        return set()
+        return ()
     gates = template.get("not_reviewed_gates", [])
     if not isinstance(gates, list):
-        return set()
-    return {gate for gate in gates if isinstance(gate, str)}
+        return ()
+    return tuple(gate for gate in gates if isinstance(gate, str))
 
 
-def _draft_vertex_circle_decision_record(
+def _accepted_route_decision_record(
     intake: dict[str, Any],
+    *,
+    decision_status: str,
+    notes: str,
 ) -> dict[str, Any]:
     accepted = set(DECISION_REQUIRED_ACCEPTED_GATES)
-    all_gates = _decision_template_gate_ids(intake)
+    all_gates = _decision_template_gate_order(intake)
     return {
         "schema": intake.get("decision_record_schema"),
-        "decision_status": "draft",
+        "decision_status": decision_status,
         "reviewer_name": "",
         "review_date": "",
         "reviewed_git_head": "",
         "run_bundle_digest": "",
         "recommended_outcome": ACCEPTED_VERTEX_CIRCLE_ROUTE,
-        "accepted_gates": sorted(accepted),
+        "accepted_gates": list(DECISION_REQUIRED_ACCEPTED_GATES),
         "rejected_gates": [],
-        "not_reviewed_gates": sorted(all_gates - accepted),
+        "not_reviewed_gates": [gate for gate in all_gates if gate not in accepted],
         "precise_gaps": [],
         "acknowledgements": {
             "no_general_proof_claimed": True,
@@ -208,11 +219,36 @@ def _draft_vertex_circle_decision_record(
             "official_status_unchanged": True,
             "source_of_truth_pr_required": True,
         },
-        "notes": (
+        "notes": notes,
+    }
+
+
+def _draft_vertex_circle_decision_record(
+    intake: dict[str, Any],
+) -> dict[str, Any]:
+    return _accepted_route_decision_record(
+        intake,
+        decision_status="draft",
+        notes=(
             "Schema preflight only. This draft shape is not a written review "
             "decision and does not accept any gate."
         ),
-    }
+    )
+
+
+def build_accepted_route_decision_template(
+    intake: dict[str, Any],
+) -> dict[str, Any]:
+    return _accepted_route_decision_record(
+        intake,
+        decision_status="final",
+        notes=(
+            "Accepted-route template only. Fill the independent reviewer "
+            "identity, review date, reviewed checkout, run-bundle digest, and "
+            "review notes before validating this as a written decision. This "
+            "unfilled template does not accept any gate."
+        ),
+    )
 
 
 def _validate_internal_notes() -> tuple[list[dict[str, Any]], list[str]]:
@@ -341,6 +377,7 @@ def validate_preflight(
         "status": STATUS,
         "trust": TRUST,
         "canonical_command": CANONICAL_COMMAND,
+        "accepted_route_template_command": ACCEPTED_ROUTE_TEMPLATE_COMMAND,
         "route_outcome": ACCEPTED_VERTEX_CIRCLE_ROUTE,
         "route_gate_ids": list(VERTEX_CIRCLE_ROUTE_GATES),
         "decision_required_accepted_gates": list(DECISION_REQUIRED_ACCEPTED_GATES),
@@ -393,6 +430,9 @@ def summary_payload(payload: dict[str, Any], errors: Sequence[str]) -> dict[str,
         "source_of_truth_update_allowed": payload.get(
             "source_of_truth_update_allowed"
         ),
+        "accepted_route_template_command": payload.get(
+            "accepted_route_template_command"
+        ),
         "next_required_external_artifact": payload.get(
             "next_required_external_artifact"
         ),
@@ -426,6 +466,8 @@ def render_markdown(payload: dict[str, Any], errors: Sequence[str]) -> str:
         ),
         f"- Source-of-truth update allowed: "
         f"`{payload.get('source_of_truth_update_allowed')}`",
+        f"- Accepted-route template: "
+        f"`{payload.get('accepted_route_template_command')}`",
         "",
         "## Internal Notes",
         "",
@@ -460,18 +502,40 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="print compact reviewer-facing JSON",
     )
     output_group.add_argument("--markdown", action="store_true", help="print Markdown")
+    output_group.add_argument(
+        "--accepted-route-template",
+        action="store_true",
+        help="print the fillable accepted-route decision draft",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        payload, errors = validate_preflight()
+        intake = load_intake(REPO_ROOT / "metadata" / "n9_review_decision_intake.yaml")
+        ledger = load_ledger(REPO_ROOT / "metadata" / "n9_review_gate_ledger.yaml")
+        payload, errors = validate_preflight(ledger=ledger, intake=intake)
+        accepted_route_template = build_accepted_route_decision_template(intake)
     except (OSError, ValueError, YAMLError) as exc:
         payload = {"schema": SCHEMA, "status": "LOAD_FAILED", "trust": TRUST}
         errors = [str(exc)]
+        accepted_route_template = {}
 
-    if args.markdown:
+    if args.accepted_route_template:
+        if errors:
+            print(
+                "accepted-route template unavailable because preflight failed",
+                file=sys.stderr,
+            )
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        elif yaml is not None:
+            print(yaml.safe_dump(accepted_route_template, sort_keys=False), end="")
+        else:  # pragma: no cover - exercised only without dependencies.
+            print(json.dumps(accepted_route_template, indent=2))
+    elif args.markdown:
         print(render_markdown(payload, errors))
     elif args.summary_json:
         print(json.dumps(summary_payload(payload, errors), indent=2, sort_keys=True))

--- a/scripts/check_n9_vertex_circle_route_decision_request.py
+++ b/scripts/check_n9_vertex_circle_route_decision_request.py
@@ -31,6 +31,7 @@ from scripts.check_n9_review_gate_ledger import (  # noqa: E402
     validate_ledger,
 )
 from scripts.check_n9_vertex_circle_route_decision_preflight import (  # noqa: E402
+    ACCEPTED_ROUTE_TEMPLATE_COMMAND,
     DECISION_REQUIRED_ACCEPTED_GATES,
     INTERNAL_REVIEW_NOTES,
     validate_preflight,
@@ -60,9 +61,7 @@ PREFLIGHT_COMMAND = (
 RUN_CAPTURE_COMMAND = (
     "python scripts/check_n9_review_run_bundle.py --check --run --summary-json"
 )
-DECISION_TEMPLATE_COMMAND = (
-    "python scripts/check_n9_review_decision_intake.py --template"
-)
+DECISION_TEMPLATE_COMMAND = ACCEPTED_ROUTE_TEMPLATE_COMMAND
 DECISION_VALIDATION_COMMAND = (
     "python scripts/check_n9_review_decision_intake.py --decision "
     "path/to/decision.yaml --check --summary-json"

--- a/tests/test_n9_vertex_circle_route_decision_preflight.py
+++ b/tests/test_n9_vertex_circle_route_decision_preflight.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 from copy import deepcopy
 from pathlib import Path
 
-from scripts.check_n9_review_decision_intake import load_intake
+from scripts.check_n9_review_decision_intake import (
+    load_intake,
+    validate_decision_record,
+)
 from scripts.check_n9_review_gate_ledger import load_ledger
 from scripts.check_n9_vertex_circle_route_decision_preflight import (
+    ACCEPTED_ROUTE_TEMPLATE_COMMAND,
     DECISION_REQUIRED_ACCEPTED_GATES,
     INTERNAL_REVIEW_NOTES,
     VERTEX_CIRCLE_ROUTE_GATES,
+    build_accepted_route_decision_template,
+    main,
     validate_preflight,
 )
 
@@ -58,6 +64,84 @@ def test_n9_vertex_circle_route_decision_preflight_is_valid() -> None:
         payload["draft_vertex_circle_decision_shape"]["validation_status"]
         == "passed"
     )
+    assert payload["accepted_route_template_command"] == ACCEPTED_ROUTE_TEMPLATE_COMMAND
+
+
+def test_n9_vertex_circle_route_preflight_builds_accepted_route_template() -> None:
+    ledger = load_ledger(LEDGER)
+    intake = load_intake(INTAKE)
+
+    template = build_accepted_route_decision_template(intake)
+    template_errors = validate_decision_record(template, intake, gate_ledger=ledger)
+
+    assert template["decision_status"] == "final"
+    assert template["recommended_outcome"] == "accepted_vertex_circle_route"
+    assert template["accepted_gates"] == list(DECISION_REQUIRED_ACCEPTED_GATES)
+    assert template["rejected_gates"] == []
+    assert template["not_reviewed_gates"] == [
+        "turn_geometry",
+        "turn_arithmetic_replay",
+        "kalmanson_corroboration",
+        "lean_compilation",
+    ]
+    assert template["acknowledgements"]["source_of_truth_pr_required"] is True
+    assert "does not accept any gate" in template["notes"]
+    assert "reviewer_name must be nonempty for final decisions" in template_errors
+    assert "review_date must be nonempty for final decisions" in template_errors
+    assert "reviewed_git_head must be nonempty for final decisions" in template_errors
+    assert "run_bundle_digest must be nonempty for final decisions" in template_errors
+
+
+def test_n9_vertex_circle_route_preflight_filled_template_validates() -> None:
+    ledger = load_ledger(LEDGER)
+    intake = load_intake(INTAKE)
+    template = build_accepted_route_decision_template(intake)
+    template.update(
+        {
+            "reviewer_name": "Independent Reviewer",
+            "review_date": "2026-06-23",
+            "reviewed_git_head": "0123456789abcdef0123456789abcdef01234567",
+            "run_bundle_digest": "sha256:review-run-bundle-placeholder",
+            "notes": (
+                "Independent written review notes would be recorded here "
+                "before validation."
+            ),
+        }
+    )
+
+    assert validate_decision_record(template, intake, gate_ledger=ledger) == []
+
+
+def test_n9_vertex_circle_route_preflight_prints_accepted_route_template(
+    capsys,
+) -> None:
+    assert main(["--accepted-route-template"]) == 0
+
+    output = capsys.readouterr().out
+
+    assert "decision_status: final" in output
+    assert "recommended_outcome: accepted_vertex_circle_route" in output
+    assert "- frontier_enumeration" in output
+    assert "- independent_review" in output
+    assert "source_of_truth_pr_required: true" in output
+
+
+def test_n9_vertex_circle_route_preflight_template_failure_is_nonzero(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.check_n9_vertex_circle_route_decision_preflight.validate_preflight",
+        lambda *, ledger, intake: ({"status": "REVIEW_PREFLIGHT_ONLY"}, ["boom"]),
+    )
+
+    assert main(["--accepted-route-template"]) == 1
+
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert "accepted-route template unavailable" in captured.err
+    assert "boom" in captured.err
 
 
 def test_n9_vertex_circle_route_preflight_rejects_closed_route_gate() -> None:

--- a/tests/test_n9_vertex_circle_route_decision_request.py
+++ b/tests/test_n9_vertex_circle_route_decision_request.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from scripts.check_n9_vertex_circle_route_decision_request import (
     ACCEPTED_VERTEX_CIRCLE_ROUTE,
+    DECISION_TEMPLATE_COMMAND,
     DECISION_REQUIRED_ACCEPTED_GATES,
     DEFAULT_REQUEST,
     build_request_payload,
@@ -29,6 +30,10 @@ def test_n9_vertex_circle_route_decision_request_is_valid() -> None:
         DECISION_REQUIRED_ACCEPTED_GATES
     )
     assert request_payload["requested_rejected_gates"] == []
+    assert request_payload["decision_template_command"] == DECISION_TEMPLATE_COMMAND
+    assert request_payload["decision_template_command"].endswith(
+        "--accepted-route-template"
+    )
     assert request_payload["external_reviewer_required"] is True
     assert request_payload["source_of_truth_update_allowed"] is False
 


### PR DESCRIPTION
## Summary

- Add `--accepted-route-template` to the n=9 vertex-circle route decision preflight checker.
- Wire the route decision request metadata and docs to the route-specific template command.
- Add regression coverage for template gate partitioning, unfilled final-decision validation guards, failure exit behavior, and request command drift.

## Boundary

This remains review infrastructure only. It does not accept any review gate, does not prove `n=9`, does not prove Erdos Problem #97, does not claim a counterexample, and does not update the official/global status.

## Verification

- `.venv/bin/python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_vertex_circle_route_decision_preflight.py --accepted-route-template`
- `.venv/bin/python scripts/check_n9_vertex_circle_route_decision_request.py --check --summary-json`
- `.venv/bin/python scripts/check_n9_review_decision_intake.py --check --summary-json`
- `.venv/bin/python -m pytest tests/test_n9_vertex_circle_route_decision_preflight.py tests/test_n9_vertex_circle_route_decision_request.py -q`
- `.venv/bin/python -m ruff check scripts/check_n9_vertex_circle_route_decision_preflight.py scripts/check_n9_vertex_circle_route_decision_request.py tests/test_n9_vertex_circle_route_decision_preflight.py tests/test_n9_vertex_circle_route_decision_request.py`
- `make verify-fast` -> `1450 passed, 668 deselected`