### PR TITLE
Extract Kalmanson equilateral-hinge lemma

### DIFF
--- a/data/certificates/kalmanson_equilateral_hinge_crosswalk.json
+++ b/data/certificates/kalmanson_equilateral_hinge_crosswalk.json
@@ -1,0 +1,2302 @@
+{
+  "claim_scope": "Arbitrary-n local strict-Kalmanson equilateral-hinge lemma and a deterministic crosswalk against the stored review-pending n=9 three-row compression; the source frontier is not regenerated and no result status is promoted.",
+  "crosswalk_sha256": "41390dbac0177ace8615e393fe4826dd5a7d325ccdc46370e07d315caa2f2a8d",
+  "interpretation_warnings": [
+    "The local hinge lemma is arbitrary-n, but this crosswalk only audits the stored n=9 compression records.",
+    "The source frontier remains review-pending and is not independently regenerated here.",
+    "No theorem forces an equilateral hinge in every hypothetical counterexample yet."
+  ],
+  "lemma": {
+    "contradiction": "the three spoke equalities make both sides equal",
+    "name": "Kalmanson equilateral hinge",
+    "oriented_vertices": [
+      "A",
+      "B",
+      "C",
+      "D"
+    ],
+    "required_centers": [
+      "A",
+      "B",
+      "D"
+    ],
+    "required_pairs": [
+      [
+        "B",
+        "C"
+      ],
+      [
+        "A",
+        "C"
+      ],
+      [
+        "A",
+        "B"
+      ]
+    ],
+    "scope": "any four cyclically ordered vertices in any strictly convex polygon",
+    "strict_inequality": "D_AD + D_BC < D_AC + D_BD"
+  },
+  "not_claimed": [
+    "general proof of Erdos Problem #97",
+    "counterexample to Erdos Problem #97",
+    "n=9 is proved",
+    "n=9 external review complete",
+    "source frontier independently regenerated",
+    "official/global status update"
+  ],
+  "provenance": {
+    "command": "python scripts/check_kalmanson_equilateral_hinge_crosswalk.py --write --assert-expected",
+    "generator": "scripts/check_kalmanson_equilateral_hinge_crosswalk.py",
+    "source_artifact": "data/certificates/n9_kalmanson_three_row_core_compression.json"
+  },
+  "records": [
+    {
+      "assignment_index": 0,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e0ebd2ae30246240",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 1,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "96321bddd4c82353",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        3,
+        7
+      ]
+    },
+    {
+      "assignment_index": 2,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e63feae238f5f321",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        3,
+        8
+      ]
+    },
+    {
+      "assignment_index": 3,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "2729ec6dd7fe0285",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 4,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e25cd6a0e96d15e3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 5,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "assignment_index": 6,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "e5b997af3dfb3ec1",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 7,
+      "full_assignment_hinge_count": 3,
+      "source_best_dihedral_core_signature16": "040f6df80220fd98",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        2,
+        4,
+        7
+      ]
+    },
+    {
+      "assignment_index": 8,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "7a94ebb2d2eaaa93",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 9,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "87d47d8059a21fc5",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 10,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "40ea654a69e7dbd0",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 11,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "d4cd9861ffade07d",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        4,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 12,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "93426ac2cbc64ef4",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 13,
+      "full_assignment_hinge_count": 3,
+      "source_best_dihedral_core_signature16": "040f6df80220fd98",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        4,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 14,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        4,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 15,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        8,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_index": 16,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "668753b1f76000ac",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_index": 17,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "80acdfb9df06d964",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 18,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "f4988be101f71900",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 19,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3d622cc603c67502",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 20,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b238003ea32f3be9",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 21,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        0,
+        7,
+        5
+      ]
+    },
+    {
+      "assignment_index": 22,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "fb604589d071cde6",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 23,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "fb604589d071cde6",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 24,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        8,
+        6,
+        3,
+        1
+      ]
+    },
+    {
+      "assignment_index": 25,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        2,
+        5,
+        6
+      ]
+    },
+    {
+      "assignment_index": 26,
+      "full_assignment_hinge_count": 3,
+      "source_best_dihedral_core_signature16": "040f6df80220fd98",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        0,
+        7,
+        4
+      ]
+    },
+    {
+      "assignment_index": 27,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "93426ac2cbc64ef4",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 28,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "668753b1f76000ac",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_index": 29,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "93426ac2cbc64ef4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 30,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "e678a5cdd95ae4a6",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        0,
+        7,
+        4
+      ]
+    },
+    {
+      "assignment_index": 31,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "0aedce7bb3ecf935",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 32,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e63feae238f5f321",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        4,
+        0
+      ]
+    },
+    {
+      "assignment_index": 33,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e8bcc99a2d283e25",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 34,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 35,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 36,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 37,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        2,
+        5,
+        7
+      ]
+    },
+    {
+      "assignment_index": 38,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        4,
+        3,
+        2,
+        5
+      ]
+    },
+    {
+      "assignment_index": 39,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "f4988be101f71900",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 40,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "60691f39b2cff736",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_index": 41,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "02119280d8c1b2c0",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_index": 42,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "de6f58c9fbdde5d7",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        5,
+        7
+      ]
+    },
+    {
+      "assignment_index": 43,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "9b2ff91a99a949ad",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        5,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 44,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3403d6ad4608db4c",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 45,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "f4988be101f71900",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 46,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "60691f39b2cff736",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_index": 47,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "02119280d8c1b2c0",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_index": 48,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        0,
+        6,
+        5
+      ]
+    },
+    {
+      "assignment_index": 49,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "ede764598621e10e",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        5,
+        0
+      ]
+    },
+    {
+      "assignment_index": 50,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "2142b326af378c7a",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 51,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        0,
+        6,
+        4
+      ]
+    },
+    {
+      "assignment_index": 52,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        5,
+        3,
+        1,
+        8
+      ]
+    },
+    {
+      "assignment_index": 53,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "40ea654a69e7dbd0",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 54,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        8
+      ]
+    },
+    {
+      "assignment_index": 55,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "577bbafb71f7eff2",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "assignment_index": 56,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        1,
+        7
+      ]
+    },
+    {
+      "assignment_index": 57,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "b596ddeddfeef065",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 58,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        8,
+        7,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 59,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e8bcc99a2d283e25",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 60,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 61,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        2,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 62,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "e5b997af3dfb3ec1",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 63,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        1,
+        3,
+        5
+      ]
+    },
+    {
+      "assignment_index": 64,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "75f4f3c8a869d7ad",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        6
+      ]
+    },
+    {
+      "assignment_index": 65,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        8,
+        6,
+        4
+      ]
+    },
+    {
+      "assignment_index": 66,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "269ae67c267a8c23",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        3,
+        7
+      ]
+    },
+    {
+      "assignment_index": 67,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "dd60f1d1dc53eb5f",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "assignment_index": 68,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "0aedce7bb3ecf935",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_index": 69,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        1,
+        0,
+        3
+      ]
+    },
+    {
+      "assignment_index": 70,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e63feae238f5f321",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        7,
+        2
+      ]
+    },
+    {
+      "assignment_index": 71,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "fb604589d071cde6",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        3,
+        4,
+        1
+      ]
+    },
+    {
+      "assignment_index": 72,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "c32bc797cfe15c60",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 73,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 74,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "40ea654a69e7dbd0",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 75,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "577bbafb71f7eff2",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        7
+      ]
+    },
+    {
+      "assignment_index": 76,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b238003ea32f3be9",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_index": 77,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e0ebd2ae30246240",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        5,
+        7
+      ]
+    },
+    {
+      "assignment_index": 78,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3d622cc603c67502",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_index": 79,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b238003ea32f3be9",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_index": 80,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "ede764598621e10e",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        6,
+        2
+      ]
+    },
+    {
+      "assignment_index": 81,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "96321bddd4c82353",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        7,
+        3
+      ]
+    },
+    {
+      "assignment_index": 82,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3c6348ed81fc32d4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        3,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_index": 83,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "2249b08e52a52bd0",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 84,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3c6348ed81fc32d4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 85,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "f73b8f0867784aec",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        3,
+        5
+      ]
+    },
+    {
+      "assignment_index": 86,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e0ebd2ae30246240",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        6,
+        8
+      ]
+    },
+    {
+      "assignment_index": 87,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "assignment_index": 88,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        3,
+        2,
+        1,
+        4
+      ]
+    },
+    {
+      "assignment_index": 89,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        4,
+        2,
+        0,
+        7
+      ]
+    },
+    {
+      "assignment_index": 90,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        8,
+        5,
+        3
+      ]
+    },
+    {
+      "assignment_index": 91,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "80acdfb9df06d964",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 92,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3d622cc603c67502",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_index": 93,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "0aedce7bb3ecf935",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_index": 94,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "e4243a182417f295",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        6,
+        3,
+        2,
+        0
+      ]
+    },
+    {
+      "assignment_index": 95,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "c32bc797cfe15c60",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        3,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_index": 96,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "0aedce7bb3ecf935",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_index": 97,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        1,
+        0,
+        3
+      ]
+    },
+    {
+      "assignment_index": 98,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "2142b326af378c7a",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 99,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 100,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 101,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    },
+    {
+      "assignment_index": 102,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "2729ec6dd7fe0285",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 103,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e25cd6a0e96d15e3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_index": 104,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        7,
+        0,
+        3,
+        5
+      ]
+    },
+    {
+      "assignment_index": 105,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "e4243a182417f295",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        3,
+        0,
+        8,
+        6
+      ]
+    },
+    {
+      "assignment_index": 106,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        7,
+        0,
+        3,
+        4
+      ]
+    },
+    {
+      "assignment_index": 107,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "87d47d8059a21fc5",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        5,
+        2
+      ]
+    },
+    {
+      "assignment_index": 108,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "de6f58c9fbdde5d7",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        5,
+        3
+      ]
+    },
+    {
+      "assignment_index": 109,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e25cd6a0e96d15e3",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        1,
+        7,
+        8
+      ]
+    },
+    {
+      "assignment_index": 110,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "9b3b16262524a7d0",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        6,
+        4,
+        2,
+        0
+      ]
+    },
+    {
+      "assignment_index": 111,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "f13d5c65e31fdcf7",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        7,
+        8,
+        0
+      ]
+    },
+    {
+      "assignment_index": 112,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        6,
+        4,
+        2,
+        0
+      ]
+    },
+    {
+      "assignment_index": 113,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e0ebd2ae30246240",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        4,
+        2
+      ]
+    },
+    {
+      "assignment_index": 114,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "40ea654a69e7dbd0",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        1,
+        7
+      ]
+    },
+    {
+      "assignment_index": 115,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "89c41c50e947eb89",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        1,
+        6,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 116,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b238003ea32f3be9",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        6,
+        7
+      ]
+    },
+    {
+      "assignment_index": 117,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "fb604589d071cde6",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 118,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "fb604589d071cde6",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 119,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "44403b12e9841fe3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    },
+    {
+      "assignment_index": 120,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e8bcc99a2d283e25",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 121,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "269ae67c267a8c23",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        7,
+        3
+      ]
+    },
+    {
+      "assignment_index": 122,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "9aecfd1a682ee4db",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        3
+      ]
+    },
+    {
+      "assignment_index": 123,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "60691f39b2cff736",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_index": 124,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "616602fcf4f72e27",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        8,
+        7,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 125,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "02119280d8c1b2c0",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_index": 126,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        3,
+        1,
+        8,
+        6
+      ]
+    },
+    {
+      "assignment_index": 127,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        7,
+        4,
+        2
+      ]
+    },
+    {
+      "assignment_index": 128,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "9b2ff91a99a949ad",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        4,
+        0,
+        8,
+        5
+      ]
+    },
+    {
+      "assignment_index": 129,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "a5d163acbe845adb",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        7,
+        4,
+        2
+      ]
+    },
+    {
+      "assignment_index": 130,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "dd60f1d1dc53eb5f",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        6,
+        4
+      ]
+    },
+    {
+      "assignment_index": 131,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "269ae67c267a8c23",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        6,
+        2
+      ]
+    },
+    {
+      "assignment_index": 132,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        7,
+        5,
+        2,
+        0
+      ]
+    },
+    {
+      "assignment_index": 133,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "61fd761373739ec5",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        4
+      ]
+    },
+    {
+      "assignment_index": 134,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        1,
+        4,
+        5
+      ]
+    },
+    {
+      "assignment_index": 135,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "7a94ebb2d2eaaa93",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 136,
+      "full_assignment_hinge_count": 3,
+      "source_best_dihedral_core_signature16": "040f6df80220fd98",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        7,
+        5,
+        3,
+        0
+      ]
+    },
+    {
+      "assignment_index": 137,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "b596ddeddfeef065",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 138,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "668753b1f76000ac",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        8,
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "assignment_index": 139,
+      "full_assignment_hinge_count": 3,
+      "source_best_dihedral_core_signature16": "040f6df80220fd98",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        7,
+        5,
+        2
+      ]
+    },
+    {
+      "assignment_index": 140,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "6ab66ac4718d17a6",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        7,
+        5,
+        2
+      ]
+    },
+    {
+      "assignment_index": 141,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "9aecfd1a682ee4db",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        2
+      ]
+    },
+    {
+      "assignment_index": 142,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "f73b8f0867784aec",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        7,
+        5
+      ]
+    },
+    {
+      "assignment_index": 143,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "676bb266831fc23f",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        5
+      ]
+    },
+    {
+      "assignment_index": 144,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3403d6ad4608db4c",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        0,
+        8,
+        2
+      ]
+    },
+    {
+      "assignment_index": 145,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "9b3b16262524a7d0",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        3,
+        5,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 146,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3c6348ed81fc32d4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 147,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e25cd6a0e96d15e3",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 148,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "de6f58c9fbdde5d7",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        3,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 149,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "96321bddd4c82353",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        3,
+        5,
+        0
+      ]
+    },
+    {
+      "assignment_index": 150,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "62f85872fdceee58",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        6,
+        0,
+        2,
+        4
+      ]
+    },
+    {
+      "assignment_index": 151,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "2249b08e52a52bd0",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 152,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "c32bc797cfe15c60",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 153,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "3d622cc603c67502",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 154,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b238003ea32f3be9",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 155,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b31d2c0274086e62",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        7,
+        3,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index": 156,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "f13d5c65e31fdcf7",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        3,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 157,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "f4988be101f71900",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    },
+    {
+      "assignment_index": 158,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "f73b8f0867784aec",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        4,
+        5,
+        7,
+        0
+      ]
+    },
+    {
+      "assignment_index": 159,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "676bb266831fc23f",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        4,
+        5,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 160,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        6,
+        4,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index": 161,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        3,
+        1,
+        7,
+        5
+      ]
+    },
+    {
+      "assignment_index": 162,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "e0ebd2ae30246240",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        1,
+        5,
+        3
+      ]
+    },
+    {
+      "assignment_index": 163,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "c32bc797cfe15c60",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        8,
+        2,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index": 164,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "0aedce7bb3ecf935",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        2,
+        1
+      ]
+    },
+    {
+      "assignment_index": 165,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "1acc1fb419410e54",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        2,
+        4,
+        7
+      ]
+    },
+    {
+      "assignment_index": 166,
+      "full_assignment_hinge_count": 3,
+      "source_best_dihedral_core_signature16": "040f6df80220fd98",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        7,
+        0,
+        2,
+        5
+      ]
+    },
+    {
+      "assignment_index": 167,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "9b3b16262524a7d0",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        0,
+        2,
+        4,
+        6
+      ]
+    },
+    {
+      "assignment_index": 168,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3cea97d2db3e26c4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        7,
+        4,
+        3
+      ]
+    },
+    {
+      "assignment_index": 169,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "30d42efee3faff0d",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        1,
+        3,
+        6,
+        8
+      ]
+    },
+    {
+      "assignment_index": 170,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        7,
+        0,
+        2,
+        4
+      ]
+    },
+    {
+      "assignment_index": 171,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "668753b1f76000ac",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        6
+      ]
+    },
+    {
+      "assignment_index": 172,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "75f4f3c8a869d7ad",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        5
+      ]
+    },
+    {
+      "assignment_index": 173,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "e678a5cdd95ae4a6",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        2,
+        4,
+        6,
+        0
+      ]
+    },
+    {
+      "assignment_index": 174,
+      "full_assignment_hinge_count": 9,
+      "source_best_dihedral_core_signature16": "93426ac2cbc64ef4",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    },
+    {
+      "assignment_index": 175,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "e5b997af3dfb3ec1",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    },
+    {
+      "assignment_index": 176,
+      "full_assignment_hinge_count": 2,
+      "source_best_dihedral_core_signature16": "9c58cf6af77b9084",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        7,
+        5,
+        3
+      ]
+    },
+    {
+      "assignment_index": 177,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "c8a6c9e680a1c8bf",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        2,
+        0,
+        5,
+        4
+      ]
+    },
+    {
+      "assignment_index": 178,
+      "full_assignment_hinge_count": 5,
+      "source_best_dihedral_core_signature16": "a5d163acbe845adb",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        7,
+        0,
+        3,
+        5
+      ]
+    },
+    {
+      "assignment_index": 179,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "6a021c3b95dd263f",
+      "source_best_kalmanson_kind": "K2",
+      "unique_hinge_orientation": [
+        7,
+        4,
+        1,
+        0
+      ]
+    },
+    {
+      "assignment_index": 180,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "89c41c50e947eb89",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        4,
+        3,
+        1
+      ]
+    },
+    {
+      "assignment_index": 181,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "3403d6ad4608db4c",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    },
+    {
+      "assignment_index": 182,
+      "full_assignment_hinge_count": 6,
+      "source_best_dihedral_core_signature16": "b31d2c0274086e62",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        5,
+        3,
+        2
+      ]
+    },
+    {
+      "assignment_index": 183,
+      "full_assignment_hinge_count": 8,
+      "source_best_dihedral_core_signature16": "b596ddeddfeef065",
+      "source_best_kalmanson_kind": "K1",
+      "unique_hinge_orientation": [
+        0,
+        8,
+        7,
+        1
+      ]
+    }
+  ],
+  "schema": "erdos97.kalmanson_equilateral_hinge_crosswalk.v1",
+  "source_artifact": {
+    "compressed_certificate_sha256": "55edb73475517dcc4e8413cdb84082957bc8426d2d67bd25cc28502ef3c124c0",
+    "frontier_regenerated_by_this_checker": false,
+    "path": "data/certificates/n9_kalmanson_three_row_core_compression.json",
+    "schema": "erdos97.n9_kalmanson_three_row_core_compression.v1",
+    "sha256": "a5387ef8575ace0cd16d55a0a29bbc45f72ca88caa7233be4c80041924fd703a",
+    "status": "REVIEW_PENDING_N9_KALMANSON_THREE_ROW_CORE_COMPRESSION",
+    "trust": "MACHINE_CHECKED_FINITE_CASE_ARTIFACT_REVIEW_PENDING"
+  },
+  "status": "REVIEW_PENDING_KALMANSON_EQUILATERAL_HINGE_CROSSWALK",
+  "summary": {
+    "ambiguous_source_records": 0,
+    "core_hinge_match_count_histogram": {
+      "1": 184
+    },
+    "covered_source_records": 184,
+    "full_assignment_hinge_count_histogram": {
+      "2": 36,
+      "3": 6,
+      "5": 18,
+      "6": 54,
+      "8": 54,
+      "9": 16
+    },
+    "generic_pair_membership_template_orbits": 1,
+    "generic_template_signatures16": [
+      "6d152657c0091e18"
+    ],
+    "source_best_kalmanson_kind_counts": {
+      "K1": 95,
+      "K2": 89
+    },
+    "source_distinct_dihedral_core_signatures16": 56,
+    "source_record_count": 184,
+    "total_full_assignment_hinge_instances": 1080,
+    "unmatched_source_records": 0
+  },
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/kalmanson-equilateral-hinge.md
+++ b/docs/kalmanson-equilateral-hinge.md
@@ -1,0 +1,114 @@
+# Kalmanson equilateral-hinge lemma
+
+Status: `LEMMA` / `N9_CROSSWALK_REVIEW_PENDING`.
+
+This note extracts one arbitrary-size local obstruction from the
+review-pending `n=9` Kalmanson three-row compression.  The lemma is a direct
+consequence of strict convex quadrilateral geometry.  Its occurrence in every
+hypothetical counterexample is not proved here.
+
+## Lemma
+
+Let distinct vertices `a,b,c,d` occur in that cyclic order in a strictly
+convex polygon.  Suppose three full rich classes have the following pair
+memberships:
+
+```text
+center a: {b,c} is contained in one rich class,
+center b: {a,c} is contained in one rich class,
+center d: {a,b} is contained in one rich class.
+```
+
+Then the configuration is impossible.
+
+Indeed, the three memberships give
+
+```text
+D_ab = D_ac,
+D_ab = D_bc,
+D_ad = D_bd.
+```
+
+For the cyclic quadrilateral `a,b,c,d`, the strict Kalmanson inequality `K2`
+is
+
+```text
+D_ad + D_bc < D_ac + D_bd.
+```
+
+The equalities make its two sides equal, a contradiction.  Only the displayed
+two witnesses from each class are used, so the same argument applies to
+selected rows containing those pairs and to rich classes of any larger size.
+It is independent of the total number of polygon vertices.
+
+An equivalent `K1` orientation is
+
+```text
+center a: {b,c} is contained in one rich class,
+center b: {c,d} is contained in one rich class,
+center c: {b,d} is contained in one rich class.
+```
+
+Here `D_ab = D_ac` and `D_cd = D_bd`, while the middle row also gives
+`D_bc = D_bd`.  Thus
+
+```text
+D_ab + D_cd < D_ac + D_bd
+```
+
+again has equal sides.  Rotation or reflection of the cyclic quadruple maps
+the `K1` and `K2` descriptions to one pair-membership template.  We call any
+such occurrence an **equilateral hinge**.
+
+## Exact `n=9` crosswalk
+
+The generated crosswalk reads, but does not regenerate,
+`data/certificates/n9_kalmanson_three_row_core_compression.json`.  For every
+stored best three-row core it checks all eight cyclic-dihedral orientations of
+the stored quadrilateral and requires the core centers to be exactly the three
+hinge centers.
+
+The result is:
+
+```text
+stored records covered: 184 / 184
+matching core orientations per record: exactly 1
+stored best certificates: K1 = 95, K2 = 89
+stored dihedral core signatures: 56
+equilateral-hinge template orbits: 1
+```
+
+Scanning every four-vertex cyclic subset in each complete assignment finds
+`1,080` oriented hinge instances in total.  Every assignment has between two
+and nine; the exact histogram is
+
+```text
+{2: 36, 3: 6, 5: 18, 6: 54, 8: 54, 9: 16}.
+```
+
+After the unused witnesses in each stored row are forgotten, all 56 full
+signatures contain that one pair-membership template.  This is the proof-facing
+gain: the next bridge target is no longer a classification of 56 full
+signatures, but a theorem forcing three co-radial witness pairs in one hinge
+orientation.
+
+## Commands
+
+```bash
+python scripts/check_kalmanson_equilateral_hinge_crosswalk.py \
+  --check --assert-expected --summary-json
+pytest -q \
+  tests/test_kalmanson_equilateral_hinge.py \
+  tests/test_kalmanson_equilateral_hinge_crosswalk.py
+```
+
+## Boundary
+
+The crosswalk is a deterministic proof-mining audit of a review-pending finite
+artifact.  It does not independently regenerate the `n=9` frontier, satisfy
+the external-review gate, promote the repo-local `n=9` result, prove the
+arbitrary-size problem, or produce a counterexample.
+
+The checker also does not establish that weak incidence, fragile-cover, or
+bootstrap hypotheses force a hinge.  A future forcing argument needs genuine
+minimality or full-rich-class geometry beyond the audited finite crosswalk.

