### PR TITLE
Strengthen the support-pair slack bound linearly

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -80,34 +80,26 @@ case. See `docs/n12-rich-support-determinant-obstruction.md` and
 
 Status: `LEMMA_DRAFT` / `REVIEW_PENDING`.
 
-A review-pending near-saturation strengthening sharpens the edge-sensitive
-pair budget above by two units for every `n >= 8`: pair-capacity slack `0`
-or `1` still forces the equilateral/turn-cover contradiction, with no
-assumption on the support-size profile, so
+A review-pending linear-slack strengthening sharpens the edge-sensitive pair
+budget above by a growing number of units for every `n >= 8`:
 
 ```text
-sum_i binom(|R_i|, 2) <= n(n - 2) - 2.
+sum_i binom(|R_i|, 2) <= n(n - 2) - ceil((n - 4)/2).
 ```
 
-The slack-1 case survives one missing capacity unit because the
-side-equality chain is a cycle minus at most one edge and the forced-turn
-set still covers at least `ceil((n-1)/2) >= 4` turn indices. Consequences:
-a hypothetical 4-bad decagon has at least six exact-four centers (raw
-budget: five), a hypothetical 4-bad hendecagon has at least four (raw
-budget: three), and the uniform saturation thresholds
-`n >= binom(k,2) + 3` become direct budget corollaries for `n >= 8`.
-
-The uniform statement stops at slack `1` because of exactly one method
-boundary: two distinct gap-2 diagonals each missing one unit disconnect the
-side-equality chain (a cycle minus two distinct edges is always
-disconnected), so the equilateral step fails. A strict form of the turn
-count (a proper forced-turn subset of size at least three already exceeds
-total turn `2*pi`) closes every other slack-2 distribution, but that
-remaining family keeps the claim at `n(n-2) - 2`. This does not prove
-`n=9`, `n=10`, `n=11`, or Erdos Problem #97. See
-`docs/near-saturation-support-obstruction.md`,
-`scripts/check_near_saturation_support_obstruction.py`, and
-`data/certificates/near_saturation_support_obstruction.json`.
+If `B` and `G` are the unsaturated gap-2 and gap-3 index sets, then at least
+`n-(2|B|+|G|)` local equal-side turn clauses remain. At most two exterior
+turns can equal `2*pi/3`, so those clauses occupy at most four turn-cycle
+edges. Since `|B|+|G|` is at most the total pair-capacity slack `d`, this gives
+`2d >= n-4`. The older two-unit argument is the `n=8` endpoint of this bound.
+Consequences still include at least six exact-four centers in a hypothetical
+4-bad decagon and at least four in a hypothetical 4-bad hendecagon; integer
+rounding keeps those headline floors unchanged while the mixed-profile budget
+is stronger. This does not prove `n=9`, `n=10`, `n=11`, or Erdos Problem #97.
+See `docs/linear-slack-support-obstruction.md` and
+`scripts/check_linear_slack_support_obstruction.py`; the earlier proof and
+artifact remain independently replayable through
+`scripts/check_near_saturation_support_obstruction.py`.
 
 ### Lemma: crossing-bisector and sharpened count
 

--- a/STATE.md
+++ b/STATE.md
@@ -307,20 +307,18 @@ not prove the full dodecagon case. See `docs/rich-support-counting-lemma.md`,
 `docs/n12-rich-support-determinant-obstruction.md`, and
 `docs/localized-rich-support-counting.md`.
 
