### PR TITLE
Add cubic marked-cofactor model lemma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ reviewability fixes that affect how an external reader should interpret the
 repository. It is intentionally not a full git history. No general proof and no
 counterexample are claimed.
 
+## 2026-07-20
+
+- Added the cubic-graph half-branch model-case lemma. A marked-root
+  factorization of the degree-six distance fiber shows that any finite sample
+  on one closed side of a polynomial cubic graph's inflection has an outer
+  endpoint with no four-point distance class. The same note records an exact
+  Sturm-certified globally convex quartic negative control with four
+  same-radius arc intersections from one endpoint, showing where this cubic
+  obstruction stops. These are a restricted failed-family lemma and a
+  one-rich-row search control only: samples straddling the cubic inflection,
+  finite quartic closure, general parametric cubics, and arbitrary strictly
+  convex polygons remain outside their scope. No general proof or
+  counterexample is claimed, and the official and local source-of-truth
+  statuses are unchanged.
+
 ## 2026-07-17
 
 - Added a review-pending exact bounded certificate for the real two-mode cyclic

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2802,6 +2802,46 @@ quartic, impossible. See `docs/parabola-model-case.md`.
 This is a restricted exact obstruction only. It does not imply that arbitrary
 strictly convex polygons reduce to parabolic configurations.
 
+### Cubic-graph half-branch model case
+
+Status: `LEMMA` / `FAILED_SEARCH_FAMILY`.
+
+Let
+
+```text
+f(x) = A*x^3 + B*x^2 + C*x + D,  A != 0,
+```
+
+and let `xi=-B/(3*A)` be its inflection abscissa. No finite sample of the
+graph whose parameters all lie in `[xi,+infinity)` or all lie in
+`(-infinity,xi]` can be a counterexample to Erdos Problem #97. More strongly,
+the sampled parameter farthest from `xi` has at most three other sampled
+points at any one Euclidean distance.
+
+After translating the inflection to the origin and, if needed, applying a
+180-degree rotation, write
+
+```text
+gamma(t) = (t, a*t^3 + b*t),  a != 0,  t >= 0.
+```
+
+If four parameters `qk<s=max T` gave one distance from `gamma(s)`, their
+monic quartic `Q(t)` would divide the monic degree-six distance fiber `P(t)`.
+Writing `P=Q*(t^2+e1*t+nu)`, evaluation at `s` forces `nu<0`. The `t^2`
+coefficient comparison gives
+
+```text
+(b/a)^2 + 1/a^2 = nu*e2 - e1*e3 + e4.
+```
+
+The left side is positive, while four distinct nonnegative roots give
+`e2>0`, `e1*e3>e4`, and hence a negative right side. See
+`docs/cubic-graph-half-branch-model-case.md`.
+
+This is a restricted exact obstruction only. It does not cover cubic samples
+that use both sides of the inflection, general parametric cubic curves, or
+arbitrary strictly convex polygons.
+
 ### Hyperbola branch model case
 
 Status: `LEMMA` / `FAILED_SEARCH_FAMILY`.

