### PR TITLE
Strengthen quartic marked-root obstruction via full Gram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ reviewability fixes that affect how an external reader should interpret the
 repository. It is intentionally not a full git history. No general proof and no
 counterexample are claimed.
 
+## 2026-07-21
+
+- Added a post-hoc full-Gram reclassification of the quartic marked-root
+  pilot. Writing `B=E11+A=C^T*C` makes every marked row homogeneous and shows
+  that the repeatedly reported negative-semidefinite root `A*=-E11` is the
+  zero Gram `B=0`. The corrected extension accounting is 315 canonical affine
+  solution states, comprising 314 lines and one singleton, rather than 315
+  lines. Exact rank and inertia checks, together with the two degenerate
+  rank-two PSD anchor rays, give a restricted lemma: a pairwise-distinct
+  planar degree-at-most-four polynomial sample at nine equally-spaced
+  parameters has a non-four-rich center among positions `-4,0,3,4`. Convexity
+  is not used. This post-hoc upgrade does not cover irregular parameters,
+  higher-dimensional samples, implicit quartics, higher degree, or arbitrary
+  strictly convex polygons, and it changes no global or source-of-truth
+  status.
+
 ## 2026-07-20
 
 - Corrected the two legacy external-source audits to hash LF-normalized
@@ -20,8 +36,9 @@ counterexample are claimed.
   rows leave `199349` rank-nine systems and `2729` canonical rank-eight
   exceptional states; exact rank-one-minor checks kill the former, and adding
   all 70 marked rows at one further center collapses the latter to 315 affine
-  lines, none with a rank-one PSD degree-four Gram. The retained artifact has
-  no unresolved state or full closure. This is a failed equally-spaced
+  solution states (314 lines and one singleton), none with a rank-one PSD
+  degree-four graph Gram. The retained artifact has no unresolved state or
+  full closure. This is a failed equally-spaced
   polynomial-graph family only, not an obstruction for irregular parameters,
   general quartic arcs, or arbitrary strictly convex polygons. No global or
   local source-of-truth status changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ counterexample are claimed.
   a portability and reproducibility repair only; it changes no mathematical
   claim or repository status.
 
+- Added an exact marked-root Gram obstruction for degree-exactly-four
+  polynomial graph samples at nine equally spaced parameters. Three anchor
+  rows leave `199349` rank-nine systems and `2729` canonical rank-eight
+  exceptional states; exact rank-one-minor checks kill the former, and adding
+  all 70 marked rows at one further center collapses the latter to 315 affine
+  lines, none with a rank-one PSD degree-four Gram. The retained artifact has
+  no unresolved state or full closure. This is a failed equally-spaced
+  polynomial-graph family only, not an obstruction for irregular parameters,
+  general quartic arcs, or arbitrary strictly convex polygons. No global or
+  local source-of-truth status changes.
 - Added the cubic-graph half-branch model-case lemma. A marked-root
   factorization of the degree-six distance fiber shows that any finite sample
   on one closed side of a polynomial cubic graph's inflection has an outer

--- a/data/certificates/quartic_marked_root_gram.json
+++ b/data/certificates/quartic_marked_root_gram.json
@@ -1,0 +1,658 @@
+{
+  "anchor_scan": {
+    "exceptional_affine_states": 2729,
+    "overlap_admissible_marked_triples": 202080,
+    "overlap_filtered_marked_triples": 140920,
+    "pair_inconsistent_pruned_triples": 0,
+    "quartets_per_center": 70,
+    "rank_counts": {
+      "8": 2731,
+      "9": 199349
+    },
+    "rank_nine_irrational_components": 0,
+    "rank_nine_lower_degree_rank_one_psd_roots": 0,
+    "rank_nine_marked_triples": 199349,
+    "rank_nine_negative_semidefinite_rank_one_roots": 199349,
+    "rank_nine_rational_quartic_grams": 0,
+    "rank_nine_whole_rank_at_most_one_lines": 0,
+    "rank_nine_without_real_rank_at_most_one": 0,
+    "rank_nine_zero_matrix_roots": 0,
+    "raw_marked_triples": 343000,
+    "sample_survivors": [
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-4",
+            "0",
+            "1",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-4",
+            "0",
+            "2",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "-2",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "-1",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "0",
+            "1",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "0",
+            "2",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-2",
+            "-1",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-2",
+            "0",
+            "1",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-2",
+            "0",
+            "2",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-1",
+            "0",
+            "1",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "-1",
+            "0",
+            "2",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "4"
+          ],
+          [
+            "0",
+            "1",
+            "2",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-4",
+            "-2",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-4",
+            "0",
+            "1",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-4",
+            "0",
+            "2",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "-2",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "-1",
+            "0",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "0",
+            "1",
+            "3"
+          ]
+        ]
+      },
+      {
+        "dimension": 2,
+        "kind": "UNRESOLVED_AFFINE_FAMILY",
+        "rank": 8,
+        "witnesses": [
+          [
+            "-4",
+            "-3",
+            "3",
+            "4"
+          ],
+          [
+            "-4",
+            "-1",
+            "0",
+            "4"
+          ],
+          [
+            "-3",
+            "0",
+            "2",
+            "3"
+          ]
+        ]
+      }
+    ],
+    "third_row_inconsistent_triples": 0
+  },
+  "claim_scope": "Exact fixed-parameter obstruction or survivor accounting for graph samples gamma(t)=(t,sum_{k=1}^4 a_k t^k) on T={-4,-3,...,4}.",
+  "controls": {
+    "higher_rank_psd_relaxation_trap": {
+      "extra_direction": [
+        "-15180",
+        "1553",
+        "-66",
+        "1"
+      ],
+      "marked_equations_hold": true,
+      "positive_semidefinite": true,
+      "rank_one": false,
+      "rejected_as_planar_quartic_graph": true
+    },
+    "positive_one_rich_row": {
+      "center": "0",
+      "claim_boundary": "ONE_RICH_ROW_ONLY_NOT_FINITE_CLOSURE",
+      "coefficients": [
+        "-51017/6552",
+        "337469/393120",
+        "-2503/65520",
+        "253/393120"
+      ],
+      "independent_divisibility_holds": true,
+      "marked_equations_hold": true,
+      "rank_one_psd_degree_four": true,
+      "squared_radius": "625",
+      "strictly_convex_on_0_24": true,
+      "witnesses": [
+        "7",
+        "15",
+        "20",
+        "24"
+      ]
+    }
+  },
+  "decisive_test_card": {
+    "hypotheses": {
+      "fixed_grid_closure": "one rank-one PSD degree-four Gram survives every center and the finite strict-convexity gate",
+      "local_only": "anchor affine systems fail the planar rank-one gate or their exceptional states die under further rows"
+    },
+    "predeclared_stopping_rule": "Report an exact fixed-grid obstruction only when the exceptional affine frontier is empty; otherwise preserve unresolved states.",
+    "question": "Can the one-rich-row quartic flexibility close all nine rows on the smallest equally spaced parameter grid not already covered by n<=8?"
+  },
+  "does_not_check": [
+    "arbitrary or irregular real parameter sets",
+    "other nine-point x-coordinate grids",
+    "polynomial graphs of degree greater than four",
+    "parametric or implicit quartic curves",
+    "multi-arc constructions",
+    "general strictly convex polygons",
+    "a proof or counterexample for Erdos Problem #97"
+  ],
+  "extension_steps": [
+    {
+      "center": "-4",
+      "deduplicated_affine_states_out": 0,
+      "deduplicated_consistent_affine_states": 315,
+      "higher_dimensional_states_retained": 0,
+      "input_affine_states": 2729,
+      "irrational_or_rank_one_line_states_retained": 0,
+      "linearly_consistent_branches": 191030,
+      "linearly_inconsistent_branches": 0,
+      "lower_degree_rank_one_psd_roots": 0,
+      "negative_semidefinite_rank_one_roots": 315,
+      "rational_line_rank_one_quartic_grams": 0,
+      "raw_state_row_branches": 191030,
+      "row_options_per_state": 70,
+      "specified_non_rank_one_grams": 0,
+      "states_without_real_rank_at_most_one": 0,
+      "unique_rank_one_quartic_gram_states": 0,
+      "zero_matrix_roots": 0
+    }
+  ],
+  "model": {
+    "anchor_centers": [
+      "0",
+      "3",
+      "4"
+    ],
+    "extension_centers": [
+      "-4",
+      "-3",
+      "-2",
+      "-1",
+      "1",
+      "2"
+    ],
+    "gram_variable_order": [
+      "A11",
+      "A12",
+      "A13",
+      "A14",
+      "A22",
+      "A23",
+      "A24",
+      "A33",
+      "A34",
+      "A44"
+    ],
+    "parameters": [
+      "-4",
+      "-3",
+      "-2",
+      "-1",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4"
+    ],
+    "planar_gate": "A=a*a^T, rank one, positive semidefinite, A44>0",
+    "row_equations_per_marked_quartet": 3
+  },
+  "outcome": {
+    "all_row_quartic_grams": 0,
+    "continuous_convex_full_closures": 0,
+    "continuously_convex_rank_one_quartic_grams": 0,
+    "rank_one_quartic_grams": 0,
+    "sample_candidates": [],
+    "strict_finite_full_closures": 0,
+    "unresolved_affine_states": 0
+  },
+  "provenance": {
+    "arithmetic": "fractions.Fraction exact rational elimination",
+    "check_command": "python scripts/check_quartic_marked_root_gram.py --check --assert-expected --json",
+    "command": "python scripts/check_quartic_marked_root_gram.py --write-artifact --check --assert-expected --json",
+    "generator": "scripts/check_quartic_marked_root_gram.py",
+    "summary_type": "QuarticClosurePilotSummary"
+  },
+  "schema": "erdos97.quartic_marked_root_gram.v1",
+  "status": "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID",
+  "trust": "EXACT_OBSTRUCTION"
+}

--- a/data/certificates/quartic_marked_root_gram.json
+++ b/data/certificates/quartic_marked_root_gram.json
@@ -522,7 +522,21 @@
     ],
     "third_row_inconsistent_triples": 0
   },
