### PR TITLE
[codex] Fix review artifact checks on Windows

### DIFF
--- a/docs/n9-groebner-decoders.md
+++ b/docs/n9-groebner-decoders.md
@@ -125,8 +125,15 @@ Running
 python3 scripts/decode_n9_groebner_f07_f13.py
 ```
 
-with sympy 1.14.0 (the version pinned in `requirements-lock.txt`) writes
-`data/certificates/n9_groebner_real_root_decoders.json` and prints
+with sympy 1.14.0 (the version pinned in `requirements-lock.txt`) regenerates
+and writes `data/certificates/n9_groebner_real_root_decoders.json`. To verify
+the committed artifact without rewriting timing fields, run
+
+```bash
+python3 scripts/decode_n9_groebner_f07_f13.py --check
+```
+
+Both modes print
 
 ```
 [F07] grevlex GB: 62 polys, zero-dim=True
@@ -155,12 +162,11 @@ exists in the variety of any of the four families.
 ## Verifier instructions
 
 1. Confirm `requirements-lock.txt` lists `sympy==1.14.0` and install it.
-2. Run `python3 scripts/decode_n9_groebner_f07_f13.py`.
-3. Diff the output JSON against the committed
-   `data/certificates/n9_groebner_real_root_decoders.json`. The artifact
-   should reproduce bit-for-bit modulo wall-clock fields
-   (`grevlex_basis_seconds`, `wall_time_seconds`,
-   `univariate_elimination.lex_basis_seconds`).
+2. Run `python3 scripts/decode_n9_groebner_f07_f13.py --check`.
+3. Confirm the check reports no non-timing drift from the committed
+   `data/certificates/n9_groebner_real_root_decoders.json`. The checker
+   ignores volatile wall-clock fields (`grevlex_basis_seconds`,
+   `wall_time_seconds`, and `univariate_elimination.lex_basis_seconds`).
 4. Sanity-check the polynomial system in the artifact against the witness
    rows in `data/certificates/2026-05-05/n9_groebner_results.json`: every
    `polys[k]` should be the difference of two squared-distance polynomials

--- a/docs/n9-reduction-chain.md
+++ b/docs/n9-reduction-chain.md
@@ -172,7 +172,7 @@ python scripts/check_n9_turn_inequality_frontier.py --check --assert-expected --
 For the algebraic cross-audit:
 
 ```bash
-python scripts/decode_n9_groebner_f07_f13.py
+python scripts/decode_n9_groebner_f07_f13.py --check
 ```
 
 These commands are review aids. Passing them does not, by itself, complete

--- a/docs/n9-review-packet.md
+++ b/docs/n9-review-packet.md
@@ -194,7 +194,7 @@ Optional corroborating commands:
 ```bash
 python scripts/independent_n9_vertex_circle_recheck.py --json
 python scripts/check_n9_vertex_circle_compact_brancher.py --check --assert-expected --json
-python scripts/decode_n9_groebner_f07_f13.py
+python scripts/decode_n9_groebner_f07_f13.py --check
 ```
 
 ## Expected invariants

--- a/scripts/check_n10_fast_cpp_singleton_replay.py
+++ b/scripts/check_n10_fast_cpp_singleton_replay.py
@@ -85,9 +85,9 @@ def digest_json(payload: Any) -> str:
 
 def display_path(path: Path) -> str:
     try:
-        return str(path.relative_to(ROOT))
+        return path.resolve().relative_to(ROOT).as_posix()
     except ValueError:
-        return str(path)
+        return path.as_posix()
 
 
 def normalize_primary_rows(primary: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/scripts/check_n9_selected_witness_combined_replay.py
+++ b/scripts/check_n9_selected_witness_combined_replay.py
@@ -99,6 +99,15 @@ Row = tuple[int, ...]
 Assignment = dict[int, int]
 
 
+def repo_path(path: Path) -> str:
+    """Return a stable repo-relative path for JSON artifacts."""
+
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
 @dataclass(frozen=True)
 class CombinedReplayResult:
     """Generated summary and certificate payloads."""
@@ -573,7 +582,7 @@ def generate_replay(*, include_components: bool = False) -> CombinedReplayResult
         "pair_cap": PAIR_CAP,
         "localized_counting": localized_counting_summary(N),
         "brancher": brancher_summary,
-        "certificate_artifact": str(DEFAULT_CERTIFICATES_ARTIFACT.relative_to(ROOT)),
+        "certificate_artifact": repo_path(DEFAULT_CERTIFICATES_ARTIFACT),
         "certificate_count": len(assignment_certificates),
         "certificate_digest_sha256": certificate_digest,
         "validation_status": "passed" if not errors else "failed",
@@ -592,7 +601,7 @@ def generate_replay(*, include_components: bool = False) -> CombinedReplayResult
         "status": CERTIFICATE_STATUS,
         "trust": TRUST,
         "claim_scope": CERTIFICATE_CLAIM_SCOPE,
-        "source_summary_artifact": str(DEFAULT_ARTIFACT.relative_to(ROOT)),
+        "source_summary_artifact": repo_path(DEFAULT_ARTIFACT),
         "certificate_count": len(assignment_certificates),
         "certificate_digest_sha256": certificate_digest,
         "certificates": assignment_certificates,

--- a/scripts/decode_n9_groebner_f07_f13.py
+++ b/scripts/decode_n9_groebner_f07_f13.py
@@ -44,7 +44,7 @@ import itertools
 import json
 import time
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 import sympy as sp
 from sympy import (
@@ -62,6 +62,31 @@ SOURCE_GROEBNER = ROOT / "data" / "certificates" / "2026-05-05" / "n9_groebner_r
 DEFAULT_OUT = ROOT / "data" / "certificates" / "n9_groebner_real_root_decoders.json"
 
 TARGET_FAMILIES = ("F07", "F08", "F09", "F13")
+TIMING_KEYS = {
+    "wall_time_seconds",
+    "grevlex_basis_seconds",
+    "lex_basis_seconds",
+}
+
+
+def without_timing_fields(payload: Any) -> Any:
+    """Return payload with volatile runtime measurements removed."""
+
+    if isinstance(payload, dict):
+        return {
+            key: without_timing_fields(value)
+            for key, value in payload.items()
+            if key not in TIMING_KEYS
+        }
+    if isinstance(payload, list):
+        return [without_timing_fields(item) for item in payload]
+    return payload
+
+
+def json_shape(payload: Any) -> Any:
+    """Normalize tuples and other JSON-serializable values to loaded-JSON shape."""
+
+    return json.loads(json.dumps(payload))
 
 
 def build_system(rows: list[list[int]], n: int = 9):
@@ -351,6 +376,11 @@ def decode_family(family: dict, *, lex_budget: float = 600.0):
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", default=str(DEFAULT_OUT))
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="regenerate and compare with --out without rewriting the artifact",
+    )
     parser.add_argument("--lex-budget", type=float, default=600.0,
                         help="seconds before lex GB is considered slow (informational)")
     args = parser.parse_args()
@@ -407,11 +437,21 @@ def main() -> int:
         ),
     }
     out_path = Path(args.out)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with out_path.open("w", encoding="utf-8", newline="\n") as fh:
-        json.dump(summary, fh, indent=2, sort_keys=False)
-        fh.write("\n")
-    print(f"\nwrote {out_path}")
+    if args.check:
+        with out_path.open("r", encoding="utf-8") as fh:
+            stored = json.load(fh)
+        generated = json_shape(summary)
+        if without_timing_fields(stored) != without_timing_fields(generated):
+            raise AssertionError(
+                f"regenerated decoder artifact differs outside timing fields: {out_path}"
+            )
+        print(f"\nchecked {out_path} (ignoring runtime timing fields)")
+    else:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8", newline="\n") as fh:
+            json.dump(summary, fh, indent=2, sort_keys=False)
+            fh.write("\n")
+        print(f"\nwrote {out_path}")
     print(f"total real solutions across F07/F08/F09/F13: {summary['headline']['total_real_solutions_across_families']}")
     print(f"strictly convex configurations: {summary['headline']['strictly_convex_solutions']}")
     return 0


### PR DESCRIPTION
## Summary

- Normalize review-artifact path fields to stable POSIX-style repo-relative paths so Windows runs compare cleanly against checked JSON.
- Add a non-writing `--check` mode for the n=9 Groebner decoder that ignores volatile timing fields.
- Update n=9 reviewer docs to use the non-writing Groebner check.

## Root Cause

Several review/check scripts serialized repo-relative paths with platform-native separators. On Windows this produced backslashes, while the committed artifacts use forward slashes. The Groebner decoder also rewrote timing fields during verification, dirtying the artifact despite no mathematical drift.

## Validation

Passing:

- `python scripts/check_n9_selected_witness_combined_replay.py --check --assert-expected --json`
- `python scripts/check_n10_fast_cpp_singleton_replay.py --check --json`
- `python scripts/decode_n9_groebner_f07_f13.py --check`
- `python -m pytest -q tests/test_n9_selected_witness_combined_replay.py tests/test_n10_fast_cpp_singleton_replay.py tests/test_n9_groebner_decoders.py`
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `git diff --check`
- `python -m ruff check .`

Known unrelated local full-suite issues on this Windows host:

- `tests/test_brp_boundary_probe.py::test_cli_default_artifact_check_is_reproducible` has a small floating boundary value mismatch.
- `tests/test_run_artifact_audit.py::test_audit_commands_cover_verify_artifacts_make_target` requires `make`, which is not installed in this shell.

No general proof, counterexample, or status promotion is claimed.