--- a/docs/cubic-graph-half-branch-model-case.md
+++ b/docs/cubic-graph-half-branch-model-case.md
@@ -1,0 +1,217 @@
+# Cubic-Graph Half-Branch Model Case
+
+Status: `LEMMA` / `FAILED_SEARCH_FAMILY`.
+
+This note records a restricted exact obstruction obtained by prescribing four
+roots of a distance fiber and retaining the quadratic cofactor. It does not
+prove Erdos Problem #97, does not produce a counterexample, and does not
+change the repository source-of-truth status.
+
+## Statement
+
+Let
+
+```text
+f(x) = A*x^3 + B*x^2 + C*x + D,  A != 0,
+```
+
+and let `xi = -B/(3*A)` be its inflection abscissa. Suppose `T` is a finite
+set of distinct real parameters contained in either closed half-line
+
+```text
+T subset [xi, +infinity)  or  T subset (-infinity, xi].
+```
+
+Then the point whose parameter is farthest from `xi` has at most three other
+sampled points at any one Euclidean distance on the graph of `f`.
+Consequently, no such one-sided finite sample can be a counterexample to
+Erdos Problem #97.
+
+The statement includes the case in which the inflection point itself is
+sampled.
+
+## Euclidean Normalization
+
+Translate the inflection point to the origin. Since
+
+```text
+f(xi + t) - f(xi) = A*t^3 + f'(xi)*t,
+```
+
+the translated graph has the form
+
+```text
+gamma(t) = (t, a*t^3 + b*t),  a != 0.
+```
+
+These are Euclidean translations, not general affine changes, so they
+preserve distances. If all translated parameters are nonpositive, a
+180-degree rotation sends them to the same normal form with nonnegative
+parameters. It is therefore enough to consider a finite set
+
+```text
+T subset [0, +infinity).
+```
+
+## Marked-Cofactor Proof
+
+Let `s = max T`. Suppose for contradiction that four distinct parameters
+
+```text
+q1, q2, q3, q4 in T \ {s}
+```
+
+give points at one common squared distance `rho` from `gamma(s)`. Then
+`0 <= qk < s` and `rho > 0`.
+
+Put
+
+```text
+mu = b/a,  kappa = 1/a^2 > 0.
+```
+
+After division by `a^2`, the monic distance fiber is
+
+```text
+P(t) = (||gamma(t) - gamma(s)||^2 - rho)/a^2
+     = (t-s)^2 * ((t^2 + s*t + s^2 + mu)^2 + kappa)
+       - rho/a^2.
+```
+
+The coefficients needed below are
+
+```text
+P(t) = t^6
+       + 2*mu*t^4
+       - 2*s*(s^2 + mu)*t^3
+       + (mu^2 + kappa)*t^2
+       - 2*s*(mu*(s^2 + mu) + kappa)*t
+       + constant.
+```
+
+In particular, the `t^5` coefficient is zero and the `t^2` coefficient is
+strictly positive.
+
+Mark the four witness roots by writing
+
+```text
+Q(t) = product_k (t-qk)
+     = t^4 - e1*t^3 + e2*t^2 - e3*t + e4,
+```
+
+where `e1,e2,e3,e4` are the elementary symmetric functions of the `qk`.
+The roots are distinct, so `Q` divides `P`. Both polynomials are monic, hence
+
+```text
+P(t) = Q(t) * (t^2 + u*t + nu)
+```
+
+for real `u,nu`. Comparing the `t^5` coefficients gives `u=e1`.
+
+Now evaluate the factorization at the center. Since every `qk<s`,
+
+```text
+Q(s) = product_k (s-qk) > 0,
+```
+
+whereas `P(s)=-rho/a^2<0`. Therefore
+
+```text
+s^2 + e1*s + nu < 0.
+```
+
+Here `s>0` and `e1>0`, so `nu<0`.
+
+The `t^2` coefficient of the factorization gives the exact identity
+
+```text
+mu^2 + kappa = nu*e2 - e1*e3 + e4.
+```
+
+Four distinct nonnegative witness parameters imply `e2>0` and
+`e1*e3>e4`. If one witness is zero, then `e4=0` while `e1,e3>0`. If all are
+positive, the expansion of `e1*e3` contains `4*e4` and additional positive
+terms. Thus
+
+```text
+nu*e2 - e1*e3 + e4 < 0.
+```
+
+This contradicts `mu^2+kappa>0`. Hence no radius centered at `gamma(s)` can
+contain four other sampled points.
+
+## Convexity Check
+
+On the normalized half-line,
+
+```text
+(a*t^3 + b*t)' = 3*a*t^2 + b.
+```
+
+This derivative is strictly monotone on `[0,+infinity)`: increasing when
+`a>0` and decreasing when `a<0`. The graph is therefore strictly convex or
+strictly concave on the closed half-branch, even though its second derivative
+vanishes at the endpoint `t=0`. Every finite set of distinct samples lies on
+one strict boundary chain of its convex hull, so all sampled points are
+vertices and no three are collinear.
+
+## Degree-Four Boundary
+
+Companion status: `EXACT_NEGATIVE_CONTROL` / one rich row only.
+
+The endpoint conclusion does not extend to arbitrary strictly convex quartic
+graphs. An exact negative control is
+
+```text
+g(t) = (3/5)*t + (3/10)*t^2 - t^3 + (13/10)*t^4.
+```
+
+Its second derivative is
+
+```text
+g''(t) = (78/5)*t^2 - 6*t + 3/5.
+```
+
+The leading coefficient is positive and the discriminant is `-36/25`, so
+`g''(t)>0` for every real `t`. Thus the graph is globally strictly convex.
+
+For `Gamma(t)=(t,g(t))`, the center `Gamma(-1)=(-1,2)`, and squared radius
+`5`, clearing denominators from the distance fiber gives
+
+```text
+100*(||Gamma(t)-Gamma(-1)||^2 - 5)
+  = 169*t^8 - 260*t^7 + 178*t^6 + 96*t^5
+    - 631*t^4 + 436*t^3 + 16*t^2 - 40*t.
+```
+
+An exact Sturm count has variation `6` at `-1` and variation `2` at `1`, so
+this polynomial has exactly four distinct roots in `(-1,1)`. They are
+isolated by
+
+```text
+(-3/10,-1/4),  {0},  (2/5,1/2),  (7/10,4/5),
+```
+
+with one root in each listed interval or singleton. Hence one endpoint of a
+strictly convex quartic arc can have four other arc points on a common circle.
+This supplies only one rich row. It is not a finite branch closure, not a
+counterexample, and not evidence that the other four points have rich rows.
+It shows that degree four is a genuinely nontrivial next target for a
+marked-root closure search.
+
+## Why the Marked Roots Matter
+
+The useful mechanism is not a local-rank or injectivity claim. The four desired
+witnesses are installed first as roots of `Q`, and the degree-six distance
+fiber is allowed to retain its hidden quadratic cofactor. Evaluating that
+cofactor at the center forces its constant term negative, while a different
+coefficient comparison forces the same expression positive. This is the
+root-first design principle suggested by the constant-Jacobian example, used
+here as an exact obstruction rather than as an analogy-based conclusion.
+
+## Scope
+
+This lemma rules out polynomial cubic graphs, and their rigid-motion images,
+only when all sampled parameters lie on one closed side of the inflection. It
+does not cover samples using both sides, arbitrary implicit or parametrically
+cubic curves, multi-arc constructions, or general strictly convex polygons.

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,6 +175,12 @@ put detailed reconciliation in the canonical synthesis.
 - [`parabola-model-case.md`](parabola-model-case.md): restricted exact lemma
   showing that finite point sets on a nondegenerate affine parabola cannot be
   counterexamples; a failed search family, not a global bridge.
