### PR TITLE
Repair truncated two-mode packet documentation

### DIFF
--- a/docs/two-mode-cyclic-exact-n80.md
+++ b/docs/two-mode-cyclic-exact-n80.md
@@ -177,7 +177,7 @@ result remains explicitly review pending.
 
 This result says nothing about arbitrary point configurations, unbounded
 `n`, complex coefficients, or additional Fourier modes.  It converts the
-+
+previous floating-point `n <= 80` scan into an exact obstruction for precisely
 the real two-mode family and finite range stated above.  Erdos Problem 97
 remains open beyond the exact small-`n` and restricted-family results recorded
 by the repository.

--- a/docs/two-mode-exact-packet-triage-2026-07-17.md
+++ b/docs/two-mode-exact-packet-triage-2026-07-17.md
@@ -34,7 +34,7 @@ unresolved occurrences. The artifact SHA-256 is
 
 ## Rewritten rather than copied
 
-+
+The packet contained a repository-shaped overlay and semantic integration
 snippets written for a generic target tree. The mathematical proof note was
 cleaned semantically, and source-of-truth updates were adapted to the live
 repository. No damaged prose was retained verbatim.


### PR DESCRIPTION
## Summary

- restore the missing scope sentence in the exact real two-mode certificate note
- restore the missing intake explanation in the July 17 packet-triage record
- remove the two orphan `+` lines left by the original semantic integration

## Why

The substantive session result was already merged in #878: verifier, retained certificate, tests, dependencies, provenance, audit registration, and conservative source-of-truth updates are all present on `main`. Re-importing the packet would duplicate that work.

Two prose fragments from that integration were accidentally truncated to literal `+` lines. This PR restores only the intended documentation, including the bounded-family scope and the distinction between rewritten repository material and discarded packet duplicates.

## Impact

Documentation-only. No verifier, certificate bytes, generated-artifact metadata, dependency pins, mathematical status, or claim strength changes.

## Validation

- full default pytest: **1604 passed, 700 deselected**
- `scripts/check_text_clean.py`
- `scripts/check_status_consistency.py`
- `scripts/check_artifact_provenance.py`
- `python -m ruff check .`
- `git diff --check`

The artifact tier was not rerun because this PR changes only two prose lines and does not alter a generated artifact or mathematical claim.