--- a/docs/n9-kalmanson-three-row-core-compression.md
+++ b/docs/n9-kalmanson-three-row-core-compression.md
@@ -91,7 +91,10 @@ witness-pair capacity filter, and the strict Kalmanson inequality convention.
 It should be reviewed as a compression layer on top of the existing
 review-pending `n=9` Kalmanson route, not as a source-of-truth theorem claim.
 
-The next proof-facing step is to classify the 56 cyclic-dihedral three-row
-signatures into reusable human-readable local lemmas, then look for bridge
-hypotheses that force one of those local cores without enumerating the whole
-`n=9` frontier.
+That classification is now carried out in
+`docs/kalmanson-equilateral-hinge.md`: after unused row witnesses are forgotten,
+all 56 cyclic-dihedral signatures contain the same three-rich-class
+equilateral-hinge subtemplate, and all 184 stored best cores match exactly one
+dihedral orientation.  The remaining proof-facing step is to find genuine
+minimality or full-rich-class hypotheses that force this hinge without
+enumerating the whole `n=9` frontier.

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1153,6 +1153,52 @@ artifacts:
       - counterexample to Erdos Problem #97
       - general proof of Erdos Problem #97
 
+  - id: kalmanson_equilateral_hinge_crosswalk
+    path: data/certificates/kalmanson_equilateral_hinge_crosswalk.json
+    sha256: cd5c188445d523cfab18e5b473030305971661ad870fa8666aef3c60ddc26e9c
+    size_bytes: 54597
+    kind: proof_mining_crosswalk_artifact
+    generator: scripts/check_kalmanson_equilateral_hinge_crosswalk.py
+    command: python scripts/check_kalmanson_equilateral_hinge_crosswalk.py --write --assert-expected
+    checker: scripts/check_kalmanson_equilateral_hinge_crosswalk.py
+    check_command: python scripts/check_kalmanson_equilateral_hinge_crosswalk.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust_class: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: Arbitrary-n local strict-Kalmanson equilateral-hinge lemma plus an exact crosswalk against the review-pending n=9 three-row compression; no n=9 or global status promotion.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.kalmanson_equilateral_hinge_crosswalk.v1
+      status: REVIEW_PENDING_KALMANSON_EQUILATERAL_HINGE_CROSSWALK
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      source_artifact.sha256: a5387ef8575ace0cd16d55a0a29bbc45f72ca88caa7233be4c80041924fd703a
+      source_artifact.frontier_regenerated_by_this_checker: false
+      summary.source_record_count: 184
+      summary.covered_source_records: 184
+      summary.unmatched_source_records: 0
+      summary.ambiguous_source_records: 0
+      summary.core_hinge_match_count_histogram.1: 184
+      summary.source_best_kalmanson_kind_counts.K1: 95
+      summary.source_best_kalmanson_kind_counts.K2: 89
+      summary.source_distinct_dihedral_core_signatures16: 56
+      summary.generic_pair_membership_template_orbits: 1
+      summary.full_assignment_hinge_count_histogram.2: 36
+      summary.full_assignment_hinge_count_histogram.3: 6
+      summary.full_assignment_hinge_count_histogram.5: 18
+      summary.full_assignment_hinge_count_histogram.6: 54
+      summary.full_assignment_hinge_count_histogram.8: 54
+      summary.full_assignment_hinge_count_histogram.9: 16
+      summary.total_full_assignment_hinge_instances: 1080
+      crosswalk_sha256: 41390dbac0177ace8615e393fe4826dd5a7d325ccdc46370e07d315caa2f2a8d
+      provenance.command: python scripts/check_kalmanson_equilateral_hinge_crosswalk.py --write --assert-expected
+    forbidden_claims:
+      - n=9 is proved
+      - n=9 external review complete
+      - source frontier independently regenerated
+      - official/global status update
+      - counterexample to Erdos Problem #97
+      - general proof of Erdos Problem #97
+
   - id: n9_vertex_circle_obstruction_shapes
     path: data/certificates/n9_vertex_circle_obstruction_shapes.json
     sha256: c10ead3203b87e72c96af7eef98b656d6b33788994b8fad6577cb59b99df78c6