-  "claim_scope": "Exact fixed-parameter obstruction or survivor accounting for graph samples gamma(t)=(t,sum_{k=1}^4 a_k t^k) on T={-4,-3,...,4}.",
+  "claim_scope": {
+    "ambient_dimension": 2,
+    "convexity_used": false,
+    "maximum_coordinate_degree": 4,
+    "pairwise_distinctness_required": true,
+    "parameter_sets": "NINE_TERM_REAL_ARITHMETIC_PROGRESSIONS",
+    "sample_size": 9,
+    "statement": "For every real planar polynomial map gamma of degree at most four, sampled at nine equally spaced parameters, if the nine sample points are pairwise distinct then at least one of the four positions corresponding after affine reparameterization to -4,0,3,4 is not four-rich within the sample.",
+    "test_center_set_guaranteed_to_contain_a_non_rich_position_after_normalization": [
+      "-4",
+      "0",
+      "3",
+      "4"
+    ]
+  },
   "controls": {
     "higher_rank_psd_relaxation_trap": {
       "extra_direction": [
@@ -559,18 +573,20 @@
     }
   },
   "decisive_test_card": {
+    "classification": "PREDECLARED_ORIGINAL_GRAPH_TEST",
     "hypotheses": {
       "fixed_grid_closure": "one rank-one PSD degree-four Gram survives every center and the finite strict-convexity gate",
       "local_only": "anchor affine systems fail the planar rank-one gate or their exceptional states die under further rows"
     },
     "predeclared_stopping_rule": "Report an exact fixed-grid obstruction only when the exceptional affine frontier is empty; otherwise preserve unresolved states.",
-    "question": "Can the one-rich-row quartic flexibility close all nine rows on the smallest equally spaced parameter grid not already covered by n<=8?"
+    "question": "Can the one-rich-row quartic flexibility close all nine rows on the smallest equally spaced parameter grid not already covered by n<=8?",
+    "result_status": "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID"
   },
   "does_not_check": [
     "arbitrary or irregular real parameter sets",
-    "other nine-point x-coordinate grids",
-    "polynomial graphs of degree greater than four",
-    "parametric or implicit quartic curves",
+    "polynomial parametrizations of degree greater than four",
+    "higher-dimensional Euclidean samples",
+    "implicit or general algebraic quartic curves not given by one polynomial parametrization",
     "multi-arc constructions",
     "general strictly convex polygons",
     "a proof or counterexample for Erdos Problem #97"
@@ -610,6 +626,36 @@
       "1",
       "2"
     ],
+    "full_gram_upgrade": {
+      "B_variable_order": [
+        "B11",
+        "B12",
+        "B13",
+        "B14",
+        "B22",
+        "B23",
+        "B24",
+        "B33",
+        "B34",
+        "B44"
+      ],
+      "E11_upper": [
+        "1",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0"
+      ],
+      "constant_coefficients": "OMITTED_BECAUSE_TRANSLATIONS_PRESERVE_DISTANCES",
+      "identity": "B=A+E11",
+      "planar_gate": "B=C^T*C, B nonzero PSD, rank(B)<=2",
+      "translated_marked_rows": "HOMOGENEOUS_LINEAR_EQUATIONS_IN_B"
+    },
     "gram_variable_order": [
       "A11",
       "A12",
@@ -645,14 +691,201 @@
     "strict_finite_full_closures": 0,
     "unresolved_affine_states": 0
   },
+  "post_hoc_full_gram_upgrade": {
+    "anchor_kernel_census": {
+      "determinant_negative": 101793,
+      "determinant_positive": 97186,
+      "determinant_zero": 370,
+      "inertia_1_1_2": 277,
+      "inertia_1_2_1": 5,
+      "inertia_1_3_0": 7051,
+      "inertia_2_0_2": 2,
+      "inertia_2_1_1": 86,
+      "inertia_2_2_0": 95884,
+      "inertia_3_1_0": 94742,
+      "inertia_4_0_0": 1302,
+      "other_rank_one_roots": 0,
+      "phantom_roots": 199349,
+      "planar_kernel_lines": 2,
+      "rank_2": 279,
+      "rank_3": 91,
+      "rank_4": 198979,
+      "unique_kernel_lines": 190895
+    },
+    "anchor_planar_rank_two_psd_candidates": [
+      {
+        "center_multiplicities": [
+          2,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "collision_pairs": [
+          [
+            "-3",
+            "4"
+          ],
+          [
+            "-2",
+            "3"
+          ],
+          [
+            "-1",
+            "2"
+          ],
+          [
+            "0",
+            "1"
+          ]
+        ],
+        "full_gram_upper": [
+          "292",
+          "-248",
+          "-88",
+          "44",
+          "211",
+          "74",
+          "-37",
+          "28",
+          "-14",
+          "7"
+        ],
+        "pairwise_distinct": false,
+        "rank": 2,
+        "strictly_convex_sample": false
+      },
+      {
+        "center_multiplicities": [
+          2,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4,
+          4
+        ],
+        "collision_pairs": [
+          [
+            "-3",
+            "4"
+          ],
+          [
+            "-2",
+            "-1"
+          ],
+          [
+            "2",
+            "3"
+          ]
+        ],
+        "full_gram_upper": [
+          "2308",
+          "108",
+          "-232",
+          "24",
+          "183",
+          "18",
+          "-21",
+          "28",
+          "-6",
+          "3"
+        ],
+        "pairwise_distinct": false,
+        "rank": 2,
+        "strictly_convex_sample": false
+      }
+    ],
+    "classification": "POST_HOC_FULL_GRAM_STRUCTURAL_UPGRADE",
+    "extension_kernel_census": {
+      "affine_rank_10_states": 1,
+      "affine_rank_9_states": 314,
+      "determinant_negative": 231,
+      "determinant_positive": 72,
+      "determinant_zero": 11,
+      "inertia_1_1_2": 11,
+      "inertia_1_2_1": 0,
+      "inertia_1_3_0": 99,
+      "inertia_2_0_2": 0,
+      "inertia_2_1_1": 0,
+      "inertia_2_2_0": 6,
+      "inertia_3_1_0": 132,
+      "inertia_4_0_0": 66,
+      "kernel_rank_2": 11,
+      "kernel_rank_3": 0,
+      "kernel_rank_4": 303,
+      "other_rank_one_roots": 0,
+      "phantom_line_roots": 314,
+      "phantom_singletons": 1,
+      "planar_kernel_lines": 0,
+      "raw_affine_rank_10_branches": 190710,
+      "raw_affine_rank_9_branches": 320
+    },
+    "homogeneous_identity": {
+      "every_marked_row_contains_phantom": true,
+      "every_translated_marked_row_is_homogeneous": true,
+      "formula": "B=A+E11",
+      "phantom_full_gram_upper": [
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0"
+      ],
+      "phantom_interpretation": "A*=-E11 is the zero full Gram B=0, not a realizable nonzero planar coefficient Gram.",
+      "universal_graph_gram_phantom_upper": [
+        "-1",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0"
+      ]
+    },
+    "outcome": {
+      "affine_reparameterization_scope": "ALL_NINE_TERM_REAL_ARITHMETIC_PROGRESSIONS",
+      "pairwise_distinct_planar_candidates_rich_at_all_four_test_centers": 0,
+      "specific_center_set_forced_to_contain_non_rich_position": [
+        "-4",
+        "0",
+        "3",
+        "4"
+      ],
+      "strictly_convex_planar_candidates_rich_at_all_four_test_centers": 0,
+      "unresolved_affine_states_after_four_test_centers": 0
+    }
+  },
+  "post_hoc_structural_upgrade_card": {
+    "classification": "POST_HOC_FULL_GRAM_STRUCTURAL_UPGRADE",
+    "derivation": "Translate A to the homogeneous full coefficient Gram B=A+E11, classify every one-dimensional kernel by exact rank and inertia, and check pairwise distinctness of the only two planar anchor rays.",
+    "predeclared": false,
+    "stronger_than_original_graph_test": "Covers arbitrary planar polynomial parametrizations of degree at most four on every nine-term arithmetic progression and does not use convexity."
+  },
   "provenance": {
-    "arithmetic": "fractions.Fraction exact rational elimination",
+    "arithmetic": "fractions.Fraction exact rational elimination plus primitive integer symmetric-matrix rank and inertia",
     "check_command": "python scripts/check_quartic_marked_root_gram.py --check --assert-expected --json",
     "command": "python scripts/check_quartic_marked_root_gram.py --write-artifact --check --assert-expected --json",
+    "full_gram_upgrade_phase": "POST_HOC",
     "generator": "scripts/check_quartic_marked_root_gram.py",
+    "original_test_phase": "PREDECLARED",
     "summary_type": "QuarticClosurePilotSummary"
   },
-  "schema": "erdos97.quartic_marked_root_gram.v1",
-  "status": "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID",
+  "schema": "erdos97.quartic_marked_root_gram.v2",
+  "status": "NO_PAIRWISE_DISTINCT_PLANAR_DEGREE_AT_MOST_FOUR_SAMPLE_RICH_AT_ALL_FOUR_TEST_CENTERS_ON_NINE_TERM_ARITHMETIC_PROGRESSION",
   "trust": "EXACT_OBSTRUCTION"
 }

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2862,20 +2862,56 @@ The exact checker lifts the coefficients to the ten entries of
 `A=a*a^T`. Each marked witness quartet gives three affine equations in `A`.
 For anchor centers `0,3,4`, the two-circle overlap cap leaves `202080` of the
 `70^3=343000` marked triples. Of these, `199349` have affine rank nine and
-their exact rank-one roots are negative semidefinite, so they fail the planar
-PSD gate. The remaining `2731` rank-eight
+their exact rank-one root is the universal matrix `A*=-E11`, so they fail the
+planar PSD graph gate. The remaining `2731` rank-eight
 triples deduplicate to `2729` affine states. Appending every one of the 70
 marked rows at center `-4` gives `191030` consistent state-row branches but
-only 315 canonical affine lines; their rank-one roots are again negative
-semidefinite. No affine state, quartic Gram, or unresolved algebraic branch
-remains. See
+only 315 canonical affine solution states: 314 affine lines and the singleton
+`{A*}`. Their only rank-at-most-one matrix is again `A*`. No affine state,
+quartic graph Gram, or unresolved algebraic branch remains. See
 `docs/quartic-marked-root-gram-pilot.md` and
 `data/certificates/quartic_marked_root_gram.json`.
 
-This is an exact obstruction for one fixed equally-spaced polynomial-graph family,
-not for irregular parameter sets, general parametric quartics, multi-arc
-constructions, or arbitrary strictly convex polygons. It is not a global
-bridge and does not prove Erdos Problem #97.
+A post-hoc exact strengthening homogenizes the same equations with the full
+coefficient Gram. For
+
+```text
+gamma(t) = C*(t,t^2,t^3,t^4)^T,
+B = C^T*C,
+```
+
+the marked equations are homogeneous in `B`, and the graph substitution is
+`B=E11+A`. Hence `A*` corresponds exactly to the zero Gram `B=0`. A
+one-dimensional kernel can represent a planar polynomial map only if its
+generator is semidefinite of rank at most two.
+
+The 315 extension states consist of one zero kernel and 314 lines. Their exact
+inertias are 231 nonsingular Lorentzian, 6 nonsingular `(2,2)`, 66 definite
+rank four, and 11 singular `(1,1,2)`. None contains a nonzero planar Gram.
+The only two PSD rank-two rays in the rigid rank-nine anchor stratum are
+
+```text
+(2308,108,-232,24,183,18,-21,28,-6,3),
+(292,-248,-88,44,211,74,-37,28,-14,7).
+```
+
+Both have positive-radius row multiplicities `(2,4,4,4,4,4,4,4,4)` across
+centers `-4,-3,...,4`, but both identify several parameter pairs and therefore
+fail pairwise distinctness; neither is four-rich at `-4`.
+
+It follows, post hoc, that a pairwise-distinct planar sample of a real
+degree-at-most-four polynomial parametrization at nine equally spaced
+parameters has a non-four-rich center among the four positions corresponding
+to `-4,0,3,4`. This uses no convexity hypothesis and extends by affine
+reparameterization to every nine-term arithmetic progression.
+
+The predeclared result remains an exact obstruction for one fixed
+equally-spaced polynomial-graph family. The post-hoc upgrade covers planar
+polynomial parametrizations of degree at most four on equally-spaced samples,
+but not irregular parameter sets, higher-dimensional samples, implicit or
+general algebraic quartics, multi-arc constructions, or arbitrary strictly
+convex polygons. It is not a global bridge and does not prove Erdos Problem
+#97.
 
 ### Hyperbola branch model case
 

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -2842,6 +2842,41 @@ This is a restricted exact obstruction only. It does not cover cubic samples
 that use both sides of the inflection, general parametric cubic curves, or
 arbitrary strictly convex polygons.
 
+### Quartic equally-spaced marked-root model case
+
+Status: `EXACT_OBSTRUCTION` / `FAILED_SEARCH_FAMILY`.
+
+Let
+
+```text
+gamma(t) = (t, a1*t + a2*t^2 + a3*t^3 + a4*t^4),  a4 != 0,
+T = {-4,-3,-2,-1,0,1,2,3,4}.
+```
+
+There is no real coefficient vector for which every center in `T` has four
+other parameters in `T` at one common Euclidean distance. In particular, no
+strictly convex sample in this fixed family is a counterexample to Erdos
+Problem #97.
+
+The exact checker lifts the coefficients to the ten entries of
+`A=a*a^T`. Each marked witness quartet gives three affine equations in `A`.
+For anchor centers `0,3,4`, the two-circle overlap cap leaves `202080` of the
+`70^3=343000` marked triples. Of these, `199349` have affine rank nine and
+their exact rank-one roots are negative semidefinite, so they fail the planar
+PSD gate. The remaining `2731` rank-eight
+triples deduplicate to `2729` affine states. Appending every one of the 70
+marked rows at center `-4` gives `191030` consistent state-row branches but
+only 315 canonical affine lines; their rank-one roots are again negative
+semidefinite. No affine state, quartic Gram, or unresolved algebraic branch
+remains. See
+`docs/quartic-marked-root-gram-pilot.md` and
+`data/certificates/quartic_marked_root_gram.json`.
+
+This is an exact obstruction for one fixed equally-spaced polynomial-graph family,
+not for irregular parameter sets, general parametric quartics, multi-arc
+constructions, or arbitrary strictly convex polygons. It is not a global
+bridge and does not prove Erdos Problem #97.
+
 ### Hyperbola branch model case
 
 Status: `LEMMA` / `FAILED_SEARCH_FAMILY`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,6 +181,12 @@ put detailed reconciliation in the canonical synthesis.
   failed search family, plus an exact globally convex quartic one-rich-row
   negative control; not a claim about samples straddling the inflection or a
   finite quartic closure.
+- [`quartic-marked-root-gram-pilot.md`](quartic-marked-root-gram-pilot.md):
+  exact fixed-grid continuation of that degree-four boundary using affine Gram
+  row equations, rank-one minors, and calibrated controls; the full exceptional
+  frontier closes after one further center, with no degree-four Gram or
+  unresolved state. A restricted nine-parameter search family only, not a
+  general quartic obstruction or a global result.
 - [`hyperbola-branch-model-case.md`](hyperbola-branch-model-case.md):
   restricted exact lemma showing that finite point sets on one branch of a
   Euclidean hyperbola cannot be counterexamples; a failed search family, not a

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,9 +184,13 @@ put detailed reconciliation in the canonical synthesis.
 - [`quartic-marked-root-gram-pilot.md`](quartic-marked-root-gram-pilot.md):
   exact fixed-grid continuation of that degree-four boundary using affine Gram
   row equations, rank-one minors, and calibrated controls; the full exceptional
-  frontier closes after one further center, with no degree-four Gram or
-  unresolved state. A restricted nine-parameter search family only, not a
-  general quartic obstruction or a global result.
+  frontier closes after one further center, with no degree-four graph Gram or
+  unresolved state. A post-hoc full-Gram reclassification also rules out
+  pairwise-distinct planar degree-at-most-four polynomial samples at nine
+  equally-spaced parameters with four-rich rows at all four centers
+  `-4,0,3,4`, without using convexity. This remains a restricted
+  equally-spaced parametrized family, not a general quartic obstruction or a
+  global result.
 - [`hyperbola-branch-model-case.md`](hyperbola-branch-model-case.md):
   restricted exact lemma showing that finite point sets on one branch of a
   Euclidean hyperbola cannot be counterexamples; a failed search family, not a

--- a/docs/quartic-marked-root-gram-pilot.md
+++ b/docs/quartic-marked-root-gram-pilot.md
@@ -1,0 +1,204 @@
+# Quartic Marked-Root Gram Pilot
+
+Status: `EXACT_OBSTRUCTION` / `FAILED_SEARCH_FAMILY`.
+
+This note records a predeclared decisive test for the degree-four boundary in
+`docs/cubic-graph-half-branch-model-case.md`. It asks whether the flexibility
+that permits one four-rich row on a strictly convex quartic graph can close all
+rows of the smallest equally spaced nine-parameter sample. The test is exact,
+but its family is deliberately narrow. It does not prove or refute Erdos
+Problem #97.
+
+## Decisive-Test Contract
+
+The fixed parameter set is
+
+```text
+T = {-4,-3,-2,-1,0,1,2,3,4}.
+```
+
+The graph family is
+
+```text
+gamma_a(t) = (t, a1*t + a2*t^2 + a3*t^3 + a4*t^4),  a4 != 0.
+```
+
+The two predeclared outcomes were:
+
+- `LOCAL_ONLY`: the one-rich-row quartic phenomenon fails the planar rank-one
+  gate or every exceptional affine state dies when further center rows are
+  imposed;
+- `FIXED_GRID_CLOSURE`: an exact degree-four planar Gram matrix survives all
+  nine center rows and the strict finite-convexity check.
+
+An exact negative conclusion is permitted only if every positive-dimensional
+affine state is either resolved by the rank-one minors or extended through the
+remaining centers. A timeout, an irrational quadratic component, or a
+higher-dimensional final state must instead be retained as `UNRESOLVED`.
+
+## Lifted Row Equations
+
+Put
+
+```text
+v(t) = (t,t^2,t^3,t^4)^T,
+f_a(t) = a^T v(t),
+A = a*a^T.
+```
+
+For a center parameter `s` and witness parameter `q`, squared distance is
+
+```text
+D_A(s,q) = (q-s)^2 + (v(q)-v(s))^T A (v(q)-v(s)).
+```
+
+The ten variables are the upper-triangular entries
+
+```text
+(A11,A12,A13,A14,A22,A23,A24,A33,A34,A44).
+```
+
+For a marked witness quartet `q0<q1<q2<q3`, the three equations
+
+```text
+D_A(s,qk) - D_A(s,q0) = 0,  k=1,2,3,
+```
+
+are affine-linear over the rationals in those ten variables. Equivalently, if
+
+```text
+Q(X) = product_k (X-qk),
+```
+
+then `Q` divides the degree-at-most-eight distance fiber after its radius is
+subtracted. The implementation checks this divisibility independently on the
+positive control, rather than using it as a restatement of the three row
+equations.
+
+Linear feasibility is only a relaxation. A planar polynomial graph requires
+
+```text
+A != 0,
+all 2-by-2 minors of A vanish,
+A is positive semidefinite,
+A44 > 0.
+```
+
+A higher-rank positive-semidefinite matrix represents a curve in a higher
+ambient dimension and is rejected.
+
+## Anchor Enumeration
+
+The anchor centers are `0,3,4`. Each center has `binom(8,4)=70` possible
+marked witness quartets, so there are `70^3=343000` raw marked triples.
+
+Two different circle centers cannot have three common witnesses. Therefore
+the exact two-circle intersection cap safely removes anchor pairs whose marked
+quartets overlap in more than two labels. It leaves `202080` marked triples.
+The affine ranks are:
+
+```text
+rank 8:   2731 marked triples
+rank 9: 199349 marked triples
+```
+
+Every rank-nine system is an affine line. Substituting its rational line
+parameter into all `2-by-2` minors gives polynomials of degree at most two; the
+common rational polynomial gcd decides whether the line has a real rank-at-
+most-one point. All `199349` rank-nine marked triples fail the combined
+nonzero, PSD, and degree-four planar Gram gate: their retained real rank-one
+roots are negative semidefinite, never Gram matrices of real planar graph
+coefficients.
+
+The rank-eight triples collapse to `2729` canonical affine RREF states. These
+states, rather than a selected representative matrix from each state, are the
+exceptional frontier passed to the remaining centers.
+
+## Exceptional-Frontier Continuation
+
+For each unused center, every one of its 70 marked quartets is appended to
+every current RREF state. Consistent child systems are canonicalized and
+deduplicated before applying nonlinear gates:
+
+- a unique Gram matrix is checked for exact rank one, PSD, and `A44>0`;
+- an affine line is intersected with all rank-one minors exactly;
+- an irrational real quadratic component or a whole rank-at-most-one line is
+  retained for the next center;
+- dimension at least two is retained as an affine state;
+- a rational degree-four Gram is checked directly against the exact distance
+  partition at every center.
+
+No witness-overlap filter is used after RREF states are merged. This makes the
+continuation a harmless superset search and prevents state deduplication from
+hiding a future witness choice.
+
+At the first extension center, `-4`, the `2729` input states and 70 row choices
+give `191030` linearly consistent state-row branches. Canonical RREF
+deduplication leaves 315 affine lines. Their exact minor intersections contain
+only negative-semidefinite rank-one roots and no rank-one PSD degree-four Gram
+matrix. Thus the exceptional frontier is empty after center `-4`; no later
+center is needed to close this fixed family.
+
+The terminal result is
+
+```text
+unresolved affine states:        0
+rank-one degree-four Grams:       0
+strict finite full closures:      0
+```
+
+Consequently, no degree-exactly-four polynomial graph on this parameter set
+has all nine rows four-rich, even before a convexity assumption is imposed.
+
+The checked extension accounting and terminal frontier are stored in
+`data/certificates/quartic_marked_root_gram.json`. The artifact is regenerated
+and compared byte-for-structure by
+
+```bash
+python scripts/check_quartic_marked_root_gram.py \
+  --check --assert-expected --json
+```
+
+## Calibrated Controls
+
+The exact positive one-rich-row fixture is
+
+```text
+f(t) = (-51017/6552)*t
+     + (337469/393120)*t^2
+     - (2503/65520)*t^3
+     + (253/393120)*t^4.
+```
+
+At center `s=0`, its witnesses are
+
+```text
+(7,-24), (15,-20), (20,-15), (24,-7),
+```
+
+all at squared distance `625`. Its second derivative has positive minimum
+
+```text
+229153/14208480
+```
+
+on `[0,24]`. It must pass the marked equations, independent divisibility,
+rank-one, degree-four, and convexity gates. It remains one rich row only.
+
+For the higher-rank relaxation trap, add `c*c^T` with
+
+```text
+c = (-15180,1553,-66,1)
+```
+
+to the positive-control Gram matrix. The three marked-row equations still hold
+and the resulting matrix is PSD, but it has rank two and is rejected as a
+planar quartic graph.
+
+## Claim Boundary
+
+The checked search concerns one fixed equally-spaced parameter set, one graph
+coordinate form, and degree exactly four. The result does not cover other
+parameter sets, parametric or implicit quartics, higher-degree graphs,
+multi-arc samples, or arbitrary strictly convex polygons. It is a failed
+search family, not a bridge lemma and not a proof of Erdos Problem #97.

--- a/docs/quartic-marked-root-gram-pilot.md
+++ b/docs/quartic-marked-root-gram-pilot.md
@@ -75,6 +75,17 @@ subtracted. The implementation checks this divisibility independently on the
 positive control, rather than using it as a restatement of the three row
 equations.
 
+Every such affine system contains the distinguished matrix
+
+```text
+A* = -E11.
+```
+
+Indeed, its quadratic term cancels the horizontal `(q-s)^2` term, so all
+lifted squared distances are zero. This is not a graph Gram: it is rank one
+and negative semidefinite. The full-Gram interpretation below identifies it
+with the zero coefficient Gram.
+
 Linear feasibility is only a relaxation. A planar polynomial graph requires
 
 ```text
@@ -102,13 +113,12 @@ rank 8:   2731 marked triples
 rank 9: 199349 marked triples
 ```
 
-Every rank-nine system is an affine line. Substituting its rational line
-parameter into all `2-by-2` minors gives polynomials of degree at most two; the
-common rational polynomial gcd decides whether the line has a real rank-at-
-most-one point. All `199349` rank-nine marked triples fail the combined
-nonzero, PSD, and degree-four planar Gram gate: their retained real rank-one
-roots are negative semidefinite, never Gram matrices of real planar graph
-coefficients.
+Every rank-nine system is an affine line through `A*`. Substituting its
+rational line parameter into all `2-by-2` minors gives polynomials of degree
+at most two; the common rational polynomial gcd decides whether the line has
+a real rank-at-most-one point. All `199349` rank-nine marked triples fail the
+combined planar graph gate: their only retained real rank-one root is `A*`,
+not a nonzero PSD degree-four Gram matrix `a*a^T` of real graph coefficients.
 
 The rank-eight triples collapse to `2729` canonical affine RREF states. These
 states, rather than a selected representative matrix from each state, are the
@@ -134,10 +144,11 @@ hiding a future witness choice.
 
 At the first extension center, `-4`, the `2729` input states and 70 row choices
 give `191030` linearly consistent state-row branches. Canonical RREF
-deduplication leaves 315 affine lines. Their exact minor intersections contain
-only negative-semidefinite rank-one roots and no rank-one PSD degree-four Gram
-matrix. Thus the exceptional frontier is empty after center `-4`; no later
-center is needed to close this fixed family.
+deduplication leaves 315 affine solution states: 314 affine lines and the
+singleton `{A*}`. The only rank-at-most-one matrix retained by any of these
+states is again `A*`; there is no rank-one PSD degree-four graph Gram. Thus the
+exceptional frontier is empty after center `-4`; no later center is needed to
+close this fixed family.
 
 The terminal result is
 
@@ -158,6 +169,103 @@ and compared byte-for-structure by
 python scripts/check_quartic_marked_root_gram.py \
   --check --assert-expected --json
 ```
+
+## Post-Hoc Full-Gram Upgrade
+
+The following strengthening was derived after the decisive-test contract and
+is not one of its predeclared outcomes. It reclassifies the same exact marked
+row systems with the full coefficient Gram; it does not change the original
+graph certificate.
+
+Let
+
+```text
+gamma(t) = C*v(t) = sum_{k=1}^4 c_k*t^k,
+B = C^T*C.
+```
+
+Translations can remove an arbitrary constant coefficient without changing
+distances. For `u(s,q)=v(q)-v(s)`,
+
+```text
+|gamma(q)-gamma(s)|^2 = u(s,q)^T*B*u(s,q).
+```
+
+Every marked equal-distance equation is therefore homogeneous and linear in
+`B`. Conversely, every nonzero solution `B >= 0` of rank at most `d` factors
+as `C^T*C` and realizes the marked equations in `R^d`; degree exactly four is
+equivalent to `B44>0`. In the graph specialization,
+
+```text
+B = E11 + A.
+```
+
+Thus an affine graph solution space is exactly `-E11 + ker(L)`, and the
+universal point `A*=-E11` is `B=0`. In particular, the repeated
+negative-semidefinite root in the original accounting is a homogenization
+base point, not evidence that every nonzero full Gram has negative sign.
+All marked-row matrices have rational entries, so their rational nullspaces
+base-change to their complete real nullspaces; this classification does not
+discard polynomial maps with irrational real coefficients.
+
+For a one-dimensional homogeneous kernel with generator `K`, a planar
+realization can exist only when `K` is positive or negative semidefinite and
+has rank at most two. A nonzero determinant already excludes the plane;
+when the determinant vanishes, exact inertia is needed. The post-hoc exact
+classification of the 315 extension states is
+
+```text
+zero kernel:                         1
+nonsingular Lorentzian kernels:    231
+nonsingular inertia-(2,2) kernels:   6
+definite rank-four kernels:         66
+singular inertia-(1,1,2) kernels:   11
+```
+
+The 66 definite kernels show why this is a planar result, not an obstruction
+in every Euclidean dimension: they factor in dimension four.
+
+The rigid rank-nine anchor stratum has exactly two PSD rank-two rays. In the
+upper-triangular order used above they are generated by
+
+```text
+K1 = (2308,108,-232,24,183,18,-21,28,-6,3),
+K2 = (292,-248,-88,44,211,74,-37,28,-14,7).
+```
+
+Both are degenerate controls rather than polygon candidates. Their maximum
+positive-radius multiplicities at centers `-4,-3,...,4` are
+
+```text
+(2,4,4,4,4,4,4,4,4).
+```
+
+For `K1`, the sampled map identifies parameter pairs `(-3,4)`, `(-2,-1)`,
+and `(2,3)`. For `K2`, it depends only on `t*(1-t)` and identifies
+`(-3,4)`, `(-2,3)`, `(-1,2)`, and `(0,1)`. Hence neither ray gives nine
+distinct points, and neither supplies a four-witness row at center `-4`.
+
+Combining those two rigid-ray checks with the exact classification of every
+rank-eight state extended through center `-4` gives the post-hoc lemma:
+
+> Let `gamma:R->R^2` be a real polynomial map of degree at most four, and
+> sample it at nine equally spaced parameters. If the nine sampled points are
+> pairwise distinct, then at least one of the four sample centers corresponding
+> to parameters `-4,0,3,4` is not four-rich within the sample.
+
+For a progression `beta+alpha*T`, with `alpha != 0`, the explicit
+normalization is
+
+```text
+gamma_tilde(u) = gamma(beta+alpha*u) - gamma(beta).
+```
+
+This preserves all sample distances and coordinate degree, and reduces the
+progression to `T`. Convexity is not used. Pairwise distinctness is required
+by the planar two-circle overlap pruning. The lemma does not cover irregular
+parameter sets, polynomial degree above four, higher-dimensional samples,
+implicit or general algebraic quartics, multi-arc constructions, or arbitrary strictly
+convex polygons.
 
 ## Calibrated Controls
 
@@ -197,8 +305,11 @@ planar quartic graph.
 
 ## Claim Boundary
 
-The checked search concerns one fixed equally-spaced parameter set, one graph
-coordinate form, and degree exactly four. The result does not cover other
-parameter sets, parametric or implicit quartics, higher-degree graphs,
-multi-arc samples, or arbitrary strictly convex polygons. It is a failed
-search family, not a bridge lemma and not a proof of Erdos Problem #97.
+The predeclared artifact concerns one fixed equally-spaced parameter set, one
+graph coordinate form, and degree exactly four. The post-hoc full-Gram lemma
+extends the planar polynomial-parametrization scope to degree at most four and
+all affine copies of the equally-spaced grid, but no further. Neither result
+covers irregular parameter sets, general implicit quartics, higher degree,
+multi-arc samples, or arbitrary strictly convex polygons. This remains a
+failed search family, not a global bridge and not a proof of Erdos Problem
+#97.

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -462,6 +462,12 @@ four exact same-radius arc intersections, certified by Sturm counts. Thus a
 one-arc marked-root continuation should start with quartic degree or with a
 cubic sample that genuinely uses both sides of its inflection. The quartic
 example is one rich row only, not finite closure or counterexample evidence.
+The exact follow-up in `docs/quartic-marked-root-gram-pilot.md` tests the
+degree-exactly-four graph family on the fixed grid `T={-4,-3,...,4}`. It lifts
+marked rows to affine equations in `A=a*a^T`, enforces the planar rank-one
+gate, and continues every exceptional affine state through the unused centers.
+Its conclusion is confined to that one parameter grid and does not address
+irregular samples or arbitrary quartic arcs.
 
 ## 4. Reciprocal-Radial Global Budget
 

--- a/docs/research-directions-2026-05-19.md
+++ b/docs/research-directions-2026-05-19.md
@@ -466,8 +466,17 @@ The exact follow-up in `docs/quartic-marked-root-gram-pilot.md` tests the
 degree-exactly-four graph family on the fixed grid `T={-4,-3,...,4}`. It lifts
 marked rows to affine equations in `A=a*a^T`, enforces the planar rank-one
 gate, and continues every exceptional affine state through the unused centers.
-Its conclusion is confined to that one parameter grid and does not address
-irregular samples or arbitrary quartic arcs.
+The predeclared graph conclusion is confined to that fixed grid. A post-hoc
+homogenization writes `B=E11+A=C^T*C` and reclassifies the same row kernels by
+exact rank and inertia. It upgrades the boundary to pairwise-distinct planar
+degree-at-most-four polynomial parametrizations sampled at any nine-term
+arithmetic progression: one of the four positions corresponding to
+`-4,0,3,4` is not four-rich. Convexity is not used. The only two rigid
+rank-nine PSD rank-two anchor rays are degenerate labelled controls with
+several coincident parameter pairs, and each has maximum multiplicities
+`(2,4,4,4,4,4,4,4,4)` across `-4,-3,...,4`. This still does not address
+irregular samples, higher-dimensional samples, implicit quartics, or arbitrary
+quartic arcs.
 
 ## 4. Reciprocal-Radial Global Budget
 

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -4204,8 +4204,8 @@ artifacts:
 
   - id: quartic_marked_root_gram
     path: data/certificates/quartic_marked_root_gram.json
-    sha256: 8db203b4d897f2ceba018db1d39e705093700fca930f117520b05c49e834bc3f
-    size_bytes: 13295
+    sha256: bd4bb0b3621cacfcdca3724c39adaefae44b60a455b607db60c83c38edb08e33
+    size_bytes: 19389
     kind: exact_restricted_family_obstruction
     generator: scripts/check_quartic_marked_root_gram.py
     command: python scripts/check_quartic_marked_root_gram.py --write-artifact --check --assert-expected --json
@@ -4214,11 +4214,11 @@ artifacts:
     direct_edit_allowed: false
     provenance_mode: embedded
     trust_class: EXACT_OBSTRUCTION
-    claim_scope: Exact obstruction to four-rich closure for degree-exactly-four polynomial graph samples on the fixed parameter set T={-4,-3,...,4}; not a general quartic obstruction, n=9 proof, or global result.
+    claim_scope: Exact obstruction for pairwise-distinct planar degree-at-most-four polynomial parametrizations sampled at nine equally-spaced parameters; one of the normalized centers -4,0,3,4 is not four-rich. Not an irregular-parameter quartic obstruction, n=9 proof, or global result.
     json_top_level_type: object
     expected_json:
-      schema: erdos97.quartic_marked_root_gram.v1
-      status: NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID
+      schema: erdos97.quartic_marked_root_gram.v2
+      status: NO_PAIRWISE_DISTINCT_PLANAR_DEGREE_AT_MOST_FOUR_SAMPLE_RICH_AT_ALL_FOUR_TEST_CENTERS_ON_NINE_TERM_ARITHMETIC_PROGRESSION
       trust: EXACT_OBSTRUCTION
       anchor_scan.raw_marked_triples: 343000
       anchor_scan.overlap_admissible_marked_triples: 202080
@@ -4226,14 +4226,23 @@ artifacts:
       anchor_scan.rank_counts.9: 199349
       anchor_scan.rank_nine_negative_semidefinite_rank_one_roots: 199349
       anchor_scan.exceptional_affine_states: 2729
+      post_hoc_full_gram_upgrade.anchor_kernel_census.planar_kernel_lines: 2
+      post_hoc_full_gram_upgrade.anchor_kernel_census.unique_kernel_lines: 190895
+      post_hoc_full_gram_upgrade.anchor_kernel_census.phantom_roots: 199349
+      post_hoc_full_gram_upgrade.extension_kernel_census.affine_rank_9_states: 314
+      post_hoc_full_gram_upgrade.extension_kernel_census.affine_rank_10_states: 1
+      post_hoc_full_gram_upgrade.extension_kernel_census.planar_kernel_lines: 0
+      post_hoc_full_gram_upgrade.outcome.unresolved_affine_states_after_four_test_centers: 0
+      post_hoc_full_gram_upgrade.outcome.pairwise_distinct_planar_candidates_rich_at_all_four_test_centers: 0
       outcome.unresolved_affine_states: 0
       outcome.rank_one_quartic_grams: 0
       outcome.all_row_quartic_grams: 0
       outcome.strict_finite_full_closures: 0
     forbidden_claims:
       - arbitrary real parameter sets are obstructed
-      - general polynomial quartic graph samples are obstructed
-      - parametric or implicit quartic curves are obstructed
+      - irregularly parameterized polynomial quartic samples are obstructed
+      - implicit or general algebraic quartic curves are obstructed
+      - higher-dimensional polynomial samples are obstructed
       - the n=9 finite case is proved
       - general proof of Erdos Problem #97
       - counterexample to Erdos Problem #97

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -4202,6 +4202,43 @@ artifacts:
       - exact or interval certificate for boundary intersections
       - official/global status update
 
+  - id: quartic_marked_root_gram
+    path: data/certificates/quartic_marked_root_gram.json
+    sha256: 8db203b4d897f2ceba018db1d39e705093700fca930f117520b05c49e834bc3f
+    size_bytes: 13295
+    kind: exact_restricted_family_obstruction
+    generator: scripts/check_quartic_marked_root_gram.py
+    command: python scripts/check_quartic_marked_root_gram.py --write-artifact --check --assert-expected --json
+    checker: scripts/check_quartic_marked_root_gram.py
+    check_command: python scripts/check_quartic_marked_root_gram.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust_class: EXACT_OBSTRUCTION
+    claim_scope: Exact obstruction to four-rich closure for degree-exactly-four polynomial graph samples on the fixed parameter set T={-4,-3,...,4}; not a general quartic obstruction, n=9 proof, or global result.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.quartic_marked_root_gram.v1
+      status: NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID
+      trust: EXACT_OBSTRUCTION
+      anchor_scan.raw_marked_triples: 343000
+      anchor_scan.overlap_admissible_marked_triples: 202080
+      anchor_scan.rank_counts.8: 2731
+      anchor_scan.rank_counts.9: 199349
+      anchor_scan.rank_nine_negative_semidefinite_rank_one_roots: 199349
+      anchor_scan.exceptional_affine_states: 2729
+      outcome.unresolved_affine_states: 0
+      outcome.rank_one_quartic_grams: 0
+      outcome.all_row_quartic_grams: 0
+      outcome.strict_finite_full_closures: 0
+    forbidden_claims:
+      - arbitrary real parameter sets are obstructed
+      - general polynomial quartic graph samples are obstructed
+      - parametric or implicit quartic curves are obstructed
+      - the n=9 finite case is proved
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+      - official/global status update
+
   - id: two_parabola_lens_grid_search
     path: data/certificates/two_parabola_lens_grid_search.json
     sha256: b514282e4d5a6ebc096551e6e61ab354d6fc90fda592f1f8e494993fb03e5c18

--- a/scripts/check_quartic_marked_root_gram.py
+++ b/scripts/check_quartic_marked_root_gram.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate and replay the exact fixed-grid quartic marked-root Gram pilot."""
+"""Generate and replay the exact quartic marked-root Gram obstruction."""
 
 from __future__ import annotations
 
@@ -17,7 +17,9 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.quartic_marked_root_gram import (  # noqa: E402
+    E11_UPPER,
     SCHEMA,
+    UNIVERSAL_PHANTOM_UPPER,
     equations_hold,
     gram_upper_from_coefficients,
     lifted_squared_distance,
@@ -40,6 +42,103 @@ POSITIVE_COEFFICIENTS = (
 )
 POSITIVE_WITNESSES = (7, 15, 20, 24)
 HIGH_RANK_DIRECTION = (-15180, 1553, -66, 1)
+EXPECTED_SCHEMA = "erdos97.quartic_marked_root_gram.v2"
+EXPECTED_STATUS = (
+    "NO_PAIRWISE_DISTINCT_PLANAR_DEGREE_AT_MOST_FOUR_SAMPLE_RICH_AT_ALL_"
+    "FOUR_TEST_CENTERS_ON_NINE_TERM_ARITHMETIC_PROGRESSION"
+)
+
+EXPECTED_ANCHOR_FULL_GRAM_CENSUS = {
+    "rank_2": 279,
+    "rank_3": 91,
+    "rank_4": 198979,
+    "determinant_negative": 101793,
+    "determinant_positive": 97186,
+    "determinant_zero": 370,
+    "inertia_1_1_2": 277,
+    "inertia_2_0_2": 2,
+    "inertia_1_2_1": 5,
+    "inertia_2_1_1": 86,
+    "inertia_1_3_0": 7051,
+    "inertia_3_1_0": 94742,
+    "inertia_2_2_0": 95884,
+    "inertia_4_0_0": 1302,
+    "planar_kernel_lines": 2,
+    "unique_kernel_lines": 190895,
+    "phantom_roots": 199349,
+    "other_rank_one_roots": 0,
+}
+
+EXPECTED_EXTENSION_FULL_GRAM_CENSUS = {
+    "raw_affine_rank_9_branches": 320,
+    "raw_affine_rank_10_branches": 190710,
+    "affine_rank_9_states": 314,
+    "affine_rank_10_states": 1,
+    "kernel_rank_2": 11,
+    "kernel_rank_3": 0,
+    "kernel_rank_4": 303,
+    "determinant_negative": 231,
+    "determinant_positive": 72,
+    "determinant_zero": 11,
+    "inertia_1_1_2": 11,
+    "inertia_2_0_2": 0,
+    "inertia_1_2_1": 0,
+    "inertia_2_1_1": 0,
+    "inertia_1_3_0": 99,
+    "inertia_3_1_0": 132,
+    "inertia_2_2_0": 6,
+    "inertia_4_0_0": 66,
+    "planar_kernel_lines": 0,
+    "phantom_line_roots": 314,
+    "phantom_singletons": 1,
+    "other_rank_one_roots": 0,
+}
+
+EXPECTED_PLANAR_ANCHOR_CANDIDATES = [
+    {
+        "full_gram_upper": [
+            "2308",
+            "108",
+            "-232",
+            "24",
+            "183",
+            "18",
+            "-21",
+            "28",
+            "-6",
+            "3",
+        ],
+        "rank": 2,
+        "center_multiplicities": [2, 4, 4, 4, 4, 4, 4, 4, 4],
+        "collision_pairs": [["-3", "4"], ["-2", "-1"], ["2", "3"]],
+        "pairwise_distinct": False,
+        "strictly_convex_sample": False,
+    },
+    {
+        "full_gram_upper": [
+            "292",
+            "-248",
+            "-88",
+            "44",
+            "211",
+            "74",
+            "-37",
+            "28",
+            "-14",
+            "7",
+        ],
+        "rank": 2,
+        "center_multiplicities": [2, 4, 4, 4, 4, 4, 4, 4, 4],
+        "collision_pairs": [
+            ["-3", "4"],
+            ["-2", "3"],
+            ["-1", "2"],
+            ["0", "1"],
+        ],
+        "pairwise_distinct": False,
+        "strictly_convex_sample": False,
+    },
+]
 
 
 def fraction_text(value: Fraction | int) -> str:
@@ -63,6 +162,17 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise TypeError(f"{path} must contain one JSON object")
     return payload
+
+
+def required_summary_attribute(summary: object, name: str) -> Any:
+    """Read one schema-v2 summary field without silently accepting v1 data."""
+
+    if not hasattr(summary, name):
+        raise AssertionError(
+            f"schema-v2 generator requires summary field {name!r}; "
+            "the exact full-Gram implementation is incomplete"
+        )
+    return getattr(summary, name)
 
 
 def control_summary() -> dict[str, Any]:
@@ -118,39 +228,90 @@ def control_summary() -> dict[str, Any]:
 
 
 def build_payload() -> dict[str, Any]:
+    if SCHEMA != EXPECTED_SCHEMA:
+        raise AssertionError(f"source schema {SCHEMA!r} != {EXPECTED_SCHEMA!r}")
     summary = quartic_closure_pilot(
         parameters=PARAMETERS,
         anchor_centers=ANCHOR_CENTERS,
     )
     anchor = summary.anchor
+    anchor_full_gram_census = dict(
+        required_summary_attribute(anchor, "full_gram_kernel_census")
+    )
+    anchor_planar_candidates = list(
+        required_summary_attribute(anchor, "full_gram_planar_candidates")
+    )
+    extension_full_gram_census = dict(
+        required_summary_attribute(summary, "full_gram_extension_census")
+    )
+    four_center_unresolved_states = required_summary_attribute(
+        summary,
+        "full_gram_four_center_unresolved_state_count",
+    )
+    pairwise_distinct_full_gram_candidates = required_summary_attribute(
+        summary,
+        "full_gram_pairwise_distinct_candidate_count",
+    )
+    strictly_convex_full_gram_candidates = required_summary_attribute(
+        summary,
+        "full_gram_strictly_convex_candidate_count",
+    )
+
     if summary.strict_finite_full_closure_candidate_count:
-        status = "EXACT_FIXED_GRID_CLOSURE_CANDIDATE"
-        trust = "EXACT_CERTIFICATE_DIAGNOSTIC"
+        original_graph_status = "EXACT_FIXED_GRID_CLOSURE_CANDIDATE"
     elif summary.unresolved_affine_state_count:
-        status = "INCONCLUSIVE_FIXED_GRID_WITH_UNRESOLVED_AFFINE_STATES"
+        original_graph_status = "INCONCLUSIVE_FIXED_GRID_WITH_UNRESOLVED_AFFINE_STATES"
+    else:
+        original_graph_status = "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID"
+
+    if pairwise_distinct_full_gram_candidates:
+        status = (
+            "PAIRWISE_DISTINCT_PLANAR_DEGREE_AT_MOST_FOUR_"
+            "FOUR_TEST_CENTER_CANDIDATE"
+        )
+        trust = "EXACT_CERTIFICATE_DIAGNOSTIC"
+    elif four_center_unresolved_states:
+        status = "INCONCLUSIVE_FULL_GRAM_WITH_UNRESOLVED_AFFINE_STATES"
         trust = "EXACT_CERTIFICATE_DIAGNOSTIC"
     else:
-        status = "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID"
+        status = EXPECTED_STATUS
         trust = "EXACT_OBSTRUCTION"
 
     payload: dict[str, Any] = {
         "schema": SCHEMA,
         "status": status,
         "trust": trust,
-        "claim_scope": (
-            "Exact fixed-parameter obstruction or survivor accounting for graph samples "
-            "gamma(t)=(t,sum_{k=1}^4 a_k t^k) on T={-4,-3,...,4}."
-        ),
+        "claim_scope": {
+            "statement": (
+                "For every real planar polynomial map gamma of degree at most four, "
+                "sampled at nine equally spaced parameters, if the nine sample points "
+                "are pairwise distinct then at least one of the four positions "
+                "corresponding after affine reparameterization to -4,0,3,4 is not "
+                "four-rich within the sample."
+            ),
+            "ambient_dimension": 2,
+            "maximum_coordinate_degree": 4,
+            "sample_size": 9,
+            "parameter_sets": "NINE_TERM_REAL_ARITHMETIC_PROGRESSIONS",
+            "pairwise_distinctness_required": True,
+            "convexity_used": False,
+            "test_center_set_guaranteed_to_contain_a_non_rich_position_"
+            "after_normalization": ["-4", "0", "3", "4"],
+        },
         "does_not_check": [
             "arbitrary or irregular real parameter sets",
-            "other nine-point x-coordinate grids",
-            "polynomial graphs of degree greater than four",
-            "parametric or implicit quartic curves",
+            "polynomial parametrizations of degree greater than four",
+            "higher-dimensional Euclidean samples",
+            (
+                "implicit or general algebraic quartic curves not given by one "
+                "polynomial parametrization"
+            ),
             "multi-arc constructions",
             "general strictly convex polygons",
             "a proof or counterexample for Erdos Problem #97",
         ],
         "decisive_test_card": {
+            "classification": "PREDECLARED_ORIGINAL_GRAPH_TEST",
             "question": (
                 "Can the one-rich-row quartic flexibility close all nine rows on the "
                 "smallest equally spaced parameter grid not already covered by n<=8?"
@@ -168,6 +329,20 @@ def build_payload() -> dict[str, Any]:
             "predeclared_stopping_rule": (
                 "Report an exact fixed-grid obstruction only when the exceptional affine "
                 "frontier is empty; otherwise preserve unresolved states."
+            ),
+            "result_status": original_graph_status,
+        },
+        "post_hoc_structural_upgrade_card": {
+            "classification": "POST_HOC_FULL_GRAM_STRUCTURAL_UPGRADE",
+            "predeclared": False,
+            "derivation": (
+                "Translate A to the homogeneous full coefficient Gram B=A+E11, "
+                "classify every one-dimensional kernel by exact rank and inertia, "
+                "and check pairwise distinctness of the only two planar anchor rays."
+            ),
+            "stronger_than_original_graph_test": (
+                "Covers arbitrary planar polynomial parametrizations of degree at most "
+                "four on every nine-term arithmetic progression and does not use convexity."
             ),
         },
         "model": {
@@ -188,6 +363,25 @@ def build_payload() -> dict[str, Any]:
             ],
             "row_equations_per_marked_quartet": 3,
             "planar_gate": "A=a*a^T, rank one, positive semidefinite, A44>0",
+            "full_gram_upgrade": {
+                "identity": "B=A+E11",
+                "E11_upper": [fraction_text(value) for value in E11_UPPER],
+                "B_variable_order": [
+                    "B11",
+                    "B12",
+                    "B13",
+                    "B14",
+                    "B22",
+                    "B23",
+                    "B24",
+                    "B33",
+                    "B34",
+                    "B44",
+                ],
+                "translated_marked_rows": "HOMOGENEOUS_LINEAR_EQUATIONS_IN_B",
+                "planar_gate": "B=C^T*C, B nonzero PSD, rank(B)<=2",
+                "constant_coefficients": "OMITTED_BECAUSE_TRANSLATIONS_PRESERVE_DISTANCES",
+            },
         },
         "controls": control_summary(),
         "anchor_scan": {
@@ -224,6 +418,45 @@ def build_payload() -> dict[str, Any]:
             "sample_survivors": list(anchor.sample_survivors),
         },
         "extension_steps": list(summary.extension_steps),
+        "post_hoc_full_gram_upgrade": {
+            "classification": "POST_HOC_FULL_GRAM_STRUCTURAL_UPGRADE",
+            "homogeneous_identity": {
+                "formula": "B=A+E11",
+                "universal_graph_gram_phantom_upper": [
+                    fraction_text(value) for value in UNIVERSAL_PHANTOM_UPPER
+                ],
+                "phantom_full_gram_upper": ["0"] * 10,
+                "phantom_interpretation": (
+                    "A*=-E11 is the zero full Gram B=0, not a realizable "
+                    "nonzero planar coefficient Gram."
+                ),
+                "every_marked_row_contains_phantom": True,
+                "every_translated_marked_row_is_homogeneous": True,
+            },
+            "anchor_kernel_census": anchor_full_gram_census,
+            "anchor_planar_rank_two_psd_candidates": anchor_planar_candidates,
+            "extension_kernel_census": extension_full_gram_census,
+            "outcome": {
+                "unresolved_affine_states_after_four_test_centers": (
+                    four_center_unresolved_states
+                ),
+                "pairwise_distinct_planar_candidates_rich_at_all_four_test_centers": (
+                    pairwise_distinct_full_gram_candidates
+                ),
+                "strictly_convex_planar_candidates_rich_at_all_four_test_centers": (
+                    strictly_convex_full_gram_candidates
+                ),
+                "specific_center_set_forced_to_contain_non_rich_position": [
+                    "-4",
+                    "0",
+                    "3",
+                    "4",
+                ],
+                "affine_reparameterization_scope": (
+                    "ALL_NINE_TERM_REAL_ARITHMETIC_PROGRESSIONS"
+                ),
+            },
+        },
         "outcome": {
             "unresolved_affine_states": summary.unresolved_affine_state_count,
             "rank_one_quartic_grams": summary.rank_one_quartic_candidate_count,
@@ -249,25 +482,72 @@ def build_payload() -> dict[str, Any]:
                 "python scripts/check_quartic_marked_root_gram.py "
                 "--check --assert-expected --json"
             ),
-            "arithmetic": "fractions.Fraction exact rational elimination",
+            "arithmetic": (
+                "fractions.Fraction exact rational elimination plus primitive "
+                "integer symmetric-matrix rank and inertia"
+            ),
             "summary_type": type(summary).__name__,
+            "original_test_phase": "PREDECLARED",
+            "full_gram_upgrade_phase": "POST_HOC",
         },
     }
     return normalize_payload(payload)
 
 
 def check_payload(payload: dict[str, Any], *, assert_expected: bool) -> None:
-    if payload.get("schema") != SCHEMA:
+    if payload.get("schema") != EXPECTED_SCHEMA or SCHEMA != EXPECTED_SCHEMA:
         raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
     if payload.get("trust") not in {"EXACT_OBSTRUCTION", "EXACT_CERTIFICATE_DIAGNOSTIC"}:
         raise AssertionError(f"unexpected trust label: {payload.get('trust')!r}")
     anchor = payload.get("anchor_scan")
     outcome = payload.get("outcome")
     controls = payload.get("controls")
+    decisive_card = payload.get("decisive_test_card")
+    structural_card = payload.get("post_hoc_structural_upgrade_card")
+    full_gram = payload.get("post_hoc_full_gram_upgrade")
     if not isinstance(anchor, dict) or not isinstance(outcome, dict):
         raise AssertionError("artifact is missing anchor_scan or outcome")
     if not isinstance(controls, dict):
         raise AssertionError("artifact is missing controls")
+    if not isinstance(decisive_card, dict) or (
+        decisive_card.get("classification") != "PREDECLARED_ORIGINAL_GRAPH_TEST"
+    ):
+        raise AssertionError("artifact must preserve the predeclared graph test")
+    if not isinstance(structural_card, dict) or (
+        structural_card.get("classification")
+        != "POST_HOC_FULL_GRAM_STRUCTURAL_UPGRADE"
+    ):
+        raise AssertionError("artifact must label the full-Gram upgrade as post hoc")
+    if not isinstance(full_gram, dict):
+        raise AssertionError("artifact is missing post_hoc_full_gram_upgrade")
+
+    homogeneous = full_gram.get("homogeneous_identity")
+    anchor_full_gram = full_gram.get("anchor_kernel_census")
+    extension_full_gram = full_gram.get("extension_kernel_census")
+    planar_candidates = full_gram.get("anchor_planar_rank_two_psd_candidates")
+    full_gram_outcome = full_gram.get("outcome")
+    if not all(
+        isinstance(value, dict)
+        for value in (
+            homogeneous,
+            anchor_full_gram,
+            extension_full_gram,
+            full_gram_outcome,
+        )
+    ) or not isinstance(planar_candidates, list):
+        raise AssertionError("artifact has malformed full-Gram structural data")
+    if homogeneous.get("formula") != "B=A+E11":
+        raise AssertionError("artifact lost the full-Gram homogenization identity")
+    if homogeneous.get("universal_graph_gram_phantom_upper") != ["-1"] + ["0"] * 9:
+        raise AssertionError("artifact lost the universal phantom A*=-E11")
+    if homogeneous.get("phantom_full_gram_upper") != ["0"] * 10:
+        raise AssertionError("universal phantom must translate to B=0")
+    if payload.get("trust") == "EXACT_OBSTRUCTION" and full_gram_outcome.get(
+        "unresolved_affine_states_after_four_test_centers"
+    ):
+        raise AssertionError(
+            "an exact full-Gram obstruction cannot retain a four-center state"
+        )
     if anchor.get("raw_marked_triples") != 343000:
         raise AssertionError("expected 70^3 raw anchor triples")
     if anchor.get("raw_marked_triples") != (
@@ -275,11 +555,43 @@ def check_payload(payload: dict[str, Any], *, assert_expected: bool) -> None:
         + anchor.get("overlap_filtered_marked_triples", 0)
     ):
         raise AssertionError("anchor overlap accounting does not reconcile")
+    if (
+        anchor_full_gram.get("rank_2", 0)
+        + anchor_full_gram.get("rank_3", 0)
+        + anchor_full_gram.get("rank_4", 0)
+        != anchor.get("rank_nine_marked_triples")
+    ):
+        raise AssertionError("anchor full-Gram rank census does not reconcile")
+    if (
+        anchor_full_gram.get("determinant_negative", 0)
+        + anchor_full_gram.get("determinant_positive", 0)
+        + anchor_full_gram.get("determinant_zero", 0)
+        != anchor.get("rank_nine_marked_triples")
+    ):
+        raise AssertionError("anchor full-Gram determinant census does not reconcile")
+    if (
+        extension_full_gram.get("affine_rank_9_states", 0)
+        + extension_full_gram.get("affine_rank_10_states", 0)
+        != 315
+    ):
+        raise AssertionError("extension affine-rank census does not reconcile")
+    if (
+        extension_full_gram.get("kernel_rank_2", 0)
+        + extension_full_gram.get("kernel_rank_3", 0)
+        + extension_full_gram.get("kernel_rank_4", 0)
+        != extension_full_gram.get("affine_rank_9_states")
+    ):
+        raise AssertionError("extension kernel-rank census does not reconcile")
     if assert_expected:
-        if payload.get("status") != "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID":
+        if payload.get("status") != EXPECTED_STATUS:
             raise AssertionError(f"unexpected default status: {payload.get('status')!r}")
         if payload.get("trust") != "EXACT_OBSTRUCTION":
             raise AssertionError(f"unexpected default trust: {payload.get('trust')!r}")
+        if (
+            decisive_card.get("result_status")
+            != "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID"
+        ):
+            raise AssertionError("unexpected original predeclared graph result")
         expected_anchor = {
             "quartets_per_center": 70,
             "raw_marked_triples": 343000,
@@ -342,6 +654,80 @@ def check_payload(payload: dict[str, Any], *, assert_expected: bool) -> None:
         if outcome != expected_outcome:
             raise AssertionError(f"unexpected default outcome: {outcome!r}")
 
+        if anchor_full_gram != EXPECTED_ANCHOR_FULL_GRAM_CENSUS:
+            raise AssertionError(
+                f"unexpected anchor full-Gram census: {anchor_full_gram!r}"
+            )
+        if extension_full_gram != EXPECTED_EXTENSION_FULL_GRAM_CENSUS:
+            raise AssertionError(
+                f"unexpected extension full-Gram census: {extension_full_gram!r}"
+            )
+        normalized_candidates = sorted(
+            planar_candidates,
+            key=lambda candidate: tuple(candidate.get("full_gram_upper", ())),
+        )
+        expected_candidates = sorted(
+            EXPECTED_PLANAR_ANCHOR_CANDIDATES,
+            key=lambda candidate: tuple(candidate["full_gram_upper"]),
+        )
+        if normalized_candidates != expected_candidates:
+            raise AssertionError(
+                f"unexpected planar anchor candidates: {planar_candidates!r}"
+            )
+        expected_full_gram_outcome = {
+            "unresolved_affine_states_after_four_test_centers": 0,
+            "pairwise_distinct_planar_candidates_rich_at_all_four_test_centers": 0,
+            "strictly_convex_planar_candidates_rich_at_all_four_test_centers": 0,
+            "specific_center_set_forced_to_contain_non_rich_position": [
+                "-4",
+                "0",
+                "3",
+                "4",
+            ],
+            "affine_reparameterization_scope": (
+                "ALL_NINE_TERM_REAL_ARITHMETIC_PROGRESSIONS"
+            ),
+        }
+        if full_gram_outcome != expected_full_gram_outcome:
+            raise AssertionError(
+                f"unexpected full-Gram outcome: {full_gram_outcome!r}"
+            )
+
+        claim_scope = payload.get("claim_scope")
+        if not isinstance(claim_scope, dict):
+            raise AssertionError("schema-v2 claim_scope must be structured")
+        expected_scope_fields = {
+            "ambient_dimension": 2,
+            "maximum_coordinate_degree": 4,
+            "sample_size": 9,
+            "parameter_sets": "NINE_TERM_REAL_ARITHMETIC_PROGRESSIONS",
+            "pairwise_distinctness_required": True,
+            "convexity_used": False,
+            "test_center_set_guaranteed_to_contain_a_non_rich_position_"
+            "after_normalization": [
+                "-4",
+                "0",
+                "3",
+                "4",
+            ],
+        }
+        for key, expected in expected_scope_fields.items():
+            if claim_scope.get(key) != expected:
+                raise AssertionError(
+                    f"unexpected claim-scope field {key}: "
+                    f"{claim_scope.get(key)!r} != {expected!r}"
+                )
+        exclusions = payload.get("does_not_check")
+        required_exclusions = {
+            "arbitrary or irregular real parameter sets",
+            "polynomial parametrizations of degree greater than four",
+            "higher-dimensional Euclidean samples",
+            "general strictly convex polygons",
+            "a proof or counterexample for Erdos Problem #97",
+        }
+        if not isinstance(exclusions, list) or not required_exclusions.issubset(exclusions):
+            raise AssertionError("schema-v2 strict claim exclusions are incomplete")
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -374,10 +760,13 @@ def main() -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        outcome = payload["outcome"]
+        full_gram_outcome = payload["post_hoc_full_gram_upgrade"]["outcome"]
+        candidate_count = full_gram_outcome[
+            "pairwise_distinct_planar_candidates_rich_at_all_four_test_centers"
+        ]
         print(
-            f"{payload['status']} unresolved={outcome['unresolved_affine_states']} "
-            f"closures={outcome['strict_finite_full_closures']}"
+            f"{payload['status']} pairwise_distinct_planar_candidates="
+            f"{candidate_count}"
         )
     return 0
 

--- a/scripts/check_quartic_marked_root_gram.py
+++ b/scripts/check_quartic_marked_root_gram.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Generate and replay the exact fixed-grid quartic marked-root Gram pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from erdos97.quartic_marked_root_gram import (  # noqa: E402
+    SCHEMA,
+    equations_hold,
+    gram_upper_from_coefficients,
+    lifted_squared_distance,
+    marked_root_divisibility_check,
+    marked_row_equations,
+    quartic_closure_pilot,
+    rank_one_psd_check,
+    second_derivative_has_constant_sign,
+)
+
+
+DEFAULT_ARTIFACT = ROOT / "data" / "certificates" / "quartic_marked_root_gram.json"
+PARAMETERS = tuple(range(-4, 5))
+ANCHOR_CENTERS = (0, 3, 4)
+POSITIVE_COEFFICIENTS = (
+    Fraction(-51017, 6552),
+    Fraction(337469, 393120),
+    Fraction(-2503, 65520),
+    Fraction(253, 393120),
+)
+POSITIVE_WITNESSES = (7, 15, 20, 24)
+HIGH_RANK_DIRECTION = (-15180, 1553, -66, 1)
+
+
+def fraction_text(value: Fraction | int) -> str:
+    exact = value if isinstance(value, Fraction) else Fraction(value)
+    if exact.denominator == 1:
+        return str(exact.numerator)
+    return f"{exact.numerator}/{exact.denominator}"
+
+
+def normalize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    # Normalize nested tuples before comparison with a JSON-loaded artifact.
+    # This also keeps optional survivor/candidate records replay-stable.
+    normalized = json.loads(json.dumps(payload, sort_keys=True))
+    if not isinstance(normalized, dict):
+        raise AssertionError("normalized payload must remain a JSON object")
+    return normalized
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"{path} must contain one JSON object")
+    return payload
+
+
+def control_summary() -> dict[str, Any]:
+    positive_gram = gram_upper_from_coefficients(POSITIVE_COEFFICIENTS)
+    positive_equations = marked_row_equations(0, POSITIVE_WITNESSES)
+    distances = tuple(
+        lifted_squared_distance(positive_gram, 0, witness)
+        for witness in POSITIVE_WITNESSES
+    )
+    if distances != (Fraction(625),) * 4:
+        raise AssertionError("positive control no longer has squared radius 625")
+    if not equations_hold(positive_equations, positive_gram):
+        raise AssertionError("positive control fails its affine marked-row equations")
+    if not marked_root_divisibility_check(0, POSITIVE_WITNESSES, positive_gram):
+        raise AssertionError("positive control fails independent marked-root divisibility")
+    positive_check = rank_one_psd_check(positive_gram)
+    if not positive_check.quartic_gram:
+        raise AssertionError("positive control fails the rank-one quartic Gram gate")
+    if not second_derivative_has_constant_sign(POSITIVE_COEFFICIENTS, 0, 24):
+        raise AssertionError("positive control fails exact interval convexity")
+
+    high_rank_component = gram_upper_from_coefficients(HIGH_RANK_DIRECTION)
+    high_rank_gram = tuple(
+        base + component
+        for base, component in zip(positive_gram, high_rank_component, strict=True)
+    )
+    high_rank_check = rank_one_psd_check(high_rank_gram)
+    if not equations_hold(positive_equations, high_rank_gram):
+        raise AssertionError("high-rank relaxation trap should satisfy the marked row")
+    if not high_rank_check.positive_semidefinite or high_rank_check.rank_one:
+        raise AssertionError("high-rank relaxation trap did not exercise the planar gate")
+
+    return {
+        "positive_one_rich_row": {
+            "coefficients": [fraction_text(value) for value in POSITIVE_COEFFICIENTS],
+            "center": "0",
+            "witnesses": [str(value) for value in POSITIVE_WITNESSES],
+            "squared_radius": "625",
+            "marked_equations_hold": True,
+            "independent_divisibility_holds": True,
+            "rank_one_psd_degree_four": True,
+            "strictly_convex_on_0_24": True,
+            "claim_boundary": "ONE_RICH_ROW_ONLY_NOT_FINITE_CLOSURE",
+        },
+        "higher_rank_psd_relaxation_trap": {
+            "extra_direction": [str(value) for value in HIGH_RANK_DIRECTION],
+            "marked_equations_hold": True,
+            "positive_semidefinite": True,
+            "rank_one": False,
+            "rejected_as_planar_quartic_graph": True,
+        },
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    summary = quartic_closure_pilot(
+        parameters=PARAMETERS,
+        anchor_centers=ANCHOR_CENTERS,
+    )
+    anchor = summary.anchor
+    if summary.strict_finite_full_closure_candidate_count:
+        status = "EXACT_FIXED_GRID_CLOSURE_CANDIDATE"
+        trust = "EXACT_CERTIFICATE_DIAGNOSTIC"
+    elif summary.unresolved_affine_state_count:
+        status = "INCONCLUSIVE_FIXED_GRID_WITH_UNRESOLVED_AFFINE_STATES"
+        trust = "EXACT_CERTIFICATE_DIAGNOSTIC"
+    else:
+        status = "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID"
+        trust = "EXACT_OBSTRUCTION"
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": status,
+        "trust": trust,
+        "claim_scope": (
+            "Exact fixed-parameter obstruction or survivor accounting for graph samples "
+            "gamma(t)=(t,sum_{k=1}^4 a_k t^k) on T={-4,-3,...,4}."
+        ),
+        "does_not_check": [
+            "arbitrary or irregular real parameter sets",
+            "other nine-point x-coordinate grids",
+            "polynomial graphs of degree greater than four",
+            "parametric or implicit quartic curves",
+            "multi-arc constructions",
+            "general strictly convex polygons",
+            "a proof or counterexample for Erdos Problem #97",
+        ],
+        "decisive_test_card": {
+            "question": (
+                "Can the one-rich-row quartic flexibility close all nine rows on the "
+                "smallest equally spaced parameter grid not already covered by n<=8?"
+            ),
+            "hypotheses": {
+                "local_only": (
+                    "anchor affine systems fail the planar rank-one gate or their "
+                    "exceptional states die under further rows"
+                ),
+                "fixed_grid_closure": (
+                    "one rank-one PSD degree-four Gram survives every center and the "
+                    "finite strict-convexity gate"
+                ),
+            },
+            "predeclared_stopping_rule": (
+                "Report an exact fixed-grid obstruction only when the exceptional affine "
+                "frontier is empty; otherwise preserve unresolved states."
+            ),
+        },
+        "model": {
+            "parameters": [str(value) for value in PARAMETERS],
+            "anchor_centers": [str(value) for value in ANCHOR_CENTERS],
+            "extension_centers": [fraction_text(value) for value in summary.extension_centers],
+            "gram_variable_order": [
+                "A11",
+                "A12",
+                "A13",
+                "A14",
+                "A22",
+                "A23",
+                "A24",
+                "A33",
+                "A34",
+                "A44",
+            ],
+            "row_equations_per_marked_quartet": 3,
+            "planar_gate": "A=a*a^T, rank one, positive semidefinite, A44>0",
+        },
+        "controls": control_summary(),
+        "anchor_scan": {
+            "quartets_per_center": anchor.quartet_count_per_center,
+            "raw_marked_triples": anchor.raw_triple_count,
+            "overlap_admissible_marked_triples": anchor.overlap_admissible_count,
+            "overlap_filtered_marked_triples": (
+                anchor.raw_triple_count - anchor.overlap_admissible_count
+            ),
+            "pair_inconsistent_pruned_triples": (
+                anchor.pair_inconsistent_pruned_triple_count
+            ),
+            "third_row_inconsistent_triples": anchor.inconsistent_count,
+            "rank_counts": {str(rank): count for rank, count in anchor.rank_counts},
+            "rank_nine_marked_triples": dict(anchor.rank_counts).get(9, 0),
+            "rank_nine_without_real_rank_at_most_one": (
+                anchor.line_without_real_rank_at_most_one_count
+            ),
+            "rank_nine_zero_matrix_roots": anchor.line_zero_matrix_root_count,
+            "rank_nine_negative_semidefinite_rank_one_roots": (
+                anchor.line_negative_semidefinite_rank_one_root_count
+            ),
+            "rank_nine_lower_degree_rank_one_psd_roots": (
+                anchor.line_lower_degree_rank_one_psd_root_count
+            ),
+            "rank_nine_rational_quartic_grams": anchor.line_rational_quartic_gram_count,
+            "rank_nine_irrational_components": (
+                anchor.line_irrational_rank_at_most_one_component_count
+            ),
+            "rank_nine_whole_rank_at_most_one_lines": (
+                anchor.line_all_rank_at_most_one_count
+            ),
+            "exceptional_affine_states": anchor.exceptional_affine_state_count,
+            "sample_survivors": list(anchor.sample_survivors),
+        },
+        "extension_steps": list(summary.extension_steps),
+        "outcome": {
+            "unresolved_affine_states": summary.unresolved_affine_state_count,
+            "rank_one_quartic_grams": summary.rank_one_quartic_candidate_count,
+            "continuously_convex_rank_one_quartic_grams": (
+                summary.convex_rank_one_candidate_count
+            ),
+            "all_row_quartic_grams": summary.all_row_quartic_candidate_count,
+            "strict_finite_full_closures": (
+                summary.strict_finite_full_closure_candidate_count
+            ),
+            "continuous_convex_full_closures": (
+                summary.continuous_convex_full_closure_candidate_count
+            ),
+            "sample_candidates": list(summary.sample_candidates),
+        },
+        "provenance": {
+            "generator": "scripts/check_quartic_marked_root_gram.py",
+            "command": (
+                "python scripts/check_quartic_marked_root_gram.py "
+                "--write-artifact --check --assert-expected --json"
+            ),
+            "check_command": (
+                "python scripts/check_quartic_marked_root_gram.py "
+                "--check --assert-expected --json"
+            ),
+            "arithmetic": "fractions.Fraction exact rational elimination",
+            "summary_type": type(summary).__name__,
+        },
+    }
+    return normalize_payload(payload)
+
+
+def check_payload(payload: dict[str, Any], *, assert_expected: bool) -> None:
+    if payload.get("schema") != SCHEMA:
+        raise AssertionError(f"unexpected schema: {payload.get('schema')!r}")
+    if payload.get("trust") not in {"EXACT_OBSTRUCTION", "EXACT_CERTIFICATE_DIAGNOSTIC"}:
+        raise AssertionError(f"unexpected trust label: {payload.get('trust')!r}")
+    anchor = payload.get("anchor_scan")
+    outcome = payload.get("outcome")
+    controls = payload.get("controls")
+    if not isinstance(anchor, dict) or not isinstance(outcome, dict):
+        raise AssertionError("artifact is missing anchor_scan or outcome")
+    if not isinstance(controls, dict):
+        raise AssertionError("artifact is missing controls")
+    if anchor.get("raw_marked_triples") != 343000:
+        raise AssertionError("expected 70^3 raw anchor triples")
+    if anchor.get("raw_marked_triples") != (
+        anchor.get("overlap_admissible_marked_triples", 0)
+        + anchor.get("overlap_filtered_marked_triples", 0)
+    ):
+        raise AssertionError("anchor overlap accounting does not reconcile")
+    if assert_expected:
+        if payload.get("status") != "NO_STRICTLY_CONVEX_DEGREE_FOUR_CLOSURE_ON_FIXED_GRID":
+            raise AssertionError(f"unexpected default status: {payload.get('status')!r}")
+        if payload.get("trust") != "EXACT_OBSTRUCTION":
+            raise AssertionError(f"unexpected default trust: {payload.get('trust')!r}")
+        expected_anchor = {
+            "quartets_per_center": 70,
+            "raw_marked_triples": 343000,
+            "overlap_admissible_marked_triples": 202080,
+            "overlap_filtered_marked_triples": 140920,
+            "pair_inconsistent_pruned_triples": 0,
+            "third_row_inconsistent_triples": 0,
+            "rank_counts": {"8": 2731, "9": 199349},
+            "rank_nine_marked_triples": 199349,
+            "rank_nine_without_real_rank_at_most_one": 0,
+            "rank_nine_zero_matrix_roots": 0,
+            "rank_nine_negative_semidefinite_rank_one_roots": 199349,
+            "rank_nine_lower_degree_rank_one_psd_roots": 0,
+            "rank_nine_rational_quartic_grams": 0,
+            "rank_nine_irrational_components": 0,
+            "rank_nine_whole_rank_at_most_one_lines": 0,
+            "exceptional_affine_states": 2729,
+        }
+        for key, expected in expected_anchor.items():
+            if anchor.get(key) != expected:
+                raise AssertionError(
+                    f"unexpected anchor field {key}: {anchor.get(key)!r} != {expected!r}"
+                )
+        steps = payload.get("extension_steps")
+        if not isinstance(steps, list) or len(steps) != 1:
+            raise AssertionError("expected exactly one extension step")
+        expected_step = {
+            "center": "-4",
+            "input_affine_states": 2729,
+            "row_options_per_state": 70,
+            "raw_state_row_branches": 191030,
+            "linearly_inconsistent_branches": 0,
+            "linearly_consistent_branches": 191030,
+            "deduplicated_consistent_affine_states": 315,
+            "states_without_real_rank_at_most_one": 0,
+            "zero_matrix_roots": 0,
+            "negative_semidefinite_rank_one_roots": 315,
+            "lower_degree_rank_one_psd_roots": 0,
+            "specified_non_rank_one_grams": 0,
+            "unique_rank_one_quartic_gram_states": 0,
+            "rational_line_rank_one_quartic_grams": 0,
+            "irrational_or_rank_one_line_states_retained": 0,
+            "higher_dimensional_states_retained": 0,
+            "deduplicated_affine_states_out": 0,
+        }
+        for key, expected in expected_step.items():
+            if steps[0].get(key) != expected:
+                raise AssertionError(
+                    f"unexpected extension field {key}: {steps[0].get(key)!r} != {expected!r}"
+                )
+        expected_outcome = {
+            "unresolved_affine_states": 0,
+            "rank_one_quartic_grams": 0,
+            "continuously_convex_rank_one_quartic_grams": 0,
+            "all_row_quartic_grams": 0,
+            "strict_finite_full_closures": 0,
+            "continuous_convex_full_closures": 0,
+            "sample_candidates": [],
+        }
+        if outcome != expected_outcome:
+            raise AssertionError(f"unexpected default outcome: {outcome!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write-artifact", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if args.write_artifact:
+        payload = build_payload()
+        args.artifact.parent.mkdir(parents=True, exist_ok=True)
+        args.artifact.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        if args.check and load_json(args.artifact) != payload:
+            raise AssertionError("serialized artifact differs from generated payload")
+    elif args.check:
+        stored = load_json(args.artifact)
+        replayed = build_payload()
+        if replayed != stored:
+            raise AssertionError("stored quartic marked-root artifact differs from exact replay")
+        payload = stored
+    else:
+        payload = load_json(args.artifact)
+
+    check_payload(payload, assert_expected=args.assert_expected)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        outcome = payload["outcome"]
+        print(
+            f"{payload['status']} unresolved={outcome['unresolved_affine_states']} "
+            f"closures={outcome['strict_finite_full_closures']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -442,6 +442,21 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
         ),
     ),
     AuditCommand(
+        ident="quartic_marked_root_gram",
+        command=(
+            "python",
+            "scripts/check_quartic_marked_root_gram.py",
+            "--check",
+            "--assert-expected",
+            "--json",
+        ),
+        claim_scope=(
+            "Exact obstruction for degree-exactly-four polynomial graph "
+            "samples on T={-4,-3,...,4}; not a general quartic obstruction, "
+            "n=9 proof, counterexample, or proof of Erdos Problem #97."
+        ),
+    ),
+    AuditCommand(
         ident="two_parabola_lens_grid_search",
         command=(
             "python",

--- a/scripts/run_artifact_audit.py
+++ b/scripts/run_artifact_audit.py
@@ -451,9 +451,12 @@ AUDIT_COMMANDS: tuple[AuditCommand, ...] = (
             "--json",
         ),
         claim_scope=(
-            "Exact obstruction for degree-exactly-four polynomial graph "
-            "samples on T={-4,-3,...,4}; not a general quartic obstruction, "
-            "n=9 proof, counterexample, or proof of Erdos Problem #97."
+            "Exact obstruction for pairwise-distinct planar polynomial "
+            "parametrizations of coordinate degree at most four sampled on "
+            "a nine-term arithmetic progression: one of the four normalized "
+            "centers -4,0,3,4 is not four-rich. Not an irregular-parameter "
+            "quartic obstruction, n=9 proof, counterexample, or proof of "
+            "Erdos Problem #97."
         ),
     ),
     AuditCommand(

--- a/src/erdos97/quartic_marked_root_gram.py
+++ b/src/erdos97/quartic_marked_root_gram.py
@@ -1,0 +1,1138 @@
+"""Exact marked-root Gram helpers for polynomial quartic graph samples.
+
+The lifted variable is the symmetric Gram matrix ``A = a a^T`` for
+
+    f_a(t) = a_1 t + a_2 t^2 + a_3 t^3 + a_4 t^4.
+
+For fixed rational parameters, each prescribed four-witness row gives three
+affine equations in the ten upper-triangular entries of ``A``.  Linear
+feasibility is only a relaxation: a planar quartic graph additionally needs
+``A`` to be nonzero, positive semidefinite, and rank one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fractions import Fraction
+from itertools import combinations
+from math import isqrt
+from typing import Iterable, Sequence
+
+
+SCHEMA = "erdos97.quartic_marked_root_gram.v1"
+
+GRAM_PAIRS: tuple[tuple[int, int], ...] = tuple(
+    (left, right)
+    for left in range(1, 5)
+    for right in range(left, 5)
+)
+PAIR_INDEX = {pair: index for index, pair in enumerate(GRAM_PAIRS)}
+VARIABLE_COUNT = len(GRAM_PAIRS)
+
+Equation = tuple[Fraction, ...]
+Rref = tuple[Equation, ...]
+
+
+@dataclass(frozen=True)
+class AffineSolution:
+    """Canonical description of a consistent rational affine system."""
+
+    rref: Rref
+    pivots: tuple[int, ...]
+    free_columns: tuple[int, ...]
+    particular: tuple[Fraction, ...]
+    nullspace: tuple[tuple[Fraction, ...], ...]
+
+    @property
+    def rank(self) -> int:
+        return len(self.pivots)
+
+    @property
+    def dimension(self) -> int:
+        return len(self.free_columns)
+
+
+@dataclass(frozen=True)
+class RankOneCheck:
+    """Exact nonlinear gate for one fully specified symmetric Gram matrix."""
+
+    rank_one: bool
+    positive_semidefinite: bool
+    degree_four: bool
+    pivot_index: int | None
+
+    @property
+    def quartic_gram(self) -> bool:
+        return self.rank_one and self.positive_semidefinite and self.degree_four
+
+
+@dataclass(frozen=True)
+class LineRankOneResult:
+    """Rank-one intersection of an affine Gram line with the minor variety."""
+
+    kind: str
+    rational_parameters: tuple[Fraction, ...] = ()
+    irreducible_quadratic: tuple[Fraction, Fraction, Fraction] | None = None
+
+
+@dataclass(frozen=True)
+class AnchorTripleSummary:
+    """Exact accounting for one three-center marked-row scan."""
+
+    parameters: tuple[Fraction, ...]
+    centers: tuple[Fraction, Fraction, Fraction]
+    quartet_count_per_center: int
+    raw_triple_count: int
+    overlap_admissible_count: int
+    pair_inconsistent_pruned_triple_count: int
+    inconsistent_count: int
+    rank_counts: tuple[tuple[int, int], ...]
+    line_without_real_rank_at_most_one_count: int
+    line_zero_matrix_root_count: int
+    line_negative_semidefinite_rank_one_root_count: int
+    line_lower_degree_rank_one_psd_root_count: int
+    line_rational_quartic_gram_count: int
+    line_irrational_rank_at_most_one_component_count: int
+    line_all_rank_at_most_one_count: int
+    exceptional_affine_state_count: int
+    sample_survivors: tuple[dict[str, object], ...]
+    exceptional_rrefs: tuple[Rref, ...] = field(repr=False, compare=False)
+    unresolved_line_rrefs: tuple[Rref, ...] = field(repr=False, compare=False)
+    rank_one_quartic_grams: tuple[tuple[Fraction, ...], ...] = field(
+        repr=False,
+        compare=False,
+    )
+
+
+@dataclass(frozen=True)
+class QuarticClosurePilotSummary:
+    """Full fixed-grid continuation from anchors through every other center."""
+
+    anchor: AnchorTripleSummary
+    extension_centers: tuple[Fraction, ...]
+    extension_steps: tuple[dict[str, int | str], ...]
+    unresolved_affine_state_count: int
+    rank_one_quartic_candidate_count: int
+    convex_rank_one_candidate_count: int
+    all_row_quartic_candidate_count: int
+    strict_finite_full_closure_candidate_count: int
+    continuous_convex_full_closure_candidate_count: int
+    sample_candidates: tuple[dict[str, object], ...]
+
+
+def _as_fraction(value: int | Fraction) -> Fraction:
+    if isinstance(value, Fraction):
+        return value
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"expected an exact integer or Fraction, got {value!r}")
+    return Fraction(value)
+
+
+def validate_parameters(parameters: Sequence[int | Fraction]) -> tuple[Fraction, ...]:
+    """Return a distinct, increasing tuple of exact parameters."""
+
+    values = tuple(_as_fraction(value) for value in parameters)
+    if len(values) < 5:
+        raise ValueError("at least five parameters are required")
+    if len(set(values)) != len(values):
+        raise ValueError("parameters must be distinct")
+    if tuple(sorted(values)) != values:
+        raise ValueError("parameters must be strictly increasing")
+    return values
+
+
+def gram_upper_from_coefficients(
+    coefficients: Sequence[int | Fraction],
+) -> tuple[Fraction, ...]:
+    """Return upper-triangular entries of ``a a^T`` in ``GRAM_PAIRS`` order."""
+
+    if len(coefficients) != 4:
+        raise ValueError("quartic graph coefficient vector must have length four")
+    values = tuple(_as_fraction(value) for value in coefficients)
+    return tuple(values[left - 1] * values[right - 1] for left, right in GRAM_PAIRS)
+
+
+def gram_matrix(upper: Sequence[int | Fraction]) -> tuple[tuple[Fraction, ...], ...]:
+    """Expand ten upper-triangular values to a symmetric 4 by 4 matrix."""
+
+    if len(upper) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    values = tuple(_as_fraction(value) for value in upper)
+    rows = [[Fraction(0) for _ in range(4)] for _ in range(4)]
+    for value, (left, right) in zip(values, GRAM_PAIRS, strict=True):
+        rows[left - 1][right - 1] = value
+        rows[right - 1][left - 1] = value
+    return tuple(tuple(row) for row in rows)
+
+
+def polynomial_value(
+    coefficients: Sequence[int | Fraction],
+    parameter: int | Fraction,
+) -> Fraction:
+    """Evaluate ``sum(a_k t^k, k=1..4)`` exactly."""
+
+    if len(coefficients) != 4:
+        raise ValueError("quartic graph coefficient vector must have length four")
+    t = _as_fraction(parameter)
+    values = tuple(_as_fraction(value) for value in coefficients)
+    return sum((value * t**degree for degree, value in enumerate(values, 1)), Fraction(0))
+
+
+def squared_distance(
+    coefficients: Sequence[int | Fraction],
+    center: int | Fraction,
+    witness: int | Fraction,
+) -> Fraction:
+    """Evaluate the squared Euclidean graph distance exactly."""
+
+    s = _as_fraction(center)
+    q = _as_fraction(witness)
+    vertical = polynomial_value(coefficients, q) - polynomial_value(coefficients, s)
+    return (q - s) ** 2 + vertical**2
+
+
+def lifted_squared_distance(
+    upper: Sequence[int | Fraction],
+    center: int | Fraction,
+    witness: int | Fraction,
+) -> Fraction:
+    """Evaluate squared distance from the ten lifted Gram coordinates."""
+
+    s = _as_fraction(center)
+    q = _as_fraction(witness)
+    values = tuple(_as_fraction(value) for value in upper)
+    if len(values) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+
+    total = (q - s) ** 2
+    for value, (left, right) in zip(values, GRAM_PAIRS, strict=True):
+        multiplier = 1 if left == right else 2
+        total += (
+            multiplier
+            * value
+            * (q**left - s**left)
+            * (q**right - s**right)
+        )
+    return total
+
+
+def marked_row_equations(
+    center: int | Fraction,
+    witnesses: Sequence[int | Fraction],
+) -> tuple[Equation, Equation, Equation]:
+    """Return the three affine Gram equations for one four-witness row.
+
+    Every returned row has eleven entries: ten coefficients followed by the
+    right-hand side.  The first witness is the deterministic reference.
+    """
+
+    s = _as_fraction(center)
+    qs = tuple(_as_fraction(value) for value in witnesses)
+    if len(qs) != 4 or len(set(qs)) != 4:
+        raise ValueError("a marked row needs four distinct witnesses")
+    if s in qs:
+        raise ValueError("the center cannot be one of its witnesses")
+    if tuple(sorted(qs)) != qs:
+        raise ValueError("witnesses must be supplied in increasing order")
+
+    reference = qs[0]
+    rows: list[Equation] = []
+    for witness in qs[1:]:
+        coefficients: list[Fraction] = []
+        for left, right in GRAM_PAIRS:
+            multiplier = 1 if left == right else 2
+            current = (witness**left - s**left) * (witness**right - s**right)
+            baseline = (reference**left - s**left) * (
+                reference**right - s**right
+            )
+            coefficients.append(Fraction(multiplier) * (current - baseline))
+        horizontal_difference = (witness - s) ** 2 - (reference - s) ** 2
+        rows.append(tuple(coefficients) + (-horizontal_difference,))
+    return rows[0], rows[1], rows[2]
+
+
+def distance_fiber_coefficients(
+    upper: Sequence[int | Fraction],
+    center: int | Fraction,
+    radius_squared: int | Fraction,
+) -> tuple[Fraction, ...]:
+    """Return low-to-high coefficients of the lifted degree-eight fiber."""
+
+    values = tuple(_as_fraction(value) for value in upper)
+    if len(values) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    s = _as_fraction(center)
+    radius = _as_fraction(radius_squared)
+    coefficients = [Fraction(0) for _ in range(9)]
+    coefficients[0] = s * s - radius
+    coefficients[1] = -2 * s
+    coefficients[2] = 1
+
+    for value, (left, right) in zip(values, GRAM_PAIRS, strict=True):
+        multiplier = 1 if left == right else 2
+        weight = multiplier * value
+        coefficients[left + right] += weight
+        coefficients[left] -= weight * s**right
+        coefficients[right] -= weight * s**left
+        coefficients[0] += weight * s ** (left + right)
+    return _polynomial_trim(coefficients)
+
+
+def marked_root_divisibility_check(
+    center: int | Fraction,
+    witnesses: Sequence[int | Fraction],
+    upper: Sequence[int | Fraction],
+) -> bool:
+    """Independently check divisibility by the marked witness polynomial."""
+
+    s = _as_fraction(center)
+    qs = tuple(_as_fraction(value) for value in witnesses)
+    if len(qs) != 4 or len(set(qs)) != 4 or s in qs:
+        raise ValueError("need four distinct witnesses different from the center")
+    radius = lifted_squared_distance(upper, s, qs[0])
+    fiber = distance_fiber_coefficients(upper, s, radius)
+    marked_polynomial: tuple[Fraction, ...] = (Fraction(1),)
+    for witness in qs:
+        product = [Fraction(0) for _ in range(len(marked_polynomial) + 1)]
+        for index, value in enumerate(marked_polynomial):
+            product[index] -= witness * value
+            product[index + 1] += value
+        marked_polynomial = tuple(product)
+    _, remainder = _polynomial_divmod(fiber, marked_polynomial)
+    return not remainder
+
+
+def equations_hold(
+    equations: Iterable[Equation],
+    upper: Sequence[int | Fraction],
+) -> bool:
+    """Check a lifted Gram vector against augmented affine equations."""
+
+    values = tuple(_as_fraction(value) for value in upper)
+    if len(values) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    return all(
+        sum((coefficient * value for coefficient, value in zip(row[:-1], values, strict=True)), Fraction(0))
+        == row[-1]
+        for row in equations
+    )
+
+
+def reduced_row_echelon(equations: Iterable[Sequence[int | Fraction]]) -> Rref | None:
+    """Return canonical RREF, or ``None`` for an inconsistent affine system."""
+
+    rows: list[list[Fraction]] = []
+    for raw_row in equations:
+        if len(raw_row) != VARIABLE_COUNT + 1:
+            raise ValueError(f"each augmented row must have {VARIABLE_COUNT + 1} entries")
+        row = [_as_fraction(value) for value in raw_row]
+        if any(row):
+            rows.append(row)
+
+    pivot_row = 0
+    for column in range(VARIABLE_COUNT):
+        pivot = next(
+            (index for index in range(pivot_row, len(rows)) if rows[index][column]),
+            None,
+        )
+        if pivot is None:
+            continue
+        rows[pivot_row], rows[pivot] = rows[pivot], rows[pivot_row]
+        pivot_value = rows[pivot_row][column]
+        rows[pivot_row] = [value / pivot_value for value in rows[pivot_row]]
+        for index, row in enumerate(rows):
+            if index == pivot_row or not row[column]:
+                continue
+            multiplier = row[column]
+            rows[index] = [
+                value - multiplier * pivot_entry
+                for value, pivot_entry in zip(row, rows[pivot_row], strict=True)
+            ]
+        pivot_row += 1
+        if pivot_row == len(rows):
+            break
+
+    cleaned: list[Equation] = []
+    for row in rows:
+        if not any(row[:-1]):
+            if row[-1]:
+                return None
+            continue
+        cleaned.append(tuple(row))
+
+    cleaned.sort(key=lambda row: next(index for index, value in enumerate(row[:-1]) if value))
+    return tuple(cleaned)
+
+
+def solve_affine(equations: Iterable[Sequence[int | Fraction]]) -> AffineSolution | None:
+    """Solve an exact affine Gram system and expose a nullspace basis."""
+
+    rref = reduced_row_echelon(equations)
+    if rref is None:
+        return None
+    pivots = tuple(
+        next(index for index, value in enumerate(row[:-1]) if value)
+        for row in rref
+    )
+    free_columns = tuple(index for index in range(VARIABLE_COUNT) if index not in pivots)
+    particular = [Fraction(0) for _ in range(VARIABLE_COUNT)]
+    for row, pivot in zip(rref, pivots, strict=True):
+        particular[pivot] = row[-1]
+
+    nullspace: list[tuple[Fraction, ...]] = []
+    for free in free_columns:
+        vector = [Fraction(0) for _ in range(VARIABLE_COUNT)]
+        vector[free] = Fraction(1)
+        for row, pivot in zip(rref, pivots, strict=True):
+            vector[pivot] = -row[free]
+        nullspace.append(tuple(vector))
+
+    return AffineSolution(
+        rref=rref,
+        pivots=pivots,
+        free_columns=free_columns,
+        particular=tuple(particular),
+        nullspace=tuple(nullspace),
+    )
+
+
+def rank_one_psd_check(upper: Sequence[int | Fraction]) -> RankOneCheck:
+    """Check exact rank-one, PSD, and degree-four conditions."""
+
+    matrix = gram_matrix(upper)
+    all_minors_zero = all(
+        matrix[row_a][column_a] * matrix[row_b][column_b]
+        - matrix[row_a][column_b] * matrix[row_b][column_a]
+        == 0
+        for row_a, row_b in combinations(range(4), 2)
+        for column_a, column_b in combinations(range(4), 2)
+    )
+    diagonal = tuple(matrix[index][index] for index in range(4))
+    nonzero = any(any(value for value in row) for row in matrix)
+    rank_one = nonzero and all_minors_zero
+    positive_semidefinite = all(
+        _determinant(
+            tuple(
+                tuple(matrix[row][column] for column in indices)
+                for row in indices
+            )
+        )
+        >= 0
+        for size in range(1, 5)
+        for indices in combinations(range(4), size)
+    )
+    pivot_index = next((index for index, value in enumerate(diagonal) if value > 0), None)
+    degree_four = matrix[3][3] > 0
+    return RankOneCheck(
+        rank_one=rank_one,
+        positive_semidefinite=positive_semidefinite,
+        degree_four=degree_four,
+        pivot_index=pivot_index,
+    )
+
+
+def _determinant(matrix: Sequence[Sequence[Fraction]]) -> Fraction:
+    """Return an exact determinant by fraction-preserving elimination."""
+
+    size = len(matrix)
+    if any(len(row) != size for row in matrix):
+        raise ValueError("determinant needs a square matrix")
+    rows = [list(row) for row in matrix]
+    determinant = Fraction(1)
+    for column in range(size):
+        pivot = next((row for row in range(column, size) if rows[row][column]), None)
+        if pivot is None:
+            return Fraction(0)
+        if pivot != column:
+            rows[column], rows[pivot] = rows[pivot], rows[column]
+            determinant = -determinant
+        pivot_value = rows[column][column]
+        determinant *= pivot_value
+        for row in range(column + 1, size):
+            if not rows[row][column]:
+                continue
+            multiplier = rows[row][column] / pivot_value
+            for index in range(column + 1, size):
+                rows[row][index] -= multiplier * rows[column][index]
+    return determinant
+
+
+def recover_rational_direction(
+    upper: Sequence[int | Fraction],
+) -> tuple[Fraction, Fraction, Fraction, Fraction]:
+    """Recover coefficient ratios from an exact rank-one PSD Gram matrix.
+
+    The returned vector ``b`` satisfies ``A = A_pp * b b^T`` with ``b_p=1``.
+    The actual coefficient vector is ``sqrt(A_pp) * b``; no square root is
+    needed for convexity or orientation checks.
+    """
+
+    check = rank_one_psd_check(upper)
+    if not check.rank_one or not check.positive_semidefinite or check.pivot_index is None:
+        raise ValueError("matrix must be nonzero, rank one, and positive semidefinite")
+    matrix = gram_matrix(upper)
+    pivot = check.pivot_index
+    pivot_value = matrix[pivot][pivot]
+    return tuple(matrix[index][pivot] / pivot_value for index in range(4))  # type: ignore[return-value]
+
+
+def second_derivative_has_constant_sign(
+    direction: Sequence[int | Fraction],
+    lower: int | Fraction,
+    upper: int | Fraction,
+) -> bool:
+    """Check strict convexity/concavity of the polynomial graph on an interval.
+
+    For a polynomial, a nonzero second derivative with one weak sign makes the
+    first derivative strictly monotone.  Isolated zeros, including endpoint
+    zeros such as for ``t^4``, are therefore accepted.
+    """
+
+    if len(direction) != 4:
+        raise ValueError("quartic graph coefficient direction must have length four")
+    values = tuple(_as_fraction(value) for value in direction)
+    lo = _as_fraction(lower)
+    hi = _as_fraction(upper)
+    if not lo < hi:
+        raise ValueError("convexity interval must have positive length")
+
+    constant = 2 * values[1]
+    linear = 6 * values[2]
+    quadratic = 12 * values[3]
+    if not (constant or linear or quadratic):
+        return False
+
+    def evaluate(t: Fraction) -> Fraction:
+        return constant + linear * t + quadratic * t * t
+
+    candidates = [evaluate(lo), evaluate(hi)]
+    if quadratic:
+        vertex = -linear / (2 * quadratic)
+        if lo <= vertex <= hi:
+            candidates.append(evaluate(vertex))
+
+    if quadratic > 0:
+        minimum = min(candidates)
+        maximum = max(evaluate(lo), evaluate(hi))
+    elif quadratic < 0:
+        minimum = min(evaluate(lo), evaluate(hi))
+        maximum = max(candidates)
+    else:
+        minimum = min(evaluate(lo), evaluate(hi))
+        maximum = max(evaluate(lo), evaluate(hi))
+    return minimum >= 0 or maximum <= 0
+
+
+def finite_graph_chain_is_strict(
+    direction: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> bool:
+    """Check that every consecutive graph triple has one strict orientation."""
+
+    ts = validate_parameters(parameters)
+    values = tuple(_as_fraction(value) for value in direction)
+    points = tuple((t, polynomial_value(values, t)) for t in ts)
+    orientations: list[Fraction] = []
+    for left, middle, right in zip(points, points[1:], points[2:], strict=False):
+        x1, y1 = left
+        x2, y2 = middle
+        x3, y3 = right
+        orientations.append((x2 - x1) * (y3 - y1) - (y2 - y1) * (x3 - x1))
+    return bool(orientations) and (
+        all(value > 0 for value in orientations)
+        or all(value < 0 for value in orientations)
+    )
+
+
+def maximum_distance_multiplicity(
+    upper: Sequence[int | Fraction],
+    center: int | Fraction,
+    parameters: Sequence[int | Fraction],
+) -> int:
+    """Return the largest exact distance class away from one center."""
+
+    ts = validate_parameters(parameters)
+    s = _as_fraction(center)
+    if s not in ts:
+        raise ValueError("center must belong to the parameter set")
+    counts: dict[Fraction, int] = {}
+    for witness in ts:
+        if witness == s:
+            continue
+        distance = lifted_squared_distance(upper, s, witness)
+        counts[distance] = counts.get(distance, 0) + 1
+    return max(counts.values(), default=0)
+
+
+def rich_center_multiplicities(
+    upper: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> tuple[int, ...]:
+    """Return the exact largest distance-class size for every center."""
+
+    ts = validate_parameters(parameters)
+    return tuple(maximum_distance_multiplicity(upper, center, ts) for center in ts)
+
+
+def _polynomial_trim(polynomial: Sequence[Fraction]) -> tuple[Fraction, ...]:
+    values = list(polynomial)
+    while values and not values[-1]:
+        values.pop()
+    return tuple(values)
+
+
+def _polynomial_divmod(
+    dividend: Sequence[Fraction],
+    divisor: Sequence[Fraction],
+) -> tuple[tuple[Fraction, ...], tuple[Fraction, ...]]:
+    numerator = list(_polynomial_trim(dividend))
+    denominator = _polynomial_trim(divisor)
+    if not denominator:
+        raise ZeroDivisionError("polynomial division by zero")
+    if len(numerator) < len(denominator):
+        return (), tuple(numerator)
+    quotient = [Fraction(0) for _ in range(len(numerator) - len(denominator) + 1)]
+    while numerator and len(numerator) >= len(denominator):
+        degree = len(numerator) - len(denominator)
+        multiplier = numerator[-1] / denominator[-1]
+        quotient[degree] = multiplier
+        for index, value in enumerate(denominator):
+            numerator[index + degree] -= multiplier * value
+        numerator = list(_polynomial_trim(numerator))
+    return _polynomial_trim(quotient), tuple(numerator)
+
+
+def _polynomial_gcd(
+    left: Sequence[Fraction],
+    right: Sequence[Fraction],
+) -> tuple[Fraction, ...]:
+    a = _polynomial_trim(left)
+    b = _polynomial_trim(right)
+    while b:
+        _, remainder = _polynomial_divmod(a, b)
+        a, b = b, remainder
+    if not a:
+        return ()
+    leading = a[-1]
+    return tuple(value / leading for value in a)
+
+
+def _matrix_entry_from_upper(
+    upper: Sequence[Fraction],
+    row: int,
+    column: int,
+) -> Fraction:
+    pair = (min(row, column) + 1, max(row, column) + 1)
+    return upper[PAIR_INDEX[pair]]
+
+
+def _minor_polynomial(
+    particular: Sequence[Fraction],
+    direction: Sequence[Fraction],
+    row_a: int,
+    row_b: int,
+    column_a: int,
+    column_b: int,
+) -> tuple[Fraction, ...]:
+    p_ac = _matrix_entry_from_upper(particular, row_a, column_a)
+    p_ad = _matrix_entry_from_upper(particular, row_a, column_b)
+    p_bc = _matrix_entry_from_upper(particular, row_b, column_a)
+    p_bd = _matrix_entry_from_upper(particular, row_b, column_b)
+    v_ac = _matrix_entry_from_upper(direction, row_a, column_a)
+    v_ad = _matrix_entry_from_upper(direction, row_a, column_b)
+    v_bc = _matrix_entry_from_upper(direction, row_b, column_a)
+    v_bd = _matrix_entry_from_upper(direction, row_b, column_b)
+    return _polynomial_trim(
+        (
+            p_ac * p_bd - p_ad * p_bc,
+            p_ac * v_bd + v_ac * p_bd - p_ad * v_bc - v_ad * p_bc,
+            v_ac * v_bd - v_ad * v_bc,
+        )
+    )
+
+
+def _fraction_square_root(value: Fraction) -> Fraction | None:
+    if value < 0:
+        return None
+    numerator_root = isqrt(value.numerator)
+    denominator_root = isqrt(value.denominator)
+    if numerator_root * numerator_root != value.numerator:
+        return None
+    if denominator_root * denominator_root != value.denominator:
+        return None
+    return Fraction(numerator_root, denominator_root)
+
+
+def rank_one_intersection_on_line(
+    particular: Sequence[int | Fraction],
+    direction: Sequence[int | Fraction],
+) -> LineRankOneResult:
+    """Solve all rank-one minors on ``particular + lambda * direction``.
+
+    The common minor gcd has degree at most two.  Irrational real quadratic
+    roots are retained exactly rather than being approximated or rejected.
+    """
+
+    p = tuple(_as_fraction(value) for value in particular)
+    v = tuple(_as_fraction(value) for value in direction)
+    if len(p) != VARIABLE_COUNT or len(v) != VARIABLE_COUNT:
+        raise ValueError(f"line vectors must have length {VARIABLE_COUNT}")
+    if not any(v):
+        raise ValueError("line direction must be nonzero")
+
+    gcd: tuple[Fraction, ...] = ()
+    found_nonzero_minor = False
+    for row_a, row_b in combinations(range(4), 2):
+        for column_a, column_b in combinations(range(4), 2):
+            polynomial = _minor_polynomial(
+                p,
+                v,
+                row_a,
+                row_b,
+                column_a,
+                column_b,
+            )
+            if not polynomial:
+                continue
+            found_nonzero_minor = True
+            gcd = polynomial if not gcd else _polynomial_gcd(gcd, polynomial)
+            if len(gcd) == 1:
+                return LineRankOneResult(kind="NO_RANK_ONE")
+
+    if not found_nonzero_minor:
+        return LineRankOneResult(kind="ALL_PARAMETERS_RANK_AT_MOST_ONE")
+    if len(gcd) == 2:
+        return LineRankOneResult(kind="RATIONAL_PARAMETERS", rational_parameters=(-gcd[0] / gcd[1],))
+    if len(gcd) != 3:
+        raise AssertionError(f"unexpected minor gcd degree: {len(gcd) - 1}")
+
+    constant, linear, quadratic = gcd
+    discriminant = linear * linear - 4 * quadratic * constant
+    if discriminant < 0:
+        return LineRankOneResult(kind="NO_REAL_RANK_ONE")
+    square_root = _fraction_square_root(discriminant)
+    if square_root is not None:
+        roots = tuple(
+            sorted(
+                {
+                    (-linear - square_root) / (2 * quadratic),
+                    (-linear + square_root) / (2 * quadratic),
+                }
+            )
+        )
+        return LineRankOneResult(kind="RATIONAL_PARAMETERS", rational_parameters=roots)
+    return LineRankOneResult(
+        kind="IRRATIONAL_REAL_QUADRATIC",
+        irreducible_quadratic=(constant, linear, quadratic),
+    )
+
+
+def _fraction_text(value: Fraction) -> str:
+    if value.denominator == 1:
+        return str(value.numerator)
+    return f"{value.numerator}/{value.denominator}"
+
+
+def _upper_at_parameter(
+    particular: Sequence[Fraction],
+    direction: Sequence[Fraction],
+    parameter: Fraction,
+) -> tuple[Fraction, ...]:
+    return tuple(
+        base + parameter * delta
+        for base, delta in zip(particular, direction, strict=True)
+    )
+
+
+def anchor_triple_scan(
+    parameters: Sequence[int | Fraction] = tuple(range(-4, 5)),
+    centers: Sequence[int | Fraction] = (0, 3, 4),
+    *,
+    sample_limit: int = 20,
+) -> AnchorTripleSummary:
+    """Enumerate three marked rows on one fixed rational parameter set.
+
+    Pairwise witness overlap greater than two is removed by the exact
+    two-circle intersection cap.  Rank-nine affine lines are intersected with
+    every 2 by 2 rank-one minor.  Lower-rank affine families and irrational
+    real quadratic branches are retained explicitly as unresolved states.
+    """
+
+    ts = validate_parameters(parameters)
+    center_values = tuple(_as_fraction(value) for value in centers)
+    if len(center_values) != 3 or len(set(center_values)) != 3:
+        raise ValueError("the pilot needs three distinct anchor centers")
+    if any(center not in ts for center in center_values):
+        raise ValueError("every center must belong to the parameter set")
+    if sample_limit < 0:
+        raise ValueError("sample_limit must be nonnegative")
+
+    options: dict[Fraction, tuple[tuple[tuple[Fraction, ...], tuple[Equation, ...]], ...]] = {}
+    for center in center_values:
+        witnesses = tuple(value for value in ts if value != center)
+        options[center] = tuple(
+            (quartet, marked_row_equations(center, quartet))
+            for quartet in combinations(witnesses, 4)
+        )
+
+    option_count = len(options[center_values[0]])
+    if any(len(options[center]) != option_count for center in center_values):
+        raise AssertionError("anchor centers unexpectedly have different option counts")
+
+    raw_triple_count = option_count**3
+    overlap_admissible_count = 0
+    pair_inconsistent_pruned_triple_count = 0
+    inconsistent_count = 0
+    rank_counts: dict[int, int] = {}
+    line_without_real_rank_at_most_one_count = 0
+    line_zero_matrix_root_count = 0
+    line_negative_semidefinite_rank_one_root_count = 0
+    line_lower_degree_rank_one_psd_root_count = 0
+    line_rational_quartic_gram_count = 0
+    line_irrational_rank_at_most_one_component_count = 0
+    line_all_rank_at_most_one_count = 0
+    exceptional_rrefs: set[Rref] = set()
+    unresolved_line_rrefs: set[Rref] = set()
+    rank_one_quartic_grams: set[tuple[Fraction, ...]] = set()
+    samples: list[dict[str, object]] = []
+
+    first_center, second_center, third_center = center_values
+    for first_witnesses, first_equations in options[first_center]:
+        first_set = frozenset(first_witnesses)
+        for second_witnesses, second_equations in options[second_center]:
+            second_set = frozenset(second_witnesses)
+            if len(first_set & second_set) > 2:
+                continue
+            admissible_third_options = tuple(
+                (third_witnesses, third_equations)
+                for third_witnesses, third_equations in options[third_center]
+                if len(first_set & frozenset(third_witnesses)) <= 2
+                and len(second_set & frozenset(third_witnesses)) <= 2
+            )
+            overlap_admissible_count += len(admissible_third_options)
+            pair_solution = solve_affine(first_equations + second_equations)
+            if pair_solution is None:
+                pair_inconsistent_pruned_triple_count += len(admissible_third_options)
+                continue
+            for third_witnesses, third_equations in admissible_third_options:
+                solution = solve_affine(pair_solution.rref + third_equations)
+                if solution is None:
+                    inconsistent_count += 1
+                    continue
+                rank_counts[solution.rank] = rank_counts.get(solution.rank, 0) + 1
+                witness_record = tuple(
+                    tuple(_fraction_text(value) for value in row)
+                    for row in (first_witnesses, second_witnesses, third_witnesses)
+                )
+
+                if solution.dimension == 0:
+                    raise AssertionError("nine anchor equations cannot have rank ten")
+
+                if solution.dimension == 1:
+                    line_result = rank_one_intersection_on_line(
+                        solution.particular,
+                        solution.nullspace[0],
+                    )
+                    if line_result.kind in {"NO_RANK_ONE", "NO_REAL_RANK_ONE"}:
+                        line_without_real_rank_at_most_one_count += 1
+                        continue
+                    if line_result.kind == "RATIONAL_PARAMETERS":
+                        viable_parameters: list[Fraction] = []
+                        for parameter in line_result.rational_parameters:
+                            upper_at_root = _upper_at_parameter(
+                                solution.particular,
+                                solution.nullspace[0],
+                                parameter,
+                            )
+                            root_check = rank_one_psd_check(upper_at_root)
+                            if root_check.quartic_gram:
+                                viable_parameters.append(parameter)
+                                rank_one_quartic_grams.add(upper_at_root)
+                            elif not root_check.rank_one:
+                                line_zero_matrix_root_count += 1
+                            elif not root_check.positive_semidefinite:
+                                line_negative_semidefinite_rank_one_root_count += 1
+                            else:
+                                line_lower_degree_rank_one_psd_root_count += 1
+                        if not viable_parameters:
+                            continue
+                        line_rational_quartic_gram_count += len(viable_parameters)
+                        if len(samples) < sample_limit:
+                            samples.append(
+                                {
+                                    "kind": "RATIONAL_LINE_RANK_ONE",
+                                    "witnesses": witness_record,
+                                    "parameters": tuple(
+                                        _fraction_text(value) for value in viable_parameters
+                                    ),
+                                }
+                            )
+                        continue
+                    if line_result.kind == "IRRATIONAL_REAL_QUADRATIC":
+                        line_irrational_rank_at_most_one_component_count += 1
+                        unresolved_line_rrefs.add(solution.rref)
+                        if len(samples) < sample_limit:
+                            samples.append(
+                                {
+                                    "kind": "IRRATIONAL_REAL_QUADRATIC_LINE",
+                                    "witnesses": witness_record,
+                                    "polynomial": tuple(
+                                        _fraction_text(value)
+                                        for value in line_result.irreducible_quadratic or ()
+                                    ),
+                                }
+                            )
+                        continue
+                    if line_result.kind == "ALL_PARAMETERS_RANK_AT_MOST_ONE":
+                        line_all_rank_at_most_one_count += 1
+                        unresolved_line_rrefs.add(solution.rref)
+                        if len(samples) < sample_limit:
+                            samples.append(
+                                {
+                                    "kind": "ENTIRE_LINE_RANK_AT_MOST_ONE",
+                                    "witnesses": witness_record,
+                                }
+                            )
+                        continue
+                    raise AssertionError(f"unhandled line classification: {line_result.kind}")
+
+                exceptional_rrefs.add(solution.rref)
+                if len(samples) < sample_limit:
+                    samples.append(
+                        {
+                            "kind": "UNRESOLVED_AFFINE_FAMILY",
+                            "witnesses": witness_record,
+                            "rank": solution.rank,
+                            "dimension": solution.dimension,
+                        }
+                    )
+
+    return AnchorTripleSummary(
+        parameters=ts,
+        centers=(center_values[0], center_values[1], center_values[2]),
+        quartet_count_per_center=option_count,
+        raw_triple_count=raw_triple_count,
+        overlap_admissible_count=overlap_admissible_count,
+        pair_inconsistent_pruned_triple_count=pair_inconsistent_pruned_triple_count,
+        inconsistent_count=inconsistent_count,
+        rank_counts=tuple(sorted(rank_counts.items())),
+        line_without_real_rank_at_most_one_count=line_without_real_rank_at_most_one_count,
+        line_zero_matrix_root_count=line_zero_matrix_root_count,
+        line_negative_semidefinite_rank_one_root_count=(
+            line_negative_semidefinite_rank_one_root_count
+        ),
+        line_lower_degree_rank_one_psd_root_count=(
+            line_lower_degree_rank_one_psd_root_count
+        ),
+        line_rational_quartic_gram_count=line_rational_quartic_gram_count,
+        line_irrational_rank_at_most_one_component_count=(
+            line_irrational_rank_at_most_one_component_count
+        ),
+        line_all_rank_at_most_one_count=line_all_rank_at_most_one_count,
+        exceptional_affine_state_count=len(exceptional_rrefs),
+        sample_survivors=tuple(samples),
+        exceptional_rrefs=tuple(sorted(exceptional_rrefs)),
+        unresolved_line_rrefs=tuple(sorted(unresolved_line_rrefs)),
+        rank_one_quartic_grams=tuple(sorted(rank_one_quartic_grams)),
+    )
+
+
+def quartic_closure_pilot(
+    parameters: Sequence[int | Fraction] = tuple(range(-4, 5)),
+    anchor_centers: Sequence[int | Fraction] = (0, 3, 4),
+    extension_centers: Sequence[int | Fraction] | None = None,
+    *,
+    sample_limit: int = 20,
+) -> QuarticClosurePilotSummary:
+    """Run the exact fixed-grid quartic marked-root closure pilot.
+
+    The three anchors are exhaustively enumerated first.  Every surviving
+    higher-dimensional affine state is then extended, center by center, across
+    all four-witness choices.  Canonical RREF states are deduplicated; the
+    extension deliberately omits overlap pruning, so deduplication cannot hide
+    a future witness choice.
+    """
+
+    ts = validate_parameters(parameters)
+    anchors = tuple(_as_fraction(value) for value in anchor_centers)
+    anchor_summary = anchor_triple_scan(
+        ts,
+        anchors,
+        sample_limit=sample_limit,
+    )
+    if extension_centers is None:
+        extension_values = tuple(value for value in ts if value not in anchors)
+    else:
+        extension_values = tuple(_as_fraction(value) for value in extension_centers)
+        expected = {value for value in ts if value not in anchors}
+        if len(extension_values) != len(set(extension_values)) or set(extension_values) != expected:
+            raise ValueError("extension centers must list every non-anchor parameter exactly once")
+
+    states = set(anchor_summary.exceptional_rrefs) | set(anchor_summary.unresolved_line_rrefs)
+    rank_one_candidates = set(anchor_summary.rank_one_quartic_grams)
+    extension_steps: list[dict[str, int | str]] = []
+
+    for center in extension_values:
+        witness_values = tuple(value for value in ts if value != center)
+        row_options = tuple(
+            marked_row_equations(center, quartet)
+            for quartet in combinations(witness_values, 4)
+        )
+        input_state_count = len(states)
+        raw_branch_count = input_state_count * len(row_options)
+        linearly_inconsistent_count = 0
+        consistent_branch_count = 0
+        consistent_states: set[Rref] = set()
+
+        for state in states:
+            for equations in row_options:
+                solution = solve_affine(state + equations)
+                if solution is None:
+                    linearly_inconsistent_count += 1
+                    continue
+                consistent_branch_count += 1
+                consistent_states.add(solution.rref)
+
+        states_without_real_rank_at_most_one = 0
+        zero_matrix_root_count = 0
+        negative_semidefinite_rank_one_root_count = 0
+        lower_degree_rank_one_psd_root_count = 0
+        specified_non_rank_one_gram_count = 0
+        unique_quartic_gram_state_count = 0
+        rational_line_quartic_gram_count = 0
+        irrational_line_state_count = 0
+        higher_dimensional_state_count = 0
+        next_states: set[Rref] = set()
+
+        for state in consistent_states:
+            solution = solve_affine(state)
+            if solution is None:
+                raise AssertionError("stored RREF state became inconsistent")
+            if solution.dimension >= 2:
+                next_states.add(solution.rref)
+                higher_dimensional_state_count += 1
+                continue
+            if solution.dimension == 1:
+                result = rank_one_intersection_on_line(
+                    solution.particular,
+                    solution.nullspace[0],
+                )
+                if result.kind in {"NO_RANK_ONE", "NO_REAL_RANK_ONE"}:
+                    states_without_real_rank_at_most_one += 1
+                    continue
+                if result.kind == "RATIONAL_PARAMETERS":
+                    viable = 0
+                    for parameter in result.rational_parameters:
+                        candidate = _upper_at_parameter(
+                            solution.particular,
+                            solution.nullspace[0],
+                            parameter,
+                        )
+                        candidate_check = rank_one_psd_check(candidate)
+                        if candidate_check.quartic_gram:
+                            rank_one_candidates.add(candidate)
+                            viable += 1
+                        elif not candidate_check.rank_one:
+                            zero_matrix_root_count += 1
+                        elif not candidate_check.positive_semidefinite:
+                            negative_semidefinite_rank_one_root_count += 1
+                        else:
+                            lower_degree_rank_one_psd_root_count += 1
+                    rational_line_quartic_gram_count += viable
+                    continue
+                if result.kind in {
+                    "IRRATIONAL_REAL_QUADRATIC",
+                    "ALL_PARAMETERS_RANK_AT_MOST_ONE",
+                }:
+                    next_states.add(solution.rref)
+                    irrational_line_state_count += 1
+                    continue
+                raise AssertionError(f"unhandled line classification: {result.kind}")
+
+            check = rank_one_psd_check(solution.particular)
+            if check.quartic_gram:
+                rank_one_candidates.add(solution.particular)
+                unique_quartic_gram_state_count += 1
+            elif not check.rank_one:
+                specified_non_rank_one_gram_count += 1
+            elif not check.positive_semidefinite:
+                negative_semidefinite_rank_one_root_count += 1
+            else:
+                lower_degree_rank_one_psd_root_count += 1
+
+        states = next_states
+        extension_steps.append(
+            {
+                "center": _fraction_text(center),
+                "input_affine_states": input_state_count,
+                "row_options_per_state": len(row_options),
+                "raw_state_row_branches": raw_branch_count,
+                "linearly_inconsistent_branches": linearly_inconsistent_count,
+                "linearly_consistent_branches": consistent_branch_count,
+                "deduplicated_consistent_affine_states": len(consistent_states),
+                "states_without_real_rank_at_most_one": (
+                    states_without_real_rank_at_most_one
+                ),
+                "zero_matrix_roots": zero_matrix_root_count,
+                "negative_semidefinite_rank_one_roots": (
+                    negative_semidefinite_rank_one_root_count
+                ),
+                "lower_degree_rank_one_psd_roots": lower_degree_rank_one_psd_root_count,
+                "specified_non_rank_one_grams": specified_non_rank_one_gram_count,
+                "unique_rank_one_quartic_gram_states": unique_quartic_gram_state_count,
+                "rational_line_rank_one_quartic_grams": rational_line_quartic_gram_count,
+                "irrational_or_rank_one_line_states_retained": irrational_line_state_count,
+                "higher_dimensional_states_retained": higher_dimensional_state_count,
+                "deduplicated_affine_states_out": len(states),
+            }
+        )
+        if not states:
+            break
+
+    convex_candidates: set[tuple[Fraction, ...]] = set()
+    all_row_candidates: set[tuple[Fraction, ...]] = set()
+    strict_finite_closure_candidates: set[tuple[Fraction, ...]] = set()
+    continuous_convex_closure_candidates: set[tuple[Fraction, ...]] = set()
+    candidate_samples: list[dict[str, object]] = []
+    for candidate in sorted(rank_one_candidates):
+        direction = recover_rational_direction(candidate)
+        continuous_convexity = second_derivative_has_constant_sign(
+            direction,
+            ts[0],
+            ts[-1],
+        )
+        strict_chain = finite_graph_chain_is_strict(direction, ts)
+        multiplicities = rich_center_multiplicities(candidate, ts)
+        all_rows_rich = all(value >= 4 for value in multiplicities)
+        if continuous_convexity and strict_chain:
+            convex_candidates.add(candidate)
+        if all_rows_rich:
+            all_row_candidates.add(candidate)
+            if strict_chain:
+                strict_finite_closure_candidates.add(candidate)
+                if continuous_convexity:
+                    continuous_convex_closure_candidates.add(candidate)
+        if len(candidate_samples) < sample_limit:
+            candidate_samples.append(
+                {
+                    "gram_upper": tuple(_fraction_text(value) for value in candidate),
+                    "continuous_convexity": continuous_convexity,
+                    "strict_finite_chain": strict_chain,
+                    "center_multiplicities": multiplicities,
+                }
+            )
+
+    return QuarticClosurePilotSummary(
+        anchor=anchor_summary,
+        extension_centers=extension_values,
+        extension_steps=tuple(extension_steps),
+        unresolved_affine_state_count=len(states),
+        rank_one_quartic_candidate_count=len(rank_one_candidates),
+        convex_rank_one_candidate_count=len(convex_candidates),
+        all_row_quartic_candidate_count=len(all_row_candidates),
+        strict_finite_full_closure_candidate_count=len(strict_finite_closure_candidates),
+        continuous_convex_full_closure_candidate_count=(
+            len(continuous_convex_closure_candidates)
+        ),
+        sample_candidates=tuple(candidate_samples),
+    )

--- a/src/erdos97/quartic_marked_root_gram.py
+++ b/src/erdos97/quartic_marked_root_gram.py
@@ -1,6 +1,6 @@
-"""Exact marked-root Gram helpers for polynomial quartic graph samples.
+"""Exact marked-root Gram helpers for degree-at-most-four plane samples.
 
-The lifted variable is the symmetric Gram matrix ``A = a a^T`` for
+For a polynomial graph, the lifted variable is ``A = a a^T`` for
 
     f_a(t) = a_1 t + a_2 t^2 + a_3 t^3 + a_4 t^4.
 
@@ -8,6 +8,12 @@ For fixed rational parameters, each prescribed four-witness row gives three
 affine equations in the ten upper-triangular entries of ``A``.  Linear
 feasibility is only a relaxation: a planar quartic graph additionally needs
 ``A`` to be nonzero, positive semidefinite, and rank one.
+
+After translating by the horizontal contribution, ``B = E11 + A``, the same
+rows are homogeneous.  More generally, a polynomial plane parametrization
+has ``B = C^T C`` for its two nonconstant coordinate-coefficient rows, so a
+nonconstant planar realization needs a nonzero PSD kernel matrix of rank at
+most two.
 """
 
 from __future__ import annotations
@@ -15,11 +21,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from fractions import Fraction
 from itertools import combinations
-from math import isqrt
+from math import gcd, isqrt, lcm
 from typing import Iterable, Sequence
 
 
-SCHEMA = "erdos97.quartic_marked_root_gram.v1"
+SCHEMA = "erdos97.quartic_marked_root_gram.v2"
 
 GRAM_PAIRS: tuple[tuple[int, int], ...] = tuple(
     (left, right)
@@ -28,6 +34,17 @@ GRAM_PAIRS: tuple[tuple[int, int], ...] = tuple(
 )
 PAIR_INDEX = {pair: index for index, pair in enumerate(GRAM_PAIRS)}
 VARIABLE_COUNT = len(GRAM_PAIRS)
+
+# The fixed horizontal coordinate of a polynomial graph contributes
+# ``E11 = e_1 e_1^T`` to its full coefficient Gram matrix.  Its negative is a
+# universal affine solution of every marked-row graph-Gram system: at that
+# value the horizontal and lifted vertical squared distances cancel exactly.
+E11_UPPER: tuple[Fraction, ...] = (Fraction(1),) + (Fraction(0),) * (
+    VARIABLE_COUNT - 1
+)
+UNIVERSAL_PHANTOM_UPPER: tuple[Fraction, ...] = tuple(
+    -value for value in E11_UPPER
+)
 
 Equation = tuple[Fraction, ...]
 Rref = tuple[Equation, ...]
@@ -76,6 +93,22 @@ class LineRankOneResult:
 
 
 @dataclass(frozen=True)
+class FullGramKernelDirectionCheck:
+    """Exact planar feasibility data for a one-dimensional full-Gram kernel.
+
+    A nonzero real scalar multiple of a symmetric direction is a Gram matrix
+    of vectors in the plane exactly when one of the two signs is positive
+    semidefinite and the direction has rank at most two.
+    """
+
+    nonzero: bool
+    rank: int
+    positive_semidefinite: bool
+    negative_semidefinite: bool
+    admits_nonzero_planar_full_gram: bool
+
+
+@dataclass(frozen=True)
 class AnchorTripleSummary:
     """Exact accounting for one three-center marked-row scan."""
 
@@ -94,6 +127,8 @@ class AnchorTripleSummary:
     line_rational_quartic_gram_count: int
     line_irrational_rank_at_most_one_component_count: int
     line_all_rank_at_most_one_count: int
+    full_gram_kernel_census: tuple[tuple[str, int], ...]
+    full_gram_planar_candidates: tuple[dict[str, object], ...]
     exceptional_affine_state_count: int
     sample_survivors: tuple[dict[str, object], ...]
     exceptional_rrefs: tuple[Rref, ...] = field(repr=False, compare=False)
@@ -102,15 +137,29 @@ class AnchorTripleSummary:
         repr=False,
         compare=False,
     )
+    full_gram_planar_grams: tuple[tuple[Fraction, ...], ...] = field(
+        repr=False,
+        compare=False,
+    )
 
 
 @dataclass(frozen=True)
 class QuarticClosurePilotSummary:
-    """Full fixed-grid continuation from anchors through every other center."""
+    """Full fixed-grid continuation from anchors through every other center.
+
+    The two full-Gram candidate counts use the centers in the proved kernel
+    obstruction: the three anchors and the first requested extension center.
+    They do not require richness at every parameter after that four-center
+    subsystem has already closed.
+    """
 
     anchor: AnchorTripleSummary
     extension_centers: tuple[Fraction, ...]
     extension_steps: tuple[dict[str, int | str], ...]
+    full_gram_extension_census: tuple[tuple[str, int], ...]
+    full_gram_four_center_unresolved_state_count: int
+    full_gram_pairwise_distinct_candidate_count: int
+    full_gram_strictly_convex_candidate_count: int
     unresolved_affine_state_count: int
     rank_one_quartic_candidate_count: int
     convex_rank_one_candidate_count: int
@@ -163,6 +212,84 @@ def gram_matrix(upper: Sequence[int | Fraction]) -> tuple[tuple[Fraction, ...], 
         rows[left - 1][right - 1] = value
         rows[right - 1][left - 1] = value
     return tuple(tuple(row) for row in rows)
+
+
+def full_gram_from_graph_gram(
+    upper: Sequence[int | Fraction],
+) -> tuple[Fraction, ...]:
+    """Translate the vertical graph Gram ``A`` to ``B = E11 + A``."""
+
+    if len(upper) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    values = tuple(_as_fraction(value) for value in upper)
+    return tuple(
+        value + horizontal
+        for value, horizontal in zip(values, E11_UPPER, strict=True)
+    )
+
+
+def graph_gram_from_full_gram(
+    upper: Sequence[int | Fraction],
+) -> tuple[Fraction, ...]:
+    """Translate a full graph Gram ``B`` back to ``A = B - E11``."""
+
+    if len(upper) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    values = tuple(_as_fraction(value) for value in upper)
+    return tuple(
+        value - horizontal
+        for value, horizontal in zip(values, E11_UPPER, strict=True)
+    )
+
+
+def full_gram_upper_from_coordinate_coefficients(
+    coordinate_coefficients: Sequence[Sequence[int | Fraction]],
+) -> tuple[Fraction, ...]:
+    """Return ``C^T C`` for nonconstant polynomial coordinate coefficients.
+
+    Every coordinate row contains the coefficients of ``t,t^2,t^3,t^4``.
+    Constant terms are deliberately absent because Euclidean translation does
+    not affect pairwise distances.
+    """
+
+    if not coordinate_coefficients:
+        raise ValueError("at least one coordinate coefficient row is required")
+    rows: list[tuple[Fraction, ...]] = []
+    for raw_row in coordinate_coefficients:
+        if len(raw_row) != 4:
+            raise ValueError("each coordinate coefficient row must have length four")
+        rows.append(tuple(_as_fraction(value) for value in raw_row))
+    return tuple(
+        sum(
+            (row[left - 1] * row[right - 1] for row in rows),
+            Fraction(0),
+        )
+        for left, right in GRAM_PAIRS
+    )
+
+
+def full_gram_squared_distance(
+    upper: Sequence[int | Fraction],
+    center: int | Fraction,
+    witness: int | Fraction,
+) -> Fraction:
+    """Evaluate ``(v(q)-v(s))^T B (v(q)-v(s))`` exactly."""
+
+    values = tuple(_as_fraction(value) for value in upper)
+    if len(values) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    s = _as_fraction(center)
+    q = _as_fraction(witness)
+    total = Fraction(0)
+    for value, (left, right) in zip(values, GRAM_PAIRS, strict=True):
+        multiplier = 1 if left == right else 2
+        total += (
+            multiplier
+            * value
+            * (q**left - s**left)
+            * (q**right - s**right)
+        )
+    return total
 
 
 def polynomial_value(
@@ -249,6 +376,38 @@ def marked_row_equations(
         horizontal_difference = (witness - s) ** 2 - (reference - s) ** 2
         rows.append(tuple(coefficients) + (-horizontal_difference,))
     return rows[0], rows[1], rows[2]
+
+
+def translate_affine_equations_to_full_gram(
+    equations: Iterable[Sequence[int | Fraction]],
+) -> tuple[Equation, ...]:
+    """Translate equations in ``A`` coordinates to ``B = E11 + A``.
+
+    An augmented row ``c*A = b`` becomes ``c*B = b + c*E11``.  In
+    particular, every row returned by :func:`marked_row_equations` becomes
+    homogeneous because it contains the universal solution ``A=-E11``.
+    """
+
+    translated: list[Equation] = []
+    for raw_row in equations:
+        if len(raw_row) != VARIABLE_COUNT + 1:
+            raise ValueError(
+                f"each augmented row must have {VARIABLE_COUNT + 1} entries"
+            )
+        row = tuple(_as_fraction(value) for value in raw_row)
+        translated_rhs = row[-1] + sum(
+            (
+                coefficient * horizontal
+                for coefficient, horizontal in zip(
+                    row[:-1],
+                    E11_UPPER,
+                    strict=True,
+                )
+            ),
+            Fraction(0),
+        )
+        translated.append(row[:-1] + (translated_rhs,))
+    return tuple(translated)
 
 
 def distance_fiber_coefficients(
@@ -396,6 +555,384 @@ def solve_affine(equations: Iterable[Sequence[int | Fraction]]) -> AffineSolutio
     )
 
 
+def symmetric_matrix_rank(upper: Sequence[int | Fraction]) -> int:
+    """Return the exact rank of a symmetric matrix in upper-triangular form."""
+
+    rows = [list(row) for row in gram_matrix(upper)]
+    rank = 0
+    for column in range(4):
+        pivot = next(
+            (row for row in range(rank, 4) if rows[row][column]),
+            None,
+        )
+        if pivot is None:
+            continue
+        rows[rank], rows[pivot] = rows[pivot], rows[rank]
+        pivot_value = rows[rank][column]
+        for row in range(4):
+            if row == rank or not rows[row][column]:
+                continue
+            multiplier = rows[row][column] / pivot_value
+            for index in range(column, 4):
+                rows[row][index] -= multiplier * rows[rank][index]
+        rank += 1
+        if rank == 4:
+            break
+    return rank
+
+
+def is_positive_semidefinite(upper: Sequence[int | Fraction]) -> bool:
+    """Check positive semidefiniteness by all exact principal minors."""
+
+    matrix = gram_matrix(upper)
+    return all(
+        _determinant(
+            tuple(
+                tuple(matrix[row][column] for column in indices)
+                for row in indices
+            )
+        )
+        >= 0
+        for size in range(1, 5)
+        for indices in combinations(range(4), size)
+    )
+
+
+def classify_full_gram_kernel_direction(
+    upper: Sequence[int | Fraction],
+) -> FullGramKernelDirectionCheck:
+    """Classify whether a kernel line contains a nonzero planar Gram matrix."""
+
+    values = tuple(_as_fraction(value) for value in upper)
+    if len(values) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    rank = symmetric_matrix_rank(values)
+    positive_semidefinite = is_positive_semidefinite(values)
+    negative_semidefinite = is_positive_semidefinite(
+        tuple(-value for value in values)
+    )
+    nonzero = rank > 0
+    return FullGramKernelDirectionCheck(
+        nonzero=nonzero,
+        rank=rank,
+        positive_semidefinite=positive_semidefinite,
+        negative_semidefinite=negative_semidefinite,
+        admits_nonzero_planar_full_gram=(
+            nonzero
+            and rank <= 2
+            and (positive_semidefinite or negative_semidefinite)
+        ),
+    )
+
+
+def canonical_primitive_upper(
+    upper: Sequence[int | Fraction],
+) -> tuple[int, ...]:
+    """Return the sign-normalized primitive integer ray representative."""
+
+    values = tuple(_as_fraction(value) for value in upper)
+    if len(values) != VARIABLE_COUNT:
+        raise ValueError(f"expected {VARIABLE_COUNT} upper-triangular entries")
+    if not any(values):
+        raise ValueError("cannot normalize the zero matrix as a kernel ray")
+    common_denominator = lcm(*(value.denominator for value in values))
+    integers = [
+        value.numerator * (common_denominator // value.denominator)
+        for value in values
+    ]
+    common_divisor = 0
+    for value in integers:
+        common_divisor = gcd(common_divisor, abs(value))
+    primitive = [value // common_divisor for value in integers]
+    first_nonzero = next(value for value in primitive if value)
+    if first_nonzero < 0:
+        primitive = [-value for value in primitive]
+    return tuple(primitive)
+
+
+def symmetric_matrix_inertia(
+    upper: Sequence[int | Fraction],
+) -> tuple[int, int, int]:
+    """Return exact ``(positive, negative, zero)`` inertia by congruence."""
+
+    def recurse(
+        matrix: tuple[tuple[Fraction, ...], ...],
+    ) -> tuple[int, int, int]:
+        size = len(matrix)
+        if not size:
+            return 0, 0, 0
+
+        diagonal_pivot = next(
+            (index for index in range(size) if matrix[index][index]),
+            None,
+        )
+        if diagonal_pivot is not None:
+            order = (diagonal_pivot,) + tuple(
+                index for index in range(size) if index != diagonal_pivot
+            )
+            permuted = tuple(
+                tuple(matrix[row][column] for column in order)
+                for row in order
+            )
+            pivot = permuted[0][0]
+            schur = tuple(
+                tuple(
+                    permuted[row][column]
+                    - permuted[row][0] * permuted[0][column] / pivot
+                    for column in range(1, size)
+                )
+                for row in range(1, size)
+            )
+            positive, negative, zero = recurse(schur)
+            if pivot > 0:
+                positive += 1
+            else:
+                negative += 1
+            return positive, negative, zero
+
+        off_diagonal_pivot = next(
+            (
+                (row, column)
+                for row in range(size)
+                for column in range(row + 1, size)
+                if matrix[row][column]
+            ),
+            None,
+        )
+        if off_diagonal_pivot is None:
+            return 0, 0, size
+        first, second = off_diagonal_pivot
+        order = (first, second) + tuple(
+            index for index in range(size) if index not in {first, second}
+        )
+        permuted = tuple(
+            tuple(matrix[row][column] for column in order)
+            for row in order
+        )
+        pivot = permuted[0][1]
+        schur = tuple(
+            tuple(
+                permuted[row][column]
+                - (
+                    permuted[row][0] * permuted[1][column]
+                    + permuted[row][1] * permuted[0][column]
+                )
+                / pivot
+                for column in range(2, size)
+            )
+            for row in range(2, size)
+        )
+        positive, negative, zero = recurse(schur)
+        return positive + 1, negative + 1, zero
+
+    return recurse(gram_matrix(upper))
+
+
+def _full_gram_center_multiplicities(
+    upper: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> tuple[int, ...]:
+    ts = validate_parameters(parameters)
+    multiplicities: list[int] = []
+    for center in ts:
+        counts: dict[Fraction, int] = {}
+        for witness in ts:
+            if witness == center:
+                continue
+            distance = full_gram_squared_distance(upper, center, witness)
+            if distance < 0:
+                raise AssertionError("a PSD full Gram produced a negative distance")
+            if distance == 0:
+                continue
+            counts[distance] = counts.get(distance, 0) + 1
+        multiplicities.append(max(counts.values(), default=0))
+    return tuple(multiplicities)
+
+
+def _full_gram_collision_pairs(
+    upper: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> tuple[tuple[Fraction, Fraction], ...]:
+    ts = validate_parameters(parameters)
+    return tuple(
+        (left, right)
+        for left, right in combinations(ts, 2)
+        if full_gram_squared_distance(upper, left, right) == 0
+    )
+
+
+def _full_gram_rational_sample_coordinates(
+    upper: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> tuple[tuple[Fraction, Fraction], ...] | None:
+    """Recover exact coordinates up to an invertible affine plane map."""
+
+    matrix = gram_matrix(upper)
+    basis = next(
+        (
+            (left, right)
+            for left, right in combinations(range(4), 2)
+            if matrix[left][left] * matrix[right][right]
+            - matrix[left][right] ** 2
+            > 0
+        ),
+        None,
+    )
+    if basis is None:
+        return None
+    left, right = basis
+    determinant = (
+        matrix[left][left] * matrix[right][right]
+        - matrix[left][right] ** 2
+    )
+    coefficient_coordinates: list[tuple[Fraction, Fraction]] = []
+    for column in range(4):
+        left_inner = matrix[left][column]
+        right_inner = matrix[right][column]
+        alpha = (
+            matrix[right][right] * left_inner
+            - matrix[left][right] * right_inner
+        ) / determinant
+        beta = (
+            matrix[left][left] * right_inner
+            - matrix[left][right] * left_inner
+        ) / determinant
+        coefficient_coordinates.append((alpha, beta))
+
+    ts = validate_parameters(parameters)
+    return tuple(
+        (
+            sum(
+                (
+                    coefficient_coordinates[degree - 1][0] * parameter**degree
+                    for degree in range(1, 5)
+                ),
+                Fraction(0),
+            ),
+            sum(
+                (
+                    coefficient_coordinates[degree - 1][1] * parameter**degree
+                    for degree in range(1, 5)
+                ),
+                Fraction(0),
+            ),
+        )
+        for parameter in ts
+    )
+
+
+def _strictly_convex_full_gram_sample(
+    upper: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> bool:
+    points = _full_gram_rational_sample_coordinates(upper, parameters)
+    if points is None or len(set(points)) != len(points):
+        return False
+
+    def cross(
+        origin: tuple[Fraction, Fraction],
+        left: tuple[Fraction, Fraction],
+        right: tuple[Fraction, Fraction],
+    ) -> Fraction:
+        return (left[0] - origin[0]) * (right[1] - origin[1]) - (
+            left[1] - origin[1]
+        ) * (right[0] - origin[0])
+
+    if any(
+        cross(points[first], points[second], points[third]) == 0
+        for first, second, third in combinations(range(len(points)), 3)
+    ):
+        return False
+
+    ordered = sorted(points)
+    lower: list[tuple[Fraction, Fraction]] = []
+    for point in ordered:
+        while len(lower) >= 2 and cross(lower[-2], lower[-1], point) <= 0:
+            lower.pop()
+        lower.append(point)
+    upper_hull: list[tuple[Fraction, Fraction]] = []
+    for point in reversed(ordered):
+        while (
+            len(upper_hull) >= 2
+            and cross(upper_hull[-2], upper_hull[-1], point) <= 0
+        ):
+            upper_hull.pop()
+        upper_hull.append(point)
+    hull = lower[:-1] + upper_hull[:-1]
+    return len(hull) == len(points)
+
+
+def _full_gram_candidate_record(
+    upper: Sequence[int | Fraction],
+    parameters: Sequence[int | Fraction],
+) -> dict[str, object]:
+    primitive = canonical_primitive_upper(upper)
+    values = tuple(Fraction(value) for value in primitive)
+    check = classify_full_gram_kernel_direction(values)
+    if not check.positive_semidefinite:
+        if not check.negative_semidefinite:
+            raise ValueError("candidate kernel ray is not semidefinite")
+        values = tuple(-value for value in values)
+    collisions = _full_gram_collision_pairs(values, parameters)
+    return {
+        "full_gram_upper": tuple(_fraction_text(value) for value in values),
+        "rank": symmetric_matrix_rank(values),
+        "center_multiplicities": _full_gram_center_multiplicities(
+            values,
+            parameters,
+        ),
+        "collision_pairs": tuple(
+            (_fraction_text(left), _fraction_text(right))
+            for left, right in collisions
+        ),
+        "pairwise_distinct": not collisions,
+        "strictly_convex_sample": _strictly_convex_full_gram_sample(
+            values,
+            parameters,
+        ),
+    }
+
+
+def _record_full_gram_kernel_direction(
+    census: dict[str, int],
+    upper: Sequence[int | Fraction],
+    *,
+    rank_key_prefix: str = "rank_",
+) -> tuple[tuple[int, ...], FullGramKernelDirectionCheck]:
+    primitive = canonical_primitive_upper(upper)
+    positive, negative, zero = symmetric_matrix_inertia(primitive)
+    rank = positive + negative
+    check = FullGramKernelDirectionCheck(
+        nonzero=rank > 0,
+        rank=rank,
+        positive_semidefinite=negative == 0,
+        negative_semidefinite=positive == 0,
+        admits_nonzero_planar_full_gram=(
+            rank > 0 and rank <= 2 and (positive == 0 or negative == 0)
+        ),
+    )
+    rank_key = f"{rank_key_prefix}{check.rank}"
+    census[rank_key] = census.get(rank_key, 0) + 1
+    census[f"inertia_{positive}_{negative}_{zero}"] = (
+        census.get(f"inertia_{positive}_{negative}_{zero}", 0) + 1
+    )
+    if check.rank < 4:
+        census["determinant_zero"] = census.get("determinant_zero", 0) + 1
+    elif negative % 2:
+        census["determinant_negative"] = (
+            census.get("determinant_negative", 0) + 1
+        )
+    else:
+        census["determinant_positive"] = (
+            census.get("determinant_positive", 0) + 1
+        )
+    if check.admits_nonzero_planar_full_gram:
+        census["planar_kernel_lines"] = (
+            census.get("planar_kernel_lines", 0) + 1
+        )
+    return primitive, check
+
+
 def rank_one_psd_check(upper: Sequence[int | Fraction]) -> RankOneCheck:
     """Check exact rank-one, PSD, and degree-four conditions."""
 
@@ -410,17 +947,7 @@ def rank_one_psd_check(upper: Sequence[int | Fraction]) -> RankOneCheck:
     diagonal = tuple(matrix[index][index] for index in range(4))
     nonzero = any(any(value for value in row) for row in matrix)
     rank_one = nonzero and all_minors_zero
-    positive_semidefinite = all(
-        _determinant(
-            tuple(
-                tuple(matrix[row][column] for column in indices)
-                for row in indices
-            )
-        )
-        >= 0
-        for size in range(1, 5)
-        for indices in combinations(range(4), size)
-    )
+    positive_semidefinite = is_positive_semidefinite(upper)
     pivot_index = next((index for index, value in enumerate(diagonal) if value > 0), None)
     degree_four = matrix[3][3] > 0
     return RankOneCheck(
@@ -791,6 +1318,29 @@ def anchor_triple_scan(
     line_rational_quartic_gram_count = 0
     line_irrational_rank_at_most_one_component_count = 0
     line_all_rank_at_most_one_count = 0
+    full_gram_census_keys = (
+        "rank_2",
+        "rank_3",
+        "rank_4",
+        "determinant_negative",
+        "determinant_positive",
+        "determinant_zero",
+        "inertia_1_1_2",
+        "inertia_2_0_2",
+        "inertia_1_2_1",
+        "inertia_2_1_1",
+        "inertia_1_3_0",
+        "inertia_3_1_0",
+        "inertia_2_2_0",
+        "inertia_4_0_0",
+        "planar_kernel_lines",
+        "unique_kernel_lines",
+        "phantom_roots",
+        "other_rank_one_roots",
+    )
+    full_gram_census = {key: 0 for key in full_gram_census_keys}
+    full_gram_primitive_kernels: set[tuple[int, ...]] = set()
+    full_gram_planar_grams: set[tuple[Fraction, ...]] = set()
     exceptional_rrefs: set[Rref] = set()
     unresolved_line_rrefs: set[Rref] = set()
     rank_one_quartic_grams: set[tuple[Fraction, ...]] = set()
@@ -829,6 +1379,20 @@ def anchor_triple_scan(
                     raise AssertionError("nine anchor equations cannot have rank ten")
 
                 if solution.dimension == 1:
+                    primitive_kernel, kernel_check = (
+                        _record_full_gram_kernel_direction(
+                            full_gram_census,
+                            solution.nullspace[0],
+                        )
+                    )
+                    full_gram_primitive_kernels.add(primitive_kernel)
+                    if kernel_check.admits_nonzero_planar_full_gram:
+                        planar_gram = tuple(
+                            Fraction(value) for value in primitive_kernel
+                        )
+                        if not kernel_check.positive_semidefinite:
+                            planar_gram = tuple(-value for value in planar_gram)
+                        full_gram_planar_grams.add(planar_gram)
                     line_result = rank_one_intersection_on_line(
                         solution.particular,
                         solution.nullspace[0],
@@ -845,6 +1409,10 @@ def anchor_triple_scan(
                                 parameter,
                             )
                             root_check = rank_one_psd_check(upper_at_root)
+                            if upper_at_root == UNIVERSAL_PHANTOM_UPPER:
+                                full_gram_census["phantom_roots"] += 1
+                            elif root_check.rank_one:
+                                full_gram_census["other_rank_one_roots"] += 1
                             if root_check.quartic_gram:
                                 viable_parameters.append(parameter)
                                 rank_one_quartic_grams.add(upper_at_root)
@@ -907,6 +1475,12 @@ def anchor_triple_scan(
                         }
                     )
 
+    full_gram_census["unique_kernel_lines"] = len(full_gram_primitive_kernels)
+    full_gram_candidate_records = tuple(
+        _full_gram_candidate_record(candidate, ts)
+        for candidate in sorted(full_gram_planar_grams)
+    )
+
     return AnchorTripleSummary(
         parameters=ts,
         centers=(center_values[0], center_values[1], center_values[2]),
@@ -929,11 +1503,16 @@ def anchor_triple_scan(
             line_irrational_rank_at_most_one_component_count
         ),
         line_all_rank_at_most_one_count=line_all_rank_at_most_one_count,
+        full_gram_kernel_census=tuple(
+            (key, full_gram_census[key]) for key in full_gram_census_keys
+        ),
+        full_gram_planar_candidates=full_gram_candidate_records,
         exceptional_affine_state_count=len(exceptional_rrefs),
         sample_survivors=tuple(samples),
         exceptional_rrefs=tuple(sorted(exceptional_rrefs)),
         unresolved_line_rrefs=tuple(sorted(unresolved_line_rrefs)),
         rank_one_quartic_grams=tuple(sorted(rank_one_quartic_grams)),
+        full_gram_planar_grams=tuple(sorted(full_gram_planar_grams)),
     )
 
 
@@ -970,9 +1549,38 @@ def quartic_closure_pilot(
 
     states = set(anchor_summary.exceptional_rrefs) | set(anchor_summary.unresolved_line_rrefs)
     rank_one_candidates = set(anchor_summary.rank_one_quartic_grams)
+    full_gram_candidates = set(anchor_summary.full_gram_planar_grams)
     extension_steps: list[dict[str, int | str]] = []
+    full_gram_extension_census_keys = (
+        "raw_affine_rank_9_branches",
+        "raw_affine_rank_10_branches",
+        "affine_rank_9_states",
+        "affine_rank_10_states",
+        "kernel_rank_2",
+        "kernel_rank_3",
+        "kernel_rank_4",
+        "determinant_negative",
+        "determinant_positive",
+        "determinant_zero",
+        "inertia_1_1_2",
+        "inertia_2_0_2",
+        "inertia_1_2_1",
+        "inertia_2_1_1",
+        "inertia_1_3_0",
+        "inertia_3_1_0",
+        "inertia_2_2_0",
+        "inertia_4_0_0",
+        "planar_kernel_lines",
+        "phantom_line_roots",
+        "phantom_singletons",
+        "other_rank_one_roots",
+    )
+    full_gram_extension_census = {
+        key: 0 for key in full_gram_extension_census_keys
+    }
+    full_gram_four_center_unresolved_state_count = 0
 
-    for center in extension_values:
+    for extension_index, center in enumerate(extension_values):
         witness_values = tuple(value for value in ts if value != center)
         row_options = tuple(
             marked_row_equations(center, quartet)
@@ -991,6 +1599,10 @@ def quartic_closure_pilot(
                     linearly_inconsistent_count += 1
                     continue
                 consistent_branch_count += 1
+                raw_rank_key = f"raw_affine_rank_{solution.rank}_branches"
+                full_gram_extension_census[raw_rank_key] = (
+                    full_gram_extension_census.get(raw_rank_key, 0) + 1
+                )
                 consistent_states.add(solution.rref)
 
         states_without_real_rank_at_most_one = 0
@@ -1008,11 +1620,29 @@ def quartic_closure_pilot(
             solution = solve_affine(state)
             if solution is None:
                 raise AssertionError("stored RREF state became inconsistent")
+            state_rank_key = f"affine_rank_{solution.rank}_states"
+            full_gram_extension_census[state_rank_key] = (
+                full_gram_extension_census.get(state_rank_key, 0) + 1
+            )
             if solution.dimension >= 2:
                 next_states.add(solution.rref)
                 higher_dimensional_state_count += 1
                 continue
             if solution.dimension == 1:
+                primitive_kernel, kernel_check = (
+                    _record_full_gram_kernel_direction(
+                        full_gram_extension_census,
+                        solution.nullspace[0],
+                        rank_key_prefix="kernel_rank_",
+                    )
+                )
+                if kernel_check.admits_nonzero_planar_full_gram:
+                    planar_gram = tuple(
+                        Fraction(value) for value in primitive_kernel
+                    )
+                    if not kernel_check.positive_semidefinite:
+                        planar_gram = tuple(-value for value in planar_gram)
+                    full_gram_candidates.add(planar_gram)
                 result = rank_one_intersection_on_line(
                     solution.particular,
                     solution.nullspace[0],
@@ -1029,6 +1659,14 @@ def quartic_closure_pilot(
                             parameter,
                         )
                         candidate_check = rank_one_psd_check(candidate)
+                        if candidate == UNIVERSAL_PHANTOM_UPPER:
+                            full_gram_extension_census[
+                                "phantom_line_roots"
+                            ] += 1
+                        elif candidate_check.rank_one:
+                            full_gram_extension_census[
+                                "other_rank_one_roots"
+                            ] += 1
                         if candidate_check.quartic_gram:
                             rank_one_candidates.add(candidate)
                             viable += 1
@@ -1050,6 +1688,10 @@ def quartic_closure_pilot(
                 raise AssertionError(f"unhandled line classification: {result.kind}")
 
             check = rank_one_psd_check(solution.particular)
+            if solution.particular == UNIVERSAL_PHANTOM_UPPER:
+                full_gram_extension_census["phantom_singletons"] += 1
+            elif check.rank_one:
+                full_gram_extension_census["other_rank_one_roots"] += 1
             if check.quartic_gram:
                 rank_one_candidates.add(solution.particular)
                 unique_quartic_gram_state_count += 1
@@ -1060,6 +1702,10 @@ def quartic_closure_pilot(
             else:
                 lower_degree_rank_one_psd_root_count += 1
 
+        if extension_index == 0:
+            full_gram_four_center_unresolved_state_count = (
+                higher_dimensional_state_count
+            )
         states = next_states
         extension_steps.append(
             {
@@ -1122,10 +1768,58 @@ def quartic_closure_pilot(
                 }
             )
 
+    full_gram_obstruction_centers = set(anchors)
+    if extension_values:
+        full_gram_obstruction_centers.add(extension_values[0])
+
+    def rich_at_full_gram_obstruction_centers(
+        candidate: tuple[Fraction, ...],
+    ) -> bool:
+        multiplicities = dict(
+            zip(
+                ts,
+                _full_gram_center_multiplicities(candidate, ts),
+                strict=True,
+            )
+        )
+        return all(
+            multiplicities[center] >= 4
+            for center in full_gram_obstruction_centers
+        )
+
+    full_gram_checked_center_candidates = {
+        candidate
+        for candidate in full_gram_candidates
+        if rich_at_full_gram_obstruction_centers(candidate)
+    }
+    full_gram_pairwise_distinct_candidates = {
+        candidate
+        for candidate in full_gram_checked_center_candidates
+        if not _full_gram_collision_pairs(candidate, ts)
+    }
+    full_gram_strictly_convex_candidates = {
+        candidate
+        for candidate in full_gram_pairwise_distinct_candidates
+        if _strictly_convex_full_gram_sample(candidate, ts)
+    }
+
     return QuarticClosurePilotSummary(
         anchor=anchor_summary,
         extension_centers=extension_values,
         extension_steps=tuple(extension_steps),
+        full_gram_extension_census=tuple(
+            (key, full_gram_extension_census[key])
+            for key in full_gram_extension_census_keys
+        ),
+        full_gram_four_center_unresolved_state_count=(
+            full_gram_four_center_unresolved_state_count
+        ),
+        full_gram_pairwise_distinct_candidate_count=len(
+            full_gram_pairwise_distinct_candidates
+        ),
+        full_gram_strictly_convex_candidate_count=len(
+            full_gram_strictly_convex_candidates
+        ),
         unresolved_affine_state_count=len(states),
         rank_one_quartic_candidate_count=len(rank_one_candidates),
         convex_rank_one_candidate_count=len(convex_candidates),

--- a/tests/test_quartic_marked_root_gram.py
+++ b/tests/test_quartic_marked_root_gram.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from itertools import combinations
 
 import pytest
 
@@ -11,9 +12,17 @@ from scripts.check_quartic_marked_root_gram import (
     normalize_payload,
 )
 from erdos97.quartic_marked_root_gram import (
+    E11_UPPER,
     GRAM_PAIRS,
+    UNIVERSAL_PHANTOM_UPPER,
+    canonical_primitive_upper,
+    classify_full_gram_kernel_direction,
     equations_hold,
     finite_graph_chain_is_strict,
+    full_gram_from_graph_gram,
+    full_gram_squared_distance,
+    full_gram_upper_from_coordinate_coefficients,
+    graph_gram_from_full_gram,
     gram_upper_from_coefficients,
     lifted_squared_distance,
     marked_root_divisibility_check,
@@ -29,6 +38,9 @@ from erdos97.quartic_marked_root_gram import (
     second_derivative_has_constant_sign,
     solve_affine,
     squared_distance,
+    symmetric_matrix_rank,
+    symmetric_matrix_inertia,
+    translate_affine_equations_to_full_gram,
     validate_parameters,
 )
 
@@ -40,6 +52,10 @@ POSITIVE_COEFFICIENTS = (
     Fraction(253, 393120),
 )
 POSITIVE_WITNESSES = (7, 15, 20, 24)
+FULL_GRAM_ANCHOR_RAYS = (
+    (2308, 108, -232, 24, 183, 18, -21, 28, -6, 3),
+    (292, -248, -88, 44, 211, 74, -37, 28, -14, 7),
+)
 
 
 def _upper_from_matrix(matrix: tuple[tuple[int, ...], ...]) -> tuple[Fraction, ...]:
@@ -59,6 +75,171 @@ def test_direct_and_lifted_distances_agree() -> None:
                 center,
                 witness,
             )
+
+
+def test_universal_phantom_annihilates_distances_and_marked_rows() -> None:
+    center = Fraction(1, 3)
+    witnesses = (Fraction(-5, 2), Fraction(-1), Fraction(2), Fraction(7, 3))
+
+    assert all(
+        lifted_squared_distance(UNIVERSAL_PHANTOM_UPPER, center, witness) == 0
+        for witness in witnesses
+    )
+    assert equations_hold(
+        marked_row_equations(center, witnesses),
+        UNIVERSAL_PHANTOM_UPPER,
+    )
+    phantom_check = rank_one_psd_check(UNIVERSAL_PHANTOM_UPPER)
+    assert phantom_check.rank_one
+    assert not phantom_check.positive_semidefinite
+    assert full_gram_from_graph_gram(UNIVERSAL_PHANTOM_UPPER) == (Fraction(0),) * 10
+
+
+def test_full_gram_translation_makes_marked_rows_homogeneous() -> None:
+    graph_equations = marked_row_equations(0, POSITIVE_WITNESSES)
+    full_equations = translate_affine_equations_to_full_gram(graph_equations)
+    graph_gram = gram_upper_from_coefficients(POSITIVE_COEFFICIENTS)
+    full_gram = full_gram_from_graph_gram(graph_gram)
+
+    assert all(row[-1] == 0 for row in full_equations)
+    assert equations_hold(graph_equations, graph_gram)
+    assert equations_hold(full_equations, full_gram)
+    assert graph_gram_from_full_gram(full_gram) == graph_gram
+    assert full_gram_from_graph_gram((0,) * 10) == E11_UPPER
+
+
+def test_coordinate_full_gram_identity_and_constant_term_cancellation() -> None:
+    x_nonconstant = (Fraction(2), Fraction(-1), Fraction(0), Fraction(3))
+    y_nonconstant = (
+        Fraction(1, 2),
+        Fraction(0),
+        Fraction(4),
+        Fraction(-2),
+    )
+    full_gram = full_gram_upper_from_coordinate_coefficients(
+        (x_nonconstant, y_nonconstant)
+    )
+    center = Fraction(-3, 2)
+    witness = Fraction(5, 3)
+
+    def coordinate_value(
+        constant: Fraction,
+        coefficients: tuple[Fraction, ...],
+        parameter: Fraction,
+    ) -> Fraction:
+        return constant + sum(
+            (
+                coefficient * parameter**degree
+                for degree, coefficient in enumerate(coefficients, 1)
+            ),
+            Fraction(0),
+        )
+
+    x_difference = coordinate_value(
+        Fraction(101), x_nonconstant, witness
+    ) - coordinate_value(Fraction(101), x_nonconstant, center)
+    y_difference = coordinate_value(
+        Fraction(-37), y_nonconstant, witness
+    ) - coordinate_value(Fraction(-37), y_nonconstant, center)
+    assert full_gram_squared_distance(full_gram, center, witness) == (
+        x_difference**2 + y_difference**2
+    )
+
+    graph_coefficients = (1, -2, 3, -4)
+    assert full_gram_upper_from_coordinate_coefficients(
+        ((1, 0, 0, 0), graph_coefficients)
+    ) == full_gram_from_graph_gram(
+        gram_upper_from_coefficients(graph_coefficients)
+    )
+
+
+def test_full_gram_kernel_gate_rejects_rank_three_determinant_zero() -> None:
+    direction = _upper_from_matrix(
+        (
+            (1, 0, 0, 0),
+            (0, 1, 0, 0),
+            (0, 0, 1, 0),
+            (0, 0, 0, 0),
+        )
+    )
+    check = classify_full_gram_kernel_direction(direction)
+
+    assert symmetric_matrix_rank(direction) == 3
+    assert check.positive_semidefinite
+    assert not check.admits_nonzero_planar_full_gram
+
+
+def test_full_gram_kernel_gate_rejects_indefinite_rank_two_and_zero() -> None:
+    indefinite = _upper_from_matrix(
+        (
+            (1, 0, 0, 0),
+            (0, -1, 0, 0),
+            (0, 0, 0, 0),
+            (0, 0, 0, 0),
+        )
+    )
+    negative_semidefinite = _upper_from_matrix(
+        (
+            (-1, 0, 0, 0),
+            (0, -2, 0, 0),
+            (0, 0, 0, 0),
+            (0, 0, 0, 0),
+        )
+    )
+    indefinite_check = classify_full_gram_kernel_direction(indefinite)
+    negative_check = classify_full_gram_kernel_direction(negative_semidefinite)
+    zero_check = classify_full_gram_kernel_direction((0,) * 10)
+
+    assert indefinite_check.rank == 2
+    assert not indefinite_check.positive_semidefinite
+    assert not indefinite_check.negative_semidefinite
+    assert not indefinite_check.admits_nonzero_planar_full_gram
+    assert negative_check.negative_semidefinite
+    assert negative_check.admits_nonzero_planar_full_gram
+    assert zero_check.rank == 0
+    assert not zero_check.nonzero
+    assert not zero_check.admits_nonzero_planar_full_gram
+
+
+def test_two_planar_anchor_rays_are_exact_degenerate_controls() -> None:
+    parameters = tuple(range(-4, 5))
+    expected_collisions = (
+        ((-3, 4), (-2, -1), (2, 3)),
+        ((-3, 4), (-2, 3), (-1, 2), (0, 1)),
+    )
+
+    for upper, collisions in zip(
+        FULL_GRAM_ANCHOR_RAYS,
+        expected_collisions,
+        strict=True,
+    ):
+        check = classify_full_gram_kernel_direction(upper)
+        assert check.rank == 2
+        assert check.positive_semidefinite
+        assert check.admits_nonzero_planar_full_gram
+        assert symmetric_matrix_inertia(upper) == (2, 0, 2)
+        assert canonical_primitive_upper(
+            tuple(Fraction(-3, 5) * value for value in upper)
+        ) == upper
+
+        actual_collisions = tuple(
+            (left, right)
+            for left, right in combinations(parameters, 2)
+            if full_gram_squared_distance(upper, left, right) == 0
+        )
+        assert actual_collisions == collisions
+
+        multiplicities = []
+        for center in parameters:
+            distance_counts: dict[Fraction, int] = {}
+            for witness in parameters:
+                if witness == center:
+                    continue
+                distance = full_gram_squared_distance(upper, center, witness)
+                if distance > 0:
+                    distance_counts[distance] = distance_counts.get(distance, 0) + 1
+            multiplicities.append(max(distance_counts.values(), default=0))
+        assert tuple(multiplicities) == (2, 4, 4, 4, 4, 4, 4, 4, 4)
 
 
 def test_exact_one_rich_row_positive_control() -> None:
@@ -237,7 +418,44 @@ def test_tiny_pilot_is_deterministic_and_overlap_cap_closes_it() -> None:
     assert first.anchor.overlap_admissible_count == 0
     assert first.anchor.exceptional_affine_state_count == 0
     assert first.unresolved_affine_state_count == 0
+    assert first.full_gram_four_center_unresolved_state_count == 0
     assert first.strict_finite_full_closure_candidate_count == 0
+
+
+@pytest.mark.slow
+def test_seven_parameter_pilot_exercises_anchor_and_extension_paths() -> None:
+    summary = quartic_closure_pilot(
+        parameters=tuple(range(-3, 4)),
+        anchor_centers=(0, 2, 3),
+        sample_limit=0,
+    )
+
+    assert summary.anchor.raw_triple_count == 3375
+    assert summary.anchor.overlap_admissible_count == 870
+    assert summary.anchor.rank_counts == ((8, 120), (9, 750))
+    assert summary.anchor.exceptional_affine_state_count == 120
+    anchor_full_gram = dict(summary.anchor.full_gram_kernel_census)
+    assert anchor_full_gram["phantom_roots"] == 750
+    assert anchor_full_gram["other_rank_one_roots"] == 0
+    assert anchor_full_gram["planar_kernel_lines"] == 1
+
+    assert len(summary.extension_steps) == 1
+    step = summary.extension_steps[0]
+    assert step["center"] == "-3"
+    assert step["raw_state_row_branches"] == 1800
+    assert step["deduplicated_consistent_affine_states"] == 24
+    assert step["negative_semidefinite_rank_one_roots"] == 24
+    assert step["deduplicated_affine_states_out"] == 0
+
+    extension_full_gram = dict(summary.full_gram_extension_census)
+    assert extension_full_gram["affine_rank_9_states"] == 23
+    assert extension_full_gram["affine_rank_10_states"] == 1
+    assert extension_full_gram["planar_kernel_lines"] == 1
+    assert extension_full_gram["phantom_line_roots"] == 23
+    assert extension_full_gram["phantom_singletons"] == 1
+    assert summary.full_gram_four_center_unresolved_state_count == 0
+    assert summary.full_gram_pairwise_distinct_candidate_count == 0
+    assert summary.unresolved_affine_state_count == 0
 
 
 def test_malformed_inputs_are_rejected() -> None:
@@ -267,8 +485,22 @@ def test_stored_fixed_grid_artifact_contract() -> None:
     payload = load_json(DEFAULT_ARTIFACT)
 
     check_payload(payload, assert_expected=True)
+    assert payload["schema"] == "erdos97.quartic_marked_root_gram.v2"
     assert payload["provenance"]["generator"] == (
         "scripts/check_quartic_marked_root_gram.py"
     )
     assert payload["controls"]["positive_one_rich_row"]["squared_radius"] == "625"
     assert payload["controls"]["higher_rank_psd_relaxation_trap"]["rank_one"] is False
+    full_gram = payload["post_hoc_full_gram_upgrade"]
+    assert full_gram["homogeneous_identity"]["formula"] == "B=A+E11"
+    assert full_gram["anchor_kernel_census"]["planar_kernel_lines"] == 2
+    assert full_gram["extension_kernel_census"]["affine_rank_9_states"] == 314
+    assert full_gram["extension_kernel_census"]["affine_rank_10_states"] == 1
+    assert full_gram["extension_kernel_census"]["planar_kernel_lines"] == 0
+    assert full_gram["outcome"][
+        "unresolved_affine_states_after_four_test_centers"
+    ] == 0
+    assert [
+        candidate["center_multiplicities"]
+        for candidate in full_gram["anchor_planar_rank_two_psd_candidates"]
+    ] == [[2, 4, 4, 4, 4, 4, 4, 4, 4]] * 2

--- a/tests/test_quartic_marked_root_gram.py
+++ b/tests/test_quartic_marked_root_gram.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from scripts.check_quartic_marked_root_gram import (
+    DEFAULT_ARTIFACT,
+    check_payload,
+    load_json,
+    normalize_payload,
+)
+from erdos97.quartic_marked_root_gram import (
+    GRAM_PAIRS,
+    equations_hold,
+    finite_graph_chain_is_strict,
+    gram_upper_from_coefficients,
+    lifted_squared_distance,
+    marked_root_divisibility_check,
+    marked_row_equations,
+    maximum_distance_multiplicity,
+    polynomial_value,
+    quartic_closure_pilot,
+    rank_one_intersection_on_line,
+    rank_one_psd_check,
+    recover_rational_direction,
+    reduced_row_echelon,
+    rich_center_multiplicities,
+    second_derivative_has_constant_sign,
+    solve_affine,
+    squared_distance,
+    validate_parameters,
+)
+
+
+POSITIVE_COEFFICIENTS = (
+    Fraction(-51017, 6552),
+    Fraction(337469, 393120),
+    Fraction(-2503, 65520),
+    Fraction(253, 393120),
+)
+POSITIVE_WITNESSES = (7, 15, 20, 24)
+
+
+def _upper_from_matrix(matrix: tuple[tuple[int, ...], ...]) -> tuple[Fraction, ...]:
+    return tuple(Fraction(matrix[left - 1][right - 1]) for left, right in GRAM_PAIRS)
+
+
+def test_direct_and_lifted_distances_agree() -> None:
+    for coefficients in (
+        (1, 0, 0, 0),
+        (1, -2, 3, -4),
+        (Fraction(2, 3), Fraction(-5, 7), Fraction(11, 13), Fraction(17, 19)),
+    ):
+        upper = gram_upper_from_coefficients(coefficients)
+        for center, witness in ((-3, 2), (0, 4), (Fraction(1, 2), Fraction(-7, 3))):
+            assert lifted_squared_distance(upper, center, witness) == squared_distance(
+                coefficients,
+                center,
+                witness,
+            )
+
+
+def test_exact_one_rich_row_positive_control() -> None:
+    upper = gram_upper_from_coefficients(POSITIVE_COEFFICIENTS)
+    equations = marked_row_equations(0, POSITIVE_WITNESSES)
+
+    assert [
+        squared_distance(POSITIVE_COEFFICIENTS, 0, witness)
+        for witness in POSITIVE_WITNESSES
+    ] == [Fraction(625)] * 4
+    assert equations_hold(equations, upper)
+    assert marked_root_divisibility_check(0, POSITIVE_WITNESSES, upper)
+    assert rank_one_psd_check(upper).quartic_gram
+    assert second_derivative_has_constant_sign(POSITIVE_COEFFICIENTS, 0, 24)
+    assert finite_graph_chain_is_strict(
+        POSITIVE_COEFFICIENTS,
+        (0, *POSITIVE_WITNESSES),
+    )
+    assert maximum_distance_multiplicity(
+        upper,
+        0,
+        (0, *POSITIVE_WITNESSES),
+    ) == 4
+    assert rich_center_multiplicities(upper, (0, *POSITIVE_WITNESSES)) == (4, 1, 1, 1, 1)
+
+
+def test_marked_divisibility_rejects_perturbed_row() -> None:
+    upper = gram_upper_from_coefficients(POSITIVE_COEFFICIENTS)
+    perturbed = (7, 15, 20, 23)
+    assert not equations_hold(marked_row_equations(0, perturbed), upper)
+    assert not marked_root_divisibility_check(0, perturbed, upper)
+
+
+def test_payload_normalization_matches_json_round_trip() -> None:
+    assert normalize_payload({"sample": ((1, 2),)}) == {"sample": [[1, 2]]}
+
+
+def test_rref_is_canonical_and_exposes_nullspace() -> None:
+    first = (1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 3)
+    second = (0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 4)
+    scaled_first = tuple(5 * value for value in first)
+
+    expected = reduced_row_echelon((first, second))
+    assert expected == reduced_row_echelon((second, scaled_first, first))
+
+    solution = solve_affine((first, second))
+    assert solution is not None
+    assert solution.rank == 2
+    assert solution.dimension == 8
+    assert solution.pivots == (0, 1)
+    for row in (first, second):
+        assert equations_hold((tuple(Fraction(value) for value in row),), solution.particular)
+        for vector in solution.nullspace:
+            homogeneous = tuple(Fraction(value) for value in row[:-1]) + (Fraction(0),)
+            assert equations_hold((homogeneous,), vector)
+
+
+def test_rref_detects_inconsistent_and_ignores_zero_rows() -> None:
+    zero = (0,) * 11
+    inconsistent = (0,) * 10 + (1,)
+
+    assert reduced_row_echelon((zero,)) == ()
+    assert reduced_row_echelon((zero, inconsistent)) is None
+    assert solve_affine((inconsistent,)) is None
+
+
+def test_rank_one_psd_gate_separates_relaxation_failures() -> None:
+    quartic = gram_upper_from_coefficients((1, 2, 3, 4))
+    cubic = gram_upper_from_coefficients((1, 2, 3, 0))
+    negative_quartic = tuple(-value for value in quartic)
+    high_rank_psd = _upper_from_matrix(
+        (
+            (1, 0, 0, 0),
+            (0, 1, 0, 0),
+            (0, 0, 0, 0),
+            (0, 0, 0, 0),
+        )
+    )
+    zero = (0,) * 10
+
+    assert rank_one_psd_check(quartic).quartic_gram
+    assert rank_one_psd_check(high_rank_psd).positive_semidefinite
+    assert not rank_one_psd_check(high_rank_psd).rank_one
+    assert rank_one_psd_check(negative_quartic).rank_one
+    assert not rank_one_psd_check(negative_quartic).positive_semidefinite
+    assert rank_one_psd_check(cubic).rank_one
+    assert rank_one_psd_check(cubic).positive_semidefinite
+    assert not rank_one_psd_check(cubic).degree_four
+    assert not rank_one_psd_check(zero).rank_one
+
+
+def test_recovery_accepts_nonsquare_rational_scale() -> None:
+    base = gram_upper_from_coefficients((1, 2, 3, 4))
+    scaled = tuple(Fraction(2) * value for value in base)
+    direction = recover_rational_direction(scaled)
+
+    assert direction == (Fraction(1), Fraction(2), Fraction(3), Fraction(4))
+
+
+@pytest.mark.parametrize(
+    ("particular", "direction", "kind", "parameters"),
+    (
+        (
+            ((0, 0, 0, 0), (0, 1, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            ((1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            "RATIONAL_PARAMETERS",
+            (Fraction(0),),
+        ),
+        (
+            ((0, 1, 0, 0), (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            "RATIONAL_PARAMETERS",
+            (Fraction(-1), Fraction(1)),
+        ),
+        (
+            ((0, 1, 0, 0), (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            ((1, 0, 0, 0), (0, -1, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            "NO_REAL_RANK_ONE",
+            (),
+        ),
+        (
+            ((0, 1, 0, 0), (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            ((1, 0, 0, 0), (0, 2, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            "IRRATIONAL_REAL_QUADRATIC",
+            (),
+        ),
+        (
+            ((0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            ((1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0)),
+            "ALL_PARAMETERS_RANK_AT_MOST_ONE",
+            (),
+        ),
+    ),
+)
+def test_rank_one_line_classifications(
+    particular: tuple[tuple[int, ...], ...],
+    direction: tuple[tuple[int, ...], ...],
+    kind: str,
+    parameters: tuple[Fraction, ...],
+) -> None:
+    result = rank_one_intersection_on_line(
+        _upper_from_matrix(particular),
+        _upper_from_matrix(direction),
+    )
+
+    assert result.kind == kind
+    assert result.rational_parameters == parameters
+
+
+def test_rank_one_line_can_have_no_common_minor_root() -> None:
+    particular = _upper_from_matrix(
+        ((0, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 0))
+    )
+    direction = _upper_from_matrix(
+        ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0))
+    )
+
+    assert rank_one_intersection_on_line(particular, direction).kind == "NO_RANK_ONE"
+
+
+def test_convexity_gate_accepts_isolated_zeros_and_rejects_sign_changes() -> None:
+    assert second_derivative_has_constant_sign((0, 0, 0, 1), -1, 1)
+    assert second_derivative_has_constant_sign((0, 0, 1, 0), 0, 1)
+    changing = (0, Fraction(-1, 2), 0, Fraction(1, 12))
+    assert not second_derivative_has_constant_sign(changing, -2, 2)
+    assert second_derivative_has_constant_sign(changing, Fraction(-1, 2), Fraction(1, 2))
+    assert not second_derivative_has_constant_sign((1, 0, 0, 0), -1, 1)
+
+
+def test_tiny_pilot_is_deterministic_and_overlap_cap_closes_it() -> None:
+    first = quartic_closure_pilot(parameters=(0, 1, 2, 3, 4), anchor_centers=(0, 1, 2))
+    second = quartic_closure_pilot(parameters=(0, 1, 2, 3, 4), anchor_centers=(0, 1, 2))
+
+    assert first == second
+    assert first.anchor.raw_triple_count == 1
+    assert first.anchor.overlap_admissible_count == 0
+    assert first.anchor.exceptional_affine_state_count == 0
+    assert first.unresolved_affine_state_count == 0
+    assert first.strict_finite_full_closure_candidate_count == 0
+
+
+def test_malformed_inputs_are_rejected() -> None:
+    with pytest.raises(ValueError, match="at least five"):
+        validate_parameters((0, 1, 2, 3))
+    with pytest.raises(ValueError, match="distinct"):
+        validate_parameters((0, 1, 2, 3, 3))
+    with pytest.raises(ValueError, match="increasing"):
+        validate_parameters((0, 2, 1, 3, 4))
+    with pytest.raises(ValueError, match="four distinct"):
+        marked_row_equations(0, (1, 1, 2, 3))
+    with pytest.raises(ValueError, match="center"):
+        marked_row_equations(0, (0, 1, 2, 3))
+    with pytest.raises(ValueError, match="increasing"):
+        marked_row_equations(0, (2, 1, 3, 4))
+    with pytest.raises(ValueError, match="direction"):
+        rank_one_intersection_on_line((0,) * 10, (0,) * 10)
+
+
+def test_polynomial_value_rejects_wrong_coefficient_count() -> None:
+    with pytest.raises(ValueError, match="length four"):
+        polynomial_value((1, 2, 3), 4)
+
+
+@pytest.mark.artifact
+def test_stored_fixed_grid_artifact_contract() -> None:
+    payload = load_json(DEFAULT_ARTIFACT)
+
+    check_payload(payload, assert_expected=True)
+    assert payload["provenance"]["generator"] == (
+        "scripts/check_quartic_marked_root_gram.py"
+    )
+    assert payload["controls"]["positive_one_rich_row"]["squared_radius"] == "625"
+    assert payload["controls"]["higher_rank_psd_relaxation_trap"]["rank_one"] is False


### PR DESCRIPTION
## Summary

- preserve the original predeclared exact obstruction for degree-four polynomial graphs on `T={-4,-3,...,4}`
- add a post-hoc full coefficient-Gram interpretation `B=C^T C=E11+A`, making every marked-row equation homogeneous
- correct the terminal accounting from “315 affine lines” to 314 affine lines plus one rank-ten singleton
- regenerate and register a schema-v2 exact certificate with rank, determinant, inertia, collision, and phantom-root invariants

## Stronger exact result

For every real planar polynomial map of coordinate degree at most four sampled at nine equally spaced parameters, if the nine sampled points are pairwise distinct, then at least one of the four normalized centers `-4,0,3,4` is not four-rich. Convexity is not used. Affine reparameterization gives the same result for every real nine-term arithmetic progression.

The key correction is that every previously reported negative-semidefinite graph-Gram root is the same universal point

```
A* = -E11,
```

which becomes the zero full Gram `B=0`. It is a homogenization base point, not a family of distinct geometric obstructions.

The exact full-Gram census is:

- 199,349 rigid anchor occurrences: kernel ranks 2/3/4 are 279/91/198,979
- exactly two planar PSD rank-two anchor rays; both have collisions and positive-radius multiplicities `(2,4,4,4,4,4,4,4,4)`, so both fail center `-4`
- 2,729 canonical rank-eight anchor states
- center-`-4` extension: 314 rank-nine lines plus one rank-ten singleton
- terminal kernels: 11 rank-two indefinite and 303 rank-four; zero nonzero planar Gram rays
- zero unresolved four-center states and zero pairwise-distinct planar candidates

## Scope

This is a restricted arithmetic-progression polynomial-parametrization lemma. It does not cover irregular parameter sets, degree above four, higher-dimensional samples, implicit/general algebraic quartics, multi-arc constructions, arbitrary strictly convex polygons, or prove/counterexample Erdos Problem #97. No global source-of-truth status is changed.

## Review follow-up

This revision addresses the prior review’s substantive findings:

- explicitly identifies and asserts the universal `A*=-E11` phantom
- separates 314 line-root occurrences from the singleton
- adds exact full-Gram feasibility and inertia checks
- adds a nonempty seven-parameter slow regression that exercises anchor enumeration, line classification, deduplication, extension, and candidate rejection

## Validation

- exact schema-v2 generation: `python scripts/check_quartic_marked_root_gram.py --write-artifact --check --assert-expected`
- independent from-disk exact replay: `python scripts/check_quartic_marked_root_gram.py --check --assert-expected`
- focused tests: 60 passed
- full Ruff, text cleanliness, artifact provenance manifest, audit registration, and diff checks passed
- artifact: 19,389 bytes, SHA-256 `bd4bb0b3621cacfcdca3724c39adaefae44b60a455b607db60c83c38edb08e33`

The repository-wide historical artifact audit was not run to completion because it launches 256 unrelated research commands; the new exact replay and its focused provenance/audit tests were run in full.