-A review-pending near-saturation strengthening sharpens that support pair
-budget by two units for every `n >= 8`: pair-capacity slack `0` or `1`
-already forces the equilateral/turn-cover contradiction with no assumption
-on the support-size profile, so `sum_i binom(|R_i|, 2) <= n(n-2) - 2`. This
-raises the counting floors to at least six exact-four centers in a
-hypothetical 4-bad decagon and at least four in a hypothetical 4-bad
-hendecagon, and it recovers the uniform saturation thresholds
-`n >= binom(k,2) + 3` as direct budget corollaries. The draft records the
-exact method boundary that keeps the uniform statement at slack `1`: two
-distinct unsaturated gap-2 diagonals disconnect the side-equality chain,
-while a strict turn count closes every other slack-2 distribution. It does
-not extend the `n=9` conclusions, does not prove `n=9`, `n=10`, or `n=11`,
-and does not change any finite-case or global status. See
-`docs/near-saturation-support-obstruction.md` and
+A review-pending linear-slack strengthening now sharpens that support pair
+budget by `ceil((n-4)/2)` units for every `n >= 8`:
+`sum_i binom(|R_i|,2) <= n(n-2)-ceil((n-4)/2)`. It keeps the original
+gap-2/gap-3 saturation argument local, so two gap-2 deficits may disconnect
+the global side-equality chain without destroying all three-equal-side turn
+clauses. This retains the previously recorded floors of at least six
+exact-four centers in a hypothetical 4-bad decagon and four in a hypothetical
+4-bad hendecagon while strengthening the underlying mixed-profile budget. It
+does not extend the `n=9` conclusions, prove `n=9`, `n=10`, or `n=11`, or
+change any finite-case or global status. See
+`docs/linear-slack-support-obstruction.md`; the earlier two-unit proof and its
+artifact remain in `docs/near-saturation-support-obstruction.md` and
 `data/certificates/near_saturation_support_obstruction.json`.
 
 A follow-up to the sharpened counting lemma above, the mixed rich-support

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -161,33 +161,32 @@ with `scripts/check_n12_rich_support_determinant.py`.
 Status: `LEMMA_DRAFT` / `REVIEW_PENDING`.
 
 For any same-radius supports `R_i` in a strictly convex `n`-gon with
-`n >= 8`, the edge-sensitive pair budget sharpens by two units:
+`n >= 8`, let `d` be the unused edge-sensitive pair capacity. The original
+near-saturation argument proves `d >= 2`. A follow-up local argument gives the
+stronger general bound
 
 ```text
-sum_i binom(|R_i|, 2) <= n(n - 2) - 2.
+d >= ceil((n-4)/2),
+sum_i binom(|R_i|, 2) <= n(n-2)-ceil((n-4)/2).
 ```
 
-Pair-capacity slack `0` or `1` leaves at most one capacity unit missing, so
-at least `n-1` gap-2 diagonals stay saturated and force all sides equal
-through a connected side-equality chain, while at least `n-1` gap-3
-diagonals stay saturated and force exterior turns of `2*pi/3` on a set
-covering the `n`-cycle minus at most one edge. That cover has at least four
-members, so the total exterior turn would be at least `8*pi/3 > 2*pi`.
-Unlike the equality-wall saturation lemma, no assumption is made on the
-support-size profile.
+If `B` and `G` are the unsaturated gap-2 and gap-3 index sets, at least
+`n-(2|B|+|G|)` local three-equal-side turn clauses remain. At most two
+exterior turns can equal `2*pi/3`, so they meet at most four clause edges.
+Together with `|B|+|G| <= d`, this gives `2d >= n-4`. Unlike the original
+proof, this does not require the side-equality chain to remain globally
+connected, and no assumption is made on the support-size profile.
 
 Consequences: a hypothetical 4-bad decagon has at least six exact-four
 centers (raw budget: five), a hypothetical 4-bad hendecagon has at least
 four (raw budget: three), and the uniform thresholds
 `n >= binom(k,2) + 3` follow directly from the sharpened budget for
-`n >= 8`. The uniform statement stops at slack `1` because two distinct
-gap-2 diagonals each missing one unit always disconnect the side-equality
-chain; a strict form of the turn count closes every other slack-2
-distribution, but that remaining family is a genuine method boundary. This
-does not prove the review-pending exact-four frontier, `n=9`, `n=10`,
-`n=11`, or Erdos Problem #97. See
-`docs/near-saturation-support-obstruction.md` and
-`scripts/check_near_saturation_support_obstruction.py`.
+`n >= 8`. This does not prove the review-pending exact-four frontier, `n=9`,
+`n=10`, `n=11`, or Erdos Problem #97. See
+`docs/near-saturation-support-obstruction.md`,
+`docs/linear-slack-support-obstruction.md`,
+`scripts/check_near_saturation_support_obstruction.py`, and
+`scripts/check_linear_slack_support_obstruction.py`.
 
 ### Selected-path self-edge obstruction
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,10 @@ put detailed reconciliation in the canonical synthesis.
   `n(n-2)-2` for `n >= 8` (slack `0` and `1` both impossible), raising the
   4-bad decagon/hendecagon exact-four floors to six and four; not an `n=9`,
   `n=10`, `n=11`, or global proof.
