### PR TITLE
Follow-up fixes from the 2026-06-28 deep review (guardrails + hygiene)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ failed route.
 ```text
 n: 12
 pattern: B12_3x4_danzer_lift
-max squared-distance spread: 0.006806368780585714
+max selected-distance spread: 0.006806368780585714
 RMS equality residual:       0.0019599509549614457
 convexity margin:            9.999999943508973e-07
 minimum edge length:         0.0007465865604262556

--- a/STATE.md
+++ b/STATE.md
@@ -1087,7 +1087,7 @@ distance equalities and strict convexity.
 ```text
 n: 12
 pattern: B12_3x4_danzer_lift
-max squared-distance spread: 0.006806368780585714
+max selected-distance spread: 0.006806368780585714
 RMS equality residual:       0.0019599509549614457
 convexity margin:            9.999999943508973e-07
 minimum edge length:         0.0007465865604262556

--- a/docs/formalization.md
+++ b/docs/formalization.md
@@ -14,6 +14,10 @@ official problem. Its first layer is deliberately abstract:
 - `lean/Erdos97/Basic.lean` defines a point-set selected-witness interface;
 - `lean/Erdos97/SelectedWitness.lean` proves the choice-based extraction from
   that abstract interface;
+- `lean/Erdos97/WitnessLemmas.lean` collects dependency-free interface-unpacking
+  lemmas for the witness, equidistance, and shared-row data;
+- `lean/Erdos97/TwoCircleCap.lean` states the two-circle intersection cap and
+  the `|S_a ∩ S_b| ≤ 2` pair-sharing cap in dependency-free conditional form;
 - `lean/Erdos97/OfficialBridge.lean` proves the first dependency-free adapter:
   official-shaped four-point radius fibers imply the local
   `HasFourEquidistantProperty` interface;

--- a/lean/Erdos97/WitnessLemmas.lean
+++ b/lean/Erdos97/WitnessLemmas.lean
@@ -12,41 +12,9 @@ namespace Erdos97
 
 universe u
 
-section Witness4
-
-variable {Point : Type u}
-
-/-- Reverse orientation of the `a_ne_b` witness distinctness field. -/
-theorem Witness4.b_ne_a (W : Witness4 Point) : Not (W.b = W.a) := by
-  intro h
-  exact W.a_ne_b h.symm
-
-/-- Reverse orientation of the `a_ne_c` witness distinctness field. -/
-theorem Witness4.c_ne_a (W : Witness4 Point) : Not (W.c = W.a) := by
-  intro h
-  exact W.a_ne_c h.symm
-
-/-- Reverse orientation of the `a_ne_d` witness distinctness field. -/
-theorem Witness4.d_ne_a (W : Witness4 Point) : Not (W.d = W.a) := by
-  intro h
-  exact W.a_ne_d h.symm
-
-/-- Reverse orientation of the `b_ne_c` witness distinctness field. -/
-theorem Witness4.c_ne_b (W : Witness4 Point) : Not (W.c = W.b) := by
-  intro h
-  exact W.b_ne_c h.symm
-
-/-- Reverse orientation of the `b_ne_d` witness distinctness field. -/
-theorem Witness4.d_ne_b (W : Witness4 Point) : Not (W.d = W.b) := by
-  intro h
-  exact W.b_ne_d h.symm
-
-/-- Reverse orientation of the `c_ne_d` witness distinctness field. -/
-theorem Witness4.d_ne_c (W : Witness4 Point) : Not (W.d = W.c) := by
-  intro h
-  exact W.c_ne_d h.symm
-
-end Witness4
+-- The reverse-orientation `Witness4.b_ne_a` … `Witness4.d_ne_c` lemmas live in
+-- `Erdos97.Basic` (imported transitively via `Erdos97.SelectedWitness`); they
+-- are intentionally not re-declared here to avoid duplicate declarations.
 
 section WitnessInSet
 

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -299,6 +299,13 @@ def command_outputs_path(command: str, raw_path: str) -> bool:
         redirect_target = redirection_value(token)
         output_target_flags.update(PATH_OUTPUT_SWITCHES_WITH_TARGET_FLAGS.get(token, set()))
         if token_matches_path(token, variants):
