### PR TITLE
Add review-pending near-saturation support obstruction draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ reviewability fixes that affect how an external reader should interpret the
 repository. It is intentionally not a full git history. No general proof and no
 counterexample are claimed.
 
+## 2026-07-17
+
+- Corrected the slack-2 method-boundary records of the near-saturation
+  support obstruction draft after an internal adversarial review: the
+  earlier record claiming the turn count fails at `n = 8` was wrong (a
+  strict form of the turn count closes every slack-2 distribution except
+  two distinct unsaturated gap-2 diagonals, which always disconnect the
+  side-equality chain). The lemma-draft statement, proof steps, and all
+  sharpened counting consequences are unchanged; the artifact schema moved
+  to `v2` and the stored artifact was regenerated. Also normalized the
+  artifact's native trust field to the canonical
+  `REVIEW_PENDING_DIAGNOSTIC` class (dropping the one-off
+  `mismatch_overrides` entry), retitled the note's statement heading from
+  "Theorem" to "Lemma draft", fixed a citation that conflated the nonagon
+  profile-deficiency refinement with the localized per-label cap, added
+  the missing `n <= 7` raw-budget step to the uniform-threshold corollary,
+  added the verification-contract fields (known counterexample attempts,
+  3-neighbor survival), moved the RESULTS.md entry into its own
+  status-labeled subsection, queued the draft in
+  `docs/review-priorities.md`, and registered the new checker line in the
+  Makefile-chain and audit-order tests. No claim, scope, or status change
+  beyond the corrected boundary record.
+
 ## 2026-07-16
 
 - Added the review-pending near-saturation support obstruction draft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ reviewability fixes that affect how an external reader should interpret the
 repository. It is intentionally not a full git history. No general proof and no
 counterexample are claimed.
 
+## 2026-07-16
+
+- Added the review-pending near-saturation support obstruction draft
+  (`docs/near-saturation-support-obstruction.md`,
+  `scripts/check_near_saturation_support_obstruction.py`,
+  `data/certificates/near_saturation_support_obstruction.json`): the
+  edge-sensitive rich-support pair budget sharpens to
+  `sum_i binom(|R_i|,2) <= n(n-2) - 2` for strictly convex `n`-gons with
+  `n >= 8`, because pair-capacity slack `0` or `1` forces the
+  equilateral/turn-cover contradiction for arbitrary support-size
+  profiles. New counting floors: at least six exact-four centers in a
+  hypothetical 4-bad decagon (previously five) and at least four in a
+  hypothetical 4-bad hendecagon (previously three). Labeled
+  `LEMMA_DRAFT` / `REVIEW_PENDING`; not a proof of `n=9`, `n=10`,
+  `n=11`, or Erdos Problem #97, and no status change.
+
 ## 2026-07-10
 
 - Migrated the three 2026-07-02 all-`m` certificate manifest entries

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_bridge_lemma_frontier.py --check --assert-expected --json
 	$(PYTHON) scripts/check_rich_support_counting_bound.py --check --json
 	$(PYTHON) scripts/check_support_saturation_obstruction.py --check --json
+	$(PYTHON) scripts/check_near_saturation_support_obstruction.py --check --check-artifact --json
 	$(PYTHON) scripts/check_n12_rich_support_determinant.py --check --json
 	$(PYTHON) scripts/check_localized_rich_support_counting.py --check --json
 	$(PYTHON) scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -76,11 +76,14 @@ already closed by support saturation; it is not a proof of the full `n=12`
 case. See `docs/n12-rich-support-determinant-obstruction.md` and
 `scripts/check_n12_rich_support_determinant.py`.
 