+- [`linear-slack-support-obstruction.md`](linear-slack-support-obstruction.md):
+  review-pending general-n strengthening of the same budget to
+  `n(n-2)-ceil((n-4)/2)` by retaining local three-side equalities after the
+  global equilateral chain disconnects; not a finite-case or global proof.
 - [`n12-rich-support-determinant-obstruction.md`](n12-rich-support-determinant-obstruction.md):
   independent determinant obstruction for the all-five-rich `n=12`
   support-count equality wall; not a proof of the full `n=12` case.

--- a/docs/linear-slack-support-obstruction.md
+++ b/docs/linear-slack-support-obstruction.md
@@ -1,0 +1,177 @@
+# Linear slack support obstruction
+
+Status: `LEMMA_DRAFT` / `REVIEW_PENDING`. This note does not claim a proof of
+Erdos Problem #97, a proof of any finite case beyond the stated counting
+lemma, or a counterexample. Independent proof review is requested before
+theorem-style use.
+
+## Statement
+
+Let `v_0,...,v_{n-1}` be the vertices of a strictly convex polygon in cyclic
+order, with `n >= 8`. At each center `i`, choose one same-radius support
+`R_i subset V \ {v_i}`. Define the usage of an unordered vertex pair by
+
+```text
+u({x,y}) = #{i : {x,y} subset R_i}.
+```
+
+Hull-edge pairs have capacity one and diagonal pairs have capacity two. The
+edge-sensitive raw budget and its unused capacity are therefore
+
+```text
+sum_i binom(|R_i|,2) = sum_pairs u({x,y}) <= n(n-2),
+d = n(n-2) - sum_i binom(|R_i|,2).
+```
+
+The claimed strengthening is
+
+```text
+d >= ceil((n-4)/2) = floor((n-3)/2),
+```
+
+or equivalently
+
+```text
+sum_i binom(|R_i|,2)
+    <= n(n-2) - ceil((n-4)/2).
+```
+
+For `n=8` this recovers the earlier two-unit near-saturation bound. It is
+strictly stronger for every `n >= 9`.
+
+## Proof
+
+Write `s_i = |v_i v_{i+1}|` for the side lengths and let `tau_i in (0,pi)` be
+the exterior turns, with indices modulo `n` and
+
+```text
+sum_i tau_i = 2*pi.
+```
+
+Let `B` be the set of indices `i` for which the gap-2 diagonal
+`{v_i,v_{i+2}}` is not saturated, and let `G` be the analogous set for the
+gap-3 diagonal `{v_i,v_{i+3}}`. The two short-diagonal families contain `2n`
+distinct pairs when `n >= 8`. Every member of `B` or `G` consumes at least one
+unit of pair-capacity slack, so
+
+```text
+|B| + |G| <= d.                                      (1)
+```
+
+### Local side equalities
+
+If gap-2 diagonal `i` is saturated, its two using centers lie on opposite
+sides of its line. The short side contains only `v_{i+1}`, so that vertex is
+one of the centers and
+
+```text
+s_i = s_{i+1}.                                       (2)
+```
+
+The earlier near-saturation proof chained these equalities around the entire
+polygon. That global step fails after two distinct gap-2 deficits. The key
+point here is that only a local chain of two equalities is needed.
+
+Fix a gap-3 index `i` such that
+
+```text
+i notin G,   i notin B,   i+1 notin B.               (3)
+```
+
+The last two conditions and (2) give
+
+```text
+s_i = s_{i+1} = s_{i+2}.
+```
+
+The saturated gap-3 diagonal has one using center on its short side, which is
+either `v_{i+1}` or `v_{i+2}`. If it is `v_{i+1}`, the equal-radius condition
+and the equilateral local side triple force `tau_{i+2}=2*pi/3`. If it is
+`v_{i+2}`, the symmetric argument forces `tau_{i+1}=2*pi/3`. Thus every index
+satisfying (3) gives the turn clause
+
+```text
+tau_{i+1} = 2*pi/3  or  tau_{i+2} = 2*pi/3.           (4)
+```
+
+### Clause count
+
+Let `M={j : tau_j=2*pi/3}`. A bad gap-3 index removes at most its own clause.
+A bad gap-2 index can remove only the clauses at indices `i-1` and `i`.
+Consequently at least
+
+```text
+h >= n - (2|B| + |G|)                                (5)
+```
+
+distinct edges of the turn-index cycle must meet `M`.
+
+There cannot be three members of `M`: three turns of `2*pi/3` already sum to
+`2*pi`, while every remaining exterior turn is strictly positive. Hence
+`|M| <= 2`. Two vertices of a cycle meet at most four distinct cycle edges, so
+`h <= 4`. Combining this with (5) gives
+
+```text
+n - 4 <= 2|B| + |G|
+      <= 2(|B|+|G|)
+      <= 2d,                                          (6)
+```
+
+where the last inequality is (1). Since `d` is an integer,
+
+```text
+d >= ceil((n-4)/2).
+```
+
+This proves the draft statement.
+
+## What changed relative to the two-unit proof
+
+`docs/near-saturation-support-obstruction.md` stopped at `d>=2` because two
+distinct gap-2 deficits disconnect the global side-equality chain. That
+diagnosis is correct for the global-equilateral argument but is not a boundary
+for the local turn clauses. Away from the at most four clause indices touched
+by those two deficits, the three consecutive sides needed for (4) are still
+equal. This closes slack `2` for `n>=9`, slack `3` for `n>=11`, and in general
+gives the linear bound above.
+
+The local clause condition already appears in the finite `n=9` base-apex
+diagnostic (`docs/n9-base-apex-frontier.md`). Its exhaustive escape search for
+`n=8,...,12` reports minimum deficits `2,3,3,4,4`, exactly matching
+`ceil((n-4)/2)`. That finite search is an independent cross-check, not an input
+to the general proof.
+
+## Consequences and scope
+
+The first budgets are
+
+| `n` | slack lower bound | support-pair budget |
+|---:|---:|---:|
+| 8 | 2 | 46 |
+| 9 | 3 | 60 |
+| 10 | 3 | 77 |
+| 11 | 4 | 95 |
+| 12 | 4 | 116 |
+
+For hypothetical 4-bad polygons, integer rounding means this does not improve
+the previously recorded floors of six exact-four centers at `n=10`, four at
+`n=11`, and one at `n=12`; it strengthens the underlying mixed-profile budget
+and excludes every support-size profile whose raw slack is below the displayed
+linear threshold.
+
+This is a support-pair counting lemma only. It does not classify the surviving
+support systems, force a selected row, prove `n=9`, `n=10`, or any larger
+finite case, or prove Erdos Problem #97.
+
+## Verification
+
+Run
+
+```bash
+python scripts/check_linear_slack_support_obstruction.py --check --json
+```
+
+The checker verifies the arithmetic rows and independently enumerates every
+gap-2/gap-3 unit-deficit placement up to the first escape for `n=8,...,12`.
+It checks the minimum deficits `2,3,3,4,4`. This validates the finite cyclic
+bookkeeping; it does not replace review of the geometric saturation lemmas.