+            # A path token written by a space-separated redirection (`> path`,
+            # `2>> path`) or piped into `tee path` is an output, even though the
+            # previous token is not an --out-style flag.
+            if previous is not None and (
+                re.fullmatch(r"\d?>{1,2}", previous) or previous == "tee"
+            ):
+                return True
             return previous in PATH_OUTPUT_FLAGS or previous in output_target_flags
         if any(
             token.startswith(f"{flag}=")
@@ -310,12 +317,6 @@ def command_outputs_path(command: str, raw_path: str) -> bool:
             token.startswith(f"{flag}=")
             and token_matches_path(token.split("=", 1)[1], variants)
             for flag in output_target_flags
-        ):
-            return True
-        if (
-            previous is not None
-            and re.fullmatch(r"\d?>{1,2}", previous)
-            and token_matches_path(token, variants)
         ):
             return True
         if redirect_target is not None and token_matches_path(redirect_target, variants):

--- a/scripts/check_artifact_provenance.py
+++ b/scripts/check_artifact_provenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -232,6 +233,10 @@ def validate_artifact(
 
 
 def command_tokens(command: str) -> list[str]:
+    if os.name == "nt":
+        # POSIX shlex treats backslashes as escapes, which collapses Windows
+        # absolute paths like C:\repo\artifact.json before path matching.
+        command = command.replace("\\", "\\\\")
     try:
         return shlex.split(command)
     except ValueError:

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -45,29 +45,44 @@ ERDOS97_TARGET_RE = (
     r"(?:erd\S*s(?:\s+problem)?\s*#?\s*97|problem\s*#?\s*97|"
     r"the\s+(?:general\s+)?(?:problem|conjecture))"
 )
+# Proof/refutation verbs that overclaim a result on the global target. Kept as
+# one bare alternation so the forward and reverse patterns cannot drift apart.
+ERDOS97_PROOF_VERBS = (
+    r"prove[sd]?|proven|proving|settle[sd]?|settling|solve[sd]?|solving|"
+    r"disprove[sd]?|disproven|disproving|resolve[sd]?|resolving|"
+    r"refute[sd]?|refuting"
+)
+# Verbs that, applied to a counterexample/solution, assert it was built. Kept
+# deliberately NARROW: "counterexample" is a pervasive technical term in this
+# repo ("minimal counterexample", "certified counterexample"), so broad verbs
+# near it produce false positives. Only verbs that rarely co-occur innocently
+# with "counterexample" are included.
+COUNTEREXAMPLE_VERBS = (
+    r"found|constructed|verified|certified|confirmed|exhibited"
+)
 BANNED_OVERCLAIM_RE_LIST = (
     re.compile(
-        rf"\b(?:prove[sd]?|proven|settled|solved|disproved)\b"
+        rf"\b(?:{ERDOS97_PROOF_VERBS})\b"
         rf"[^.\n]{{0,120}}\b{ERDOS97_TARGET_RE}\b",
         re.I,
     ),
     re.compile(
         rf"\b{ERDOS97_TARGET_RE}\b"
-        rf"[^.\n]{{0,120}}\b(?:prove[sd]?|proven|settled|solved|disproved)\b",
+        rf"[^.\n]{{0,120}}\b(?:{ERDOS97_PROOF_VERBS})\b",
         re.I,
     ),
     re.compile(
-        r"\b(?:found|constructed|verified|certified|confirmed|have|has|is|are)\b"
+        rf"\b(?:{COUNTEREXAMPLE_VERBS}|have|has|is|are)\b"
         r"[^.\n]{0,100}\b(?:counterexample|solution)\b",
         re.I,
     ),
     re.compile(
-        r"\b(?:counterexample|solution)\b[^.\n]{0,100}"
-        r"\b(?:found|constructed|verified|certified|confirmed)\b",
+        rf"\b(?:counterexample|solution)\b[^.\n]{{0,100}}"
+        rf"\b(?:{COUNTEREXAMPLE_VERBS})\b",
         re.I,
     ),
     re.compile(
-        rf"\b(?:found|constructed|verified|certified|confirmed|have|has)\b"
+        rf"\b(?:{COUNTEREXAMPLE_VERBS}|have|has)\b"
         rf"[^.\n]{{0,100}}\bproof\b[^.\n]{{0,80}}\b(?:of|for)\b"
         rf"[^.\n]{{0,80}}\b{ERDOS97_TARGET_RE}\b",
         re.I,
@@ -80,7 +95,7 @@ OVERCLAIM_ALLOW_RE = re.compile(
     re.I,
 )
 CLAIM_CONTEXT_BOUNDARY_RE = re.compile(
-    r"(?i)(?:[.;|]|\b(?:but|however|although|though)\b)"
+    r"(?i)(?:[.;|:,]|\s[-–—]\s|\b(?:but|however|although|though)\b)"
 )
 STALE_PATTERN_CATALOG_RE = re.compile(
     r"\b(?:remains\s+live|live/unresolved|survives\s+current\s+fixed-order\s+exact\s+filters)\b",
@@ -192,7 +207,10 @@ def find_forbidden_overclaim_lines(text: str) -> list[tuple[int, str]]:
             continue
         scan_text = normalized
         previous_prefix_len = 0
-        if previous and line_continues_wrapped_sentence(normalized):
+        if previous and (
+            line_continues_wrapped_sentence(normalized)
+            or previous_line_opens_sentence(previous)
+        ):
             scan_text = f"{previous} {normalized}"
             previous_prefix_len = len(previous) + 1
         previous = normalized
@@ -216,6 +234,19 @@ def line_continues_wrapped_sentence(line: str) -> bool:
     """Heuristic for Markdown prose wrapped in the middle of a sentence."""
 
     return bool(line) and (line[0].islower() or line[0].isdigit() or line[0] in "`([{")
+
+
+def previous_line_opens_sentence(previous: str) -> bool:
+    """True when the previous prose line did not finish its sentence.
+
+    Catches overclaims hand-wrapped onto a continuation line that starts with an
+    uppercase word, which ``line_continues_wrapped_sentence`` alone would miss.
+    A line ending in sentence-final punctuation (``.!?``) or a clause/list
+    terminator (``:;``) is treated as complete and is not joined forward.
+    """
+
+    stripped = previous.rstrip()
+    return bool(stripped) and stripped[-1] not in ".!?:;"
 
 
 def local_claim_context(line: str, start: int, end: int) -> str:

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -236,6 +236,9 @@ def line_continues_wrapped_sentence(line: str) -> bool:
     return bool(line) and (line[0].islower() or line[0].isdigit() or line[0] in "`([{")
 
 
+_BLOCK_LINE_PREFIX_RE = re.compile(r"^(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>|\||`{3}|~{3})")
+
+
 def previous_line_opens_sentence(previous: str) -> bool:
     """True when the previous prose line did not finish its sentence.
 
@@ -243,10 +246,17 @@ def previous_line_opens_sentence(previous: str) -> bool:
     uppercase word, which ``line_continues_wrapped_sentence`` alone would miss.
     A line ending in sentence-final punctuation (``.!?``) or a clause/list
     terminator (``:;``) is treated as complete and is not joined forward.
+
+    Block-level Markdown lines (headings, list items, block quotes, table rows,
+    code fences) are NOT prose continuations even when they lack terminal
+    punctuation; joining them would leak a negation in e.g. ``## Not solved``
+    into a following standalone overclaim and wrongly excuse it.
     """
 
     stripped = previous.rstrip()
-    return bool(stripped) and stripped[-1] not in ".!?:;"
+    if not stripped or _BLOCK_LINE_PREFIX_RE.match(stripped):
+        return False
+    return stripped[-1] not in ".!?:;"
 
 
 def local_claim_context(line: str, start: int, end: int) -> str:

--- a/scripts/check_status_consistency.py
+++ b/scripts/check_status_consistency.py
@@ -207,10 +207,16 @@ def find_forbidden_overclaim_lines(text: str) -> list[tuple[int, str]]:
             continue
         scan_text = normalized
         previous_prefix_len = 0
+        joined_wrapped_continuation = False
+        joined_open_previous = False
+        joined_previous = ""
         if previous and (
             line_continues_wrapped_sentence(normalized)
             or previous_line_opens_sentence(previous)
         ):
+            joined_wrapped_continuation = line_continues_wrapped_sentence(normalized)
+            joined_open_previous = previous_line_opens_sentence(previous)
+            joined_previous = previous
             scan_text = f"{previous} {normalized}"
             previous_prefix_len = len(previous) + 1
         previous = normalized
@@ -222,7 +228,23 @@ def find_forbidden_overclaim_lines(text: str) -> list[tuple[int, str]]:
                 continue
             if match.end() <= previous_prefix_len:
                 continue
-            context = local_claim_context(scan_text, match.start(), match.end())
+            context_text = scan_text
+            context_start = match.start()
+            context_end = match.end()
+            if (
+                previous_prefix_len
+                and joined_open_previous
+                and not joined_wrapped_continuation
+                and match.start() >= previous_prefix_len
+                and not previous_line_ends_with_governing_negation(joined_previous)
+            ):
+                # When an uppercase-led line is joined only because the previous
+                # line was unterminated, a negation in the previous line should
+                # not govern a complete positive claim that starts on this line.
+                context_text = normalized
+                context_start -= previous_prefix_len
+                context_end -= previous_prefix_len
+            context = local_claim_context(context_text, context_start, context_end)
             if OVERCLAIM_ALLOW_RE.search(context):
                 continue
             hits.append((index, normalized))
@@ -257,6 +279,18 @@ def previous_line_opens_sentence(previous: str) -> bool:
     if not stripped or _BLOCK_LINE_PREFIX_RE.match(stripped):
         return False
     return stripped[-1] not in ".!?:;"
+
+
+WRAPPED_NEGATION_TRAILER_RE = re.compile(
+    r"(?i)\b(?:does\s+not|do\s+not|should\s+not|must\s+not|can\s*not|"
+    r"cannot|not|never|without|not\s+a|not\s+an)\s*$"
+)
+
+
+def previous_line_ends_with_governing_negation(previous: str) -> bool:
+    """True when a wrapped next line can inherit a trailing negation."""
+
+    return bool(WRAPPED_NEGATION_TRAILER_RE.search(previous.rstrip()))
 
 
 def local_claim_context(line: str, start: int, end: int) -> str:

--- a/tests/test_artifact_provenance.py
+++ b/tests/test_artifact_provenance.py
@@ -313,6 +313,17 @@ def test_command_path_detection_accepts_common_artifact_path_forms() -> None:
     )
 
 
+def test_command_outputs_path_detects_space_separated_redirection_and_tee() -> None:
+    path = "data/certificates/example.json"
+    # Space-separated shell redirection writes were previously missed.
+    assert command_outputs_path(f"python generator.py > {path}", path)
+    assert command_outputs_path(f"python generator.py 2>> {path}", path)
+    assert command_outputs_path(f"python generator.py | tee {path}", path)
+    # Reading a path (positional arg or input redirection) is not an output.
+    assert not command_outputs_path(f"python checker.py {path}", path)
+    assert not command_outputs_path(f"python checker.py < {path}", path)
+
+
 def test_manifest_accepts_exact_certificate_diagnostic_trust(tmp_path: Path) -> None:
     artifact = tmp_path / "artifact.json"
     generator = tmp_path / "generator.py"

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -78,6 +78,16 @@ def test_forbidden_overclaim_detector_does_not_carry_block_line_negation() -> No
     )
 
 
+def test_forbidden_overclaim_detector_does_not_borrow_previous_line_negation() -> None:
+    # Uppercase-led next-line claims are joined for scanning, but a negation in
+    # the previous line must not govern a complete positive claim on this line.
+    for text in (
+        "No status change\nWe have proven Erdos Problem #97.",
+        "Cannot stress enough\nWe have proven Erdos Problem #97.",
+    ):
+        assert find_forbidden_overclaim_lines(text), text
+
+
 def test_forbidden_overclaim_detector_keeps_governing_negation() -> None:
     # A negation that genuinely governs the verb in its own clause stays allowed.
     assert find_forbidden_overclaim_lines("This does not prove Erdos Problem #97.") == []

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -34,3 +34,35 @@ def test_forbidden_overclaim_detector_allows_explicit_nonclaims() -> None:
     )
 
     assert find_forbidden_overclaim_lines(text) == []
+
+
+def test_forbidden_overclaim_detector_blocks_known_evasions() -> None:
+    # A negation in a different comma/colon/dash clause must not excuse the claim.
+    assert find_forbidden_overclaim_lines(
+        "Summary - no longer open: we have proven Erdos Problem #97"
+    )
+    assert find_forbidden_overclaim_lines(
+        "Cannot stress enough, we have proven Erdos Problem #97 today"
+    )
+    # Synonym proof/refutation verbs applied to the global target.
+    for line in (
+        "We resolved Erdos Problem #97.",
+        "We have refuted the conjecture.",
+        "We have settled the problem.",
+    ):
+        assert find_forbidden_overclaim_lines(line), line
+    # An uppercase-led wrapped continuation line still joins to the claim verb.
+    assert find_forbidden_overclaim_lines(
+        "We have constructed a valid\nCounterexample to the conjecture."
+    )
+
+
+def test_forbidden_overclaim_detector_keeps_governing_negation() -> None:
+    # A negation that genuinely governs the verb in its own clause stays allowed.
+    assert find_forbidden_overclaim_lines("This does not prove Erdos Problem #97.") == []
+    assert (
+        find_forbidden_overclaim_lines(
+            "minimality produces a remaining center; this is not a counterexample."
+        )
+        == []
+    )

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -57,6 +57,27 @@ def test_forbidden_overclaim_detector_blocks_known_evasions() -> None:
     )
 
 
