### PR TITLE
Normalize legacy external audit hashes to LF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ counterexample are claimed.
 
 ## 2026-07-20
 
+- Corrected the two legacy external-source audits to hash LF-normalized
+  bytes, repinned all six affected digests to the canonical Git blobs, and
+  added CRLF fixture coverage through both public audit entry points. This is
+  a portability and reproducibility repair only; it changes no mathematical
+  claim or repository status.
+
 - Added the cubic-graph half-branch model-case lemma. A marked-root
   factorization of the degree-six distance fiber shows that any finite sample
   on one closed side of a polynomial cubic graph's inflection has an outer

--- a/docs/external-exact-five-occurrence-contract-2026-07-18.md
+++ b/docs/external-exact-five-occurrence-contract-2026-07-18.md
@@ -24,17 +24,20 @@ Repository:
 commit  5e43baeb6fb5f5c51745e05696a7f1b29bf52b0a
 
 LargeOppositeCapsBiApexSurface.lean
-SHA256  40dffe39fa980b23baeca91809d32f5f2ae3d6faa7fded1a1a9c1f096f8d331b
+LF-SHA256  f6ad84e10773d6298b775858889a07ebbbf63029306b7d45200cd982d38c593f
 
 FirstApexShellRole.lean
-SHA256  b2ac9b20c6ef1db57c3dcdcea9289cf1b3a6074eb325297c398c411d555fff03
+LF-SHA256  ac0212e83499063557c9ccba0de6d33f794f49058cec927a4c2183581df455d6
 
 LargeCapUniqueFivePhysicalOmissionTransitionGlobal.lean
-SHA256  7651c4312bda034174a461960da50b25270abe1509931f33822c11e50b12babc
+LF-SHA256  d8f855b54355e49766bb11e5ff0864786cdd0770b3adcbfdad713f2f46fbd362
 
 ParentExactFiveAssembler.lean
-SHA256  0082e83a319af8b5e8484967c1a88eadf63bc4a0a7876e571855b60762c683ff
+LF-SHA256  3e7d8bcdebd8a5c4f19cb49db3223eb17b9c3eb3970be544e2db2ba04cf00122
 ```
+
+All four digests normalize checkout CRLF line endings to LF before hashing,
+so the documented replay matches canonical Git blob bytes across platforms.
 
 Reproduce the source audit with:
 

--- a/docs/external-removable-vertex-frontier-audit-2026-07-18.md
+++ b/docs/external-removable-vertex-frontier-audit-2026-07-18.md
@@ -14,9 +14,12 @@ Repository:
 ```text
 commit  5e43baeb6fb5f5c51745e05696a7f1b29bf52b0a
 source  lean/Erdos9796Proof/P97/U1LargeCapRouteBTail.lean