--- a/docs/localized-rich-support-counting.md
+++ b/docs/localized-rich-support-counting.md
@@ -93,11 +93,12 @@ n = 12: no exact-four center is forced by these two budgets alone
 For `n = 5, 6, 7`, the edge-sensitive global pair budget already rules out
 4-bad supports.
 
-A review-pending near-saturation strengthening of the global pair budget
-(`docs/near-saturation-support-obstruction.md`) sharpens the `n = 10` and
-`n = 11` floors in this table to six and four exact-four centers and forces
-one exact-four center at `n = 12` from the budget alone; the rows above
-record only what the raw budgets prove.
+A review-pending linear-slack strengthening of the global pair budget
+(`docs/linear-slack-support-obstruction.md`) replaces the constant two-unit
+improvement by `ceil((n-4)/2)`. It sharpens the `n = 10` and `n = 11` floors
+in this table to six and four exact-four centers and forces one exact-four
+center at `n = 12` from the budget alone; the rows above record only what the
+raw budgets prove.
 
 The support-saturation obstruction in `docs/support-saturation-obstruction.md`
 adds a separate equality-wall count: all centers having support size at least

--- a/docs/near-saturation-support-obstruction.md
+++ b/docs/near-saturation-support-obstruction.md
@@ -244,10 +244,22 @@ search's `q <= 2`), but it is a proof-facing budget statement with no
 enumeration, and it is the first improvement at `n = 11`, where no search
 result exists.
 
-## Boundary: why slack 2 is out of reach for this method
+## Former boundary: the global-equilateral proof at slack 2
 
