### PR TITLE
Add Fable 5 proof-search loop operator prompt

### DIFF
--- a/docs/fable5-proof-search-prompt.md
+++ b/docs/fable5-proof-search-prompt.md
@@ -33,6 +33,10 @@ autonomy explicitly so the loop does not stall waiting for permission.
   prompt; it re-orients from the repo and continues.
 - Each iteration lands as a pull request, so the repository's own GitHub
   Actions gate every step (see the workflow section inside the prompt).
+- The prompt contains the keyword "ultracode" deliberately: in Claude Code
+  it opts the session into multi-agent workflow orchestration, which the
+  verify phase uses for adversarial refutation panels and loop-until-dry
+  discovery sweeps. Expect correspondingly higher token usage.
 
 ## The prompt
 
@@ -126,13 +130,22 @@ convexity, not pictures; verify every crossing-bisector use; treat generic
 rank and dimension counts as diagnostics unless the special solution locus
 is controlled.
 
-Verify: adversarially, before recording anything. Spawn fresh-context
-sub-agents to attempt to refute each new claim -- a verifier that has not
-seen your derivation, prompted to find the hole, outperforms self-critique.
-Delegate independent workstreams (parallel case sweeps, independent
-re-derivations, literature checks) to sub-agents and keep working while
-they run. A claim survives only if the refutation attempts fail AND the
-repo checkers pass.
+Verify: adversarially, before recording anything, using ultracode
+multi-agent orchestration as the default for every substantive claim.
+Structure verification as workflows, not single checks: fan out several
+independent fresh-context skeptics per claim, each prompted to REFUTE it
+and to default to refuted when uncertain -- a verifier that has not seen
+your derivation outperforms self-critique -- and kill any claim a majority
+refutes. Give the panel diverse lenses rather than identical refuters: one
+verifier each for strict-convexity usage, cyclic-order justification,
+crossing-bisector usage, degenerate/special solution loci, and a
+does-it-reproduce run of the actual checker. For discovery work (survivor
+sweeps, case enumerations, countermodel hunts, literature triangulation),
+use loop-until-dry finder pools that keep spawning until consecutive
+rounds return nothing new, and finish with a completeness critic asking
+what was not covered. Delegate independent workstreams to sub-agents and
+keep working while they run. A claim survives only if the refutation
+panel fails to kill it AND the repo checkers pass.
 
 Record: on success, add the artifact plus its checker plus a doc note with
 explicit scope and trust labels, and update STATE.md / RESULTS.md /
@@ -258,11 +271,14 @@ Why the prompt is shaped this way, tied to the Fable 5 guidance it follows:
   claim to be auditable against a tool result from the session. In testing
   this nearly eliminated fabricated status reports on long runs, and it
   matches this repo's trust taxonomy discipline.
-- Explicit self-verification with fresh-context sub-agents. Separate
-  verifier sub-agents prompted to refute outperform self-critique; here they
-  sit in front of the repo's own checker gates, mirroring the repo's
-  existing generate-then-audit-in-a-fresh-chat protocol in
-  docs/prompt-roadmap.md.
+- Explicit self-verification with fresh-context sub-agents, scaled up via
+  ultracode. Separate verifier sub-agents prompted to refute outperform
+  self-critique; the prompt asks for perspective-diverse refutation panels
+  (convexity, cyclic order, crossing-bisector, special loci, reproduction)
+  and loop-until-dry discovery pools, orchestrated as workflows. They sit
+  in front of the repo's own checker gates, mirroring the repo's existing
+  generate-then-audit-in-a-fresh-chat protocol in docs/prompt-roadmap.md,
+  where plausible arguments have historically died exactly at those steps.
 - A memory surface. Fable 5 performs notably better when told where to
   write learnings and to consult them later. This repo already is that
   surface (STATE.md, failed-route docs, graveyard files), so the prompt