-A review-pending near-saturation strengthening
-(`LEMMA_DRAFT` / `REVIEW_PENDING`) sharpens the same pair budget by two
-units for every `n >= 8`: pair-capacity slack `0` or `1` still forces the
-equilateral/turn-cover contradiction, with no assumption on the support-size
-profile, so
+### Near-saturation support obstruction
+
+Status: `LEMMA_DRAFT` / `REVIEW_PENDING`.
+
+A review-pending near-saturation strengthening sharpens the edge-sensitive
+pair budget above by two units for every `n >= 8`: pair-capacity slack `0`
+or `1` still forces the equilateral/turn-cover contradiction, with no
+assumption on the support-size profile, so
 
 ```text
 sum_i binom(|R_i|, 2) <= n(n - 2) - 2.
@@ -92,11 +95,16 @@ set still covers at least `ceil((n-1)/2) >= 4` turn indices. Consequences:
 a hypothetical 4-bad decagon has at least six exact-four centers (raw
 budget: five), a hypothetical 4-bad hendecagon has at least four (raw
 budget: three), and the uniform saturation thresholds
-`n >= binom(k,2) + 3` become direct budget corollaries. The method provably
-stops at slack `1`: two missing gap-2 units can disconnect the
-side-equality chain, and at `n = 8` two missing gap-3 units leave a
-forced-turn cover of size three, which is not a contradiction. This does
-not prove `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
+`n >= binom(k,2) + 3` become direct budget corollaries for `n >= 8`.
+
+The uniform statement stops at slack `1` because of exactly one method
+boundary: two distinct gap-2 diagonals each missing one unit disconnect the
+side-equality chain (a cycle minus two distinct edges is always
+disconnected), so the equilateral step fails. A strict form of the turn
+count (a proper forced-turn subset of size at least three already exceeds
+total turn `2*pi`) closes every other slack-2 distribution, but that
+remaining family keeps the claim at `n(n-2) - 2`. This does not prove
+`n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
 `docs/near-saturation-support-obstruction.md`,
 `scripts/check_near_saturation_support_obstruction.py`, and
 `data/certificates/near_saturation_support_obstruction.json`.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -76,6 +76,31 @@ already closed by support saturation; it is not a proof of the full `n=12`
 case. See `docs/n12-rich-support-determinant-obstruction.md` and
 `scripts/check_n12_rich_support_determinant.py`.
 
+A review-pending near-saturation strengthening
+(`LEMMA_DRAFT` / `REVIEW_PENDING`) sharpens the same pair budget by two
+units for every `n >= 8`: pair-capacity slack `0` or `1` still forces the
+equilateral/turn-cover contradiction, with no assumption on the support-size
+profile, so
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 2) - 2.
+```
+
+The slack-1 case survives one missing capacity unit because the
+side-equality chain is a cycle minus at most one edge and the forced-turn
+set still covers at least `ceil((n-1)/2) >= 4` turn indices. Consequences:
+a hypothetical 4-bad decagon has at least six exact-four centers (raw
+budget: five), a hypothetical 4-bad hendecagon has at least four (raw
+budget: three), and the uniform saturation thresholds
+`n >= binom(k,2) + 3` become direct budget corollaries. The method provably
+stops at slack `1`: two missing gap-2 units can disconnect the
+side-equality chain, and at `n = 8` two missing gap-3 units leave a
+forced-turn cover of size three, which is not a contradiction. This does
+not prove `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
+`docs/near-saturation-support-obstruction.md`,
+`scripts/check_near_saturation_support_obstruction.py`, and
+`data/certificates/near_saturation_support_obstruction.json`.
+
 ### Lemma: crossing-bisector and sharpened count
 
 Status: `EXACT_OBSTRUCTION`.

--- a/STATE.md
+++ b/STATE.md
@@ -314,14 +314,17 @@ on the support-size profile, so `sum_i binom(|R_i|, 2) <= n(n-2) - 2`. This
 raises the counting floors to at least six exact-four centers in a
 hypothetical 4-bad decagon and at least four in a hypothetical 4-bad
 hendecagon, and it recovers the uniform saturation thresholds
-`n >= binom(k,2) + 3` as direct budget corollaries. The draft records why
-the method stops at slack `1`. It does not extend the `n=9` conclusions,
-does not prove `n=9`, `n=10`, or `n=11`, and does not change any
-finite-case or global status. See
+`n >= binom(k,2) + 3` as direct budget corollaries. The draft records the
+exact method boundary that keeps the uniform statement at slack `1`: two
+distinct unsaturated gap-2 diagonals disconnect the side-equality chain,
+while a strict turn count closes every other slack-2 distribution. It does
+not extend the `n=9` conclusions, does not prove `n=9`, `n=10`, or `n=11`,
+and does not change any finite-case or global status. See
 `docs/near-saturation-support-obstruction.md` and
 `data/certificates/near_saturation_support_obstruction.json`.
 
-The follow-up mixed rich-support reduction enumerates every four- or
+A follow-up to the sharpened counting lemma above, the mixed rich-support
+reduction, enumerates every four- or
 five-witness support at every center, for `126^9 =
 8,004,512,848,309,157,376` raw assignments. With the same pair/crossing
 filters plus witness-pair capacity, the exact search leaves `184` complete

--- a/STATE.md
+++ b/STATE.md
@@ -307,6 +307,20 @@ not prove the full dodecagon case. See `docs/rich-support-counting-lemma.md`,
 `docs/n12-rich-support-determinant-obstruction.md`, and
 `docs/localized-rich-support-counting.md`.
 
+A review-pending near-saturation strengthening sharpens that support pair
+budget by two units for every `n >= 8`: pair-capacity slack `0` or `1`
+already forces the equilateral/turn-cover contradiction with no assumption
+on the support-size profile, so `sum_i binom(|R_i|, 2) <= n(n-2) - 2`. This
+raises the counting floors to at least six exact-four centers in a
+hypothetical 4-bad decagon and at least four in a hypothetical 4-bad
+hendecagon, and it recovers the uniform saturation thresholds
+`n >= binom(k,2) + 3` as direct budget corollaries. The draft records why
+the method stops at slack `1`. It does not extend the `n=9` conclusions,
+does not prove `n=9`, `n=10`, or `n=11`, and does not change any
+finite-case or global status. See
+`docs/near-saturation-support-obstruction.md` and
+`data/certificates/near_saturation_support_obstruction.json`.
+
 The follow-up mixed rich-support reduction enumerates every four- or
 five-witness support at every center, for `126^9 =
 8,004,512,848,309,157,376` raw assignments. With the same pair/crossing

--- a/data/certificates/near_saturation_support_obstruction.json
+++ b/data/certificates/near_saturation_support_obstruction.json
@@ -1,0 +1,1368 @@
+{
+  "case_rows": [
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 4,
+          "forced_turn_units_pi_over_3": 8,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 4,
+          "forced_turn_units_pi_over_3": 8,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 4,
+          "forced_turn_units_pi_over_3": 8,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 8,
+      "raw_pair_budget": 48,
+      "sharpened_pair_budget": 46,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 5,
+          "forced_turn_units_pi_over_3": 10,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 5,
+          "forced_turn_units_pi_over_3": 10,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 4,
+          "forced_turn_units_pi_over_3": 8,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 9,
+      "raw_pair_budget": 63,
+      "sharpened_pair_budget": 61,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 5,
+          "forced_turn_units_pi_over_3": 10,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 5,
+          "forced_turn_units_pi_over_3": 10,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 5,
+          "forced_turn_units_pi_over_3": 10,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 10,
+      "raw_pair_budget": 80,
+      "sharpened_pair_budget": 78,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 6,
+          "forced_turn_units_pi_over_3": 12,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 6,
+          "forced_turn_units_pi_over_3": 12,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 5,
+          "forced_turn_units_pi_over_3": 10,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 11,
+      "raw_pair_budget": 99,
+      "sharpened_pair_budget": 97,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 6,
+          "forced_turn_units_pi_over_3": 12,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 6,
+          "forced_turn_units_pi_over_3": 12,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 6,
+          "forced_turn_units_pi_over_3": 12,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 12,
+      "raw_pair_budget": 120,
+      "sharpened_pair_budget": 118,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 7,
+          "forced_turn_units_pi_over_3": 14,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 7,
+          "forced_turn_units_pi_over_3": 14,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 6,
+          "forced_turn_units_pi_over_3": 12,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 13,
+      "raw_pair_budget": 143,
+      "sharpened_pair_budget": 141,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 7,
+          "forced_turn_units_pi_over_3": 14,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 7,
+          "forced_turn_units_pi_over_3": 14,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 7,
+          "forced_turn_units_pi_over_3": 14,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 14,
+      "raw_pair_budget": 168,
+      "sharpened_pair_budget": 166,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 8,
+          "forced_turn_units_pi_over_3": 16,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 8,
+          "forced_turn_units_pi_over_3": 16,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 7,
+          "forced_turn_units_pi_over_3": 14,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 15,
+      "raw_pair_budget": 195,
+      "sharpened_pair_budget": 193,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    },
+    {
+      "cases": {
+        "all_capacities_saturated": {
+          "forced_turn_set_cover_lower_bound": 8,
+          "forced_turn_units_pi_over_3": 16,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap2_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 8,
+          "forced_turn_units_pi_over_3": 16,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        },
+        "one_gap3_unit_missing": {
+          "forced_turn_set_cover_lower_bound": 8,
+          "forced_turn_units_pi_over_3": 16,
+          "side_chain_connected": true,
+          "total_turn_units_pi_over_3": 6,
+          "turn_contradiction": true
+        }
+      },
+      "n": 16,
+      "raw_pair_budget": 224,
+      "sharpened_pair_budget": 222,
+      "short_diagonals_distinct": true,
+      "slack_le_1_contradiction_in_every_case": true
+    }
+  ],
+  "claim_scope": "Review-pending near-saturation strengthening of the edge-sensitive rich-support pair budget: for strictly convex n-gons with n >= 8, sum_i binom(|R_i|,2) <= n(n-2) - 2. Discrete bookkeeping checks only; not a realization search, not a proof of n=9, n=10, or n=11, not a proof of Erdos Problem #97, and not a counterexample.",
+  "cover_formulas_brute_force_verified_to_n_12": true,
+  "four_bad_profile_rows": [
+    {
+      "max_q_among_surviving_profiles": 1,
+      "min_exact_four_centers_sharpened": 8,
+      "n": 9,
+      "newly_excluded_profile_count": 2,
+      "newly_excluded_profiles": [
+        {
+          "pair_cost": 63,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            6
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 62,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5
+          ],
+          "raw_slack": 1
+        }
+      ],
+      "raw_budget_q_bound": 2,
+      "raw_feasible_profile_count": 4,
+      "raw_pair_budget": 63,
+      "sharpened_pair_budget": 61,
+      "sharpened_q_bound": 1,
+      "surviving_profile_count": 2
+    },
+    {
+      "max_q_among_surviving_profiles": 4,
+      "min_exact_four_centers_sharpened": 6,
+      "n": 10,
+      "newly_excluded_profile_count": 2,
+      "newly_excluded_profiles": [
+        {
+          "pair_cost": 79,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 80,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5
+          ],
+          "raw_slack": 0
+        }
+      ],
+      "raw_budget_q_bound": 5,
+      "raw_feasible_profile_count": 12,
+      "raw_pair_budget": 80,
+      "sharpened_pair_budget": 78,
+      "sharpened_q_bound": 4,
+      "surviving_profile_count": 10
+    },
+    {
+      "max_q_among_surviving_profiles": 7,
+      "min_exact_four_centers_sharpened": 4,
+      "n": 11,
+      "newly_excluded_profile_count": 4,
+      "newly_excluded_profiles": [
+        {
+          "pair_cost": 99,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            6,
+            6,
+            7
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 98,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 99,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 98,
+          "profile": [
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5
+          ],
+          "raw_slack": 1
+        }
+      ],
+      "raw_budget_q_bound": 8,
+      "raw_feasible_profile_count": 37,
+      "raw_pair_budget": 99,
+      "sharpened_pair_budget": 97,
+      "sharpened_q_bound": 7,
+      "surviving_profile_count": 33
+    },
+    {
+      "max_q_among_surviving_profiles": 11,
+      "min_exact_four_centers_sharpened": 1,
+      "n": 12,
+      "newly_excluded_profile_count": 14,
+      "newly_excluded_profiles": [
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            6,
+            10
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 119,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            10
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            8,
+            8
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            6,
+            6,
+            9
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 119,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            9
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            6,
+            6,
+            7,
+            7
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            6,
+            8
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 119,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            7,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 119,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            6,
+            8
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            6,
+            6,
+            6,
+            6
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            7
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 119,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            6
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 119,
+          "profile": [
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 120,
+          "profile": [
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5
+          ],
+          "raw_slack": 0
+        }
+      ],
+      "raw_budget_q_bound": 12,
+      "raw_feasible_profile_count": 109,
+      "raw_pair_budget": 120,
+      "sharpened_pair_budget": 118,
+      "sharpened_q_bound": 11,
+      "surviving_profile_count": 95
+    },
+    {
+      "max_q_among_surviving_profiles": 13,
+      "min_exact_four_centers_sharpened": 0,
+      "n": 13,
+      "newly_excluded_profile_count": 30,
+      "newly_excluded_profiles": [
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            12
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            7,
+            11
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            8,
+            10
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            9,
+            9
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            6,
+            8,
+            9
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            7,
+            7,
+            9
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            11
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            8,
+            9
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            6,
+            10
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            6,
+            7,
+            7,
+            8
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            7,
+            7,
+            7,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            6,
+            6,
+            6,
+            7,
+            8
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            6,
+            10
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            6,
+            8,
+            8
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            7,
+            7,
+            8
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            6,
+            6,
+            9
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            7,
+            9
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            8,
+            8
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            9
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            6,
+            6,
+            6,
+            7,
+            7
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            6,
+            6,
+            6,
+            6,
+            6,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            7,
+            7,
+            7
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            6,
+            8
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            7,
+            7
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            7,
+            8
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            8
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            6,
+            6,
+            6
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 143,
+          "profile": [
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            7
+          ],
+          "raw_slack": 0
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            6,
+            6,
+            6
+          ],
+          "raw_slack": 1
+        },
+        {
+          "pair_cost": 142,
+          "profile": [
+            4,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            5,
+            6,
+            7
+          ],
+          "raw_slack": 1
+        }
+      ],
+      "raw_budget_q_bound": 13,
+      "raw_feasible_profile_count": 293,
+      "raw_pair_budget": 143,
+      "sharpened_pair_budget": 141,
+      "sharpened_q_bound": 13,
+      "surviving_profile_count": 263
+    }
+  ],
+  "lemma_draft": "For any same-radius supports R_i in a strictly convex n-gon with n >= 8, sum_i binom(|R_i|, 2) <= n(n-2) - 2; equivalently pair-capacity slack 0 and 1 are impossible.",
+  "proof_accounting": {
+    "capacities": "hull-edge witness pairs have capacity 1, diagonal witness pairs capacity 2 with at most one using center per side",
+    "step_1_2": "each saturated gap-2 diagonal forces one side equality; a cycle minus at most one edge stays connected, so all sides are equal",
+    "step_3": "each saturated gap-3 diagonal forces an exterior turn 2*pi/3 at one of the two short-side vertices",
+    "step_4_5": "the forced-turn set covers the n-cycle minus at most one edge, so it has at least 4 members and the total exterior turn would be at least 8*pi/3 > 2*pi"
+  },
+  "provenance": {
+    "command": "python scripts/check_near_saturation_support_obstruction.py --write-artifact",
+    "generator": "scripts/check_near_saturation_support_obstruction.py",
+    "notes": "Deterministic bookkeeping summary for the review-pending near-saturation rich-support obstruction; regenerated, never hand-edited."
+  },
+  "schema": "erdos97.near_saturation_support_obstruction.v1",
+  "slack_two_failure_records": {
+    "claim_scope": "method-boundary records only; no claim about slack-2 realizability",
+    "equilateral_step_failure": {
+      "n": 8,
+      "removed_side_chain_edges": [
+        0,
+        4
+      ],
+      "side_chain_disconnected": true
+    },
+    "turn_count_failure": {
+      "forced_turn_units_pi_over_3": 6,
+      "min_cover_after_two_missing_gap3_units": 3,
+      "n": 8,
+      "total_turn_units_pi_over_3": 6,
+      "turn_contradiction": false
+    }
+  },
+  "status": "REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION",
+  "trust": "LEMMA_DRAFT_REVIEW_PENDING",
+  "uniform_threshold_consistency": {
+    "all_match": true,
+    "rows": [
+      {
+        "k": 4,
+        "match": true,
+        "min_n_allowed_by_sharpened_budget": 9,
+        "support_saturation_threshold": 9
+      },
+      {
+        "k": 5,
+        "match": true,
+        "min_n_allowed_by_sharpened_budget": 13,
+        "support_saturation_threshold": 13
+      },
+      {
+        "k": 6,
+        "match": true,
+        "min_n_allowed_by_sharpened_budget": 18,
+        "support_saturation_threshold": 18
+      },
+      {
+        "k": 7,
+        "match": true,
+        "min_n_allowed_by_sharpened_budget": 24,
+        "support_saturation_threshold": 24
+      },
+      {
+        "k": 8,
+        "match": true,
+        "min_n_allowed_by_sharpened_budget": 31,
+        "support_saturation_threshold": 31
+      }
+    ]
+  }
+}

--- a/data/certificates/near_saturation_support_obstruction.json
+++ b/data/certificates/near_saturation_support_obstruction.json
@@ -2,7 +2,7 @@
   "case_rows": [
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 4,
           "forced_turn_units_pi_over_3": 8,
           "side_chain_connected": true,
@@ -32,7 +32,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 5,
           "forced_turn_units_pi_over_3": 10,
           "side_chain_connected": true,
@@ -62,7 +62,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 5,
           "forced_turn_units_pi_over_3": 10,
           "side_chain_connected": true,
@@ -92,7 +92,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 6,
           "forced_turn_units_pi_over_3": 12,
           "side_chain_connected": true,
@@ -122,7 +122,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 6,
           "forced_turn_units_pi_over_3": 12,
           "side_chain_connected": true,
@@ -152,7 +152,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 7,
           "forced_turn_units_pi_over_3": 14,
           "side_chain_connected": true,
@@ -182,7 +182,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 7,
           "forced_turn_units_pi_over_3": 14,
           "side_chain_connected": true,
@@ -212,7 +212,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 8,
           "forced_turn_units_pi_over_3": 16,
           "side_chain_connected": true,
@@ -242,7 +242,7 @@
     },
     {
       "cases": {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
           "forced_turn_set_cover_lower_bound": 8,
           "forced_turn_units_pi_over_3": 16,
           "side_chain_connected": true,
@@ -1297,7 +1297,24 @@
       "surviving_profile_count": 263
     }
   ],
+  "headline": {
+    "n10_min_exact_four_centers": 6,
+    "n10_sharpened_q_bound": 4,
+    "n11_min_exact_four_centers": 4,
+    "n11_sharpened_q_bound": 7,
+    "n12_min_exact_four_centers": 1,
+    "n12_sharpened_q_bound": 11,
+    "n9_sharpened_q_bound": 1,
+    "newly_excluded_profile_counts": {
+      "10": 2,
+      "11": 4,
+      "12": 14,
+      "13": 30,
+      "9": 2
+    }
+  },
   "lemma_draft": "For any same-radius supports R_i in a strictly convex n-gon with n >= 8, sum_i binom(|R_i|, 2) <= n(n-2) - 2; equivalently pair-capacity slack 0 and 1 are impossible.",
+  "note_status_label": "LEMMA_DRAFT / REVIEW_PENDING",
   "proof_accounting": {
     "capacities": "hull-edge witness pairs have capacity 1, diagonal witness pairs capacity 2 with at most one using center per side",
     "step_1_2": "each saturated gap-2 diagonal forces one side equality; a cycle minus at most one edge stays connected, so all sides are equal",
@@ -1309,27 +1326,30 @@
     "generator": "scripts/check_near_saturation_support_obstruction.py",
     "notes": "Deterministic bookkeeping summary for the review-pending near-saturation rich-support obstruction; regenerated, never hand-edited."
   },
-  "schema": "erdos97.near_saturation_support_obstruction.v1",
-  "slack_two_failure_records": {
-    "claim_scope": "method-boundary records only; no claim about slack-2 realizability",
-    "equilateral_step_failure": {
-      "n": 8,
-      "removed_side_chain_edges": [
+  "schema": "erdos97.near_saturation_support_obstruction.v2",
+  "slack_two_boundary_records": {
+    "chain_disconnection_failure": {
+      "cycle_minus_two_distinct_edges_always_disconnected_n8_to_12": true,
+      "exhibit_removed_side_chain_edges": [
         0,
         4
       ],
-      "side_chain_disconnected": true
+      "exhibit_side_chain_disconnected": true,
+      "n": 8
     },
-    "turn_count_failure": {
-      "forced_turn_units_pi_over_3": 6,
-      "min_cover_after_two_missing_gap3_units": 3,
+    "claim_scope": "method-boundary records only; no claim about slack-2 realizability",
+    "strict_turn_closure_of_other_distributions": {
+      "all_le_two_edge_removal_covers_meet_strict_threshold": true,
+      "general_bound_ceil_n_minus_2_over_2_verified_n8_to_12": true,
+      "min_cover_over_all_le_two_edge_removals": 3,
+      "min_cover_over_all_two_edge_removals": 3,
       "n": 8,
-      "total_turn_units_pi_over_3": 6,
-      "turn_contradiction": false
+      "nonstrict_test_fails_for_some_two_edge_removals": true,
+      "strict_turn_set_threshold": 3
     }
   },
   "status": "REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION",
-  "trust": "LEMMA_DRAFT_REVIEW_PENDING",
+  "trust": "REVIEW_PENDING_DIAGNOSTIC",
   "uniform_threshold_consistency": {
     "all_match": true,
     "rows": [

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -156,6 +156,35 @@ wall already closed by support saturation. It does not prove the full `n=12`
 case, any mixed exact-four/size-five catalogue, or Erdos Problem #97. Check it
 with `scripts/check_n12_rich_support_determinant.py`.
 
+### Near-saturation support obstruction
+
+Status: `LEMMA_DRAFT` / `REVIEW_PENDING`.
+
+For any same-radius supports `R_i` in a strictly convex `n`-gon with
+`n >= 8`, the edge-sensitive pair budget sharpens by two units:
+
+```text
+sum_i binom(|R_i|, 2) <= n(n - 2) - 2.
+```
+
+Pair-capacity slack `0` or `1` leaves at most one capacity unit missing, so
+at least `n-1` gap-2 diagonals stay saturated and force all sides equal
+through a connected side-equality chain, while at least `n-1` gap-3
+diagonals stay saturated and force exterior turns of `2*pi/3` on a set
+covering the `n`-cycle minus at most one edge. That cover has at least four
+members, so the total exterior turn would be at least `8*pi/3 > 2*pi`.
+Unlike the equality-wall saturation lemma, no assumption is made on the
+support-size profile.
+
+Consequences: a hypothetical 4-bad decagon has at least six exact-four
+centers (raw budget: five), a hypothetical 4-bad hendecagon has at least
+four (raw budget: three), and the uniform thresholds
+`n >= binom(k,2) + 3` follow directly from the sharpened budget. The method
+provably stops at slack `1`. This does not prove the review-pending
+exact-four frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
+`docs/near-saturation-support-obstruction.md` and
+`scripts/check_near_saturation_support_obstruction.py`.
+
 ### Selected-path self-edge obstruction
 
 Status: `LEMMA`.

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -179,9 +179,13 @@ support-size profile.
 Consequences: a hypothetical 4-bad decagon has at least six exact-four
 centers (raw budget: five), a hypothetical 4-bad hendecagon has at least
 four (raw budget: three), and the uniform thresholds
-`n >= binom(k,2) + 3` follow directly from the sharpened budget. The method
-provably stops at slack `1`. This does not prove the review-pending
-exact-four frontier, `n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
+`n >= binom(k,2) + 3` follow directly from the sharpened budget for
+`n >= 8`. The uniform statement stops at slack `1` because two distinct
+gap-2 diagonals each missing one unit always disconnect the side-equality
+chain; a strict form of the turn count closes every other slack-2
+distribution, but that remaining family is a genuine method boundary. This
+does not prove the review-pending exact-four frontier, `n=9`, `n=10`,
+`n=11`, or Erdos Problem #97. See
 `docs/near-saturation-support-obstruction.md` and
 `scripts/check_near_saturation_support_obstruction.py`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,11 @@ put detailed reconciliation in the canonical synthesis.
   equality-wall obstruction strengthening all-centers rich-support thresholds
   to `n >= binom(k,2)+3` for `k >= 4`; not an `n=9`, `n=10`, `n=11`, or
   global proof.
+- [`near-saturation-support-obstruction.md`](near-saturation-support-obstruction.md):
+  review-pending draft sharpening the edge-sensitive support pair budget to
+  `n(n-2)-2` for `n >= 8` (slack `0` and `1` both impossible), raising the
+  4-bad decagon/hendecagon exact-four floors to six and four; not an `n=9`,
+  `n=10`, `n=11`, or global proof.
 - [`n12-rich-support-determinant-obstruction.md`](n12-rich-support-determinant-obstruction.md):
   independent determinant obstruction for the all-five-rich `n=12`
   support-count equality wall; not a proof of the full `n=12` case.

--- a/docs/localized-rich-support-counting.md
+++ b/docs/localized-rich-support-counting.md
@@ -93,6 +93,12 @@ n = 12: no exact-four center is forced by these two budgets alone
 For `n = 5, 6, 7`, the edge-sensitive global pair budget already rules out
 4-bad supports.
 
+A review-pending near-saturation strengthening of the global pair budget
+(`docs/near-saturation-support-obstruction.md`) sharpens the `n = 10` and
+`n = 11` floors in this table to six and four exact-four centers and forces
+one exact-four center at `n = 12` from the budget alone; the rows above
+record only what the raw budgets prove.
+
 The support-saturation obstruction in `docs/support-saturation-obstruction.md`
 adds a separate equality-wall count: all centers having support size at least
 five is impossible for `n <= 12`. Thus a hypothetical 4-bad dodecagon has at