-The argument does not extend to `d = 2` as stated, and this note claims
-nothing about `d = 2`. The method boundary is exactly one failure mode.
+The general-n follow-up in `docs/linear-slack-support-obstruction.md` bypasses
+the boundary below by using only local triples of equal consecutive sides. It
+proves the stronger review-pending bound
+
+```text
+d >= ceil((n-4)/2).
+```
+
+Thus slack `2` is closed for `n >= 9`, even though the global side-equality
+chain can disconnect. The discussion below records the exact limitation of
+the original all-sides-equal argument and remains the live boundary at `n=8`.
+
+The original argument does not extend to `d = 2` as stated. Its method
+boundary is exactly one failure mode.
 
 **The genuine failure mode: the equilateral step.** If the two missing
 units sit on two DISTINCT gap-2 diagonals, the side-equality chain loses
@@ -273,12 +285,14 @@ edges, leaving a vertex cover of size at least `ceil((n-2)/2) >= 3` for
 
 The headline proof deliberately uses the non-strict test `|M| >= 4`, which
 genuinely fails on some two-edge removals (for `n = 8`, adjacent-pair
-removals leave a minimum cover of exactly `3`). The uniform statement
-therefore still stops at slack `1` because of the equilateral failure mode
-above, not because of the turn count.
+removals leave a minimum cover of exactly `3`). The original global-equilateral
+statement therefore stopped at slack `1` because of the equilateral failure
+mode above, not because of the turn count.
 
-These are records about this proof method, not claims about the
-realizability of the remaining slack-2 support systems.
+These are records about the original proof method, not claims about the
+realizability of slack-2 support systems. The linear follow-up shows that the
+remaining family cannot occur when `n >= 9`; it leaves `d=2` open only at the
+level of this support-pair lemma when `n=8`.
 
 ## Known counterexample attempts
 

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -787,15 +787,16 @@ condition that the surviving multi-block family does not automatically satisfy:
 - bootstrap-core/private-halo analysis, as recorded in
   `docs/bootstrap-core-bridge.md`, which adds a `rho > 3` closure-rank witness,
   deletion closures, and weighted cyclic outside-pair capacity.
-- the review-pending near-saturation support obstruction in
-  `docs/near-saturation-support-obstruction.md`, which sharpens the
-  edge-sensitive support pair budget to `n(n-2) - 2` for `n >= 8` and
-  raises the 4-bad decagon/hendecagon exact-four floors to six and four.
-  Before theorem-style use, independently check the one-center-per-side
-  saturation step, the cycle-minus-one-edge equilateral chain, the
-  gap-3/turn conversion, the strict turn count in the boundary section,
-  and the exhaustive profile enumeration in
-  `scripts/check_near_saturation_support_obstruction.py`.
+- the review-pending linear-slack support obstruction in
+  `docs/linear-slack-support-obstruction.md`, which sharpens the
+  edge-sensitive support pair budget to
+  `n(n-2)-ceil((n-4)/2)` for `n >= 8`. Before theorem-style use,
+  independently check the one-center-per-side saturation step, the local
+  three-side equality indexing, the gap-3/turn conversion, the claim that at
+  most two `2*pi/3` turns can occur, and the finite escape cross-check in
+  `scripts/check_linear_slack_support_obstruction.py`. The earlier two-unit
+  proof and artifact remain as an independent endpoint replay in
+  `docs/near-saturation-support-obstruction.md`.
 - the review-pending complement-seeding refinement in
   `docs/bootstrap-core-complement-seeding.md`, which gives
   `2|U| <= 3|V\U|` for a cardinality-minimum generator and forces a strictly