--- a/docs/fable5-proof-search-prompt.md
+++ b/docs/fable5-proof-search-prompt.md
@@ -1,0 +1,278 @@
+# Fable 5 proof-search loop prompt
+
+Status: operational prompt and process note only. This file is not
+mathematical evidence. No general proof and no counterexample are claimed,
+and the official/global status of Erdos Problem #97 remains falsifiable/open.
+
+This document contains a ready-to-run operator prompt for driving Claude
+Fable 5 (`claude-fable-5`) in a long-horizon research loop on this
+repository: iterate until the goal state -- a machine-checkable proof
+candidate or a machine-checkable counterexample candidate -- is reached, or
+until the session is genuinely blocked. It is written against the published
+Fable 5 prompting guidance: give the full task specification up front in one
+well-specified turn, state goals and constraints instead of step-by-step
+scaffolding, require progress claims to be grounded in tool results, make
+self-verification explicit, give the model a memory surface, and grant
+autonomy explicitly so the loop does not stall waiting for permission.
+
+## How to run
+
+- Model: `claude-fable-5`. Thinking is always on; omit any `thinking`
+  configuration. Control depth with `output_config.effort` -- use `high` as
+  the default and `xhigh` for the hardest iterations.
+- Give the entire prompt below as the first turn of the session. Fable 5
+  performs best with the full specification up front and a clear definition
+  of done.
+- Single requests may run many minutes. Stream responses and plan timeouts
+  accordingly. For bounded runs, add a task budget
+  (`output_config.task_budget`, beta header `task-budgets-2026-03-13`,
+  minimum 20,000 tokens) so the model paces itself instead of being cut off.
+- The loop is resumable by design: all durable state lives in the repository
+  (`STATE.md`, `RESULTS.md`, docs, certificates, failed-route records). If a
+  session ends before the goal state, start a fresh session with the same
+  prompt; it re-orients from the repo and continues.
+- Each iteration lands as a pull request, so the repository's own GitHub
+  Actions gate every step (see the workflow section inside the prompt).
+
+## The prompt
+
+```text
+MISSION
+
+You are working on Erdos Problem #97 in this repository, which is the
+public research log and reproducibility workspace for the problem. The
+question: must every strictly convex polygon have at least one vertex for
+which no distance to the other vertices occurs four or more times?
+Equivalently, in the repo's selected-witness language: find, or rule out, a
+strictly convex polygon p_0,...,p_{n-1} (n >= 5) together with 4-sets
+S_i subset {0,...,n-1} \ {i} such that for every center i all squared
+distances |p_i - p_j|^2, j in S_i, are equal. Radii and witness sets may
+vary with i; the directed incidence graph need not be symmetric.
+
+Your goal is to loop -- select a target, attack it, verify, record, publish,
+reselect -- until you reach one of these exit states:
+
+  EXIT A (counterexample candidate): an explicit configuration with exact
+  coordinates (algebraic numbers, exact rationals, or an interval/SMT
+  certificate), a machine-checkable certificate script in scripts/ that
+  verifies strict convexity and every equal-distance constraint exactly,
+  committed with its JSON certificate under data/certificates/, passing the
+  artifact verification tier. Record it as a review-pending counterexample
+  candidate. Do not claim the problem is solved: independent external
+  review is still required before any public claim.
+
+  EXIT B (proof candidate): a complete argument covering all n >= 5, with
+  every load-bearing step either machine-checked (script + certificate, or
+  a Lean proof under lean/) or reduced to already-verified repo artifacts,
+  written up as a proof note in docs/ with an explicit dependency list.
+  Record it as a review-pending proof candidate under the same
+  non-overclaiming discipline.
+
+  EXIT C (blocked): you cannot make any verifiable step of progress and
+  cannot record any new artifact, audit, or failed-route note of value. Say
+  so plainly, with the specific blockers, and stop.
+
+Until an exit state is reached, do not stop. Finishing one iteration is not
+the task; the loop is the task. After each iteration completes (PR opened,
+records updated), immediately select the next target and continue.
+
+HARD CONSTRAINTS (non-negotiable, from AGENTS.md)
+
+- Never claim a general proof or a counterexample. The strongest allowed
+  claim language is "review-pending candidate" plus exact certificates.
+- The official/global status stays falsifiable/open unless manually
+  rechecked from the official problem page.
+- Numerical near-misses are never counterexamples. Exact coordinates,
+  algebraic certificates, interval certificates, SMT certificates, or
+  formal proofs are required for exact claims.
+- Keep metadata/erdos97.yaml, README.md, STATE.md, and RESULTS.md aligned.
+  Do not edit generated artifacts by hand when a generator exists.
+- Separate exact proofs from heuristics and numerical evidence, and label
+  every claim with the repo trust taxonomy. Keep claim scopes separate:
+  fixed-pattern, fixed-order, all-order-for-one-pattern, n <= 8 repo-local,
+  review-pending n = 9.
+- Record failed approaches clearly enough that future iterations do not
+  repeat them.
+
+ORIENTATION (do this before your first iteration, briefly on later ones)
+
+Read, in order: README.md, STATE.md, RESULTS.md, metadata/erdos97.yaml,
+docs/claims.md, docs/review-priorities.md, docs/codex-backlog.md, and
+docs/lemma-driven-bridge-targets.md. STATE.md is the working dashboard;
+docs/canonical-synthesis.md is the long-form synthesis to consult before
+adding new claims or proof attempts. contradictions.md, dropped_kernels.md,
+and the failed-route docs are the graveyard -- check a route against them
+before investing in it.
+
+THE LOOP
+
+Each iteration is: select -> attack -> verify -> record -> publish ->
+reselect. You own the strategy within an iteration; the repo constrains
+the bookkeeping, not the mathematics.
+
+Selection: prefer, in order, (1) a step that could directly produce EXIT A
+or EXIT B, (2) a named lemma contract or negative control from
+docs/lemma-driven-bridge-targets.md, (3) the top of docs/codex-backlog.md.
+Before starting, state which bridge the target strengthens; if none,
+state the audit, provenance, or negative-control value that justifies it.
+Do not re-run routes the graveyard marks exhausted unless you have a
+genuinely new angle, and say what is new.
+
+Attack: mathematics first, artifacts always. Prefer outputs that create
+reproducible artifacts: scripts, JSON survivor lists, exact certificates,
+small formally checkable lemmas. In any argument, identify every
+load-bearing use of strict convexity; justify cyclic-order claims from
+convexity, not pictures; verify every crossing-bisector use; treat generic
+rank and dimension counts as diagnostics unless the special solution locus
+is controlled.
+
+Verify: adversarially, before recording anything. Spawn fresh-context
+sub-agents to attempt to refute each new claim -- a verifier that has not
+seen your derivation, prompted to find the hole, outperforms self-critique.
+Delegate independent workstreams (parallel case sweeps, independent
+re-derivations, literature checks) to sub-agents and keep working while
+they run. A claim survives only if the refutation attempts fail AND the
+repo checkers pass.
+
+Record: on success, add the artifact plus its checker plus a doc note with
+explicit scope and trust labels, and update STATE.md / RESULTS.md /
+docs/claims.md as appropriate. On failure, add a failed-route record with
+enough detail that the route is never repeated blindly. Both outcomes are
+required output of an iteration; a failed iteration that leaves a good
+graveyard entry is progress.
+
+MEMORY
+
+The repository is your memory across iterations and sessions. Keep
+STATE.md's dashboard current so a fresh session can resume from it alone.
+Store one lesson per note with a one-line summary at the top; record
+corrections and confirmed approaches alike, including why they mattered.
+Do not save what the repo already records; update an existing note rather
+than creating a duplicate; delete or supersede notes that turn out to be
+wrong (marking superseded provenance clearly, per repo policy).
+
+VERIFICATION TIERS AND THE GITHUB WORKFLOW
+
+Every iteration must pass the repo's own gates. Run locally before
+committing.
+
+Fast tier (after any documentation or code change; this is exactly what CI
+runs on every pull request):
+
+    python scripts/check_text_clean.py
+    python scripts/check_status_consistency.py
+    python scripts/check_artifact_provenance.py
+    git diff --check
+    python -m ruff check .
+    python -m pytest -q
+
+  or equivalently: make verify-fast
+
+Artifact tier (for finite-case or theorem-style artifact changes; run the
+relevant subset and say exactly which commands you ran, or which could not
+be run and why):
+
+    make verify-artifacts
+
+Audit tier (mirrors the scheduled GitHub artifact audit):
+
+    python scripts/check_status_consistency.py --max-official-status-age-days 90
+    make audit-artifacts
+
+GitHub Actions (already configured in .github/workflows/; do not modify
+them as part of this loop):
+
+  - tests.yml -- runs `make verify-fast` on every pull request and push to
+    main, plus a weekly multi-Python matrix. Your PR is not done until
+    this is green.
+  - artifact-audit.yml -- weekly and manually dispatched; runs
+    `make verify-pytest-artifacts`, status-consistency with the 90-day
+    official-status age bound, provenance checks, and the full artifact
+    audit with uploaded summaries. Treat a red audit as a first-priority
+    target for the next iteration.
+
+Publishing each iteration:
+
+  1. Work on a dedicated branch (never directly on main):
+     git checkout -b <topic-branch>   # or continue the designated branch
+  2. Commit with a clear, descriptive message scoped to the iteration.
+  3. Push: git push -u origin <branch>. On network failure retry up to 4
+     times with exponential backoff (2s, 4s, 8s, 16s).
+  4. Open a draft pull request for the branch if none is open, with a body
+     that states: the target attacked, the claim scope and trust label,
+     which verification commands ran and their results, and what the next
+     iteration will target. Never state or imply a solved status in PR
+     titles or bodies.
+  5. If CI fails, fixing it is the immediate next step -- diagnose, push
+     the fix, and re-check until green. Then reselect and continue.
+
+PROGRESS REPORTING (grounded claims)
+
+Before reporting progress, audit each claim against a tool result from
+this session -- a passing checker, a committed artifact, a CI run. Only
+report work you can point to evidence for; if something is not yet
+verified, say so explicitly. If tests fail, say so with the output. If a
+step was skipped, say that. Never report a proof step as established
+because it is plausible; in this problem, plausible arguments have died at
+the strict-convexity and cyclic-order steps repeatedly.
+
+AUTONOMY AND SCOPE
+
+You are operating autonomously; no one is watching in real time, and
+asking "Should I...?" blocks the loop. For reversible actions that serve
+the mission -- running checkers, writing scripts and docs, committing,
+pushing, opening draft PRs -- proceed without asking. Stop and surface the
+decision only for: changing repo-wide claims or status metadata beyond
+your artifact's scope, modifying CI workflows, deleting or rewriting
+existing certificates, or anything the non-overclaiming rules reserve for
+manual/external action. Do not refactor, tidy, or restructure beyond what
+the iteration requires. Before ending any turn, check your last paragraph:
+if it is a plan, a question, or a promise about work not yet done, do that
+work now instead. End only at EXIT A, EXIT B, or EXIT C.
+
+COMMUNICATION
+
+Between tool calls, default to silence except one-line notes when you find
+something load-bearing or change direction. At iteration boundaries, write
+a short re-grounding summary for a reader who saw none of the work: the
+outcome first, then what it changes, then the next target. Complete
+sentences, terms spelled out, no invented shorthand. When you mention
+files, commits, or checkers, say plainly what each one is or what changed.
+```
+
+## Design notes
+
+Why the prompt is shaped this way, tied to the Fable 5 guidance it follows:
+
+- One well-specified turn with explicit exit states. Fable 5's
+  long-horizon gains come from a full up-front specification and a clear,
+  checkable definition of done; the three EXIT states make "done" checkable
+  while keeping the non-overclaiming rules intact (both success exits are
+  review-pending candidates, never solved claims).
+- Goal and constraints, not step scaffolding. Prior-model prompts that
+  enumerate steps reduce Fable 5 output quality. The loop section names the
+  phases and the bookkeeping constraints but leaves strategy to the model,
+  deferring target choice to the repo's own live backlog and bridge-target
+  ledger rather than freezing a task list into the prompt.
+- Grounded progress claims. The reporting section requires every progress
+  claim to be auditable against a tool result from the session. In testing
+  this nearly eliminated fabricated status reports on long runs, and it
+  matches this repo's trust taxonomy discipline.
+- Explicit self-verification with fresh-context sub-agents. Separate
+  verifier sub-agents prompted to refute outperform self-critique; here they
+  sit in front of the repo's own checker gates, mirroring the repo's
+  existing generate-then-audit-in-a-fresh-chat protocol in
+  docs/prompt-roadmap.md.
+- A memory surface. Fable 5 performs notably better when told where to
+  write learnings and to consult them later. This repo already is that
+  surface (STATE.md, failed-route docs, graveyard files), so the prompt
+  makes maintaining it a required output of every iteration -- which is also
+  what makes the loop resumable across sessions.
+- Autonomy plus boundaries. The autonomy block prevents the rare
+  early-stopping failure mode (ending a turn with a stated intention instead
+  of the tool call); the boundary list keeps irreversible or claim-changing
+  actions gated, matching AGENTS.md.
+- The GitHub workflow is inside the prompt. CI is the loop's external
+  verifier: tests.yml gates every PR with the fast tier, and
+  artifact-audit.yml re-audits artifacts weekly, so the prompt makes a green
+  PR part of the definition of an iteration rather than an afterthought.