--- a/docs/near-saturation-support-obstruction.md
+++ b/docs/near-saturation-support-obstruction.md
@@ -31,8 +31,8 @@ R_i subset V \ {v_i},
 ```
 
 meaning that all members of `R_i` lie on one circle centered at `v_i`. The
-sizes `|R_i|` are arbitrary; no 4-badness hypothesis is used in the theorem
-itself.
+sizes `|R_i|` are arbitrary; no 4-badness hypothesis is used in the lemma
+draft itself.
 
 For an unordered vertex pair `{x,y}`, define its usage
 
@@ -63,7 +63,7 @@ Define the pair-capacity slack
 d = n(n-2) - sum_i binom(|R_i|, 2) = sum_pairs (capacity - usage) >= 0.
 ```
 
-## Theorem (near-saturation obstruction)
+## Lemma draft (near-saturation obstruction)
 
 For every strictly convex `n`-gon with `n >= 8`, and every choice of
 same-radius supports as above,
@@ -143,10 +143,13 @@ of the cycle on turn indices. At most one gap-3 diagonal is unsaturated, so
   edge, which is a path with `n-1` edges, so
   `|M| >= ceil((n-1)/2) >= 4` for `n >= 8`.
 
-Note that when a gap-3 diagonal is the unsaturated pair, all gap-2 diagonals
-are saturated, so Step 2 is unaffected; and when a gap-2 diagonal is the
-unsaturated pair, all gap-3 diagonals are saturated. In every `d <= 1` case
-both Step 2 and the cover bound `|M| >= 4` hold.
+The single missing unit, if any, sits in exactly one of three places: on a
+gap-3 diagonal (then all gap-2 diagonals are saturated, so Step 2 is
+unaffected, and the cover loses one edge); on a gap-2 diagonal (then all
+gap-3 diagonals are saturated, so the cover is the full cycle, and Step 2
+survives by the chain argument); or on a hull edge or a gap `>= 4` diagonal
+(then every short diagonal is saturated and both steps hold with no loss).
+In every `d <= 1` case both Step 2 and the cover bound `|M| >= 4` hold.
 
 ### Step 5: turn contradiction
 
@@ -164,8 +167,11 @@ All consequences below inherit the `REVIEW_PENDING` status of this note.
 
 ### Uniform thresholds are recovered
 
-If every center has `|R_i| >= k >= 4`, then
-`n * binom(k,2) <= n(n-2) - 2` forces `n - 2 - binom(k,2) >= 1`, i.e.
+If every center has `|R_i| >= k >= 4`, then for `n <= 7` the raw budget
+already excludes the support system (`6n > n(n-2)`, recorded in
+`docs/rich-support-counting-lemma.md`), and for `n >= 8` the sharpened
+budget applies: `n * binom(k,2) <= n(n-2) - 2` forces
+`n - 2 - binom(k,2) >= 1`, i.e.
 
 ```text
 n >= binom(k, 2) + 3.
@@ -186,8 +192,10 @@ q <= (n^2 - 8n - 2) / 4.
 ```
 
 ```text
-n = 9:  q <= 1  (raw budget: 2; the localized vertex-deficiency refinement
-                 in docs/localized-rich-support-counting.md already gives 0)
+n = 9:  q <= 1  (raw budget: 2; the nonagon profile-deficiency refinement
+                 in docs/rich-support-counting-lemma.md and the localized
+                 per-label cap in docs/localized-rich-support-counting.md
+                 each already give 0)
 n = 10: q <= 4  (raw budget: 5)  => at least 6 exact-four centers
 n = 11: q <= 7  (raw budget: 8)  => at least 4 exact-four centers
 n = 12: q <= 11 (raw budget: 12) => at least 1 exact-four center
@@ -211,9 +219,9 @@ n = 12: 14 profiles, including the uniform (5)*12
 n = 13: 30 profiles; the surviving maximum q stays at the trivial 13
 ```
 
-The two `n = 9` profiles were already excluded by the localized
-vertex-deficiency refinement, so at `n = 9` this lemma only rederives known
-exclusions. At `n = 12`, the `q <= 11` bound itself was already known,
+The two `n = 9` profiles were already excluded by the nonagon
+profile-deficiency refinement of `docs/rich-support-counting-lemma.md`, so
+at `n = 9` this lemma only rederives known exclusions. At `n = 12`, the `q <= 11` bound itself was already known,
 because the only raw-feasible profile with `q = 12` is the uniform `(5)*12`
 killed by the uniform saturation lemma; the thirteen mixed `n = 12`
 profiles are newly excluded objects but do not move that count. The
@@ -239,22 +247,63 @@ result exists.
 ## Boundary: why slack 2 is out of reach for this method
 
 The argument does not extend to `d = 2` as stated, and this note claims
-nothing about `d = 2`. Two exact failure records:
+nothing about `d = 2`. The method boundary is exactly one failure mode.
 
-1. **Equilateral step fails.** If both missing units sit on two different
-   gap-2 diagonals, the side-equality chain loses two edges of the `n`-cycle
-   and can disconnect into two arcs, so the sides are only forced into at
-   most two length classes. Step 3's conversion of a chord equality into
-   `tau = 2*pi/3` needs both sides at the pivot vertex equal, which can now
-   fail, and no turn contradiction follows from these steps.
+**The genuine failure mode: the equilateral step.** If the two missing
+units sit on two DISTINCT gap-2 diagonals, the side-equality chain loses
+two edges of the `n`-cycle. A cycle minus two distinct edges is always
+disconnected (it has `n` vertices, `n - 2` edges, and no cycle), so the
+sides are only forced into at most two length classes. Step 3's conversion
+of a chord equality into `tau = 2*pi/3` needs all three relevant sides at
+the pivot equal, which can now fail, and no turn contradiction follows from
+these steps.
 
-2. **Turn count fails at n = 8.** Even when the equilateral step survives
-   (both missing units on gap-3 diagonals), `M` only covers the `8`-cycle
-   minus two edges, whose minimum vertex cover is `3`, and
-   `3 * (2*pi/3) = 2*pi` is not a contradiction.
+**Every other slack-2 distribution still contradicts.** Step 5 admits a
+strict sharpening: since every exterior turn is positive and
+`sum_j tau_j = 2*pi` exactly, a forced-turn set `M` with `|M| >= 3` is
+already impossible for `n >= 4`. If `M` is a proper subset of the turn
+indices, the remaining turns add a strictly positive amount to
+`|M| * (2*pi/3) >= 2*pi`; if `M` is everything, the total is
+`n * 2*pi/3 > 2*pi`. Under any slack-2 distribution other than the
+two-distinct-gap-2 case, the side chain loses at most one edge (a single
+gap-2 diagonal short by one or by two units removes only one chain edge),
+so all sides are equal, and the turn-index cycle loses at most two cover
+edges, leaving a vertex cover of size at least `ceil((n-2)/2) >= 3` for
+`n >= 8`. The strict sharpening then closes the case.
 
-These are records about this proof method, not claims that slack-2 support
-systems are realizable.
+The headline proof deliberately uses the non-strict test `|M| >= 4`, which
+genuinely fails on some two-edge removals (for `n = 8`, adjacent-pair
+removals leave a minimum cover of exactly `3`). The uniform statement
+therefore still stops at slack `1` because of the equilateral failure mode
+above, not because of the turn count.
+
+These are records about this proof method, not claims about the
+realizability of the remaining slack-2 support systems.
+
+## Known counterexample attempts
+
+Adversarial checks performed against the statement, with no countermodel
+found:
+
+- the strict-turn re-derivation above, which located and corrected an error
+  in an earlier draft of this note's boundary records but left the lemma
+  statement and Steps 1-5 unchanged;
+- exact brute-force verification of every vertex-cover bound used by Steps
+  4-5 and the boundary records (all cycle-minus-`0`/`1`/`2`-edge covers for
+  `n = 3..12`);
+- exhaustive enumeration of all raw-feasible 4-bad support-size profiles
+  for `n = 9..13`, cross-checked against the sharpened budget;
+- the two-distinct-gap-2 slack-2 family, which is a boundary of the proof
+  method but not a countermodel: it concerns `d = 2`, outside the claim.
+
+## Survival of known 3-neighbor examples
+
+Known `k = 3` constructions (for example the Danzer-style 9-point
+three-neighbor examples recorded as literature risk in
+`docs/public-provenance.md`) give each center a support of size `3`, with
+total pair cost `n * binom(3,2) = 3n`. For every `n >= 8`,
+`3n <= n(n-2) - 2`, so the sharpened budget imposes nothing on
+three-neighbor configurations and is consistent with their existence.
 
 ## What this does not prove
 
@@ -267,8 +316,10 @@ systems are realizable.
 - The 4-bad consequences are support-size profile constraints only; they say
   nothing about which selected-witness systems on the surviving profiles are
   realizable.
-- It does not supersede the localized vertex-deficiency refinement at
-  `n = 9`, which remains stronger there.
+- It does not supersede the nonagon profile-deficiency refinement of
+  `docs/rich-support-counting-lemma.md` or the localized per-label cap of
+  `docs/localized-rich-support-counting.md` at `n = 9`; both remain
+  stronger there.
 
 ## Verification command
 
@@ -281,8 +332,10 @@ The checker verifies the budget arithmetic, the `d <= 1` case bookkeeping
 missing edge, vertex-cover sizes, turn-unit comparison), the sharpened
 small-`n` consequence table, the exact list of newly excluded boundary
 profiles, consistency with the raw-budget and uniform-saturation lemmas, and
-the two slack-2 failure records. It is an arithmetic checker for the proof
-note; it is not a realization search.
+the slack-2 method-boundary records (the chain-disconnection failure mode
+and the cover bounds behind the strict-turn closure of the other
+distributions). It is an arithmetic checker for the proof note; it is not a
+realization search.
 
 The stored artifact
 `data/certificates/near_saturation_support_obstruction.json` is generated by
@@ -294,5 +347,5 @@ python scripts/check_near_saturation_support_obstruction.py --write-artifact
 and replayed by
 
 ```bash
-python scripts/check_near_saturation_support_obstruction.py --check-artifact --json
+python scripts/check_near_saturation_support_obstruction.py --check --check-artifact --json
 ```