--- a/scripts/check_linear_slack_support_obstruction.py
+++ b/scripts/check_linear_slack_support_obstruction.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Check the linear rich-support slack obstruction bookkeeping.
+
+The review-pending proof note ``docs/linear-slack-support-obstruction.md``
+claims that, for same-radius supports on a strictly convex n-gon with n >= 8,
+the unused edge-sensitive pair capacity ``d`` satisfies
+
+    d >= ceil((n - 4) / 2) = floor((n - 3) / 2).
+
+This checker verifies the discrete cyclic bookkeeping and independently
+enumerates the minimum gap-2/gap-3 deficit needed to escape the resulting turn
+clauses for n = 8,...,12. It does not verify the Euclidean lemmas used by the
+proof note and is not a realization search or a proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from itertools import combinations
+import json
+
+
+SCHEMA = "erdos97.linear_slack_support_obstruction.v1"
+STATUS = "REVIEW_PENDING_LINEAR_SLACK_OBSTRUCTION"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+MIN_N = 8
+FINITE_CROSSCHECK_MAX_N = 12
+
+
+def raw_pair_budget(n: int) -> int:
+    """Return the edge-sensitive witness-pair capacity n(n-2)."""
+
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+    return n * (n - 2)
+
+
+def linear_slack_lower_bound(n: int) -> int:
+    """Return ceil((n-4)/2), claimed for n >= 8."""
+
+    if n < MIN_N:
+        raise ValueError("the linear slack bound is claimed only for n >= 8")
+    return (n - 3) // 2
+
+
+def linear_pair_budget(n: int) -> int:
+    """Return n(n-2) minus the claimed linear slack lower bound."""
+
+    return raw_pair_budget(n) - linear_slack_lower_bound(n)
+
+
+def clean_gap3_indices(
+    n: int,
+    unsaturated_gap2: frozenset[int],
+    unsaturated_gap3: frozenset[int],
+) -> tuple[int, ...]:
+    """Indices whose local gap-2/gap-3 data force a two-turn clause.
+
+    Gap-3 index i is clean precisely when its own diagonal is saturated and
+    the gap-2 diagonals indexed i and i+1 are both saturated. Those two
+    gap-2 equalities make side lengths s_i, s_(i+1), s_(i+2) equal locally;
+    no global equilateral side chain is assumed.
+    """
+
+    if n < MIN_N:
+        raise ValueError("short-diagonal bookkeeping requires n >= 8")
+    bad2 = {index % n for index in unsaturated_gap2}
+    bad3 = {index % n for index in unsaturated_gap3}
+    return tuple(
+        index
+        for index in range(n)
+        if index not in bad3
+        and index not in bad2
+        and (index + 1) % n not in bad2
+    )
+
+
+def forced_turn_edges(
+    n: int,
+    unsaturated_gap2: frozenset[int],
+    unsaturated_gap3: frozenset[int],
+) -> tuple[tuple[int, int], ...]:
+    """Return the turn-cycle edges hit by a forced 2*pi/3 turn."""
+
+    return tuple(
+        ((index + 1) % n, (index + 2) % n)
+        for index in clean_gap3_indices(n, unsaturated_gap2, unsaturated_gap3)
+    )
+
+
+def minimum_turn_cover_size(n: int, edges: tuple[tuple[int, int], ...]) -> int:
+    """Return the exact minimum vertex cover for a small turn-edge set."""
+
+    for size in range(n + 1):
+        for chosen_tuple in combinations(range(n), size):
+            chosen = set(chosen_tuple)
+            if all(left in chosen or right in chosen for left, right in edges):
+                return size
+    raise AssertionError("the full turn set must cover every edge")
+
+
+def forces_turn_contradiction(
+    n: int,
+    unsaturated_gap2: frozenset[int],
+    unsaturated_gap3: frozenset[int],
+) -> bool:
+    """Whether the clauses force at least three 2*pi/3 exterior turns."""
+
+    edges = forced_turn_edges(n, unsaturated_gap2, unsaturated_gap3)
+    return minimum_turn_cover_size(n, edges) >= 3
+
+
+@dataclass(frozen=True)
+class EscapeRecord:
+    n: int
+    minimum_unit_deficit: int
+    unsaturated_gap2: tuple[int, ...]
+    unsaturated_gap3: tuple[int, ...]
+    clean_clause_count: int
+    minimum_forced_turns: int
+
+
+def minimum_unit_deficit_to_escape(n: int) -> EscapeRecord:
+    """Enumerate the first gap-2/gap-3 unit-deficit placement that escapes.
+
+    A short diagonal with a larger shortfall consumes more total slack without
+    removing any additional clause, so unit deficits are the extremal case for
+    finding the minimum total slack.
+    """
+
+    if not MIN_N <= n <= FINITE_CROSSCHECK_MAX_N:
+        raise ValueError("the exhaustive cross-check is limited to 8 <= n <= 12")
+    tagged = tuple((gap, index) for gap in (2, 3) for index in range(n))
+    for deficit in range(2 * n + 1):
+        for removed in combinations(tagged, deficit):
+            bad2 = frozenset(index for gap, index in removed if gap == 2)
+            bad3 = frozenset(index for gap, index in removed if gap == 3)
+            edges = forced_turn_edges(n, bad2, bad3)
+            cover = minimum_turn_cover_size(n, edges)
+            if cover < 3:
+                return EscapeRecord(
+                    n=n,
+                    minimum_unit_deficit=deficit,
+                    unsaturated_gap2=tuple(sorted(bad2)),
+                    unsaturated_gap3=tuple(sorted(bad3)),
+                    clean_clause_count=len(edges),
+                    minimum_forced_turns=cover,
+                )
+    raise AssertionError("removing every short diagonal must escape the clauses")
+
+
+def bound_row(n: int) -> dict[str, int]:
+    """Return one exact arithmetic row for the claimed bound."""
+
+    slack = linear_slack_lower_bound(n)
+    return {
+        "n": n,
+        "raw_pair_budget": raw_pair_budget(n),
+        "linear_slack_lower_bound": slack,
+        "linear_pair_budget": linear_pair_budget(n),
+        "twice_slack": 2 * slack,
+        "n_minus_4": n - 4,
+    }
+
+
+def build_summary() -> dict[str, object]:
+    """Build the deterministic reviewer-facing JSON summary."""
+
+    escape_records = [
+        asdict(minimum_unit_deficit_to_escape(n))
+        for n in range(MIN_N, FINITE_CROSSCHECK_MAX_N + 1)
+    ]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": (
+            "Review-pending general-n strengthening of the edge-sensitive "
+            "rich-support pair budget: pair-capacity slack d is at least "
+            "ceil((n-4)/2) for n >= 8. Discrete bookkeeping checks only; "
+            "not a realization search, not a finite-case proof beyond the "
+            "stated counting lemma, not a proof of Erdos Problem #97, and "
+            "not a counterexample."
+        ),
+        "lemma_draft": (
+            "For same-radius supports R_i in a strictly convex n-gon with "
+            "n >= 8, sum_i binom(|R_i|,2) <= "
+            "n(n-2)-ceil((n-4)/2)."
+        ),
+        "proof_accounting": {
+            "B": "indices of unsaturated gap-2 diagonals",
+            "G": "indices of unsaturated gap-3 diagonals",
+            "clean_clause_lower_bound": "h >= n - (2|B| + |G|)",
+            "turn_budget": (
+                "at most two exterior turns can equal 2*pi/3, so they hit "
+                "at most four distinct turn-cycle edges"
+            ),
+            "slack_chain": (
+                "n-4 <= 2|B|+|G| <= 2(|B|+|G|) <= 2d"
+            ),
+        },
+        "bound_rows": [bound_row(n) for n in range(8, 33)],
+        "finite_escape_crosscheck": escape_records,
+    }
+
+
+def check_expected(summary: dict[str, object]) -> None:
+    """Assert the formula and independent finite escape cross-check."""
+
+    rows = summary["bound_rows"]
+    assert isinstance(rows, list)
+    for row in rows:
+        assert isinstance(row, dict)
+        n = int(row["n"])
+        slack = int(row["linear_slack_lower_bound"])
+        if 2 * slack < n - 4:
+            raise AssertionError(f"n={n}: lower bound misses n-4")
+        if slack > 0 and 2 * (slack - 1) >= n - 4:
+            raise AssertionError(f"n={n}: lower bound is not the ceiling")
+        if int(row["linear_pair_budget"]) != raw_pair_budget(n) - slack:
+            raise AssertionError(f"n={n}: pair-budget arithmetic mismatch")
+
+    records = summary["finite_escape_crosscheck"]
+    assert isinstance(records, list)
+    expected = {8: 2, 9: 3, 10: 3, 11: 4, 12: 4}
+    got = {
+        int(record["n"]): int(record["minimum_unit_deficit"])
+        for record in records
+        if isinstance(record, dict)
+    }
+    if got != expected:
+        raise AssertionError(f"finite escape minima {got} != {expected}")
+    for n, deficit in got.items():
+        if deficit != linear_slack_lower_bound(n):
+            raise AssertionError(f"n={n}: finite minimum disagrees with formula")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="assert expected rows")
+    parser.add_argument("--json", action="store_true", help="emit full JSON")
+    args = parser.parse_args()
+
+    summary = build_summary()
+    if args.check:
+        check_expected(summary)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"schema: {SCHEMA}")
+        print(f"trust: {TRUST}")
+        print("linear slack bound: ceil((n-4)/2) for n >= 8")
+        print(
+            "finite escape minima: "
+            + ", ".join(
+                f"n={row['n']} -> {row['minimum_unit_deficit']}"
+                for row in summary["finite_escape_crosscheck"]
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_linear_slack_support_obstruction.py
+++ b/tests/test_linear_slack_support_obstruction.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_linear_slack_support_obstruction import (  # noqa: E402
+    SCHEMA,
+    build_summary,
+    check_expected,
+    clean_gap3_indices,
+    forced_turn_edges,
+    linear_pair_budget,
+    linear_slack_lower_bound,
+    minimum_unit_deficit_to_escape,
+)
+from erdos97.n9_base_apex import (  # noqa: E402
+    minimum_capacity_deficit_to_escape_turn_cover,
+)
+
+
+def test_linear_slack_formula_and_budget() -> None:
+    expected = {8: 2, 9: 3, 10: 3, 11: 4, 12: 4, 13: 5}
+    assert {n: linear_slack_lower_bound(n) for n in expected} == expected
+    assert linear_pair_budget(8) == 46
+    assert linear_pair_budget(9) == 60
+    assert linear_pair_budget(12) == 116
+    with pytest.raises(ValueError):
+        linear_slack_lower_bound(7)
+
+
+def test_clean_clause_indices_use_only_local_side_equalities() -> None:
+    assert clean_gap3_indices(9, frozenset(), frozenset()) == tuple(range(9))
+
+    # A gap-2 deficit at index 2 removes only clauses 1 and 2, because the
+    # clean clause at i needs gap-2 indices i and i+1.
+    assert clean_gap3_indices(9, frozenset({2}), frozenset()) == (
+        0,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+    )
+    # A gap-3 deficit removes only its own clause.
+    assert 5 not in clean_gap3_indices(9, frozenset(), frozenset({5}))
+    assert forced_turn_edges(9, frozenset(), frozenset({5}))[0] == (1, 2)
+
+
+def test_finite_escape_minima_match_formula_and_prior_independent_search() -> None:
+    for n in range(8, 13):
+        local = minimum_unit_deficit_to_escape(n)
+        prior = minimum_capacity_deficit_to_escape_turn_cover(
+            n,
+            contradiction_threshold=3,
+        )
+        assert local.minimum_unit_deficit == linear_slack_lower_bound(n)
+        assert prior.minimum_capacity_deficit == local.minimum_unit_deficit
+        assert local.minimum_forced_turns < 3
+
+
+def test_linear_slack_summary() -> None:
+    summary = build_summary()
+    check_expected(summary)
+    assert summary["schema"] == SCHEMA
+    assert summary["trust"] == "REVIEW_PENDING_DIAGNOSTIC"
+    assert [
+        row["minimum_unit_deficit"]
+        for row in summary["finite_escape_crosscheck"]
+    ] == [2, 3, 3, 4, 4]
+
+
+def test_linear_slack_cli_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_linear_slack_support_obstruction.py",
+            "--check",
+            "--json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == SCHEMA
+    assert payload["status"] == "REVIEW_PENDING_LINEAR_SLACK_OBSTRUCTION"


### PR DESCRIPTION
## What changed

- Adds a review-pending general-`n` support-pair lemma:
  `d >= ceil((n-4)/2)`, where `d` is unused edge-sensitive pair capacity.
- Replaces the former global-equilateral slack-2 boundary with a local three-side argument.
- Adds an independent checker and tests. The finite escape minima for `n=8,...,12` are `2,3,3,4,4`, matching the older base-apex search.
- Updates the proof-facing claim, state, results, index, and review ledgers without changing the global status.

## Why

The earlier proof stopped at `d >= 2` because two deficient gap-2 diagonals can disconnect the global side-equality chain. Global equilateralness is unnecessary: every unaffected gap-3 window still supplies a local turn clause. If `B` and `G` are the deficient gap-2 and gap-3 index sets, at least `n-(2|B|+|G|)` clause edges remain. At most two exterior turns can equal `2*pi/3`, so at most four such edges can be covered. Together with `|B|+|G| <= d`, this yields `2d >= n-4`.

## Scope

This is a support-pair counting lemma only. It does not prove `n=9`, `n=10`, any larger finite case, or Erdős Problem #97. It does not claim a counterexample. The official/global status remains open and the source-of-truth local finite result remains `n <= 8`.

## Validation

- `python scripts/check_linear_slack_support_obstruction.py --check --json`
- `make verify-fast`
  - 1,573 passed
  - 689 deselected
- Text cleanliness, status consistency, artifact provenance, Ruff, and `git diff --check` all pass.