-SHA256  d2aaf3c9d51360143769c60312c1e3d8c18e8c166d4c757eb7b6ab68de5573ad
-README  9601dfa1e09df058bfcfa6673141559b884c495876d40344989bbcfe3fdc265d
+LF-SHA256  03478c4ba4bd2b5019ea047b96748c333408d487857bdcc227ba5ae534227e48
+README LF-SHA256  6625641332bdb1d18ba11459158ee77951e7d50fc7a575c735a94974a8a10004
 ```
+
+The digests are computed after normalizing checkout CRLF line endings to LF,
+matching the canonical Git blob bytes on both Windows and POSIX checkouts.
 
 Run:
 

--- a/reports/adversarial-review-2026-07-20.md
+++ b/reports/adversarial-review-2026-07-20.md
@@ -84,6 +84,9 @@ repo-authored statement overclaims a proof or counterexample.
 
 #### H1 — The 2026-07-18 external audits pin CRLF hashes; their documented reproduction fails on any standard checkout
 
+Post-review disposition: **resolved after the reviewed snapshot by PR #890**.
+The finding and snapshot count are retained here as historical review evidence.
+
 - Location: `src/erdos97/external_frontier_audit.py:18-23`
   (`EXPECTED_SOURCE_SHA256`, `EXPECTED_README_SHA256`),
   `src/erdos97/external_exact_five_contract.py:16,32-45`;

--- a/src/erdos97/external_exact_five_contract.py
+++ b/src/erdos97/external_exact_five_contract.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 
-from erdos97.external_frontier_audit import _git_commit
+from erdos97.external_frontier_audit import _git_commit, _lf_bytes
 
 
 EXPECTED_COMMIT = "5e43baeb6fb5f5c51745e05696a7f1b29bf52b0a"
@@ -31,16 +31,16 @@ ASSEMBLER_SOURCE = Path(
 
 EXPECTED_SOURCE_SHA256 = {
     PARENT_SOURCE: (
-        "40dffe39fa980b23baeca91809d32f5f2ae3d6faa7fded1a1a9c1f096f8d331b"
+        "f6ad84e10773d6298b775858889a07ebbbf63029306b7d45200cd982d38c593f"
     ),
     ROLE_SOURCE: (
-        "b2ac9b20c6ef1db57c3dcdcea9289cf1b3a6074eb325297c398c411d555fff03"
+        "ac0212e83499063557c9ccba0de6d33f794f49058cec927a4c2183581df455d6"
     ),
     TRANSITION_SOURCE: (
-        "7651c4312bda034174a461960da50b25270abe1509931f33822c11e50b12babc"
+        "d8f855b54355e49766bb11e5ff0864786cdd0770b3adcbfdad713f2f46fbd362"
     ),
     ASSEMBLER_SOURCE: (
-        "0082e83a319af8b5e8484967c1a88eadf63bc4a0a7876e571855b60762c683ff"
+        "3e7d8bcdebd8a5c4f19cb49db3223eb17b9c3eb3970be544e2db2ba04cf00122"
     ),
 }
 
@@ -148,7 +148,7 @@ def audit_external_exact_five_contract(
             raise FileNotFoundError(
                 f"missing external contract source: {source_path}"
             )
-        source_bytes = source_path.read_bytes()
+        source_bytes = _lf_bytes(source_path.read_bytes())
         source = source_bytes.decode("utf-8")
         path_key = relative_path.as_posix()
         source_hashes[path_key] = sha256(source_bytes).hexdigest()

--- a/src/erdos97/external_frontier_audit.py
+++ b/src/erdos97/external_frontier_audit.py
@@ -16,10 +16,10 @@ import subprocess
 TAIL_SOURCE = Path("lean/Erdos9796Proof/P97/U1LargeCapRouteBTail.lean")
 EXPECTED_COMMIT = "5e43baeb6fb5f5c51745e05696a7f1b29bf52b0a"
 EXPECTED_SOURCE_SHA256 = (
-    "d2aaf3c9d51360143769c60312c1e3d8c18e8c166d4c757eb7b6ab68de5573ad"
+    "03478c4ba4bd2b5019ea047b96748c333408d487857bdcc227ba5ae534227e48"
 )
 EXPECTED_README_SHA256 = (
-    "9601dfa1e09df058bfcfa6673141559b884c495876d40344989bbcfe3fdc265d"
+    "6625641332bdb1d18ba11459158ee77951e7d50fc7a575c735a94974a8a10004"
 )
 
 EXPECTED_OPEN_DECLARATIONS = frozenset(
@@ -39,6 +39,11 @@ EXPECTED_OPEN_DECLARATIONS = frozenset(
     }
 )
 EXPECTED_TEXTUAL_HOLES = 32
+
+
+def _lf_bytes(data: bytes) -> bytes:
+    """Normalize checkout line endings to the committed LF convention."""
+    return data.replace(b"\r\n", b"\n")
 
 
 @dataclass(frozen=True)
@@ -213,8 +218,8 @@ def audit_external_frontier(checkout: Path) -> ExternalFrontierAudit:
     if not readme_path.is_file():
         raise FileNotFoundError(f"missing external README: {readme_path}")
 
-    source_bytes = source_path.read_bytes()
-    readme_bytes = readme_path.read_bytes()
+    source_bytes = _lf_bytes(source_path.read_bytes())
+    readme_bytes = _lf_bytes(readme_path.read_bytes())
     source = source_bytes.decode("utf-8")
     readme = readme_bytes.decode("utf-8")
     hole_lines, textual_holes = _open_declarations(source)

--- a/tests/test_external_exact_five_contract.py
+++ b/tests/test_external_exact_five_contract.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+import erdos97.external_exact_five_contract as exact_five
 from erdos97.external_exact_five_contract import (
     EXPECTED_MARKERS,
     EXPECTED_SOURCE_SHA256,
@@ -24,3 +30,30 @@ def test_marker_inventory_has_no_duplicates() -> None:
         for marker in source_markers
     ]
     assert len(markers) == len(set(markers))
+
+
+def test_public_audit_normalizes_crlf_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = tmp_path / "external"
+    expected_hashes = {}
+    for relative_path, markers in exact_five.EXPECTED_MARKERS.items():
+        source_lf = ("\n".join(markers) + "\n").encode()
+        source_path = checkout / relative_path
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(source_lf.replace(b"\n", b"\r\n"))
+        expected_hashes[relative_path] = sha256(source_lf).hexdigest()
+
+    monkeypatch.setattr(exact_five, "_git_commit", lambda _: "fixture-commit")
+    monkeypatch.setattr(exact_five, "EXPECTED_COMMIT", "fixture-commit")
+    monkeypatch.setattr(
+        exact_five, "EXPECTED_SOURCE_SHA256", expected_hashes
+    )
+
+    result = exact_five.audit_external_exact_five_contract(checkout)
+
+    assert result.expected_snapshot_match
+    assert not result.missing_markers
+    assert result.source_sha256 == {
+        path.as_posix(): digest for path, digest in expected_hashes.items()
+    }

--- a/tests/test_external_frontier_audit.py
+++ b/tests/test_external_frontier_audit.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+import erdos97.external_frontier_audit as frontier
 from erdos97.external_frontier_audit import (
     _open_declarations,
     _readme_counts,
@@ -38,3 +44,41 @@ def test_readme_counts_are_fail_closed() -> None:
         32,
     )
     assert _readme_counts("proof complete") == (None, None)
+
+
+def test_public_audit_normalizes_crlf_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = tmp_path / "external"
+    source_path = checkout / frontier.TAIL_SOURCE
+    source_path.parent.mkdir(parents=True)
+    source_lf = b"""theorem first : True := by
+  sorry
+  sorry
+lemma second : False := by sorry
+"""
+    readme_lf = b"2 `sorry`-carrying symbols / 3 textual holes\n"
+    source_path.write_bytes(source_lf.replace(b"\n", b"\r\n"))
+    (checkout / "README.md").write_bytes(
+        readme_lf.replace(b"\n", b"\r\n")
+    )
+
+    monkeypatch.setattr(frontier, "_git_commit", lambda _: "fixture-commit")
+    monkeypatch.setattr(frontier, "EXPECTED_COMMIT", "fixture-commit")
+    monkeypatch.setattr(
+        frontier, "EXPECTED_OPEN_DECLARATIONS", frozenset({"first", "second"})
+    )
+    monkeypatch.setattr(frontier, "EXPECTED_TEXTUAL_HOLES", 3)
+    monkeypatch.setattr(
+        frontier, "EXPECTED_SOURCE_SHA256", sha256(source_lf).hexdigest()
+    )
+    monkeypatch.setattr(
+        frontier, "EXPECTED_README_SHA256", sha256(readme_lf).hexdigest()
+    )
+
+    result = frontier.audit_external_frontier(checkout)
+
+    assert result.expected_snapshot_match
+    assert result.readme_source_agree
+    assert result.source_sha256 == sha256(source_lf).hexdigest()
+    assert result.readme_sha256 == sha256(readme_lf).hexdigest()


### PR DESCRIPTION
## Summary

- normalize the legacy removable-frontier and exact-five audit inputs from CRLF to LF before hashing
- repin all six affected digests to the canonical Git blob bytes
- add CRLF fixtures that exercise both public audit functions end to end
- update the audit notes and changelog with the portable hash convention

Addresses H1 from the merged adversarial review in #888 and records the post-review disposition in that report.

## Root cause

The original pins were recorded from a Windows checkout with `core.autocrlf=true`. Both audit functions hashed checkout bytes directly, so their documented `--assert-expected` commands failed on ordinary LF/POSIX checkouts even at the exact pinned commit. The failure was fail-closed, but the promised reproduction was not portable.

## Scope

This is a provenance and reproducibility repair only. It does not build or validate the external Lean development, change a mathematical claim, promote a review gate, prove Erdős Problem #97, or change the repository's strongest-result status.

## Validation

- focused audit tests: **8 passed**
- `check_text_clean.py`
- `check_status_consistency.py`
- `check_artifact_provenance.py`
- `python -m ruff check --no-cache .`
- `git diff --check`
- fresh LF-preserving checkout of external commit `5e43baeb6fb5f5c51745e05696a7f1b29bf52b0a`:
  - `audit_external_removable_vertex_frontier.py --assert-expected --json`: success
  - `audit_external_exact_five_contract.py --assert-expected --json`: success

The local full pytest tier did not complete within a bounded run on this Windows machine; hosted PR CI remains the required full-suite gate.