+- [`cubic-graph-half-branch-model-case.md`](cubic-graph-half-branch-model-case.md):
+  marked-cofactor lemma showing that a finite sample on one closed half-branch
+  of a nondegenerate polynomial cubic graph cannot be a counterexample; a
+  failed search family, plus an exact globally convex quartic one-rich-row
+  negative control; not a claim about samples straddling the inflection or a
+  finite quartic closure.
 - [`hyperbola-branch-model-case.md`](hyperbola-branch-model-case.md):
   restricted exact lemma showing that finite point sets on one branch of a
   Euclidean hyperbola cannot be counterexamples; a failed search family, not a

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -454,6 +454,15 @@ should not be duplicated here. The convex-body discretization route is only
 interesting if it uses multi-arc closure in a way the one-parabola endpoint
 argument cannot see.
 
+A second exact boundary is now recorded in
+`docs/cubic-graph-half-branch-model-case.md`: a finite sample on one closed
+half-branch of a polynomial cubic graph always has a good outer endpoint. The
+same note gives a globally strictly convex quartic graph with one endpoint and
+four exact same-radius arc intersections, certified by Sturm counts. Thus a
+one-arc marked-root continuation should start with quartic degree or with a
+cubic sample that genuinely uses both sides of its inflection. The quartic
+example is one rich row only, not finite closure or counterexample evidence.
+
 ## 4. Reciprocal-Radial Global Budget
 
 Trust label: `RESEARCH_PACKET`.


### PR DESCRIPTION
## Summary

- add an exact marked-cofactor obstruction for finite samples on one closed half-branch of any nondegenerate polynomial cubic graph
- record the proof in the claims ledger and research index without changing the repository's official/global or local strongest status
- add a Sturm-certified globally strictly convex quartic negative control showing that a one-sided endpoint can already have four same-radius arc witnesses in degree four

## Key identity

After Euclidean normalization to `gamma(t)=(t,a*t^3+b*t)` on `t>=0`, four marked witness roots give

```text
P(t)=Q(t)*(t^2+e1*t+nu)
(mu^2+kappa)=nu*e2-e1*e3+e4
```

Evaluation at the outer center forces `nu<0`, while distinct nonnegative witnesses give `e2>0` and `e1*e3>e4`. The right side is therefore negative, contradicting `mu^2+kappa>0`.

## Scope

This is `LEMMA / FAILED_SEARCH_FAMILY` only. It does not cover cubic samples straddling the inflection, arbitrary parametric cubics, finite quartic branch closure, or general strictly convex polygons. It neither proves Erdős #97 nor supplies a counterexample.

## Validation

- text-clean, status-consistency, artifact-provenance, diff, and Ruff checks passed
- broad fast pytest run: 1,601 passed; three environment-sensitive checks initially failed because the isolated runner lacked `PYTHONPATH=src` and the release guard correctly saw the pre-commit dirty tree
- all three affected tests passed on the clean commit with `PYTHONPATH=src`
- the symbolic distance expansion, coefficient identity, convexity discriminant, and quartic Sturm counts were independently rederived twice