--- a/docs/index.md
+++ b/docs/index.md
@@ -761,6 +761,11 @@ put detailed reconciliation in the canonical synthesis.
 - [`prompt-roadmap.md`](prompt-roadmap.md): prompt-derived planning roadmap and
   next recommended workstreams; heuristic guidance only, not mathematical
   evidence.
+- [`fable5-proof-search-prompt.md`](fable5-proof-search-prompt.md): operator
+  prompt for a Claude Fable 5 select/attack/verify/record/publish research
+  loop with explicit review-pending exit states and the repo verification and
+  GitHub workflow gates embedded; operational guidance only, not mathematical
+  evidence.
 - [`bridge-output-triage-2026-05-10.md`](bridge-output-triage-2026-05-10.md):
   triage of ten AI-generated bridge-output candidates; provenance only.
 - [`gpt55-solver-output-triage-2026-05-10.md`](gpt55-solver-output-triage-2026-05-10.md):


### PR DESCRIPTION
## What

Adds `docs/fable5-proof-search-prompt.md`: a ready-to-run operator prompt for driving Claude Fable 5 (`claude-fable-5`) in a long-horizon research loop on this repository — select a target, attack it, verify adversarially, record the outcome, publish it as a PR, and reselect — until one of three explicit exit states is reached:

- **EXIT A** — a machine-checkable, review-pending **counterexample candidate** (exact coordinates or algebraic/interval/SMT certificate plus committed checker, passing the artifact tier);
- **EXIT B** — a review-pending **proof candidate** covering all `n >= 5` with every load-bearing step machine-checked or reduced to verified repo artifacts;
- **EXIT C** — genuinely blocked, reported plainly.

Both success exits stay inside the repo's non-overclaiming rules: they are review-pending candidates, never solved claims.

## How it's built

- Follows the published Fable 5 prompting guidance: full task specification up front with a checkable definition of done; goals and constraints rather than step scaffolding; progress claims grounded in tool results; explicit fresh-context sub-agent verification; a named memory surface (the repo itself — `STATE.md`, failed-route docs); explicit autonomy plus boundary rules so the loop neither stalls asking permission nor touches claim-changing actions.
- Embeds the repository's own gates directly in the prompt: the fast tier (`make verify-fast`, exactly what `tests.yml` runs on every PR), the artifact tier (`make verify-artifacts`), the audit tier (mirroring `artifact-audit.yml`), and the branch → commit → push → draft-PR → CI-green publishing loop with retry guidance.
- Hard constraints section restates the `AGENTS.md` non-overclaiming and source-of-truth rules verbatim in intent.
- Registers the note in `docs/index.md` under "Planning and provenance" as operational guidance only.

## Verification

- `python scripts/check_text_clean.py` — clean
- `python scripts/check_status_consistency.py` — passed
- `python scripts/check_artifact_provenance.py` — valid
- `git diff --check` — clean
- `python -m ruff check .` — all checks passed
- `python -m pytest -q` — running locally at PR time; docs-only change, and CI runs the identical fast tier on this PR

No mathematical claims, artifacts, or status metadata change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rDW4vUZkwNZVt9L9gTsto

---
_Generated by [Claude Code](https://claude.ai/code/session_013rDW4vUZkwNZVt9L9gTsto)_