### PR TITLE
Reject signed-zero artifact drift

### DIFF
--- a/src/erdos97/portable_compare.py
+++ b/src/erdos97/portable_compare.py
@@ -53,14 +53,16 @@ def assert_portable_payload_equal(
             if stored != current:
                 raise AssertionError(f"{path}: non-finite float mismatch")
             return
-        if stored == current:
-            return
         # A sign change is a semantic change even if both values are tiny.
         sign_changed = math.copysign(1.0, stored) != math.copysign(1.0, current)
-        if stored == 0.0 or current == 0.0 or sign_changed:
+        stored_zero = stored == 0.0
+        current_zero = current == 0.0
+        if sign_changed or stored_zero != current_zero:
             raise AssertionError(
                 f"{path}: float sign/zero mismatch ({stored!r} != {current!r})"
             )
+        if stored == current:
+            return
         if not math.isclose(
             stored,
             current,

--- a/tests/test_portable_compare.py
+++ b/tests/test_portable_compare.py
@@ -1,0 +1,31 @@
+"""Regression tests for portable float-bearing artifact comparisons."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from erdos97.portable_compare import assert_portable_payload_equal
+
+
+@pytest.mark.parametrize(
+    ("stored", "current"),
+    (
+        (0.0, -0.0),
+        (-0.0, 0.0),
+        (0.0, math.ulp(0.0)),
+        (-0.0, -math.ulp(0.0)),
+    ),
+)
+def test_portable_comparison_rejects_sign_and_exact_zero_drift(
+    stored: float,
+    current: float,
+) -> None:
+    with pytest.raises(AssertionError, match="float sign/zero mismatch"):
+        assert_portable_payload_equal(stored, current)
+
+
+@pytest.mark.parametrize("value", (0.0, -0.0))
+def test_portable_comparison_accepts_identically_signed_zero(value: float) -> None:
+    assert_portable_payload_equal(value, value)


### PR DESCRIPTION
## What changed

- Moves float sign/zero validation ahead of the equality fast path in the portable artifact comparator.
- Rejects `+0.0` versus `-0.0` in both directions.
- Rejects exact zero versus a same-sign nonzero subnormal.
- Adds focused regression tests for rejected and accepted zero cases.

## Root cause

Python considers `0.0 == -0.0` true. The comparator returned from its equality fast path before checking `copysign`, even though the module contract says sign changes are semantic and must fail closed.

## Impact

Artifact replay continues to tolerate the intended last-tail drift for finite nonzero floats, while signed-zero and exact-zero semantic changes can no longer pass silently. No mathematical claim or stored artifact changes.

## Validation

- `make verify-fast`
  - 1,574 passed
  - 689 deselected
- 19 focused comparator, signed-band, and quarter-cell tests passed.
- Both affected stored-artifact replay commands passed.
- Text cleanliness, status consistency, artifact provenance, Ruff, and `git diff --check` all pass.