+def test_forbidden_overclaim_detector_does_not_carry_block_line_negation() -> None:
+    # A negation on a heading / list item / block quote must NOT be joined to a
+    # following standalone overclaim and excuse it (regression for the wrap-join).
+    assert find_forbidden_overclaim_lines(
+        "## Not solved\nWe have proven Erdos Problem #97."
+    )
+    assert find_forbidden_overclaim_lines(
+        "- not yet\nWe have proven Erdos Problem #97."
+    )
+    assert find_forbidden_overclaim_lines(
+        "> not a proof\nWe have proven Erdos Problem #97."
+    )
+    # A genuine wrapped prose sentence with a governing negation is still allowed.
+    assert (
+        find_forbidden_overclaim_lines(
+            "This fixed-pattern obstruction does not\nProve Erdos Problem #97."
+        )
+        == []
+    )
+
+
 def test_forbidden_overclaim_detector_keeps_governing_negation() -> None:
     # A negation that genuinely governs the verb in its own clause stays allowed.
     assert find_forbidden_overclaim_lines("This does not prove Erdos Problem #97.") == []


### PR DESCRIPTION
## Summary

Implements the safe, self-contained findings from the deep review in `reports/deep-review-2026-06-28.md` (PR #865). All changes are guardrail-hardening / hygiene — **no mathematical claim, certificate, or generated artifact is touched**, and `make verify-fast` stays green.

## Implemented

**M1 — harden the overclaim-consistency guardrail** (`scripts/check_status_consistency.py`)
The forbidden-overclaim detector (run in `verify-fast` / PR CI on README/STATE/RESULTS + metadata) had confirmed bypasses, now closed:
- a negation token in a *different* comma/colon/dash clause no longer excuses the claim (clause boundary now splits on `:` `,` and spaced dashes);
- a sentence hand-wrapped onto an uppercase-led continuation line is now joined;
- common proof/refutation synonyms (`resolved`, `refuted`, `settled` forms, …) are now in the global-target verb set, which is also factored into one shared alternation (removing a latent forward/reverse duplication).
The counterexample-verb set is kept **deliberately narrow**: "counterexample" is a pervasive technical term here ("minimal counterexample", "certified counterexample"), so broadening it produces false positives. New regression tests cover the newly-blocked evasions and confirm governing negations stay allowed.

**M6 — provenance guard detects space-separated redirection writes** (`scripts/check_artifact_provenance.py`)
`command_outputs_path` returned `False` for `gen.py > path` (space-separated), so the "generated artifact must have a replaying `check_command`" rule wasn't enforced for that write form. Redirect (`>`/`>>`, optional fd) and `tee` are now folded into the path-token detection; the now-dead branch is removed; reads (`< path`, positional args) stay non-outputs. Regression test added.

**M3 — remove duplicate Lean lemmas** (`lean/Erdos97/WitnessLemmas.lean`)
`WitnessLemmas.lean` re-declared the six reverse-orientation `Witness4.*` distinctness lemmas already in `Basic.lean` (imported transitively via `SelectedWitness`), which would break `lake build` with duplicate declarations. The redundant section is dropped; the rest of the file is unique and downstream uses resolve to `Basic`'s identical lemmas.

**Low cleanups**
- Align the B12 near-miss spread label in README/STATE to the canonical "selected-distance spread" used in RESULTS and `docs/verification-contract.md`.
- List `WitnessLemmas.lean` and `TwoCircleCap.lean` in `docs/formalization.md`.

## Deferred (with rationale)

- **M2 (widen the overclaim scan to all `docs/` and `docs/claims.md`) — NOT done; it is not a safe mechanical change.** Running the detector across the corpus flags ~100 lines, essentially all legitimate: "minimal counterexample" as a technical term, "a counterexample to the [sub-claim]", "Erdos #97 is proved" inside *forbidden-outcome lists*, "A certified counterexample must include…" requirements, "does not prove … Erdos #97". A blanket scope extension would break CI on legitimate prose. Doing M2 properly requires making the detector context-aware (distinguishing technical/negated/list/requirement forms from genuine claims) — a deliberate design task, not a one-line scope flip.
- **M4 (restore the dropped `validate_strict_inequality_support` self-check to the templated `t02`–`t09` packets) — deferred.** The check validates template-specific nested-chord support data; restoring it correctly means matching each template's stored strict-inequality schema. A half-correct check on review-pending proof-mining code would be worse than the gap, so this needs focused per-template work + verification.
- **M5 (run the `artifact`-marked certificate test tier in PR CI) — deferred to a maintainer call.** It adds 537 tests to every PR (a real CI-runtime tradeoff); it already runs in the scheduled/manual `artifact-audit` workflow.

## Verification
- `check_text_clean`, `check_status_consistency`, `check_artifact_provenance`, `git diff --check`, `ruff` — all pass.
- Targeted + affected tests pass (status-consistency, artifact-provenance, run_artifact_audit, audit-path, lean); new regression tests added for M1 and M6. Full default `pytest` re-run in progress locally and on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAUPaZBZ9iGxLnHUYZeDnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUPaZBZ9iGxLnHUYZeDnx)_