--- a/docs/near-saturation-support-obstruction.md
+++ b/docs/near-saturation-support-obstruction.md
@@ -1,0 +1,298 @@
+# Near-saturation support obstruction
+
+Status: `LEMMA_DRAFT` / `REVIEW_PENDING`. This note does not claim a general
+proof of Erdos Problem #97 and does not claim a counterexample. Independent
+proof review is requested before theorem-style use.
+
+This note strengthens the edge-sensitive rich-support pair budget of
+`docs/rich-support-counting-lemma.md` by two units for every `n >= 8`. It
+extends the support-saturation turn-cover argument of
+`docs/support-saturation-obstruction.md` in two directions at once:
+
+1. from uniform support sizes at the exact equality wall to arbitrary mixed
+   support-size profiles; and
+2. from pair-capacity slack `0` to pair-capacity slack `1`.
+
+The proof reuses only ingredients already recorded in the repository: the
+hull-edge and diagonal perpendicular-bisector capacities, the base-apex
+one-center-per-side fact, and the equilateral/turn-cover endgame of the
+`n <= 8` geometric proof. The new content is the bookkeeping showing those
+ingredients survive one missing capacity unit with no assumption on the
+support-size profile.
+
+## Setting
+
+Let `P` be a strictly convex polygon with vertices `v_0, ..., v_{n-1}` in
+cyclic hull order, `n >= 8`. For each center `i` choose one same-radius
+support
+
+```text
+R_i subset V \ {v_i},
+```
+
+meaning that all members of `R_i` lie on one circle centered at `v_i`. The
+sizes `|R_i|` are arbitrary; no 4-badness hypothesis is used in the theorem
+itself.
+
+For an unordered vertex pair `{x,y}`, define its usage
+
+```text
+u({x,y}) = #{ i : {x,y} subset R_i }.
+```
+
+The repository's capacity facts (the hull-edge and diagonal caps are proved
+in `docs/rich-support-counting-lemma.md` and
+`docs/localized-rich-support-counting.md`; the one-center-per-side refinement
+is the base-apex lemma of `docs/n8-geometric-proof.md`):
+
+- if `{x,y}` is a hull edge, `u({x,y}) <= 1`;
+- if `{x,y}` is a diagonal, `u({x,y}) <= 2`, with at most one using center
+  strictly on each side of the line `xy`, and no using center on the line
+  itself (a center on both the line and the bisector would be the chord
+  midpoint, which is interior to a strictly convex polygon, not a vertex).
+
+Summing capacities gives the known budget
+
+```text
+sum_i binom(|R_i|, 2) = sum_pairs u <= n + 2*(binom(n,2) - n) = n(n-2).
+```
+
+Define the pair-capacity slack
+
+```text
+d = n(n-2) - sum_i binom(|R_i|, 2) = sum_pairs (capacity - usage) >= 0.
+```
+
+## Theorem (near-saturation obstruction)
+
+For every strictly convex `n`-gon with `n >= 8`, and every choice of
+same-radius supports as above,
+
+```text
+d >= 2.
+```
+
+Equivalently,
+
+```text
+sum_i binom(|R_i|, 2) <= n(n-2) - 2.
+```
+
+## Proof
+
+Suppose `d <= 1`. Then at most one pair has usage strictly below its
+capacity, and its shortfall is exactly one unit.
+
+Write `s_i = |v_i v_{i+1}|` for the side lengths and `tau_j in (0, pi)` for
+the exterior turns, indices mod `n`, with `sum_j tau_j = 2*pi`. For `n >= 8`
+the `n` gap-2 pairs `{v_i, v_{i+2}}` and the `n` gap-3 pairs `{v_i, v_{i+3}}`
+are `2n` pairwise distinct diagonals, so at most one of them is unsaturated.
+
+### Step 1: a saturated gap-2 diagonal forces a side equality
+
+Suppose `u({v_i, v_{i+2}}) = 2`. By the one-center-per-side capacity fact,
+the two using centers lie one on each side of the line through `v_i` and
+`v_{i+2}`. By strict convexity, the open side of that line containing
+`v_{i+1}` contains no other vertex, so the short-side center is `v_{i+1}`
+itself. Then `v_i, v_{i+2} in R_{i+1}` lie on one circle centered at
+`v_{i+1}`, hence
+
+```text
+s_i = |v_{i+1} v_i| = |v_{i+1} v_{i+2}| = s_{i+1}.
+```
+
+### Step 2: all sides are equal
+
+At most one gap-2 diagonal is unsaturated, so at least `n-1` of the `n`
+cyclic side equalities `s_i = s_{i+1}` hold. A cycle minus at most one edge
+is still connected, so all sides are equal; call the common value `s`.
+
+### Step 3: a saturated gap-3 diagonal forces one exterior turn `2*pi/3`
+
+Suppose `u({v_i, v_{i+3}}) = 2`. As in Step 1, exactly one using center lies
+on the short side of the line through `v_i` and `v_{i+3}`, and that side
+contains exactly the vertices `v_{i+1}` and `v_{i+2}`.
+
+If the short-side center is `v_{i+1}`, then
+`|v_{i+1} v_{i+3}| = |v_{i+1} v_i| = s`. In the triangle
+`v_{i+1} v_{i+2} v_{i+3}`, the two legs at `v_{i+2}` are consecutive polygon
+sides of length `s` and the apex angle at `v_{i+2}` is the interior angle
+`pi - tau_{i+2}`, so
+
+```text
+|v_{i+1} v_{i+3}| = 2 s cos(tau_{i+2} / 2).
+```
+
+Setting this equal to `s` gives `cos(tau_{i+2}/2) = 1/2`, and since
+`tau_{i+2}/2 in (0, pi/2)`, this forces `tau_{i+2} = 2*pi/3`.
+
+If the short-side center is `v_{i+2}`, the symmetric computation forces
+`tau_{i+1} = 2*pi/3`.
+
+Either way the set `M = { j : tau_j = 2*pi/3 }` meets `{i+1, i+2}`.
+
+### Step 4: `M` is large
+
+The index pairs `{i+1, i+2}` for `i = 0, ..., n-1` are exactly the `n` edges
+of the cycle on turn indices. At most one gap-3 diagonal is unsaturated, so
+`M` meets at least `n-1` of those `n` edges.
+
+- If all `n` gap-3 diagonals are saturated, `M` is a vertex cover of the
+  `n`-cycle, so `|M| >= ceil(n/2) >= 4` for `n >= 8`.
+- If one is unsaturated, `M` is a vertex cover of the `n`-cycle minus one
+  edge, which is a path with `n-1` edges, so
+  `|M| >= ceil((n-1)/2) >= 4` for `n >= 8`.
+
+Note that when a gap-3 diagonal is the unsaturated pair, all gap-2 diagonals
+are saturated, so Step 2 is unaffected; and when a gap-2 diagonal is the
+unsaturated pair, all gap-3 diagonals are saturated. In every `d <= 1` case
+both Step 2 and the cover bound `|M| >= 4` hold.
+
+### Step 5: turn contradiction
+
+All exterior turns are positive, so
+
+```text
+2*pi = sum_j tau_j >= sum_{j in M} tau_j = |M| * (2*pi/3) >= 8*pi/3 > 2*pi,
+```
+
+a contradiction. Hence `d >= 2`.
+
+## Consequences
+
+All consequences below inherit the `REVIEW_PENDING` status of this note.
+
+### Uniform thresholds are recovered
+
+If every center has `|R_i| >= k >= 4`, then
+`n * binom(k,2) <= n(n-2) - 2` forces `n - 2 - binom(k,2) >= 1`, i.e.
+
+```text
+n >= binom(k, 2) + 3.
+```
+
+This recovers the thresholds of `docs/support-saturation-obstruction.md`
+(`k=4: n>=9`, `k=5: n>=13`, ...) as direct budget corollaries. The uniform
+equality-wall lemma is the special case `d = 0` with all sizes equal.
+
+### Sharpened mixed-profile counts for 4-bad polygons
+
+In a hypothetical 4-bad `n`-gon, choose a maximum rich class at each center,
+so `|R_i| >= 4` everywhere, and let `q` be the number of centers with
+`|R_i| >= 5`. Then `6n + 4q <= n(n-2) - 2`, i.e.
+
+```text
+q <= (n^2 - 8n - 2) / 4.
+```
+
+```text
+n = 9:  q <= 1  (raw budget: 2; the localized vertex-deficiency refinement
+                 in docs/localized-rich-support-counting.md already gives 0)
+n = 10: q <= 4  (raw budget: 5)  => at least 6 exact-four centers
+n = 11: q <= 7  (raw budget: 8)  => at least 4 exact-four centers
+n = 12: q <= 11 (raw budget: 12) => at least 1 exact-four center
+n = 13: no constraint beyond the trivial q <= 13
+```
+
+Among all support-size profiles with every size at least `4` that the raw
+budget allows, the profiles newly excluded by this lemma (raw slack `0` or
+`1`) are exactly:
+
+```text
+n = 9:  (4,4,4,4,4,4,4,4,6)          cost 63, slack 0
+        (4,4,4,4,4,4,4,5,5)          cost 62, slack 1
+n = 10: (4,4,4,4,4,4,4,4,5,7)        cost 79, slack 1
+        (4,4,4,4,4,5,5,5,5,5)        cost 80, slack 0
+n = 11: (4,4,4,4,4,4,4,4,6,6,7)      cost 99, slack 0
+        (4,4,4,4,4,4,4,5,5,6,7)      cost 98, slack 1
+        (4,4,4,4,5,5,5,5,5,5,6)      cost 99, slack 0
+        (4,4,4,5,5,5,5,5,5,5,5)      cost 98, slack 1
+n = 12: 14 profiles, including the uniform (5)*12
+n = 13: 30 profiles; the surviving maximum q stays at the trivial 13
+```
+
+The two `n = 9` profiles were already excluded by the localized
+vertex-deficiency refinement, so at `n = 9` this lemma only rederives known
+exclusions. At `n = 12`, the `q <= 11` bound itself was already known,
+because the only raw-feasible profile with `q = 12` is the uniform `(5)*12`
+killed by the uniform saturation lemma; the thirteen mixed `n = 12`
+profiles are newly excluded objects but do not move that count. The
+genuinely bound-improving rows are `n = 10` and `n = 11`.
+
+For `n = 8`, the 4-bad cost `6*8 = 48` exceeds the sharpened budget `46`, so
+a 4-bad octagon is excluded by the budget alone. This is a consistency
+remark: it repackages the equality-case endgame of
+`docs/n8-geometric-proof.md` and does not replace the repository's `n <= 8`
+source-of-truth theorem or its review history.
+
+### Relation to existing n=10 evidence
+
+The review-pending `n=10` mixed rich-support capacity diagnostic
+(`docs/n10-mixed-rich-support-capacity.md`) obstructs all support
+assignments with `q = 3, ..., 7` size-five supports under the row-pair cap,
+two-overlap crossing, and witness-pair capacity filters, by exhaustive
+search. The counting bound here is weaker at `n = 10` (`q <= 4` versus the
+search's `q <= 2`), but it is a proof-facing budget statement with no
+enumeration, and it is the first improvement at `n = 11`, where no search
+result exists.
+
+## Boundary: why slack 2 is out of reach for this method
+
+The argument does not extend to `d = 2` as stated, and this note claims
+nothing about `d = 2`. Two exact failure records:
+
+1. **Equilateral step fails.** If both missing units sit on two different
+   gap-2 diagonals, the side-equality chain loses two edges of the `n`-cycle
+   and can disconnect into two arcs, so the sides are only forced into at
+   most two length classes. Step 3's conversion of a chord equality into
+   `tau = 2*pi/3` needs both sides at the pivot vertex equal, which can now
+   fail, and no turn contradiction follows from these steps.
+
+2. **Turn count fails at n = 8.** Even when the equilateral step survives
+   (both missing units on gap-3 diagonals), `M` only covers the `8`-cycle
+   minus two edges, whose minimum vertex cover is `3`, and
+   `3 * (2*pi/3) = 2*pi` is not a contradiction.
+
+These are records about this proof method, not claims that slack-2 support
+systems are realizable.
+
+## What this does not prove
+
+- It does not prove `n = 9`, `n = 10`, `n = 11`, or any finite case beyond
+  the counting statement itself.
+- It does not prove Erdos Problem #97 and does not produce or certify a
+  counterexample.
+- It does not change the official/global falsifiable/open status or the
+  repository's `n <= 8` source-of-truth result.
+- The 4-bad consequences are support-size profile constraints only; they say
+  nothing about which selected-witness systems on the surviving profiles are
+  realizable.
+- It does not supersede the localized vertex-deficiency refinement at
+  `n = 9`, which remains stronger there.
+
+## Verification command
+
+```bash
+python scripts/check_near_saturation_support_obstruction.py --check --json
+```
+
+The checker verifies the budget arithmetic, the `d <= 1` case bookkeeping
+(distinctness of the `2n` short diagonals, chain connectivity after one
+missing edge, vertex-cover sizes, turn-unit comparison), the sharpened
+small-`n` consequence table, the exact list of newly excluded boundary
+profiles, consistency with the raw-budget and uniform-saturation lemmas, and
+the two slack-2 failure records. It is an arithmetic checker for the proof
+note; it is not a realization search.
+
+The stored artifact
+`data/certificates/near_saturation_support_obstruction.json` is generated by
+
+```bash
+python scripts/check_near_saturation_support_obstruction.py --write-artifact
+```
+
+and replayed by
+
+```bash
+python scripts/check_near_saturation_support_obstruction.py --check-artifact --json
+```

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -787,6 +787,15 @@ condition that the surviving multi-block family does not automatically satisfy:
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.
+- the review-pending near-saturation support obstruction in
+  `docs/near-saturation-support-obstruction.md`, which sharpens the
+  edge-sensitive support pair budget to `n(n-2) - 2` for `n >= 8` and
+  raises the 4-bad decagon/hendecagon exact-four floors to six and four.
+  Before theorem-style use, independently check the one-center-per-side
+  saturation step, the cycle-minus-one-edge equilateral chain, the
+  gap-3/turn conversion, the strict turn count in the boundary section,
+  and the exhaustive profile enumeration in
+  `scripts/check_near_saturation_support_obstruction.py`.
 - the review-pending complement-seeding refinement in
   `docs/bootstrap-core-complement-seeding.md`, which gives
   `2|U| <= 3|V\U|` for a cardinality-minimum generator and forces a strictly

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -32,6 +32,10 @@ native_trust_policy:
       native_value: "NUMERICAL_NONLINEAR_DIAGNOSTIC"
       trust_class: REVIEW_PENDING_DIAGNOSTIC
       rationale: Native producer label is preserved verbatim; the canonical class is the conservative repository review category.
+    near_saturation_support_obstruction:
+      native_value: "LEMMA_DRAFT_REVIEW_PENDING"
+      trust_class: REVIEW_PENDING_DIAGNOSTIC
+      rationale: Native producer label is preserved verbatim; the canonical class is the conservative repository review category.
     c25_c29_sparse_frontier_probe:
       native_value: "FIXED_ORDER_DIAGNOSTIC"
       trust_class: REVIEW_PENDING_DIAGNOSTIC
@@ -11633,4 +11637,40 @@ artifacts:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97
       - independent proof of the n=9 finite case
+      - official/global status update
+
+  - id: near_saturation_support_obstruction
+    path: data/certificates/near_saturation_support_obstruction.json
+    sha256: d45224f05ff0c6de26c6aa5f2ae748730e662d65b2d709d554af3ab7847527a8
+    size_bytes: 29310
+    kind: counting_lemma_bookkeeping
+    generator: scripts/check_near_saturation_support_obstruction.py
+    command: python scripts/check_near_saturation_support_obstruction.py --write-artifact
+    checker: scripts/check_near_saturation_support_obstruction.py
+    check_command: python scripts/check_near_saturation_support_obstruction.py --check --check-artifact --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust_class: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: >
+      Deterministic discrete bookkeeping for the review-pending
+      near-saturation rich-support obstruction draft: sharpened pair budget
+      n(n-2)-2 for n >= 8, slack-0/slack-1 case rows, sharpened 4-bad
+      support-size profile exclusions for n = 9..13, uniform-threshold
+      consistency, and the exact slack-2 method-failure records. Counting
+      bookkeeping only; the geometric lemma draft remains review-pending and
+      this is not a proof of n=9, n=10, n=11, or Erdos Problem #97.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.near_saturation_support_obstruction.v1
+      status: REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION
+      trust: LEMMA_DRAFT_REVIEW_PENDING
+      provenance.command: python scripts/check_near_saturation_support_obstruction.py --write-artifact
+      cover_formulas_brute_force_verified_to_n_12: true
+      uniform_threshold_consistency.all_match: true
+      slack_two_failure_records.turn_count_failure.min_cover_after_two_missing_gap3_units: 3
+      slack_two_failure_records.turn_count_failure.turn_contradiction: false
+    forbidden_claims:
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+      - proof of the n=9, n=10, or n=11 finite case
       - official/global status update

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -32,10 +32,6 @@ native_trust_policy:
       native_value: "NUMERICAL_NONLINEAR_DIAGNOSTIC"
       trust_class: REVIEW_PENDING_DIAGNOSTIC
       rationale: Native producer label is preserved verbatim; the canonical class is the conservative repository review category.
-    near_saturation_support_obstruction:
-      native_value: "LEMMA_DRAFT_REVIEW_PENDING"
-      trust_class: REVIEW_PENDING_DIAGNOSTIC
-      rationale: Native producer label is preserved verbatim; the canonical class is the conservative repository review category.
     c25_c29_sparse_frontier_probe:
       native_value: "FIXED_ORDER_DIAGNOSTIC"
       trust_class: REVIEW_PENDING_DIAGNOSTIC
@@ -11641,8 +11637,8 @@ artifacts:
 
   - id: near_saturation_support_obstruction
     path: data/certificates/near_saturation_support_obstruction.json
-    sha256: d45224f05ff0c6de26c6aa5f2ae748730e662d65b2d709d554af3ab7847527a8
-    size_bytes: 29310
+    sha256: 887287400d8395f17c85c5de3b4b9b37fd654b1f8ae05b82c7754822b87295ca
+    size_bytes: 30091
     kind: counting_lemma_bookkeeping
     generator: scripts/check_near_saturation_support_obstruction.py
     command: python scripts/check_near_saturation_support_obstruction.py --write-artifact
@@ -11661,14 +11657,31 @@ artifacts:
       this is not a proof of n=9, n=10, n=11, or Erdos Problem #97.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.near_saturation_support_obstruction.v1
+      schema: erdos97.near_saturation_support_obstruction.v2
       status: REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION
-      trust: LEMMA_DRAFT_REVIEW_PENDING
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      note_status_label: LEMMA_DRAFT / REVIEW_PENDING
       provenance.command: python scripts/check_near_saturation_support_obstruction.py --write-artifact
       cover_formulas_brute_force_verified_to_n_12: true
       uniform_threshold_consistency.all_match: true
-      slack_two_failure_records.turn_count_failure.min_cover_after_two_missing_gap3_units: 3
-      slack_two_failure_records.turn_count_failure.turn_contradiction: false
+      headline.n9_sharpened_q_bound: 1
+      headline.n10_sharpened_q_bound: 4
+      headline.n11_sharpened_q_bound: 7
+      headline.n12_sharpened_q_bound: 11
+      headline.n10_min_exact_four_centers: 6
+      headline.n11_min_exact_four_centers: 4
+      headline.n12_min_exact_four_centers: 1
+      headline.newly_excluded_profile_counts.9: 2
+      headline.newly_excluded_profile_counts.10: 2
+      headline.newly_excluded_profile_counts.11: 4
+      headline.newly_excluded_profile_counts.12: 14
+      headline.newly_excluded_profile_counts.13: 30
+      slack_two_boundary_records.chain_disconnection_failure.exhibit_side_chain_disconnected: true
+      slack_two_boundary_records.chain_disconnection_failure.cycle_minus_two_distinct_edges_always_disconnected_n8_to_12: true
+      slack_two_boundary_records.strict_turn_closure_of_other_distributions.min_cover_over_all_two_edge_removals: 3
+      slack_two_boundary_records.strict_turn_closure_of_other_distributions.all_le_two_edge_removal_covers_meet_strict_threshold: true
+      slack_two_boundary_records.strict_turn_closure_of_other_distributions.general_bound_ceil_n_minus_2_over_2_verified_n8_to_12: true
+      slack_two_boundary_records.strict_turn_closure_of_other_distributions.nonstrict_test_fails_for_some_two_edge_removals: true
     forbidden_claims:
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97

--- a/scripts/check_near_saturation_support_obstruction.py
+++ b/scripts/check_near_saturation_support_obstruction.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Check the near-saturation rich-support obstruction bookkeeping.
+
+This standalone checker records the arithmetic and case bookkeeping for the
+review-pending lemma draft in docs/near-saturation-support-obstruction.md:
+
+    For every strictly convex n-gon with n >= 8 and any choice of one
+    same-radius support R_i at each center,
+
+        sum_i binom(|R_i|, 2) <= n(n-2) - 2.
+
+Equivalently, pair-capacity slack 0 and slack 1 are both impossible.  The
+proof extends the support-saturation turn-cover argument from uniform sizes
+at the exact equality wall to arbitrary mixed size profiles and one missing
+capacity unit.
+
+The checker verifies only the discrete bookkeeping used by the proof note
+(distinct short diagonals, chain connectivity, vertex-cover sizes, turn-unit
+arithmetic, profile enumeration, and consistency with the raw-budget and
+uniform-saturation lemmas).  It is not a realization search, it does not
+verify Euclidean geometry, and it does not prove n=9, n=10, n=11, or Erdos
+Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from itertools import combinations
+from math import comb
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "erdos97.near_saturation_support_obstruction.v1"
+STATUS = "REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION"
+TRUST = "LEMMA_DRAFT_REVIEW_PENDING"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / (
+    "near_saturation_support_obstruction.json"
+)
+
+BRUTE_FORCE_MAX_VERTICES = 14
+
+
+def raw_pair_budget(n: int) -> int:
+    """Edge-sensitive pair budget n(n-2) from the counting lemma."""
+
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    return n * (n - 2)
+
+
+def sharpened_pair_budget(n: int) -> int:
+    """Near-saturation budget n(n-2) - 2, claimed for n >= 8."""
+
+    if n < 8:
+        raise ValueError("the near-saturation budget is claimed only for n >= 8")
+    return raw_pair_budget(n) - 2
+
+
+def short_diagonal_pairs(n: int) -> tuple[set[frozenset[int]], set[frozenset[int]]]:
+    """Return the gap-2 and gap-3 diagonal pair sets of the n-cycle."""
+
+    if n < 8:
+        raise ValueError("short-diagonal bookkeeping is used only for n >= 8")
+    gap2 = {frozenset({i, (i + 2) % n}) for i in range(n)}
+    gap3 = {frozenset({i, (i + 3) % n}) for i in range(n)}
+    return gap2, gap3
+
+
+def short_diagonals_distinct(n: int) -> bool:
+    """Check that the n gap-2 and n gap-3 pairs are 2n distinct diagonals."""
+
+    gap2, gap3 = short_diagonal_pairs(n)
+    if len(gap2) != n or len(gap3) != n:
+        return False
+    if gap2 & gap3:
+        return False
+    hull = {frozenset({i, (i + 1) % n}) for i in range(n)}
+    return not ((gap2 | gap3) & hull)
+
+
+def cycle_minus_edges_connected(n: int, removed: tuple[int, ...]) -> bool:
+    """Check connectivity of the n-cycle after removing the listed edges.
+
+    Edge j joins vertices j and j+1 mod n.
+    """
+
+    if n < 3:
+        raise ValueError("cycle size must be at least 3")
+    removed_set = set(removed)
+    adjacency: dict[int, set[int]] = {v: set() for v in range(n)}
+    for j in range(n):
+        if j in removed_set:
+            continue
+        adjacency[j].add((j + 1) % n)
+        adjacency[(j + 1) % n].add(j)
+    seen = {0}
+    stack = [0]
+    while stack:
+        v = stack.pop()
+        for w in adjacency[v]:
+            if w not in seen:
+                seen.add(w)
+                stack.append(w)
+    return len(seen) == n
+
+
+def side_chain_connected_after_one_removal(n: int) -> bool:
+    """Check Step 2: the side-equality chain survives any one missing edge."""
+
+    return all(cycle_minus_edges_connected(n, (j,)) for j in range(n))
+
+
+def min_vertex_cover_cycle(n: int) -> int:
+    """Minimum vertex-cover size of the n-cycle: ceil(n/2)."""
+
+    if n < 3:
+        raise ValueError("cycle size must be at least 3")
+    return (n + 1) // 2
+
+
+def min_vertex_cover_path_edges(edge_count: int) -> int:
+    """Minimum vertex-cover size of a path with the given edge count."""
+
+    if edge_count < 0:
+        raise ValueError("edge count must be nonnegative")
+    return (edge_count + 1) // 2
+
+
+def brute_force_min_cover(n: int, edges: list[tuple[int, int]]) -> int:
+    """Exact minimum vertex cover by subset search (small n only)."""
+
+    if n > BRUTE_FORCE_MAX_VERTICES:
+        raise ValueError("brute-force cover search is limited to small n")
+    for size in range(n + 1):
+        for subset in combinations(range(n), size):
+            chosen = set(subset)
+            if all(a in chosen or b in chosen for a, b in edges):
+                return size
+    raise AssertionError("unreachable: the full vertex set covers everything")
+
+
+def cover_formulas_verified(max_n: int = 12) -> bool:
+    """Brute-force check of the two cover formulas used in Step 4."""
+
+    for n in range(3, max_n + 1):
+        cycle_edges = [(j, (j + 1) % n) for j in range(n)]
+        if brute_force_min_cover(n, cycle_edges) != min_vertex_cover_cycle(n):
+            return False
+        for removed in range(n):
+            path_edges = [edge for j, edge in enumerate(cycle_edges) if j != removed]
+            if brute_force_min_cover(n, path_edges) != min_vertex_cover_path_edges(
+                n - 1
+            ):
+                return False
+    return True
+
+
+def slack_one_case_row(n: int) -> dict[str, Any]:
+    """Case bookkeeping for one n: the three d <= 1 sub-cases of the proof.
+
+    Turn units are counted in multiples of pi/3; each forced exterior turn
+    2*pi/3 contributes 2 units and the total turn 2*pi is 6 units.
+    """
+
+    if n < 8:
+        raise ValueError("the lemma is claimed only for n >= 8")
+    cases = {
+        "all_capacities_saturated": {
+            "side_chain_connected": True,
+            "cover_lower_bound": min_vertex_cover_cycle(n),
+        },
+        "one_gap2_unit_missing": {
+            "side_chain_connected": side_chain_connected_after_one_removal(n),
+            "cover_lower_bound": min_vertex_cover_cycle(n),
+        },
+        "one_gap3_unit_missing": {
+            "side_chain_connected": True,
+            "cover_lower_bound": min_vertex_cover_path_edges(n - 1),
+        },
+    }
+    rows: dict[str, Any] = {}
+    all_contradict = True
+    for name, data in cases.items():
+        turn_units = 2 * int(data["cover_lower_bound"])
+        contradiction = bool(data["side_chain_connected"]) and turn_units > 6
+        all_contradict = all_contradict and contradiction
+        rows[name] = {
+            "side_chain_connected": data["side_chain_connected"],
+            "forced_turn_set_cover_lower_bound": data["cover_lower_bound"],
+            "forced_turn_units_pi_over_3": turn_units,
+            "total_turn_units_pi_over_3": 6,
+            "turn_contradiction": contradiction,
+        }
+    return {
+        "n": n,
+        "raw_pair_budget": raw_pair_budget(n),
+        "sharpened_pair_budget": sharpened_pair_budget(n),
+        "short_diagonals_distinct": short_diagonals_distinct(n),
+        "cases": rows,
+        "slack_le_1_contradiction_in_every_case": (
+            all_contradict and short_diagonals_distinct(n)
+        ),
+    }
+
+
+def four_bad_q_bound(n: int) -> int | None:
+    """Sharpened bound on centers with support size >= 5 in a 4-bad n-gon.
+
+    Returns None when the sharpened budget already excludes 4-bad supports.
+    """
+
+    budget = sharpened_pair_budget(n)
+    if 6 * n > budget:
+        return None
+    return min(n, (budget - 6 * n) // 4)
+
+
+def raw_four_bad_q_bound(n: int) -> int | None:
+    """Raw-budget bound on centers with support size >= 5, for comparison."""
+
+    budget = raw_pair_budget(n)
+    if 6 * n > budget:
+        return None
+    return min(n, (budget - 6 * n) // 4)
+
+
+def enumerate_profiles(n: int) -> tuple[list[dict[str, Any]], list[tuple[int, ...]]]:
+    """Split raw-feasible 4-bad support-size profiles by the sharpened budget.
+
+    Profiles are nondecreasing size tuples with 4 <= size < n and raw pair
+    cost at most n(n-2).  A profile is newly excluded when its raw slack is
+    0 or 1.
+    """
+
+    raw_budget = raw_pair_budget(n)
+    sharpened = sharpened_pair_budget(n)
+    newly_excluded: list[dict[str, Any]] = []
+    surviving: list[tuple[int, ...]] = []
+
+    def visit(start_size: int, remaining: int, used: int, profile: list[int]) -> None:
+        if remaining == 0:
+            if used > sharpened:
+                newly_excluded.append(
+                    {
+                        "profile": list(profile),
+                        "pair_cost": used,
+                        "raw_slack": raw_budget - used,
+                    }
+                )
+            else:
+                surviving.append(tuple(profile))
+            return
+        for size in range(start_size, n):
+            new_used = used + comb(size, 2)
+            if new_used + (remaining - 1) * comb(size, 2) > raw_budget:
+                break
+            profile.append(size)
+            visit(size, remaining - 1, new_used, profile)
+            profile.pop()
+
+    visit(4, n, 0, [])
+    return newly_excluded, surviving
+
+
+def profile_row(n: int) -> dict[str, Any]:
+    """Profile-level consequence row for one n."""
+
+    newly_excluded, surviving = enumerate_profiles(n)
+    surviving_q = [sum(1 for size in profile if size >= 5) for profile in surviving]
+    max_surviving_q = max(surviving_q) if surviving_q else None
+    return {
+        "n": n,
+        "raw_pair_budget": raw_pair_budget(n),
+        "sharpened_pair_budget": sharpened_pair_budget(n),
+        "raw_feasible_profile_count": len(newly_excluded) + len(surviving),
+        "newly_excluded_profile_count": len(newly_excluded),
+        "newly_excluded_profiles": newly_excluded,
+        "surviving_profile_count": len(surviving),
+        "max_q_among_surviving_profiles": max_surviving_q,
+        "raw_budget_q_bound": raw_four_bad_q_bound(n),
+        "sharpened_q_bound": four_bad_q_bound(n),
+        "min_exact_four_centers_sharpened": (
+            None if four_bad_q_bound(n) is None else n - int(four_bad_q_bound(n))
+        ),
+    }
+
+
+def uniform_threshold_consistency(min_k: int = 4, max_k: int = 8) -> dict[str, Any]:
+    """Check that the sharpened budget recovers n >= binom(k,2) + 3."""
+
+    rows: list[dict[str, Any]] = []
+    all_match = True
+    for k in range(min_k, max_k + 1):
+        expected = comb(k, 2) + 3
+        found = None
+        n = 8
+        while found is None:
+            if n * comb(k, 2) <= sharpened_pair_budget(n):
+                found = n
+            n += 1
+        match = found == expected
+        all_match = all_match and match
+        rows.append(
+            {
+                "k": k,
+                "min_n_allowed_by_sharpened_budget": found,
+                "support_saturation_threshold": expected,
+                "match": match,
+            }
+        )
+    return {"rows": rows, "all_match": all_match}
+
+
+def slack_two_failure_records() -> dict[str, Any]:
+    """Record exactly why the method stops at slack 1.
+
+    These are records about the proof method; they claim nothing about the
+    realizability of slack-2 support systems.
+    """
+
+    n = 8
+    # Failure 1: two missing gap-2 units can disconnect the side chain.
+    disconnect_removed = (0, 4)
+    chain_disconnected = not cycle_minus_edges_connected(n, disconnect_removed)
+
+    # Failure 2: two missing gap-3 units can leave a cover of size 3 at n=8,
+    # and 3 forced turns of 2*pi/3 only reach the total turn 2*pi.
+    cycle_edges = [(j, (j + 1) % n) for j in range(n)]
+    min_cover_after_two = min(
+        brute_force_min_cover(
+            n, [edge for j, edge in enumerate(cycle_edges) if j not in removed]
+        )
+        for removed in combinations(range(n), 2)
+    )
+    turn_units = 2 * min_cover_after_two
+    return {
+        "claim_scope": (
+            "method-boundary records only; no claim about slack-2 realizability"
+        ),
+        "equilateral_step_failure": {
+            "n": n,
+            "removed_side_chain_edges": list(disconnect_removed),
+            "side_chain_disconnected": chain_disconnected,
+        },
+        "turn_count_failure": {
+            "n": n,
+            "min_cover_after_two_missing_gap3_units": min_cover_after_two,
+            "forced_turn_units_pi_over_3": turn_units,
+            "total_turn_units_pi_over_3": 6,
+            "turn_contradiction": turn_units > 6,
+        },
+    }
+
+
+def build_summary(min_n: int = 8, max_n: int = 16) -> dict[str, Any]:
+    """Build the stable JSON summary for the lemma-draft bookkeeping."""
+
+    if min_n < 8:
+        raise ValueError("min_n must be at least 8")
+    if max_n < min_n:
+        raise ValueError("max_n must be at least min_n")
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Review-pending near-saturation strengthening of the "
+            "edge-sensitive rich-support pair budget: for strictly convex "
+            "n-gons with n >= 8, sum_i binom(|R_i|,2) <= n(n-2) - 2. "
+            "Discrete bookkeeping checks only; not a realization search, "
+            "not a proof of n=9, n=10, or n=11, not a proof of Erdos "
+            "Problem #97, and not a counterexample."
+        ),
+        "lemma_draft": (
+            "For any same-radius supports R_i in a strictly convex n-gon "
+            "with n >= 8, sum_i binom(|R_i|, 2) <= n(n-2) - 2; equivalently "
+            "pair-capacity slack 0 and 1 are impossible."
+        ),
+        "proof_accounting": {
+            "capacities": (
+                "hull-edge witness pairs have capacity 1, diagonal witness "
+                "pairs capacity 2 with at most one using center per side"
+            ),
+            "step_1_2": (
+                "each saturated gap-2 diagonal forces one side equality; a "
+                "cycle minus at most one edge stays connected, so all sides "
+                "are equal"
+            ),
+            "step_3": (
+                "each saturated gap-3 diagonal forces an exterior turn "
+                "2*pi/3 at one of the two short-side vertices"
+            ),
+            "step_4_5": (
+                "the forced-turn set covers the n-cycle minus at most one "
+                "edge, so it has at least 4 members and the total exterior "
+                "turn would be at least 8*pi/3 > 2*pi"
+            ),
+        },
+        "cover_formulas_brute_force_verified_to_n_12": cover_formulas_verified(),
+        "case_rows": [slack_one_case_row(n) for n in range(min_n, max_n + 1)],
+        "uniform_threshold_consistency": uniform_threshold_consistency(),
+        "four_bad_profile_rows": [profile_row(n) for n in range(9, 14)],
+        "slack_two_failure_records": slack_two_failure_records(),
+    }
+
+
+def check_expected(summary: dict[str, Any]) -> None:
+    """Assert the expected bookkeeping for the default range."""
+
+    if not summary["cover_formulas_brute_force_verified_to_n_12"]:
+        raise AssertionError("vertex-cover formulas failed brute-force verification")
+
+    for row in summary["case_rows"]:
+        if not row["slack_le_1_contradiction_in_every_case"]:
+            raise AssertionError(f"n={row['n']}: missing slack<=1 contradiction")
+        if row["sharpened_pair_budget"] != row["raw_pair_budget"] - 2:
+            raise AssertionError(f"n={row['n']}: budget arithmetic mismatch")
+
+    consistency = summary["uniform_threshold_consistency"]
+    if not consistency["all_match"]:
+        raise AssertionError(
+            "sharpened budget does not recover the uniform saturation thresholds"
+        )
+
+    profile_rows = {row["n"]: row for row in summary["four_bad_profile_rows"]}
+    expected_counts = {
+        # n: (newly excluded, surviving, max surviving q, sharpened q bound,
+        #     raw q bound, min exact-four centers)
+        9: (2, 2, 1, 1, 2, 8),
+        10: (2, 10, 4, 4, 5, 6),
+        11: (4, 33, 7, 7, 8, 4),
+        12: (14, 95, 11, 11, 12, 1),
+        13: (30, 263, 13, 13, 13, 0),
+    }
+    for n, (
+        newly,
+        surviving,
+        max_q,
+        q_bound,
+        raw_q,
+        min_exact_four,
+    ) in expected_counts.items():
+        row = profile_rows[n]
+        got = (
+            row["newly_excluded_profile_count"],
+            row["surviving_profile_count"],
+            row["max_q_among_surviving_profiles"],
+            row["sharpened_q_bound"],
+            row["raw_budget_q_bound"],
+            row["min_exact_four_centers_sharpened"],
+        )
+        want = (newly, surviving, max_q, q_bound, raw_q, min_exact_four)
+        if got != want:
+            raise AssertionError(f"n={n}: got {got}, expected {want}")
+        if row["max_q_among_surviving_profiles"] > row["sharpened_q_bound"]:
+            raise AssertionError(f"n={n}: profile enumeration exceeds the q bound")
+
+    expected_boundary_profiles = {
+        9: [
+            ([4, 4, 4, 4, 4, 4, 4, 4, 6], 63, 0),
+            ([4, 4, 4, 4, 4, 4, 4, 5, 5], 62, 1),
+        ],
+        10: [
+            ([4, 4, 4, 4, 4, 4, 4, 4, 5, 7], 79, 1),
+            ([4, 4, 4, 4, 4, 5, 5, 5, 5, 5], 80, 0),
+        ],
+        11: [
+            ([4, 4, 4, 4, 4, 4, 4, 4, 6, 6, 7], 99, 0),
+            ([4, 4, 4, 4, 4, 4, 4, 5, 5, 6, 7], 98, 1),
+            ([4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6], 99, 0),
+            ([4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5], 98, 1),
+        ],
+    }
+    for n, expected_profiles in expected_boundary_profiles.items():
+        got_profiles = [
+            (entry["profile"], entry["pair_cost"], entry["raw_slack"])
+            for entry in profile_rows[n]["newly_excluded_profiles"]
+        ]
+        want_profiles = [
+            (profile, cost, slack) for profile, cost, slack in expected_profiles
+        ]
+        if got_profiles != want_profiles:
+            raise AssertionError(
+                f"n={n}: newly excluded profiles {got_profiles} != {want_profiles}"
+            )
+
+    failures = summary["slack_two_failure_records"]
+    if not failures["equilateral_step_failure"]["side_chain_disconnected"]:
+        raise AssertionError("expected the slack-2 side-chain disconnection record")
+    turn_failure = failures["turn_count_failure"]
+    if turn_failure["min_cover_after_two_missing_gap3_units"] != 3:
+        raise AssertionError("expected a size-3 cover after two missing gap-3 units")
+    if turn_failure["turn_contradiction"]:
+        raise AssertionError("the slack-2 turn record must not be a contradiction")
+
+
+def artifact_payload(summary: dict[str, Any]) -> dict[str, Any]:
+    """Wrap the summary with an embedded provenance block."""
+
+    payload = dict(summary)
+    payload["provenance"] = {
+        "command": (
+            "python scripts/check_near_saturation_support_obstruction.py "
+            "--write-artifact"
+        ),
+        "generator": "scripts/check_near_saturation_support_obstruction.py",
+        "notes": (
+            "Deterministic bookkeeping summary for the review-pending "
+            "near-saturation rich-support obstruction; regenerated, never "
+            "hand-edited."
+        ),
+    }
+    return payload
+
+
+def check_artifact(path: Path, summary: dict[str, Any]) -> None:
+    """Check the stored artifact against a freshly built summary."""
+
+    stored = json.loads(path.read_text())
+    expected = artifact_payload(summary)
+    if stored != expected:
+        stored_keys = set(stored) if isinstance(stored, dict) else None
+        raise AssertionError(
+            "stored artifact does not match the regenerated summary "
+            f"(stored top-level keys: {sorted(stored_keys) if stored_keys else stored_keys})"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-n", type=int, default=8)
+    parser.add_argument("--max-n", type=int, default=16)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="assert the expected default bookkeeping",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument(
+        "--write-artifact",
+        action="store_true",
+        help="write the summary artifact with embedded provenance",
+    )
+    parser.add_argument(
+        "--check-artifact",
+        action="store_true",
+        help="check the stored artifact against a fresh regeneration",
+    )
+    parser.add_argument(
+        "--artifact",
+        type=Path,
+        default=DEFAULT_ARTIFACT,
+        help="artifact path for --write-artifact / --check-artifact",
+    )
+    args = parser.parse_args()
+
+    summary = build_summary(args.min_n, args.max_n)
+    if args.check or args.check_artifact or args.write_artifact:
+        if (args.min_n, args.max_n) != (8, 16):
+            raise SystemExit(
+                "--check/--write-artifact/--check-artifact are only defined "
+                "for the default n range"
+            )
+        check_expected(summary)
+    if args.write_artifact:
+        args.artifact.parent.mkdir(parents=True, exist_ok=True)
+        args.artifact.write_text(
+            json.dumps(artifact_payload(summary), indent=2, sort_keys=True) + "\n"
+        )
+        print(f"wrote {args.artifact}")
+    if args.check_artifact:
+        check_artifact(args.artifact, summary)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif not args.write_artifact:
+        print(f"schema: {summary['schema']}")
+        print(f"trust: {summary['trust']}")
+        for row in summary["four_bad_profile_rows"]:
+            print(
+                f"n={row['n']}: sharpened q bound={row['sharpened_q_bound']} "
+                f"(raw {row['raw_budget_q_bound']}), newly excluded "
+                f"profiles={row['newly_excluded_profile_count']}, min "
+                f"exact-four centers={row['min_exact_four_centers_sharpened']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_near_saturation_support_obstruction.py
+++ b/scripts/check_near_saturation_support_obstruction.py
@@ -31,9 +31,10 @@ from math import comb
 from pathlib import Path
 from typing import Any
 
-SCHEMA = "erdos97.near_saturation_support_obstruction.v1"
+SCHEMA = "erdos97.near_saturation_support_obstruction.v2"
 STATUS = "REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION"
-TRUST = "LEMMA_DRAFT_REVIEW_PENDING"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+NOTE_STATUS_LABEL = "LEMMA_DRAFT / REVIEW_PENDING"
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / (
@@ -41,6 +42,8 @@ DEFAULT_ARTIFACT = REPO_ROOT / "data" / "certificates" / (
 )
 
 BRUTE_FORCE_MAX_VERTICES = 14
+# Total exterior turn 2*pi is 6 units of pi/3; each forced turn 2*pi/3 is 2.
+TOTAL_TURN_UNITS_PI_OVER_3 = 6
 
 
 def raw_pair_budget(n: int) -> int:
@@ -81,21 +84,24 @@ def short_diagonals_distinct(n: int) -> bool:
     return not ((gap2 | gap3) & hull)
 
 
-def cycle_minus_edges_connected(n: int, removed: tuple[int, ...]) -> bool:
-    """Check connectivity of the n-cycle after removing the listed edges.
-
-    Edge j joins vertices j and j+1 mod n.
-    """
+def cycle_edges(n: int) -> list[tuple[int, int]]:
+    """Edges of the n-cycle in the convention: edge j joins j and j+1 mod n."""
 
     if n < 3:
         raise ValueError("cycle size must be at least 3")
+    return [(j, (j + 1) % n) for j in range(n)]
+
+
+def cycle_minus_edges_connected(n: int, removed: tuple[int, ...]) -> bool:
+    """Check connectivity of the n-cycle after removing the listed edges."""
+
     removed_set = set(removed)
     adjacency: dict[int, set[int]] = {v: set() for v in range(n)}
-    for j in range(n):
+    for j, (a, b) in enumerate(cycle_edges(n)):
         if j in removed_set:
             continue
-        adjacency[j].add((j + 1) % n)
-        adjacency[(j + 1) % n].add(j)
+        adjacency[a].add(b)
+        adjacency[b].add(a)
     seen = {0}
     stack = [0]
     while stack:
@@ -142,33 +148,53 @@ def brute_force_min_cover(n: int, edges: list[tuple[int, int]]) -> int:
     raise AssertionError("unreachable: the full vertex set covers everything")
 
 
+def min_cover_after_removals(n: int, removed: tuple[int, ...]) -> int:
+    """Exact minimum vertex cover of the n-cycle minus the listed edges."""
+
+    removed_set = set(removed)
+    edges = [edge for j, edge in enumerate(cycle_edges(n)) if j not in removed_set]
+    return brute_force_min_cover(n, edges)
+
+
 def cover_formulas_verified(max_n: int = 12) -> bool:
     """Brute-force check of the two cover formulas used in Step 4."""
 
     for n in range(3, max_n + 1):
-        cycle_edges = [(j, (j + 1) % n) for j in range(n)]
-        if brute_force_min_cover(n, cycle_edges) != min_vertex_cover_cycle(n):
+        if min_cover_after_removals(n, ()) != min_vertex_cover_cycle(n):
             return False
         for removed in range(n):
-            path_edges = [edge for j, edge in enumerate(cycle_edges) if j != removed]
-            if brute_force_min_cover(n, path_edges) != min_vertex_cover_path_edges(
+            if min_cover_after_removals(n, (removed,)) != min_vertex_cover_path_edges(
                 n - 1
             ):
                 return False
     return True
 
 
+def forced_turn_units(cover_lower_bound: int) -> int:
+    """Turn units (multiples of pi/3) forced by a turn set of the given size."""
+
+    return 2 * cover_lower_bound
+
+
+def nonstrict_turn_contradiction(cover_lower_bound: int) -> bool:
+    """The proof's Step 5 test: |M| forced turns strictly exceed 2*pi."""
+
+    return forced_turn_units(cover_lower_bound) > TOTAL_TURN_UNITS_PI_OVER_3
+
+
 def slack_one_case_row(n: int) -> dict[str, Any]:
     """Case bookkeeping for one n: the three d <= 1 sub-cases of the proof.
 
-    Turn units are counted in multiples of pi/3; each forced exterior turn
-    2*pi/3 contributes 2 units and the total turn 2*pi is 6 units.
+    The three rows split by where the (at most one) missing capacity unit
+    sits: on no short diagonal at all (this covers d = 0 and a d = 1 unit on
+    a hull edge or a gap >= 4 diagonal), on one gap-2 diagonal, or on one
+    gap-3 diagonal.
     """
 
     if n < 8:
         raise ValueError("the lemma is claimed only for n >= 8")
     cases = {
-        "all_capacities_saturated": {
+        "no_short_diagonal_unit_missing": {
             "side_chain_connected": True,
             "cover_lower_bound": min_vertex_cover_cycle(n),
         },
@@ -184,14 +210,16 @@ def slack_one_case_row(n: int) -> dict[str, Any]:
     rows: dict[str, Any] = {}
     all_contradict = True
     for name, data in cases.items():
-        turn_units = 2 * int(data["cover_lower_bound"])
-        contradiction = bool(data["side_chain_connected"]) and turn_units > 6
+        cover = int(data["cover_lower_bound"])
+        contradiction = bool(data["side_chain_connected"]) and (
+            nonstrict_turn_contradiction(cover)
+        )
         all_contradict = all_contradict and contradiction
         rows[name] = {
             "side_chain_connected": data["side_chain_connected"],
-            "forced_turn_set_cover_lower_bound": data["cover_lower_bound"],
-            "forced_turn_units_pi_over_3": turn_units,
-            "total_turn_units_pi_over_3": 6,
+            "forced_turn_set_cover_lower_bound": cover,
+            "forced_turn_units_pi_over_3": forced_turn_units(cover),
+            "total_turn_units_pi_over_3": TOTAL_TURN_UNITS_PI_OVER_3,
             "turn_contradiction": contradiction,
         }
     return {
@@ -206,25 +234,29 @@ def slack_one_case_row(n: int) -> dict[str, Any]:
     }
 
 
-def four_bad_q_bound(n: int) -> int | None:
-    """Sharpened bound on centers with support size >= 5 in a 4-bad n-gon.
+def four_bad_q_bound_for_budget(n: int, budget: int) -> int | None:
+    """Bound on centers with support size >= 5 in a 4-bad n-gon.
 
-    Returns None when the sharpened budget already excludes 4-bad supports.
+    Returns None when the budget already excludes 4-bad supports (the
+    exact-four baseline alone exceeds it, as the sharpened budget does at
+    n = 8).
     """
 
-    budget = sharpened_pair_budget(n)
     if 6 * n > budget:
         return None
-    return min(n, (budget - 6 * n) // 4)
+    return min(n, (budget - 6 * n) // (comb(5, 2) - comb(4, 2)))
+
+
+def four_bad_q_bound(n: int) -> int | None:
+    """Sharpened-budget bound on centers with support size >= 5."""
+
+    return four_bad_q_bound_for_budget(n, sharpened_pair_budget(n))
 
 
 def raw_four_bad_q_bound(n: int) -> int | None:
     """Raw-budget bound on centers with support size >= 5, for comparison."""
 
-    budget = raw_pair_budget(n)
-    if 6 * n > budget:
-        return None
-    return min(n, (budget - 6 * n) // 4)
+    return four_bad_q_bound_for_budget(n, raw_pair_budget(n))
 
 
 def enumerate_profiles(n: int) -> tuple[list[dict[str, Any]], list[tuple[int, ...]]]:
@@ -271,6 +303,7 @@ def profile_row(n: int) -> dict[str, Any]:
     newly_excluded, surviving = enumerate_profiles(n)
     surviving_q = [sum(1 for size in profile if size >= 5) for profile in surviving]
     max_surviving_q = max(surviving_q) if surviving_q else None
+    sharpened_q = four_bad_q_bound(n)
     return {
         "n": n,
         "raw_pair_budget": raw_pair_budget(n),
@@ -281,15 +314,20 @@ def profile_row(n: int) -> dict[str, Any]:
         "surviving_profile_count": len(surviving),
         "max_q_among_surviving_profiles": max_surviving_q,
         "raw_budget_q_bound": raw_four_bad_q_bound(n),
-        "sharpened_q_bound": four_bad_q_bound(n),
+        "sharpened_q_bound": sharpened_q,
         "min_exact_four_centers_sharpened": (
-            None if four_bad_q_bound(n) is None else n - int(four_bad_q_bound(n))
+            None if sharpened_q is None else n - sharpened_q
         ),
     }
 
 
 def uniform_threshold_consistency(min_k: int = 4, max_k: int = 8) -> dict[str, Any]:
-    """Check that the sharpened budget recovers n >= binom(k,2) + 3."""
+    """Check that the sharpened budget recovers n >= binom(k,2) + 3.
+
+    The scan starts at n = 8 because the raw budget already excludes
+    every-center size >= 4 supports for n <= 7 (6n > n(n-2)); the sharpened
+    budget is only claimed for n >= 8.
+    """
 
     rows: list[dict[str, Any]] = []
     all_match = True
@@ -314,43 +352,97 @@ def uniform_threshold_consistency(min_k: int = 4, max_k: int = 8) -> dict[str, A
     return {"rows": rows, "all_match": all_match}
 
 
-def slack_two_failure_records() -> dict[str, Any]:
-    """Record exactly why the method stops at slack 1.
+def slack_two_boundary_records() -> dict[str, Any]:
+    """Record the exact slack-2 boundary of the proof method.
 
-    These are records about the proof method; they claim nothing about the
-    realizability of slack-2 support systems.
+    Two records, both about the proof method rather than realizability:
+
+    1. The genuine failure mode: two DISTINCT gap-2 diagonals each short by
+       one unit remove two side-chain edges, and a cycle minus two distinct
+       edges is always disconnected, so the equilateral step fails and no
+       turn contradiction follows from these steps.
+
+    2. The corrected turn accounting: with the strict form of Step 5 (the
+       forced-turn set M is a proper subset of the n turn indices, so
+       |M| >= 3 already forces total turn > 2*pi for n >= 4), every other
+       slack-2 distribution still contradicts, because the cover of the
+       turn-index cycle loses at most two edges and stays at least
+       ceil((n-2)/2) >= 3 for n >= 8.  The note's headline proof uses the
+       non-strict test (|M| >= 4), which genuinely fails on some two-edge
+       removals (minimum cover exactly 3), so the uniform theorem still
+       stops at slack 1 because of record 1, not because of the turn count.
     """
 
     n = 8
-    # Failure 1: two missing gap-2 units can disconnect the side chain.
+    # Record 1: two missing gap-2 units always disconnect the side chain.
     disconnect_removed = (0, 4)
-    chain_disconnected = not cycle_minus_edges_connected(n, disconnect_removed)
-
-    # Failure 2: two missing gap-3 units can leave a cover of size 3 at n=8,
-    # and 3 forced turns of 2*pi/3 only reach the total turn 2*pi.
-    cycle_edges = [(j, (j + 1) % n) for j in range(n)]
-    min_cover_after_two = min(
-        brute_force_min_cover(
-            n, [edge for j, edge in enumerate(cycle_edges) if j not in removed]
-        )
-        for removed in combinations(range(n), 2)
+    exhibit_disconnected = not cycle_minus_edges_connected(n, disconnect_removed)
+    always_disconnected = all(
+        not cycle_minus_edges_connected(m, pair)
+        for m in range(8, 13)
+        for pair in combinations(range(m), 2)
     )
-    turn_units = 2 * min_cover_after_two
+
+    # Record 2: cover bounds for at most two missing gap-3 units.
+    two_removal_covers = [
+        min_cover_after_removals(n, pair) for pair in combinations(range(n), 2)
+    ]
+    min_cover_two_removals = min(two_removal_covers)
+    min_cover_le_two_removals = min(
+        min_cover_after_removals(n, ()),
+        min(min_cover_after_removals(n, (j,)) for j in range(n)),
+        min_cover_two_removals,
+    )
+    general_bound_holds = all(
+        min_cover_after_removals(m, removed) >= max(3, (m - 2 + 1) // 2)
+        for m in range(8, 13)
+        for count in (0, 1, 2)
+        for removed in combinations(range(m), count)
+    )
     return {
         "claim_scope": (
             "method-boundary records only; no claim about slack-2 realizability"
         ),
-        "equilateral_step_failure": {
+        "chain_disconnection_failure": {
             "n": n,
-            "removed_side_chain_edges": list(disconnect_removed),
-            "side_chain_disconnected": chain_disconnected,
+            "exhibit_removed_side_chain_edges": list(disconnect_removed),
+            "exhibit_side_chain_disconnected": exhibit_disconnected,
+            "cycle_minus_two_distinct_edges_always_disconnected_n8_to_12": (
+                always_disconnected
+            ),
         },
-        "turn_count_failure": {
+        "strict_turn_closure_of_other_distributions": {
             "n": n,
-            "min_cover_after_two_missing_gap3_units": min_cover_after_two,
-            "forced_turn_units_pi_over_3": turn_units,
-            "total_turn_units_pi_over_3": 6,
-            "turn_contradiction": turn_units > 6,
+            "strict_turn_set_threshold": 3,
+            "min_cover_over_all_two_edge_removals": min_cover_two_removals,
+            "min_cover_over_all_le_two_edge_removals": min_cover_le_two_removals,
+            "all_le_two_edge_removal_covers_meet_strict_threshold": (
+                min_cover_le_two_removals >= 3
+            ),
+            "general_bound_ceil_n_minus_2_over_2_verified_n8_to_12": (
+                general_bound_holds
+            ),
+            "nonstrict_test_fails_for_some_two_edge_removals": (
+                not nonstrict_turn_contradiction(min_cover_two_removals)
+            ),
+        },
+    }
+
+
+def headline_counts(profile_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compact headline block for provenance pinning and ledger crosswalks."""
+
+    rows = {row["n"]: row for row in profile_rows}
+    return {
+        "n9_sharpened_q_bound": rows[9]["sharpened_q_bound"],
+        "n10_sharpened_q_bound": rows[10]["sharpened_q_bound"],
+        "n11_sharpened_q_bound": rows[11]["sharpened_q_bound"],
+        "n12_sharpened_q_bound": rows[12]["sharpened_q_bound"],
+        "n10_min_exact_four_centers": rows[10]["min_exact_four_centers_sharpened"],
+        "n11_min_exact_four_centers": rows[11]["min_exact_four_centers_sharpened"],
+        "n12_min_exact_four_centers": rows[12]["min_exact_four_centers_sharpened"],
+        "newly_excluded_profile_counts": {
+            str(n): rows[n]["newly_excluded_profile_count"] for n in range(9, 14)
         },
     }
 
@@ -362,10 +454,12 @@ def build_summary(min_n: int = 8, max_n: int = 16) -> dict[str, Any]:
         raise ValueError("min_n must be at least 8")
     if max_n < min_n:
         raise ValueError("max_n must be at least min_n")
+    profile_rows = [profile_row(n) for n in range(9, 14)]
     return {
         "schema": SCHEMA,
         "status": STATUS,
         "trust": TRUST,
+        "note_status_label": NOTE_STATUS_LABEL,
         "claim_scope": (
             "Review-pending near-saturation strengthening of the "
             "edge-sensitive rich-support pair budget: for strictly convex "
@@ -402,8 +496,9 @@ def build_summary(min_n: int = 8, max_n: int = 16) -> dict[str, Any]:
         "cover_formulas_brute_force_verified_to_n_12": cover_formulas_verified(),
         "case_rows": [slack_one_case_row(n) for n in range(min_n, max_n + 1)],
         "uniform_threshold_consistency": uniform_threshold_consistency(),
-        "four_bad_profile_rows": [profile_row(n) for n in range(9, 14)],
-        "slack_two_failure_records": slack_two_failure_records(),
+        "four_bad_profile_rows": profile_rows,
+        "headline": headline_counts(profile_rows),
+        "slack_two_boundary_records": slack_two_boundary_records(),
     }
 
 
@@ -455,7 +550,11 @@ def check_expected(summary: dict[str, Any]) -> None:
         want = (newly, surviving, max_q, q_bound, raw_q, min_exact_four)
         if got != want:
             raise AssertionError(f"n={n}: got {got}, expected {want}")
-        if row["max_q_among_surviving_profiles"] > row["sharpened_q_bound"]:
+        max_q_value = row["max_q_among_surviving_profiles"]
+        q_bound_value = row["sharpened_q_bound"]
+        if max_q_value is None or q_bound_value is None:
+            raise AssertionError(f"n={n}: unexpected empty profile or q bound")
+        if max_q_value > q_bound_value:
             raise AssertionError(f"n={n}: profile enumeration exceeds the q bound")
 
     expected_boundary_profiles = {
@@ -487,14 +586,43 @@ def check_expected(summary: dict[str, Any]) -> None:
                 f"n={n}: newly excluded profiles {got_profiles} != {want_profiles}"
             )
 
-    failures = summary["slack_two_failure_records"]
-    if not failures["equilateral_step_failure"]["side_chain_disconnected"]:
-        raise AssertionError("expected the slack-2 side-chain disconnection record")
-    turn_failure = failures["turn_count_failure"]
-    if turn_failure["min_cover_after_two_missing_gap3_units"] != 3:
-        raise AssertionError("expected a size-3 cover after two missing gap-3 units")
-    if turn_failure["turn_contradiction"]:
-        raise AssertionError("the slack-2 turn record must not be a contradiction")
+    headline = summary["headline"]
+    expected_headline = {
+        "n9_sharpened_q_bound": 1,
+        "n10_sharpened_q_bound": 4,
+        "n11_sharpened_q_bound": 7,
+        "n12_sharpened_q_bound": 11,
+        "n10_min_exact_four_centers": 6,
+        "n11_min_exact_four_centers": 4,
+        "n12_min_exact_four_centers": 1,
+        "newly_excluded_profile_counts": {
+            "9": 2,
+            "10": 2,
+            "11": 4,
+            "12": 14,
+            "13": 30,
+        },
+    }
+    if headline != expected_headline:
+        raise AssertionError(f"unexpected headline block: {headline}")
+
+    boundary = summary["slack_two_boundary_records"]
+    chain = boundary["chain_disconnection_failure"]
+    if not chain["exhibit_side_chain_disconnected"]:
+        raise AssertionError("expected the slack-2 side-chain disconnection exhibit")
+    if not chain["cycle_minus_two_distinct_edges_always_disconnected_n8_to_12"]:
+        raise AssertionError("expected cycle-minus-two-edges disconnection to hold")
+    strict = boundary["strict_turn_closure_of_other_distributions"]
+    if strict["min_cover_over_all_two_edge_removals"] != 3:
+        raise AssertionError("expected minimum two-edge-removal cover exactly 3")
+    if not strict["all_le_two_edge_removal_covers_meet_strict_threshold"]:
+        raise AssertionError("expected all <=2-edge-removal covers to be >= 3")
+    if not strict["general_bound_ceil_n_minus_2_over_2_verified_n8_to_12"]:
+        raise AssertionError("expected the general two-removal cover bound to hold")
+    if not strict["nonstrict_test_fails_for_some_two_edge_removals"]:
+        raise AssertionError(
+            "expected the non-strict turn test to fail at the minimum cover"
+        )
 
 
 def artifact_payload(summary: dict[str, Any]) -> dict[str, Any]:
@@ -519,20 +647,33 @@ def artifact_payload(summary: dict[str, Any]) -> dict[str, Any]:
 def check_artifact(path: Path, summary: dict[str, Any]) -> None:
     """Check the stored artifact against a freshly built summary."""
 
-    stored = json.loads(path.read_text())
+    try:
+        stored_text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise SystemExit(
+            f"stored artifact not found: {path}; regenerate it with "
+            "python scripts/check_near_saturation_support_obstruction.py "
+            "--write-artifact"
+        ) from None
+    try:
+        stored = json.loads(stored_text)
+    except json.JSONDecodeError as error:
+        raise SystemExit(
+            f"stored artifact is not valid JSON: {path} ({error}); regenerate "
+            "it with python scripts/check_near_saturation_support_obstruction.py "
+            "--write-artifact"
+        ) from None
     expected = artifact_payload(summary)
     if stored != expected:
-        stored_keys = set(stored) if isinstance(stored, dict) else None
+        stored_keys = sorted(stored) if isinstance(stored, dict) else None
         raise AssertionError(
             "stored artifact does not match the regenerated summary "
-            f"(stored top-level keys: {sorted(stored_keys) if stored_keys else stored_keys})"
+            f"(stored top-level keys: {stored_keys})"
         )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--min-n", type=int, default=8)
-    parser.add_argument("--max-n", type=int, default=16)
     parser.add_argument(
         "--check",
         action="store_true",
@@ -557,18 +698,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    summary = build_summary(args.min_n, args.max_n)
+    summary = build_summary()
     if args.check or args.check_artifact or args.write_artifact:
-        if (args.min_n, args.max_n) != (8, 16):
-            raise SystemExit(
-                "--check/--write-artifact/--check-artifact are only defined "
-                "for the default n range"
-            )
         check_expected(summary)
     if args.write_artifact:
         args.artifact.parent.mkdir(parents=True, exist_ok=True)
         args.artifact.write_text(
-            json.dumps(artifact_payload(summary), indent=2, sort_keys=True) + "\n"
+            json.dumps(artifact_payload(summary), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
         )
         print(f"wrote {args.artifact}")
     if args.check_artifact:
@@ -578,7 +716,7 @@ def main() -> int:
         print(json.dumps(summary, indent=2, sort_keys=True))
     elif not args.write_artifact:
         print(f"schema: {summary['schema']}")
-        print(f"trust: {summary['trust']}")
+        print(f"trust: {summary['trust']} (note status: {NOTE_STATUS_LABEL})")
         for row in summary["four_bad_profile_rows"]:
             print(
                 f"n={row['n']}: sharpened q bound={row['sharpened_q_bound']} "

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -1989,6 +1989,24 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="near_saturation_support_obstruction",
+        command=(
+            "python",
+            "scripts/check_near_saturation_support_obstruction.py",
+            "--check",
+            "--check-artifact",
+            "--json",
+        ),
+        claim_scope=(
+            "Review-pending near-saturation strengthening of the "
+            "edge-sensitive rich-support pair budget to n(n-2)-2 for "
+            "n >= 8, with sharpened 4-bad support-size profile counts for "
+            "n = 9..13; discrete bookkeeping checks only, not a proof of "
+            "n=9, not a proof of n=10, not a proof of n=11, not a proof of "
+            "Erdos Problem #97, and not a counterexample."
+        ),
+    ),
+    AuditCommand(
         ident="n12_rich_support_determinant",
         command=(
             "python",

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -215,6 +215,10 @@ def test_verify_bridge_frontier_includes_bootstrap_audits() -> None:
         "python scripts/check_bridge_lemma_frontier.py --check --assert-expected --json",
         "python scripts/check_rich_support_counting_bound.py --check --json",
         "python scripts/check_support_saturation_obstruction.py --check --json",
+        (
+            "python scripts/check_near_saturation_support_obstruction.py "
+            "--check --check-artifact --json"
+        ),
         "python scripts/check_n12_rich_support_determinant.py --check --json",
         "python scripts/check_localized_rich_support_counting.py --check --json",
         (

--- a/tests/test_near_saturation_support_obstruction.py
+++ b/tests/test_near_saturation_support_obstruction.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_near_saturation_support_obstruction import (  # noqa: E402
+    DEFAULT_ARTIFACT,
+    build_summary,
+    check_artifact,
+    check_expected,
+    cycle_minus_edges_connected,
+    enumerate_profiles,
+    four_bad_q_bound,
+    min_vertex_cover_cycle,
+    min_vertex_cover_path_edges,
+    raw_pair_budget,
+    sharpened_pair_budget,
+    short_diagonals_distinct,
+    slack_one_case_row,
+)
+
+
+def test_near_saturation_expected_summary() -> None:
+    summary = build_summary()
+
+    check_expected(summary)
+    assert summary["trust"] == "LEMMA_DRAFT_REVIEW_PENDING"
+    rows = {row["n"]: row for row in summary["four_bad_profile_rows"]}
+    assert rows[10]["sharpened_q_bound"] == 4
+    assert rows[10]["min_exact_four_centers_sharpened"] == 6
+    assert rows[11]["sharpened_q_bound"] == 7
+    assert rows[11]["min_exact_four_centers_sharpened"] == 4
+
+
+def test_near_saturation_budgets_and_cases() -> None:
+    assert raw_pair_budget(10) == 80
+    assert sharpened_pair_budget(10) == 78
+    assert sharpened_pair_budget(8) == 46
+    with pytest.raises(ValueError):
+        sharpened_pair_budget(7)
+
+    assert short_diagonals_distinct(8)
+    assert short_diagonals_distinct(11)
+
+    for n in (8, 9, 11, 16):
+        row = slack_one_case_row(n)
+        assert row["slack_le_1_contradiction_in_every_case"]
+        for case in row["cases"].values():
+            assert case["forced_turn_units_pi_over_3"] > 6
+
+
+def test_near_saturation_cover_and_chain_helpers() -> None:
+    assert min_vertex_cover_cycle(8) == 4
+    assert min_vertex_cover_cycle(11) == 6
+    assert min_vertex_cover_path_edges(7) == 4
+    assert min_vertex_cover_path_edges(10) == 5
+
+    assert cycle_minus_edges_connected(8, (3,))
+    assert not cycle_minus_edges_connected(8, (0, 4))
+
+
+def test_near_saturation_profile_enumeration() -> None:
+    newly_excluded, surviving = enumerate_profiles(10)
+    excluded_profiles = [tuple(entry["profile"]) for entry in newly_excluded]
+    assert excluded_profiles == [
+        (4, 4, 4, 4, 4, 4, 4, 4, 5, 7),
+        (4, 4, 4, 4, 4, 5, 5, 5, 5, 5),
+    ]
+    assert max(sum(1 for s in profile if s >= 5) for profile in surviving) == 4
+    assert four_bad_q_bound(10) == 4
+    assert four_bad_q_bound(11) == 7
+    assert four_bad_q_bound(12) == 11
+
+
+def test_near_saturation_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_near_saturation_support_obstruction.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "erdos97.near_saturation_support_obstruction.v1"
+    assert payload["status"] == "REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION"
+    assert payload["uniform_threshold_consistency"]["all_match"]
+    failures = payload["slack_two_failure_records"]
+    assert failures["turn_count_failure"]["turn_contradiction"] is False
+
+
+@pytest.mark.artifact
+def test_near_saturation_stored_artifact_matches() -> None:
+    summary = build_summary()
+    check_artifact(DEFAULT_ARTIFACT, summary)

--- a/tests/test_near_saturation_support_obstruction.py
+++ b/tests/test_near_saturation_support_obstruction.py
@@ -20,6 +20,7 @@ from check_near_saturation_support_obstruction import (  # noqa: E402
     cycle_minus_edges_connected,
     enumerate_profiles,
     four_bad_q_bound,
+    min_cover_after_removals,
     min_vertex_cover_cycle,
     min_vertex_cover_path_edges,
     raw_pair_budget,
@@ -33,12 +34,15 @@ def test_near_saturation_expected_summary() -> None:
     summary = build_summary()
 
     check_expected(summary)
-    assert summary["trust"] == "LEMMA_DRAFT_REVIEW_PENDING"
+    assert summary["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert summary["note_status_label"] == "LEMMA_DRAFT / REVIEW_PENDING"
     rows = {row["n"]: row for row in summary["four_bad_profile_rows"]}
     assert rows[10]["sharpened_q_bound"] == 4
     assert rows[10]["min_exact_four_centers_sharpened"] == 6
     assert rows[11]["sharpened_q_bound"] == 7
     assert rows[11]["min_exact_four_centers_sharpened"] == 4
+    assert summary["headline"]["n10_min_exact_four_centers"] == 6
+    assert summary["headline"]["n11_min_exact_four_centers"] == 4
 
 
 def test_near_saturation_budgets_and_cases() -> None:
@@ -54,6 +58,11 @@ def test_near_saturation_budgets_and_cases() -> None:
     for n in (8, 9, 11, 16):
         row = slack_one_case_row(n)
         assert row["slack_le_1_contradiction_in_every_case"]
+        assert set(row["cases"]) == {
+            "no_short_diagonal_unit_missing",
+            "one_gap2_unit_missing",
+            "one_gap3_unit_missing",
+        }
         for case in row["cases"].values():
             assert case["forced_turn_units_pi_over_3"] > 6
 
@@ -67,6 +76,12 @@ def test_near_saturation_cover_and_chain_helpers() -> None:
     assert cycle_minus_edges_connected(8, (3,))
     assert not cycle_minus_edges_connected(8, (0, 4))
 
+    # Adjacent-pair removals at n=8 are exactly where the non-strict turn
+    # test fails: the minimum cover drops to 3 but never below.
+    assert min_cover_after_removals(8, (0, 1)) == 3
+    assert min_cover_after_removals(8, (0, 4)) == 4
+    assert min_cover_after_removals(8, ()) == 4
+
 
 def test_near_saturation_profile_enumeration() -> None:
     newly_excluded, surviving = enumerate_profiles(10)
@@ -79,6 +94,20 @@ def test_near_saturation_profile_enumeration() -> None:
     assert four_bad_q_bound(10) == 4
     assert four_bad_q_bound(11) == 7
     assert four_bad_q_bound(12) == 11
+
+
+def test_near_saturation_slack_two_boundary_records() -> None:
+    summary = build_summary()
+    boundary = summary["slack_two_boundary_records"]
+    chain = boundary["chain_disconnection_failure"]
+    assert chain["exhibit_side_chain_disconnected"]
+    assert chain["cycle_minus_two_distinct_edges_always_disconnected_n8_to_12"]
+    strict = boundary["strict_turn_closure_of_other_distributions"]
+    assert strict["strict_turn_set_threshold"] == 3
+    assert strict["min_cover_over_all_two_edge_removals"] == 3
+    assert strict["all_le_two_edge_removal_covers_meet_strict_threshold"]
+    assert strict["general_bound_ceil_n_minus_2_over_2_verified_n8_to_12"]
+    assert strict["nonstrict_test_fails_for_some_two_edge_removals"]
 
 
 def test_near_saturation_cli_json() -> None:
@@ -96,11 +125,16 @@ def test_near_saturation_cli_json() -> None:
     )
 
     payload = json.loads(result.stdout)
-    assert payload["schema"] == "erdos97.near_saturation_support_obstruction.v1"
+    assert payload["schema"] == "erdos97.near_saturation_support_obstruction.v2"
     assert payload["status"] == "REVIEW_PENDING_NEAR_SATURATION_OBSTRUCTION"
+    assert payload["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
     assert payload["uniform_threshold_consistency"]["all_match"]
-    failures = payload["slack_two_failure_records"]
-    assert failures["turn_count_failure"]["turn_contradiction"] is False
+
+
+def test_near_saturation_check_artifact_missing_path_is_clean() -> None:
+    summary = build_summary()
+    with pytest.raises(SystemExit, match="write-artifact"):
+        check_artifact(ROOT / "data" / "certificates" / "no_such_artifact.json", summary)
 
 
 @pytest.mark.artifact

--- a/tests/test_run_artifact_audit.py
+++ b/tests/test_run_artifact_audit.py
@@ -879,6 +879,11 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
         in command_texts
     )
     assert (
+        "python scripts/check_near_saturation_support_obstruction.py --check "
+        "--check-artifact --json"
+        in command_texts
+    )
+    assert (
         "python scripts/check_n12_rich_support_determinant.py --check --json"
         in command_texts
     )
@@ -896,6 +901,13 @@ def test_audit_commands_include_registered_followup_checkers() -> None:
     )
     assert ordered_command_texts.index(
         "python scripts/check_support_saturation_obstruction.py --check --json"
+    ) < ordered_command_texts.index(
+        "python scripts/check_near_saturation_support_obstruction.py --check "
+        "--check-artifact --json"
+    )
+    assert ordered_command_texts.index(
+        "python scripts/check_near_saturation_support_obstruction.py --check "
+        "--check-artifact --json"
     ) < ordered_command_texts.index(
         "python scripts/check_n12_rich_support_determinant.py --check --json"
     )


### PR DESCRIPTION
## What exact mathematical object is studied

Same-radius support systems in strictly convex `n`-gons: one support `R_i` (all members on one circle centered at `v_i`) chosen at each center, with arbitrary sizes. The unit of progress is a near-saturation strengthening of the edge-sensitive rich-support pair budget:

```
sum_i binom(|R_i|, 2) <= n(n-2) - 2   for every n >= 8,
```

i.e. pair-capacity slack `0` and slack `1` are both geometrically impossible. The proof extends the repository's support-saturation turn-cover argument (a) from uniform support sizes at the exact equality wall to arbitrary mixed size profiles, and (b) from slack 0 to slack 1: with at most one capacity unit missing, at least `n-1` gap-2 diagonals stay saturated and force all sides equal through a connected chain, at least `n-1` gap-3 diagonals stay saturated and force exterior turns of `2*pi/3` on a set covering the turn-index cycle minus at most one edge, so at least four turns of `2*pi/3` would exceed the total turn `2*pi`.

## Result class and trust label

`LEMMA_DRAFT` / `REVIEW_PENDING` (weakest compatible label; promotable only by independent review; queued in `docs/review-priorities.md`). The stored bookkeeping artifact carries the canonical `REVIEW_PENDING_DIAGNOSTIC` trust class natively.

## Hypotheses required

Strict convexity, `n >= 8`, and only already-recorded capacity facts: hull-edge bisector capacity 1, diagonal bisector capacity 2 with the base-apex one-center-per-side refinement from `docs/n8-geometric-proof.md`. No 4-badness assumption in the lemma draft itself.

## Which bridge this strengthens

The rich-support counting reduction (same lane as `docs/rich-support-counting-lemma.md`, `docs/support-saturation-obstruction.md`, `docs/localized-rich-support-counting.md`): it constrains arbitrary hypothetical counterexamples by counting plus elementary convexity, before any search or filter.

## What it rules out

- Any support system with pair-capacity slack `0` or `1` in a strictly convex `n`-gon, `n >= 8`.
- New counting floors: a hypothetical 4-bad decagon has at least **6** exact-four centers (raw budget: 5); a hypothetical 4-bad hendecagon has at least **4** (raw budget: 3). Newly excluded boundary size-profiles are listed exactly in the note (e.g. `(4^5 5^5)` and `(4^8 5 7)` at `n=10`; four profiles at `n=11`).
- The uniform thresholds `n >= binom(k,2)+3` become direct budget corollaries (with the `n <= 7` range covered by the raw budget).

## What it does NOT rule out

- Slack `>= 2` support systems. The note records the exact method boundary: two distinct unsaturated gap-2 diagonals always disconnect the side-equality chain, so the equilateral step fails there; a strict form of the turn count closes every other slack-2 distribution, but that remaining family keeps the uniform claim at `n(n-2) - 2`.
- `n=9`, `n=10`, `n=11`, the review-pending exact-four frontier, or Erdos Problem #97. No counterexample is claimed; no finite-case or global status changes. At `n=9` the nonagon profile-deficiency refinement (`docs/rich-support-counting-lemma.md`) and the localized per-label cap (`docs/localized-rich-support-counting.md`) remain stronger; at `n=10` the search-based `q<=2` diagnostic remains stronger than this counting `q<=4`.

## Review pass applied in this PR

A ten-angle internal adversarial review (second commit) corrected the draft before external review: the original slack-2 boundary record claiming "the turn count fails at n=8" was mathematically false and was replaced by the corrected boundary above (lemma statement, proof steps, and all counting consequences unchanged); the artifact trust field was normalized to the canonical class (dropping a one-off manifest override); the statement heading was retitled from "Theorem" to "Lemma draft"; a citation conflating the two prior n=9 refinements was fixed; the missing `n <= 7` step was added to the uniform corollary; verification-contract fields (known counterexample attempts, 3-neighbor survival) were added; the RESULTS.md entry moved into its own status-labeled subsection; the checker was registered in the Makefile-chain and audit-order tests; headline counts are now pinned in the provenance manifest; and artifact IO is pinned to utf-8 with clean missing-artifact diagnostics. Artifact regenerated under schema `v2`.

## Verify commands

```
make verify-fast                                                        # green: 1535+ passed
python scripts/check_near_saturation_support_obstruction.py --check --check-artifact --json
python -m pytest tests/test_near_saturation_support_obstruction.py -q -m "artifact or not artifact"
```

The checker is registered in `Makefile` (`verify-bridge-frontier`), `scripts/run_artifact_audit.py`, and `metadata/generated_artifacts.yaml` (provenance check green).

## Files changed

- `docs/near-saturation-support-obstruction.md` (proof note, corrected boundary records, contract fields, non-claims)
- `scripts/check_near_saturation_support_obstruction.py` (bookkeeping checker + artifact generator/replayer)
- `data/certificates/near_saturation_support_obstruction.json` (generated artifact, embedded provenance, schema v2)
- `tests/test_near_saturation_support_obstruction.py`, `tests/test_makefile_targets.py`, `tests/test_run_artifact_audit.py`
- Ledgers: `STATE.md`, `RESULTS.md`, `CHANGELOG.md`, `docs/claims.md`, `docs/index.md`, `docs/review-priorities.md`, `docs/localized-rich-support-counting.md`
- Registrations: `Makefile`, `scripts/run_artifact_audit.py`, `metadata/generated_artifacts.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qrtTyznfYquHBVhMdVsqo