--- a/scripts/check_kalmanson_equilateral_hinge_crosswalk.py
+++ b/scripts/check_kalmanson_equilateral_hinge_crosswalk.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Crosswalk the n=9 three-row compression to one generic hinge lemma.
+
+This checker reads the stored review-pending core-compression artifact.  It
+does not regenerate the n=9 selected-witness frontier.  Its mathematical
+payload is the arbitrary-n local Kalmanson equilateral-hinge recognizer; the
+stored records are used only for a deterministic proof-mining crosswalk.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.kalmanson_equilateral_hinge import (  # noqa: E402
+    HingeInstance,
+    find_core_hinge_instances,
+    find_hinge_instances,
+)
+
+DEFAULT_SOURCE = (
+    ROOT / "data" / "certificates" / "n9_kalmanson_three_row_core_compression.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "kalmanson_equilateral_hinge_crosswalk.json"
+)
+
+SCHEMA = "erdos97.kalmanson_equilateral_hinge_crosswalk.v1"
+STATUS = "REVIEW_PENDING_KALMANSON_EQUILATERAL_HINGE_CROSSWALK"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Arbitrary-n local strict-Kalmanson equilateral-hinge lemma and a "
+    "deterministic crosswalk against the stored review-pending n=9 three-row "
+    "compression; the source frontier is not regenerated and no result status "
+    "is promoted."
+)
+SOURCE_SCHEMA = "erdos97.n9_kalmanson_three_row_core_compression.v1"
+SOURCE_SHA256 = "a5387ef8575ace0cd16d55a0a29bbc45f72ca88caa7233be4c80041924fd703a"
+SOURCE_COMPRESSED_SHA256 = (
+    "55edb73475517dcc4e8413cdb84082957bc8426d2d67bd25cc28502ef3c124c0"
+)
+EXPECTED_RECORDS = 184
+EXPECTED_KIND_COUNTS = {"K1": 95, "K2": 89}
+EXPECTED_SOURCE_SIGNATURES = 56
+EXPECTED_TEMPLATE_ORBITS = 1
+EXPECTED_CORE_MATCH_HISTOGRAM = {"1": 184}
+EXPECTED_FULL_HINGE_HISTOGRAM = {
+    "2": 36,
+    "3": 6,
+    "5": 18,
+    "6": 54,
+    "8": 54,
+    "9": 16,
+}
+EXPECTED_TOTAL_FULL_HINGES = 1_080
+EXPECTED_CROSSWALK_SHA256 = (
+    "41390dbac0177ace8615e393fe4826dd5a7d325ccdc46370e07d315caa2f2a8d"
+)
+
+PROVENANCE = {
+    "generator": "scripts/check_kalmanson_equilateral_hinge_crosswalk.py",
+    "command": (
+        "python scripts/check_kalmanson_equilateral_hinge_crosswalk.py "
+        "--write --assert-expected"
+    ),
+    "source_artifact": (
+        "data/certificates/n9_kalmanson_three_row_core_compression.json"
+    ),
+}
+
+NOT_CLAIMED = [
+    "general proof of Erdos Problem #97",
+    "counterexample to Erdos Problem #97",
+    "n=9 is proved",
+    "n=9 external review complete",
+    "source frontier independently regenerated",
+    "official/global status update",
+]
+
+
+def canonical_json(value: object) -> bytes:
+    """Return a stable compact JSON encoding."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load one JSON object."""
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a stable human-readable JSON artifact."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _integer_list(value: object, name: str) -> list[int]:
+    if not isinstance(value, list) or any(
+        isinstance(item, bool) or not isinstance(item, int) for item in value
+    ):
+        raise ValueError(f"{name} must be a list of integer labels")
+    return value
+
+
+def _template_signature(hinge: HingeInstance) -> str:
+    """Forget labels while retaining the oriented membership template."""
+    slots = {hinge.a: "A", hinge.b: "B", hinge.c: "C", hinge.d: "D"}
+    value = {
+        "centers": [slots[center] for center in hinge.centers],
+        "required_pairs": [
+            [slots[left], slots[right]] for left, right in hinge.required_pairs
+        ],
+    }
+    return hashlib.sha256(canonical_json(value)).hexdigest()[:16]
+
+
+def _source_record_data(record: dict[str, Any]) -> tuple[list[list[int]], list[int], list[int], str, str]:
+    rows_value = record.get("rows")
+    if not isinstance(rows_value, list):
+        raise ValueError("record.rows must be a list")
+    rows = [
+        _integer_list(row, f"record.rows[{index}]")
+        for index, row in enumerate(rows_value)
+    ]
+
+    edge = record.get("best_kalmanson_self_edge")
+    core = record.get("best_kalmanson_minimal_core")
+    if not isinstance(edge, dict) or not isinstance(core, dict):
+        raise ValueError("record must contain best edge and best core objects")
+    quadruple = _integer_list(edge.get("quadrilateral"), "best quadrilateral")
+    centers = _integer_list(core.get("row_indices"), "best core centers")
+    kind = edge.get("kind")
+    signature = record.get("best_kalmanson_dihedral_core_signature16")
+    if kind not in {"K1", "K2"}:
+        raise ValueError(f"unexpected best Kalmanson kind: {kind!r}")
+    if not isinstance(signature, str):
+        raise ValueError("best core signature must be a string")
+    return rows, quadruple, centers, kind, signature
+
+
+def build_payload(source_path: Path = DEFAULT_SOURCE) -> dict[str, Any]:
+    """Build the exact crosswalk payload from the pinned source artifact."""
+    source_digest = sha256_file(source_path)
+    if source_digest != SOURCE_SHA256:
+        raise AssertionError(
+            f"source sha256: expected {SOURCE_SHA256}, got {source_digest}"
+        )
+    source = load_json(source_path)
+    if source.get("schema") != SOURCE_SCHEMA:
+        raise AssertionError(
+            f"source schema: expected {SOURCE_SCHEMA!r}, got {source.get('schema')!r}"
+        )
+    if source.get("compressed_certificate_sha256") != SOURCE_COMPRESSED_SHA256:
+        raise AssertionError("source compressed-certificate digest is not pinned value")
+
+    cyclic_order = _integer_list(source.get("cyclic_order"), "source.cyclic_order")
+    records_value = source.get("records")
+    if not isinstance(records_value, list):
+        raise ValueError("source.records must be a list")
+
+    kind_counts: Counter[str] = Counter()
+    source_signatures: set[str] = set()
+    template_signatures: set[str] = set()
+    core_match_counts: Counter[int] = Counter()
+    full_hinge_counts: Counter[int] = Counter()
+    crosswalk_records: list[dict[str, Any]] = []
+
+    for position, value in enumerate(records_value):
+        if not isinstance(value, dict):
+            raise ValueError(f"source.records[{position}] must be an object")
+        assignment_index = value.get("assignment_index")
+        if isinstance(assignment_index, bool) or not isinstance(assignment_index, int):
+            raise ValueError("assignment_index must be an integer")
+        rows, quadruple, core_centers, kind, source_signature = _source_record_data(value)
+        core_hits = find_core_hinge_instances(rows, quadruple, core_centers)
+        full_hits = find_hinge_instances(rows, cyclic_order)
+        core_match_counts[len(core_hits)] += 1
+        full_hinge_counts[len(full_hits)] += 1
+        kind_counts[kind] += 1
+        source_signatures.add(source_signature)
+
+        for hit in core_hits:
+            template_signatures.add(_template_signature(hit))
+        if len(core_hits) != 1:
+            explanation = [hit.as_dict() for hit in core_hits]
+            raise AssertionError(
+                f"assignment {assignment_index} has {len(core_hits)} core hinges: "
+                f"{explanation}"
+            )
+        hit = core_hits[0]
+        if hit.inequality_kind != kind:
+            raise AssertionError(
+                f"assignment {assignment_index}: hinge kind {hit.inequality_kind} "
+                f"does not match stored best kind {kind}"
+            )
+
+        crosswalk_records.append(
+            {
+                "assignment_index": assignment_index,
+                "source_best_kalmanson_kind": kind,
+                "source_best_dihedral_core_signature16": source_signature,
+                "unique_hinge_orientation": [hit.a, hit.b, hit.c, hit.d],
+                "full_assignment_hinge_count": len(full_hits),
+            }
+        )
+
+    crosswalk_records.sort(key=lambda record: record["assignment_index"])
+    crosswalk_digest = hashlib.sha256(
+        canonical_json({"records": crosswalk_records})
+    ).hexdigest()
+    summary = {
+        "source_record_count": len(records_value),
+        "covered_source_records": sum(
+            count for matches, count in core_match_counts.items() if matches > 0
+        ),
+        "unmatched_source_records": core_match_counts.get(0, 0),
+        "ambiguous_source_records": sum(
+            count for matches, count in core_match_counts.items() if matches > 1
+        ),
+        "core_hinge_match_count_histogram": {
+            str(key): count for key, count in sorted(core_match_counts.items())
+        },
+        "source_best_kalmanson_kind_counts": dict(sorted(kind_counts.items())),
+        "source_distinct_dihedral_core_signatures16": len(source_signatures),
+        "generic_pair_membership_template_orbits": len(template_signatures),
+        "generic_template_signatures16": sorted(template_signatures),
+        "full_assignment_hinge_count_histogram": {
+            str(key): count for key, count in sorted(full_hinge_counts.items())
+        },
+        "total_full_assignment_hinge_instances": sum(
+            size * count for size, count in full_hinge_counts.items()
+        ),
+    }
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "lemma": {
+            "name": "Kalmanson equilateral hinge",
+            "scope": "any four cyclically ordered vertices in any strictly convex polygon",
+            "oriented_vertices": ["A", "B", "C", "D"],
+            "required_centers": ["A", "B", "D"],
+            "required_pairs": [["B", "C"], ["A", "C"], ["A", "B"]],
+            "strict_inequality": "D_AD + D_BC < D_AC + D_BD",
+            "contradiction": "the three spoke equalities make both sides equal",
+        },
+        "source_artifact": {
+            "path": str(source_path.relative_to(ROOT)),
+            "sha256": source_digest,
+            "schema": source.get("schema"),
+            "status": source.get("status"),
+            "trust": source.get("trust"),
+            "compressed_certificate_sha256": source.get(
+                "compressed_certificate_sha256"
+            ),
+            "frontier_regenerated_by_this_checker": False,
+        },
+        "summary": summary,
+        "crosswalk_sha256": crosswalk_digest,
+        "records": crosswalk_records,
+        "interpretation_warnings": [
+            "The local hinge lemma is arbitrary-n, but this crosswalk only audits the stored n=9 compression records.",
+            "The source frontier remains review-pending and is not independently regenerated here.",
+            "No theorem forces an equilateral hinge in every hypothetical counterexample yet.",
+        ],
+        "not_claimed": list(NOT_CLAIMED),
+        "provenance": dict(PROVENANCE),
+    }
+
+
+def summary_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the artifact without record-level details."""
+    return {key: value for key, value in payload.items() if key != "records"}
+
+
+def assert_expected_payload(payload: dict[str, Any]) -> None:
+    """Assert all pinned crosswalk counts and trust-boundary fields."""
+    errors: list[str] = []
+    expected_scalars = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "crosswalk_sha256": EXPECTED_CROSSWALK_SHA256,
+    }
+    for key, expected in expected_scalars.items():
+        if payload.get(key) != expected:
+            errors.append(f"{key}: expected {expected!r}, got {payload.get(key)!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        errors.append("summary must be an object")
+        summary = {}
+    expected_summary = {
+        "source_record_count": EXPECTED_RECORDS,
+        "covered_source_records": EXPECTED_RECORDS,
+        "unmatched_source_records": 0,
+        "ambiguous_source_records": 0,
+        "core_hinge_match_count_histogram": EXPECTED_CORE_MATCH_HISTOGRAM,
+        "source_best_kalmanson_kind_counts": EXPECTED_KIND_COUNTS,
+        "source_distinct_dihedral_core_signatures16": EXPECTED_SOURCE_SIGNATURES,
+        "generic_pair_membership_template_orbits": EXPECTED_TEMPLATE_ORBITS,
+        "full_assignment_hinge_count_histogram": EXPECTED_FULL_HINGE_HISTOGRAM,
+        "total_full_assignment_hinge_instances": EXPECTED_TOTAL_FULL_HINGES,
+    }
+    for key, expected in expected_summary.items():
+        if summary.get(key) != expected:
+            errors.append(
+                f"summary.{key}: expected {expected!r}, got {summary.get(key)!r}"
+            )
+
+    source = payload.get("source_artifact")
+    if not isinstance(source, dict):
+        errors.append("source_artifact must be an object")
+        source = {}
+    if source.get("sha256") != SOURCE_SHA256:
+        errors.append("source_artifact.sha256 does not match pinned input")
+    if source.get("frontier_regenerated_by_this_checker") is not False:
+        errors.append("frontier_regenerated_by_this_checker must remain false")
+    records = payload.get("records")
+    if not isinstance(records, list) or len(records) != EXPECTED_RECORDS:
+        errors.append(f"records must contain exactly {EXPECTED_RECORDS} entries")
+    if payload.get("not_claimed") != NOT_CLAIMED:
+        errors.append("not_claimed boundary changed")
+    if errors:
+        raise AssertionError("\n".join(errors))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--json", action="store_true")
+    output.add_argument("--summary-json", action="store_true")
+    args = parser.parse_args()
+
+    payload = build_payload(args.source)
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.check:
+        stored = load_json(args.artifact)
+        if stored != payload:
+            raise AssertionError(f"{args.artifact} does not match regenerated payload")
+    if args.write:
+        write_json(args.artifact, payload)
+
+    if args.summary_json:
+        print(json.dumps(summary_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        print("Kalmanson equilateral-hinge crosswalk")
+        print(f"source records: {summary['source_record_count']}")
+        print(f"covered records: {summary['covered_source_records']}")
+        print(
+            "source signatures -> generic template orbits: "
+            f"{summary['source_distinct_dihedral_core_signatures16']} -> "
+            f"{summary['generic_pair_membership_template_orbits']}"
+        )
+        print(
+            "total full-assignment hinges: "
+            f"{summary['total_full_assignment_hinge_instances']}"
+        )
+        print(f"crosswalk sha256: {payload['crosswalk_sha256']}")
+        if args.write:
+            print(f"wrote {args.artifact}")
+        if args.assert_expected:
+            print("OK: expected crosswalk invariants verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -583,6 +583,23 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="kalmanson_equilateral_hinge_crosswalk",
+        command=(
+            "python",
+            "scripts/check_kalmanson_equilateral_hinge_crosswalk.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Arbitrary-n local strict-Kalmanson equilateral-hinge lemma and "
+            "an exact proof-mining crosswalk against the stored review-pending "
+            "n=9 three-row compression. The source frontier is not "
+            "regenerated, no general forcing theorem is claimed, and no n=9 "
+            "or official/global result status is promoted."
+        ),
+    ),
+    AuditCommand(
         ident="n9_vertex_circle_obstruction_shapes",
         command=(
             "python",

--- a/src/erdos97/kalmanson_equilateral_hinge.py
+++ b/src/erdos97/kalmanson_equilateral_hinge.py
@@ -1,0 +1,288 @@
+"""Generic three-row equilateral hinge behind a Kalmanson self-edge.
+
+For cyclically ordered ``A,B,C,D``, the three row requirements
+
+``A: {B,C}``, ``B: {A,C}``, and ``D: {A,B}``
+
+force the two sides of the strict K2 inequality to be equal.  A dihedral
+reorientation of a stored cyclic quadruple may present the same inequality as
+either K1 or K2.  This module only recognizes that local equality pattern; it
+does not assert that a polygon or a family of row systems must contain one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import combinations
+from typing import TypeAlias
+
+Label: TypeAlias = int
+Pair: TypeAlias = tuple[Label, Label]
+Equality: TypeAlias = tuple[Pair, Pair]
+RowsInput: TypeAlias = Mapping[Label, Sequence[Label]] | Sequence[Sequence[Label]]
+
+
+def _label(value: object, name: str) -> Label:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an int (not bool)")
+    return value
+
+
+def _label_sequence(
+    values: object,
+    name: str,
+    *,
+    expected_length: int | None = None,
+) -> tuple[Label, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{name} must be a sequence of ints")
+    labels = tuple(_label(value, f"{name}[{index}]") for index, value in enumerate(values))
+    if expected_length is not None and len(labels) != expected_length:
+        raise ValueError(f"{name} must contain exactly {expected_length} labels")
+    if len(set(labels)) != len(labels):
+        raise ValueError(f"{name} must not contain duplicate labels")
+    return labels
+
+
+def _pair(a: Label, b: Label) -> Pair:
+    if a == b:
+        raise ValueError("a distance pair requires two distinct labels")
+    return (a, b) if a < b else (b, a)
+
+
+@dataclass(frozen=True)
+class HingeInstance:
+    """One oriented K2 hinge, expressed against a stored cyclic quadruple."""
+
+    quadruple: tuple[Label, Label, Label, Label]
+    a: Label
+    b: Label
+    c: Label
+    d: Label
+    centers: tuple[Label, Label, Label]
+    required_pairs: tuple[Pair, Pair, Pair]
+    inequality_kind: str
+    inequality: str
+    left_pairs: tuple[Pair, Pair]
+    right_pairs: tuple[Pair, Pair]
+    equalities: tuple[Equality, Equality, Equality]
+
+    @property
+    def kind(self) -> str:
+        """Short alias for ``inequality_kind``."""
+        return self.inequality_kind
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a deterministic JSON-compatible explanation."""
+        return {
+            "quadruple": list(self.quadruple),
+            "a": self.a,
+            "b": self.b,
+            "c": self.c,
+            "d": self.d,
+            "centers": list(self.centers),
+            "required_pairs": [list(pair) for pair in self.required_pairs],
+            "inequality_kind": self.inequality_kind,
+            "inequality": self.inequality,
+            "left_pairs": [list(pair) for pair in self.left_pairs],
+            "right_pairs": [list(pair) for pair in self.right_pairs],
+            "equalities": [
+                {
+                    "center": center,
+                    "left_pair": list(left),
+                    "right_pair": list(right),
+                }
+                for center, (left, right) in zip(
+                    self.centers,
+                    self.equalities,
+                    strict=True,
+                )
+            ],
+        }
+
+
+def dihedral_orientations(
+    quadruple: Sequence[Label],
+) -> tuple[tuple[Label, Label, Label, Label], ...]:
+    """Return the four rotations and four reflected rotations of a quadruple."""
+    quad = _label_sequence(quadruple, "quadruple", expected_length=4)
+    return tuple(
+        tuple(quad[(start + direction * offset) % 4] for offset in range(4))
+        for direction in (1, -1)
+        for start in range(4)
+    )
+
+
+def _normalize_rows(
+    rows: RowsInput,
+    labels: tuple[Label, ...] | None,
+) -> tuple[dict[Label, frozenset[Label]], tuple[Label, ...]]:
+    if isinstance(rows, Mapping):
+        items: list[tuple[Label, Sequence[Label]]] = []
+        for raw_center, raw_row in rows.items():
+            center = _label(raw_center, "row center")
+            items.append((center, raw_row))
+        if labels is None:
+            labels = tuple(center for center, _ in items)
+        elif any(center not in labels for center, _ in items):
+            raise ValueError("rows contain a center outside the cyclic order")
+    else:
+        if isinstance(rows, (str, bytes)) or not isinstance(rows, Sequence):
+            raise TypeError("rows must be a mapping or a sequence of rows")
+        if labels is None:
+            labels = tuple(range(len(rows)))
+        elif len(rows) != len(labels):
+            raise ValueError("sequence rows must align one-for-one with the cyclic order")
+        items = list(zip(labels, rows, strict=True))
+
+    known = set(labels)
+    normalized: dict[Label, frozenset[Label]] = {}
+    for center, raw_row in items:
+        if isinstance(raw_row, (str, bytes)) or not isinstance(raw_row, Sequence):
+            raise TypeError(f"row at center {center} must be a sequence of ints")
+        witnesses = tuple(
+            _label(value, f"row[{center}][{index}]")
+            for index, value in enumerate(raw_row)
+        )
+        if len(set(witnesses)) != len(witnesses):
+            raise ValueError(f"row at center {center} contains duplicate witnesses")
+        if center in witnesses:
+            raise ValueError(f"row at center {center} contains its own center")
+        unknown = set(witnesses) - known
+        if unknown:
+            raise ValueError(
+                f"row at center {center} contains unknown labels: {sorted(unknown)}"
+            )
+        normalized[center] = frozenset(witnesses)
+    return normalized, labels
+
+
+def _inequality_data(
+    quadruple: tuple[Label, Label, Label, Label],
+    oriented: tuple[Label, Label, Label, Label],
+) -> tuple[str, str, tuple[Pair, Pair], tuple[Pair, Pair]]:
+    q0, q1, q2, q3 = quadruple
+    candidates = (
+        (
+            "K1",
+            f"d({q0},{q1}) + d({q2},{q3}) < d({q0},{q2}) + d({q1},{q3})",
+            (_pair(q0, q1), _pair(q2, q3)),
+            (_pair(q0, q2), _pair(q1, q3)),
+        ),
+        (
+            "K2",
+            f"d({q0},{q3}) + d({q1},{q2}) < d({q0},{q2}) + d({q1},{q3})",
+            (_pair(q0, q3), _pair(q1, q2)),
+            (_pair(q0, q2), _pair(q1, q3)),
+        ),
+    )
+    a, b, c, d = oriented
+    oriented_left = {_pair(a, d), _pair(b, c)}
+    oriented_right = {_pair(a, c), _pair(b, d)}
+    for kind, description, left, right in candidates:
+        if set(left) == oriented_left and set(right) == oriented_right:
+            return kind, description, left, right
+    raise AssertionError("a dihedral orientation must encode stored K1 or K2")
+
+
+def _instance(
+    quadruple: tuple[Label, Label, Label, Label],
+    oriented: tuple[Label, Label, Label, Label],
+) -> HingeInstance:
+    a, b, c, d = oriented
+    kind, description, left, right = _inequality_data(quadruple, oriented)
+    return HingeInstance(
+        quadruple=quadruple,
+        a=a,
+        b=b,
+        c=c,
+        d=d,
+        centers=(a, b, d),
+        required_pairs=((b, c), (a, c), (a, b)),
+        inequality_kind=kind,
+        inequality=description,
+        left_pairs=left,
+        right_pairs=right,
+        equalities=(
+            ((_pair(a, b)), (_pair(a, c))),
+            ((_pair(a, b)), (_pair(b, c))),
+            ((_pair(a, d)), (_pair(b, d))),
+        ),
+    )
+
+
+def _requirements_hold(
+    rows: Mapping[Label, frozenset[Label]],
+    instance: HingeInstance,
+) -> bool:
+    return all(
+        center in rows and set(required) <= rows[center]
+        for center, required in zip(
+            instance.centers,
+            instance.required_pairs,
+            strict=True,
+        )
+    )
+
+
+def find_hinge_instances(
+    rows: RowsInput,
+    cyclic_order: Sequence[Label],
+) -> tuple[HingeInstance, ...]:
+    """Find every Kalmanson equilateral hinge in an arbitrary cyclic order.
+
+    A mapping may omit centers; a sequence supplies one row per cyclic-order
+    position.  Every supplied center and witness must be a known cyclic label.
+    """
+    order = _label_sequence(cyclic_order, "cyclic_order")
+    normalized, _ = _normalize_rows(rows, order)
+    found: list[HingeInstance] = []
+    for quadruple in combinations(order, 4):
+        for oriented in dihedral_orientations(quadruple):
+            instance = _instance(quadruple, oriented)
+            if _requirements_hold(normalized, instance):
+                found.append(instance)
+    return tuple(found)
+
+
+def find_core_hinge_instances(
+    rows: RowsInput,
+    quadruple: Sequence[Label],
+    core_centers: Sequence[Label],
+) -> tuple[HingeInstance, ...]:
+    """Find hinge orientations whose required centers are one three-row core.
+
+    For sequence input, centers are the integer labels ``0..len(rows)-1``.
+    Mapping input uses its keys as the complete label universe.  ``quadruple``
+    is already in cyclic order; its eight dihedral presentations are checked.
+    """
+    quad = _label_sequence(quadruple, "quadruple", expected_length=4)
+    core = _label_sequence(core_centers, "core_centers", expected_length=3)
+    normalized, labels = _normalize_rows(rows, None)
+    known = set(labels)
+    unknown_quad = set(quad) - known
+    if unknown_quad:
+        raise ValueError(f"quadruple contains unknown labels: {sorted(unknown_quad)}")
+    unknown_core = set(core) - known
+    if unknown_core:
+        raise ValueError(f"core_centers contains unknown labels: {sorted(unknown_core)}")
+
+    required_center_set = set(core)
+    found: list[HingeInstance] = []
+    for oriented in dihedral_orientations(quad):
+        instance = _instance(quad, oriented)
+        if set(instance.centers) == required_center_set and _requirements_hold(
+            normalized,
+            instance,
+        ):
+            found.append(instance)
+    return tuple(found)
+
+
+__all__ = [
+    "HingeInstance",
+    "dihedral_orientations",
+    "find_core_hinge_instances",
+    "find_hinge_instances",
+]

--- a/tests/test_kalmanson_equilateral_hinge.py
+++ b/tests/test_kalmanson_equilateral_hinge.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from erdos97.kalmanson_equilateral_hinge import (
+    dihedral_orientations,
+    find_core_hinge_instances,
+    find_hinge_instances,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPRESSION_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_kalmanson_three_row_core_compression.json"
+)
+
+
+def test_direct_k2_hinge_and_explanation() -> None:
+    rows = {
+        10: [20, 30],
+        20: [10, 30],
+        30: [],
+        40: [10, 20],
+    }
+
+    instances = find_hinge_instances(rows, [10, 20, 30, 40])
+
+    assert len(instances) == 1
+    hinge = instances[0]
+    assert (hinge.a, hinge.b, hinge.c, hinge.d) == (10, 20, 30, 40)
+    assert hinge.centers == (10, 20, 40)
+    assert hinge.required_pairs == ((20, 30), (10, 30), (10, 20))
+    assert hinge.kind == hinge.inequality_kind == "K2"
+    assert hinge.left_pairs == ((10, 40), (20, 30))
+    assert hinge.right_pairs == ((10, 30), (20, 40))
+    assert hinge.equalities == (
+        ((10, 20), (10, 30)),
+        ((10, 20), (20, 30)),
+        ((10, 40), (20, 40)),
+    )
+    assert hinge.as_dict()["inequality_kind"] == "K2"
+
+
+def test_dihedral_orientation_can_present_the_hinge_as_k1() -> None:
+    # This is the generic hinge at (A,B,C,D)=(1,2,3,0), a rotation of the
+    # stored cyclic quadruple (0,1,2,3).  Its K2 is stored K1.
+    rows = [[1, 2], [2, 3], [1, 3], []]
+
+    instances = find_hinge_instances(rows, [0, 1, 2, 3])
+
+    assert len(dihedral_orientations((0, 1, 2, 3))) == 8
+    assert len(set(dihedral_orientations((0, 1, 2, 3)))) == 8
+    assert len(instances) == 1
+    hinge = instances[0]
+    assert (hinge.a, hinge.b, hinge.c, hinge.d) == (1, 2, 3, 0)
+    assert hinge.centers == (1, 2, 0)
+    assert hinge.inequality_kind == "K1"
+    assert hinge.left_pairs == ((0, 1), (2, 3))
+    assert hinge.right_pairs == ((0, 2), (1, 3))
+
+
+def test_missing_required_pair_or_center_excludes_a_hinge() -> None:
+    rows = [[1, 2], [0, 2], [], [0]]
+    assert find_hinge_instances(rows, [0, 1, 2, 3]) == ()
+
+    complete_rows = [[1, 2], [0, 2], [], [0, 1]]
+    assert find_core_hinge_instances(complete_rows, [0, 1, 2, 3], [0, 1, 2]) == ()
+
+
+def test_record_zero_best_core_has_one_dihedral_hinge() -> None:
+    payload = json.loads(COMPRESSION_ARTIFACT.read_text(encoding="utf-8"))
+    record = payload["records"][0]
+
+    instances = find_core_hinge_instances(
+        record["rows"],
+        record["best_kalmanson_self_edge"]["quadrilateral"],
+        record["best_kalmanson_minimal_core"]["row_indices"],
+    )
+
+    assert len(instances) == 1
+    hinge = instances[0]
+    assert (hinge.a, hinge.b, hinge.c, hinge.d) == (1, 2, 7, 0)
+    assert hinge.centers == (1, 2, 0)
+    assert hinge.inequality_kind == record["best_kalmanson_self_edge"]["kind"] == "K1"
+
+
+@pytest.mark.parametrize(
+    ("call", "error"),
+    [
+        (lambda: dihedral_orientations([0, 1, 2]), ValueError),
+        (lambda: dihedral_orientations([0, 1, 2, 2]), ValueError),
+        (lambda: dihedral_orientations([0, 1, 2, True]), TypeError),
+        (lambda: find_hinge_instances([], [0, 1, 1, 2]), ValueError),
+        (lambda: find_hinge_instances({0: [1], 4: []}, [0, 1, 2, 3]), ValueError),
+        (lambda: find_hinge_instances({0: [4]}, [0, 1, 2, 3]), ValueError),
+        (lambda: find_hinge_instances({0: [0]}, [0, 1, 2, 3]), ValueError),
+        (lambda: find_hinge_instances({0: [1, 1]}, [0, 1, 2, 3]), ValueError),
+        (lambda: find_hinge_instances({0: [True]}, [0, 1, 2, 3]), TypeError),
+        (lambda: find_hinge_instances([[1], [0]], [0, 1, 2]), ValueError),
+        (
+            lambda: find_core_hinge_instances(
+                [[1], [0], [], []],
+                [0, 1, 2, 3],
+                [0, 1],
+            ),
+            ValueError,
+        ),
+        (
+            lambda: find_core_hinge_instances(
+                [[1], [0], [], []],
+                [0, 1, 2, 4],
+                [0, 1, 2],
+            ),
+            ValueError,
+        ),
+    ],
+)
+def test_malformed_inputs_are_rejected(call, error) -> None:
+    with pytest.raises(error):
+        call()

--- a/tests/test_kalmanson_equilateral_hinge_crosswalk.py
+++ b/tests/test_kalmanson_equilateral_hinge_crosswalk.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_kalmanson_equilateral_hinge_crosswalk.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_kalmanson_equilateral_hinge_crosswalk",
+        SCRIPT,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def generated_payload():
+    checker = load_checker()
+    return checker, checker.build_payload()
+
+
+@pytest.mark.artifact
+def test_crosswalk_matches_all_stored_best_cores(generated_payload) -> None:
+    checker, payload = generated_payload
+
+    checker.assert_expected_payload(payload)
+    summary = payload["summary"]
+    assert summary["covered_source_records"] == 184
+    assert summary["core_hinge_match_count_histogram"] == {"1": 184}
+    assert summary["source_best_kalmanson_kind_counts"] == {"K1": 95, "K2": 89}
+
+
+@pytest.mark.artifact
+def test_crosswalk_collapses_signatures_to_one_template(generated_payload) -> None:
+    _, payload = generated_payload
+    summary = payload["summary"]
+
+    assert summary["source_distinct_dihedral_core_signatures16"] == 56
+    assert summary["generic_pair_membership_template_orbits"] == 1
+    assert len(summary["generic_template_signatures16"]) == 1
+
+
+@pytest.mark.artifact
+def test_crosswalk_full_assignment_histogram(generated_payload) -> None:
+    _, payload = generated_payload
+    summary = payload["summary"]
+
+    assert summary["full_assignment_hinge_count_histogram"] == {
+        "2": 36,
+        "3": 6,
+        "5": 18,
+        "6": 54,
+        "8": 54,
+        "9": 16,
+    }
+    assert summary["total_full_assignment_hinge_instances"] == 1_080
+
+
+@pytest.mark.artifact
+def test_crosswalk_rejects_status_promotion(generated_payload) -> None:
+    checker, payload = generated_payload
+    edited = dict(payload)
+    edited["claim_scope"] = checker.CLAIM_SCOPE + " n=9 is proved."
+
+    with pytest.raises(AssertionError, match="claim_scope"):
+        checker.assert_expected_payload(edited)


### PR DESCRIPTION
## What changed

- extracts a reusable arbitrary-`n` Kalmanson equilateral-hinge lemma;
- adds a typed recognizer for the one three-rich-class pair-membership template;
- crosswalks all 184 stored best three-row cores to exactly one dihedral hinge orientation;
- records the exact collapse `56 full signatures -> 1 pair-membership subtemplate`;
- pins the complete-assignment hinge histogram and registers the generated crosswalk in artifact audit.

## Why

The existing three-row compression ended with 56 cyclic-dihedral full signatures and named their classification as the next proof-facing task. Forgetting unused witnesses reveals that every signature contains the same local strict-Kalmanson obstruction. The bridge program now has one small forcing target: three co-radial witness pairs.

## Exact results

- stored records covered: `184/184`;
- matching best-core orientations: exactly one per record;
- stored best kinds: `K1 = 95`, `K2 = 89`;
- full signatures: `56`;
- generic pair-membership templates: `1`;
- full-assignment hinge instances: `1,080`;
- per-assignment histogram: `{2:36, 3:6, 5:18, 6:54, 8:54, 9:16}`.

## Validation

- `python scripts/check_kalmanson_equilateral_hinge_crosswalk.py --check --assert-expected --summary-json`
- 20 focused tests passed (16 fast + 4 artifact)
- 15 artifact-audit integration tests passed
- Ruff, text hygiene, status consistency, artifact provenance, and `git diff --check` passed
- full fast pytest run had 1,589 passes; its three setup-dependent failures were rerun with the repository path/full dependencies and a clean worktree, and all passed
- independent math and code reviews found no blocking issue and independently reproduced the crosswalk counts

## Claim boundary

The local hinge lemma is arbitrary-`n`, but this PR does **not** prove that every hypothetical counterexample contains a hinge. The crosswalk reads the existing review-pending `n=9` compression artifact; it does not regenerate that frontier, satisfy external review, promote `n=9`, settle Erdős Problem #97, or produce a counterexample.
