### PR TITLE
Compress seeded full-cone certificates

### DIFF
--- a/data/runs/sparse_full_cone_seeded_compression_2026-07-29/README.md
+++ b/data/runs/sparse_full_cone_seeded_compression_2026-07-29/README.md
@@ -1,0 +1,33 @@
+# Sparse full-cone seeded certificate compression (2026-07-29)
+
+`summary.json` records deterministic randomized compression of the sixteen
+exact C25/C29 certificates in the seeded full-cone CEGAR packet, followed by
+direct and translation-orbit coverage over all 48 stored fresh orders.
+
+The checker:
+
+- verifies the source seeded-CEGAR artifact SHA-256;
+- exact-replays all 16 compressed positive circuits;
+- exact-replays all 432 quotient-preserving affine certificate images;
+- reconstructs the 48 target orders from the source packet;
+- recomputes direct and translation-orbit coverage;
+- recomputes the quotient-vector overlap ledger.
+
+Expected summary: 48 verified target orders, 16 verified compressed exact
+certificates, and 432 verified exact affine certificate images.
+
+Artifact SHA-256:
+
+```text
+7abd2868e3bd7fad660dbd76fbfa5167dd15040c72c228b6e032a619618fd211
+```
+
+Replay:
+
+```bash
+python scripts/exploration/compress_sparse_full_cone_seeded_certificates.py \
+  --check data/runs/sparse_full_cone_seeded_compression_2026-07-29/summary.json
+```
+
+This is bounded fixed-pattern evidence. It is not an all-order obstruction,
+geometric realization result, counterexample, or proof of Erdos Problem #97.

--- a/data/runs/sparse_full_cone_seeded_compression_2026-07-29/summary.json
+++ b/data/runs/sparse_full_cone_seeded_compression_2026-07-29/summary.json
@@ -1,0 +1,21975 @@
+{
+  "claim_scope": "Randomized alternative-circuit search for sixteen fixed C25/C29 patterns and orders, followed by exact direct and translation-orbit coverage over forty-eight stored orders. Retained certificates and images are exact, but the search is not exhaustive and does not prove an all-order obstruction, geometric realizability, a counterexample, or Erdos Problem #97.",
+  "configuration": {
+    "per_model_seed_stride": 1000,
+    "per_pattern_seed_stride": 100000,
+    "seed": 20260729,
+    "target_order_selection": "all counterfactual probe and seeded CEGAR models",
+    "tolerance": 1e-09,
+    "trials_per_model": 24
+  },
+  "runs": [
+    {
+      "circulant_offsets": [
+        2,
+        5,
+        9,
+        14
+      ],
+      "compressed_models": [
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "a05729c302ae78e56519087df8d932694361d50708fef38d83ecbb9538f246eb",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 0,
+            "source_order": [
+              0,
+              18,
+              11,
+              4,
+              22,
+              15,
+              8,
+              1,
+              19,
+              12,
+              5,
+              23,
+              16,
+              9,
+              2,
+              20,
+              13,
+              6,
+              24,
+              17,
+              10,
+              3,
+              21,
+              14,
+              7
+            ],
+            "source_unique_ordered_quad_count": 7,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 20,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:0"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:0",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 25,
+                "target_id": "seeded:0"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              18,
+              11,
+              4,
+              22,
+              15,
+              8,
+              1,
+              19,
+              12,
+              5,
+              23,
+              16,
+              9,
+              2,
+              20,
+              13,
+              6,
+              24,
+              17,
+              10,
+              3,
+              21,
+              14,
+              7
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  8,
+                  5,
+                  14
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  5,
+                  2,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  16,
+                  14,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  5,
+                  13,
+                  10
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  14
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  2,
+                  10,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 7,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 7
+          },
+          "compressed_positive_inequalities": 7,
+          "compressed_unique_ordered_quad_count": 7,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 143,
+              "seed": 20260729,
+              "trial": 0,
+              "unique_ordered_quad_count": 143
+            },
+            {
+              "positive_inequalities": 140,
+              "seed": 20260731,
+              "trial": 2,
+              "unique_ordered_quad_count": 140
+            },
+            {
+              "positive_inequalities": 112,
+              "seed": 20260732,
+              "trial": 3,
+              "unique_ordered_quad_count": 111
+            },
+            {
+              "positive_inequalities": 7,
+              "seed": 20260749,
+              "trial": 20,
+              "unique_ordered_quad_count": 7
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "112": 2,
+            "113": 1,
+            "118": 1,
+            "120": 1,
+            "123": 1,
+            "126": 1,
+            "127": 3,
+            "129": 1,
+            "130": 1,
+            "132": 3,
+            "137": 1,
+            "140": 2,
+            "143": 2,
+            "147": 1,
+            "151": 1,
+            "155": 1,
+            "7": 1
+          },
+          "numerical_support_size_max": 155,
+          "numerical_support_size_min": 7,
+          "order": [
+            0,
+            18,
+            11,
+            4,
+            22,
+            15,
+            8,
+            1,
+            19,
+            12,
+            5,
+            23,
+            16,
+            9,
+            2,
+            20,
+            13,
+            6,
+            24,
+            17,
+            10,
+            3,
+            21,
+            14,
+            7
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 6,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 6,
+            "support_size": 7
+          },
+          "quad_reduction": 181,
+          "quad_reduction_fraction": 0.9627659574468085,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "26dfb2e8b2dedadbc54dbb13e3c5f33e228a5c85bb1f10b678fd1f7e299fcf39",
+              "679de7afd00291e7b4ca9a737071439eab90048459b303fff11f3372d46d5c2c",
+              "7037f5f7455eee6378b19b5e6279b7d19c2e65309f324cdfaf24f462563dba17",
+              "7856dee41217a796496e0b0404ece9aa6b91e9f7ebe41d83a569ec8a8e3911fc",
+              "857c13b00ca25b4aa68d5407fe8a9bebe64107ffc3765763d180250c5c6daf8c",
+              "bb4836271654ca58205acef8c9a3aee21eeaa5d4c2a3ca3d4c212f4cd3f5f5ae",
+              "d3cb9e459e7b4a560f8b5ff27076bff3c7bcd5b99e68fb53d42eefb131956f40"
+            ],
+            "unique_vector_count": 7
+          },
+          "random_objective_seed": 20260729,
+          "source_model_index": 0,
+          "source_positive_inequalities": 188,
+          "source_target_id": "seeded:0",
+          "source_unique_ordered_quad_count": 188,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "ca4231a17148e0eac6a71451a8228cc87056a2e14c9d2e94c4fafdd4d6ed345b",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 1,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              15,
+              7,
+              4,
+              1,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "source_unique_ordered_quad_count": 116,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 14,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:1"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:1",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:1"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              15,
+              7,
+              4,
+              1,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  22,
+                  9
+                ],
+                "weight": 5738
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  7,
+                  12
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  1,
+                  12
+                ],
+                "weight": 35201
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  2,
+                  20
+                ],
+                "weight": 1925
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  15,
+                  6
+                ],
+                "weight": 3131
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  12,
+                  17
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  15,
+                  3
+                ],
+                "weight": 2607
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  6,
+                  17
+                ],
+                "weight": 3131
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  5,
+                  20
+                ],
+                "weight": 1728
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  7
+                ],
+                "weight": 37956
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  2,
+                  24
+                ],
+                "weight": 3720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  2,
+                  10
+                ],
+                "weight": 1739
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  15
+                ],
+                "weight": 5459
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  10,
+                  21
+                ],
+                "weight": 1739
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  12
+                ],
+                "weight": 279
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 3374
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  23,
+                  12
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  9,
+                  6
+                ],
+                "weight": 35201
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  8,
+                  22,
+                  19
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  8,
+                  16,
+                  3
+                ],
+                "weight": 3407
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  22,
+                  7,
+                  20
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  22,
+                  23,
+                  3
+                ],
+                "weight": 4556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  19,
+                  16,
+                  17
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  16,
+                  23,
+                  17
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  9,
+                  17,
+                  3
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  19,
+                  15
+                ],
+                "weight": 4346
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  2,
+                  9
+                ],
+                "weight": 3374
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  10,
+                  18
+                ],
+                "weight": 107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  18,
+                  7
+                ],
+                "weight": 107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  7,
+                  20
+                ],
+                "weight": 4244
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  2,
+                  3
+                ],
+                "weight": 4346
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  6,
+                  17
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  16,
+                  10
+                ],
+                "weight": 107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  16,
+                  7
+                ],
+                "weight": 1006
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  13,
+                  24
+                ],
+                "weight": 3722
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  24,
+                  15,
+                  23
+                ],
+                "weight": 11288
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  7,
+                  12
+                ],
+                "weight": 8157
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  23,
+                  12
+                ],
+                "weight": 11288
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  16,
+                  2
+                ],
+                "weight": 2757
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  16,
+                  13
+                ],
+                "weight": 1589
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  16,
+                  23
+                ],
+                "weight": 4556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  2,
+                  3
+                ],
+                "weight": 20357
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  18,
+                  3
+                ],
+                "weight": 4277
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  20,
+                  3
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  10,
+                  6
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  6,
+                  17
+                ],
+                "weight": 23535
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  2,
+                  9
+                ],
+                "weight": 5495
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  10,
+                  18
+                ],
+                "weight": 4868
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  24,
+                  10
+                ],
+                "weight": 20140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  10,
+                  15
+                ],
+                "weight": 11900
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  10,
+                  4
+                ],
+                "weight": 2955
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  18,
+                  7
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  21,
+                  9
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  15,
+                  23
+                ],
+                "weight": 11900
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  7,
+                  6
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  15,
+                  9,
+                  20
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  1,
+                  17,
+                  3
+                ],
+                "weight": 15416
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  24,
+                  17
+                ],
+                "weight": 305
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  15
+                ],
+                "weight": 4346
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  6,
+                  3
+                ],
+                "weight": 31623
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  2,
+                  24,
+                  4
+                ],
+                "weight": 26558
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  24,
+                  6
+                ],
+                "weight": 3722
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  10,
+                  4
+                ],
+                "weight": 2471
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  7,
+                  4
+                ],
+                "weight": 4137
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  18,
+                  1
+                ],
+                "weight": 2364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  21,
+                  17,
+                  3
+                ],
+                "weight": 765
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  9,
+                  3
+                ],
+                "weight": 2364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  15,
+                  4,
+                  6
+                ],
+                "weight": 6608
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  15,
+                  6
+                ],
+                "weight": 31032
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  17,
+                  3
+                ],
+                "weight": 6344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  21
+                ],
+                "weight": 5769
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  10,
+                  15
+                ],
+                "weight": 26686
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  21,
+                  12
+                ],
+                "weight": 14371
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  15,
+                  4,
+                  20
+                ],
+                "weight": 15651
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  15,
+                  12,
+                  20
+                ],
+                "weight": 1728
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  4,
+                  20,
+                  6
+                ],
+                "weight": 15651
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  23,
+                  12,
+                  3
+                ],
+                "weight": 12643
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  10,
+                  21,
+                  17
+                ],
+                "weight": 3720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  7,
+                  3
+                ],
+                "weight": 3755
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  20,
+                  17
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  4,
+                  6,
+                  17
+                ],
+                "weight": 24126
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  20,
+                  17,
+                  3
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  7,
+                  3
+                ],
+                "weight": 6271
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  23,
+                  9
+                ],
+                "weight": 5147
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  17
+                ],
+                "weight": 3720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  21,
+                  15
+                ],
+                "weight": 1148
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  7,
+                  9
+                ],
+                "weight": 348
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  21,
+                  6
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  18,
+                  15,
+                  3
+                ],
+                "weight": 1148
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  7,
+                  20
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  21,
+                  15,
+                  12
+                ],
+                "weight": 5769
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  15,
+                  4,
+                  17
+                ],
+                "weight": 17669
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  15,
+                  9,
+                  6
+                ],
+                "weight": 3722
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  4,
+                  23,
+                  9
+                ],
+                "weight": 5147
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  12,
+                  20,
+                  3
+                ],
+                "weight": 1925
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  4,
+                  1
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  1,
+                  20
+                ],
+                "weight": 591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  15,
+                  4,
+                  17
+                ],
+                "weight": 6457
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  7,
+                  17
+                ],
+                "weight": 4485
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  4,
+                  12
+                ],
+                "weight": 174
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  1,
+                  23
+                ],
+                "weight": 23188
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  12,
+                  9
+                ],
+                "weight": 939
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  12,
+                  17,
+                  3
+                ],
+                "weight": 765
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  4,
+                  1
+                ],
+                "weight": 2955
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  18,
+                  4,
+                  3
+                ],
+                "weight": 765
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  1,
+                  3
+                ],
+                "weight": 11799
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  6,
+                  17
+                ],
+                "weight": 1182
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  1,
+                  20
+                ],
+                "weight": 35792
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 7914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  20,
+                  17
+                ],
+                "weight": 1182
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  23,
+                  12,
+                  17
+                ],
+                "weight": 5943
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  12,
+                  9,
+                  20
+                ],
+                "weight": 1925
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  9,
+                  6,
+                  3
+                ],
+                "weight": 1773
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  23,
+                  17,
+                  3
+                ],
+                "weight": 13857
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 36974
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 116,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 802552
+          },
+          "compressed_positive_inequalities": 116,
+          "compressed_unique_ordered_quad_count": 116,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 160,
+              "seed": 20261729,
+              "trial": 0,
+              "unique_ordered_quad_count": 160
+            },
+            {
+              "positive_inequalities": 147,
+              "seed": 20261730,
+              "trial": 1,
+              "unique_ordered_quad_count": 146
+            },
+            {
+              "positive_inequalities": 133,
+              "seed": 20261731,
+              "trial": 2,
+              "unique_ordered_quad_count": 133
+            },
+            {
+              "positive_inequalities": 132,
+              "seed": 20261732,
+              "trial": 3,
+              "unique_ordered_quad_count": 132
+            },
+            {
+              "positive_inequalities": 130,
+              "seed": 20261736,
+              "trial": 7,
+              "unique_ordered_quad_count": 129
+            },
+            {
+              "positive_inequalities": 121,
+              "seed": 20261739,
+              "trial": 10,
+              "unique_ordered_quad_count": 121
+            },
+            {
+              "positive_inequalities": 116,
+              "seed": 20261743,
+              "trial": 14,
+              "unique_ordered_quad_count": 116
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "116": 1,
+            "117": 1,
+            "121": 1,
+            "123": 1,
+            "128": 1,
+            "130": 3,
+            "131": 1,
+            "132": 1,
+            "133": 1,
+            "138": 1,
+            "140": 1,
+            "141": 1,
+            "144": 1,
+            "145": 2,
+            "147": 1,
+            "150": 1,
+            "151": 1,
+            "152": 1,
+            "157": 1,
+            "160": 2
+          },
+          "numerical_support_size_max": 160,
+          "numerical_support_size_min": 116,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            15,
+            7,
+            4,
+            1,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 115,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 115,
+            "support_size": 116
+          },
+          "quad_reduction": 86,
+          "quad_reduction_fraction": 0.42574257425742573,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "02b6dae0b100820d0747056ca1b82c8b3dee729f4e2e9430e77c7c4849329165",
+              "0423c2d39264fc317149630872584d7096a8023bededcfdfeabda9107b696182",
+              "067e850b3f7fc59a0865c7d7134a862eb9a240498e86e0927bc97a4d3413658a",
+              "06a5d39359f87157ca2271b2cbc18b90ad2c3f80817f0b0e4361f60980e08dbd",
+              "0b382927462c76e9b307bc8a18b6796e236ccc1e2d80c97fc87d6ff3ac9578a3",
+              "0c97522ccb7a6c421ed7ed9210e388957f772c5e54aed731fbc4f5823fca01d8",
+              "0d8ce5d3ee301e714d0b4cf64fb50ad6477088738777ac5988da538f1f0e81a1",
+              "0e3336c29bcbeba508f609be50159cf006b1586b519e27888bd9085c11c64be9",
+              "113f43219ae3512dece6d23e791f3b09c4e15e9deb1965d32fdde998b5f71319",
+              "11da6d07960979c356196d4b26fcf9b0392e91cffa2a32618b19bd01f439dae7",
+              "16117d959275062fe0af3f7068d9102d75c992f64c960fc3bf59b27ca424d964",
+              "19697671be201a9516fe2fe0bd54fab9bdd5d3a74ce6b0893e878a753b2042c1",
+              "19ccbf7b79ef23d17b9df2271966362a81d912a6febf97164fcddf31d2304775",
+              "1f03e0c61080535ef2b76b2f2a597a12a22789b97d658b6c34ed7438b5107340",
+              "20d04f72cbd1642f23d507e034d750094a8447e0678bc41cb220ccb42f135952",
+              "22be39e4ec8876f259d428109bcc9cbe4ba55c3f90783abfdcafa625cc628603",
+              "2413d4f498d7e85df82c07a47c7bc31efeb3a18ddda4772a80bde1e95f6a04fb",
+              "270b4ba405fd1cc09c8dc4d1580baf0680a175a5cc85fd4204f6aa71697b2c0c",
+              "2a47ffffc6e5b7f57c1977f2dd39656b01699d2733bafe3cabb16d563c74a56e",
+              "2d0841f0b868ded78d7339318988ac08a7ea4ce43adae867ef2dfb19edf6760d",
+              "2e279c8999174f4020890f041ea2aea59b9216035b56bd2dda5c6b5600ce0686",
+              "2f5ebe4184cb21df433593a6b884d88e432b11b16a114ae589f8d5d132d081e7",
+              "3e4df8ce43157e6164500e771c58d4dee0725f2cdf1098df91175189d8fc57b8",
+              "41c704eba06fbda675d0ad5e5850e629342e3aec2c687f09ca14e157e2dbe340",
+              "43afc59caf0e6c94ed1054967aaae28a72c965aed1122f39890ad565f9fb9ef1",
+              "43d442229a7b317835ffe2a7010ecd2b2d0f674824826dcbae49f6adabb6b3e0",
+              "4730d6c18ddfa0b01fa015530addec4d791830b662c0029a53cb9189709ea132",
+              "4888908461d2f9ecbb2bcbd092be11a6bdeef38d8007d1adc22b77ee74226ffd",
+              "4a0cc08507c7919d94e319ebb8e33b615faccad1fc3288c3de559f67626c74f9",
+              "4f4b75deb9c694f9c8e6314f120396901b401a7f7ccef7e7801aa35a82aebc3b",
+              "507599b2783cb2812064e602b939cc6619f16984e3b08569fe05003619654a28",
+              "50b018facf899e2a556efcb5e207e52afce95bc1d230b969cef76f4a80b7184a",
+              "50e4ef3f21a2ea5c5d71f3614132620d5199e8b33c0b37785775201a121b61f2",
+              "5300db57aeb7355c8a2333c7674d7edff75cb21cd9fd04cd00aeb96008060374",
+              "57c7459f347fa6ba1fce15407b93447ebeeb37b481f65a57bdde55c5c202a3db",
+              "5e2f79843c404ea897953469d3d2d57ee1ba135d6075acd7b72b33e3193a3a56",
+              "5fe24afd5b4b1bc77a24e51596c3a5930e3b576181da79f0c29cc7d002d63e95",
+              "610664c677016aeb2221226df9f3fe5c4202ecb68dea163e67d32156a1e3602f",
+              "62b120c60f1df03ac7753559c000d627fbc8e8cffdca60d759b12007fc201035",
+              "62d1be9565d649d7c8e9753eadee8aa806f228f4b61d7f739971e5f7c31c2d81",
+              "638661d2efe705a91af67744d23fda82f81b05e51b829744ff7d7d481abb0647",
+              "64c90c8c03721326b10dc8140ec57363de3969eba4b482747e904c139b344877",
+              "66c10ae172168cc31777c50a43d991b5829f2df243e2bdf1ff9d23976f315886",
+              "695a06d33bb3edf85123a56cef91b3c8ef6a2b7992fcd4fc5d69fd76f6d7c241",
+              "6aa185b7139a19ff8da6cbaa7752453818473f4f6565dfbceeb1d19d580ca71f",
+              "6c5307e190db797b0650fd13cd8e63367e4f2f678816de8920f3bc8768d43613",
+              "6ed3e5541800792c539eeda7f60cc65559b0ac5531a4ad311ae8b822911485e3",
+              "6f308037a1afd39b631842d7f4b58b6f832499562a82fc07a5d856ad37890766",
+              "753160dbc0419f974fbbab94cdfb47a1dd8ad811d9f405b9c69137c241d23817",
+              "75494c17def58ccbabfdd91d4a342171dac9300e4811772c97aa4c7313c7eafc",
+              "7681b82957066b870aa6a5f0db03fb619b129d5b6253633ce2825624d11deb1c",
+              "7930eaae6774e4d28a52a88bbeb994380384b302118d53ecbee2826645f6a4f2",
+              "7a368a94946c66d48aa136786d94635560aaff303e4864b8422b5e29d7ef70d5",
+              "7dd0c364654e34a2973bd7c036ae69afa143af95f529a60c92482bebc2d147a6",
+              "7e7df4e46b4d5b0b3c94480f23d000acbf129d8d83477651b66eaaabb04ca2c1",
+              "7fa0ba0b89a65c0e95df9f5953b90203e14cf7bf5ce8ae7f0ee97dccdde56a01",
+              "805eb64cbdce4534a832775e71594ef09b2cace30f273dadba95b6c765f6c3da",
+              "82abc28c22bae2fa4df3c34105c95f9b06165338a1e68b51c4d6bfc5b8a1fd09",
+              "8542b33069c2a3ce97b9b3d8aca4eb4e36ada7d1900402ecfa7484d534894171",
+              "89fd83f86649367c3c2ef2c61dd11bb4a4319fcedf5269d52c350ba587be5791",
+              "8a6892cdf165330112c53f190b3fcf2afa9cd3b989a948d51f3913cc9771dba7",
+              "8bb19f93fc15e5ddab26e3a89e6f08d27f0fb7ffb3dda1ba7058e79e85397552",
+              "8bfe0872f40fecf48ac0f01a5d3413398da77d0c2631aee7c46e28185956c692",
+              "9139b3b00af0d484622ddfe9d74efa8c0b0c9bcc658c69dfdc4692b3348714d1",
+              "951b82ccb0365baa951a3481054a1dc39ab192452a45352804b45146233221b6",
+              "97bd31091d697b912f14a3bbc84bc648e18a960c70a00e5b4bf61ec231690cba",
+              "9a05cc2a80cc6a1962c75c7363203953ba9026d8e569488bf5a29e4ddae07e65",
+              "a38c31fb971a73473467e2e57cf034506dd45325e5c8babd61c020e6ef50d684",
+              "a9edde803d7eb949c3b313bdacb306ecbf972305b5c3f90a3faba80236f54a8d",
+              "af18cbbdd49de5bcc19a0662e6b972837bdde15c41acd26591971fd67bcb515f",
+              "af57924add56befbda9dc42b2ee3b4dfbb5d38ab4b390562a82040b444f89c5a",
+              "b71d348b05e8435ae4fddd75e73e100ec4f2b986bb91fb480028627baa4df137",
+              "b771f4705e7d0273395dee4b31b10bb5e95f11b29fb7e049b33440c9b2509f6e",
+              "ba279f3b625d25ce1c8f92634519ed414698385c7bf9828bcceebeb420fb93ad",
+              "ba7263249c8bad41660c2190595e14d7430790c435ae185da6e3391835700d3a",
+              "bf143c7f677e123a7f4ebce3844c1dfd2067cc578baced1905d9fd72515d7071",
+              "c3cceacd2a4e0e55f14c30ae18e67f825d215198f914f87f0c851164ecb50c3c",
+              "c5bdcd3d6b533e6122d6df9d0b246fbd42950b71beba08749f0b159d29f1f59a",
+              "c86d10039250e9fb38728cc4d221c6d81e2684bbdb0da1142b62aeea7a2e07d6",
+              "c9ec5ec92ba087b432f37fb3b4c3efa96523241fd290382b0609b0bc38dbc772",
+              "caa807d0409f8126bb1a1bad7c25da3fa369e19b54ebdc7e987bd99efd282edd",
+              "cbc91c03ba3f1b7e8d5036cdb6e363b712f88e9849136b6a9dcaed4093cf1c79",
+              "cc4f5edd1efbbf9f2dc020efcb25cd0ec86eed585876eaceb3343523b6e363be",
+              "d00fb14dd40bbf923ead15e9414d18e19acafa4e0e4b8026fed04de0518b66c4",
+              "d31a3ea59874d5a18b23d5ebb43e9a4c2d66043fb315fcdad482e181781114f6",
+              "d53e8af0f7bd09af565f6ecfb97fc86bf01cb88ce4aaef81a20292a681c9fd48",
+              "d54b4956a2ac6051c86c224c09c8c5ea254284ed5911b27ad1cac3b468a8a8ca",
+              "d6e79e7ebedf5d27a6c1a1054825e9e5f587484021ba3cba855fed552b681e16",
+              "d975bf42113199c35db1b83b2f4305d7e53906f23b46344b2d8a7334b4316ab4",
+              "d99a1727af91091aac6a2a6009f837caf53340aef58c722e4f1a216ad4a1b152",
+              "dbb182e7b4fab21767f63cb89c9c043b3b6252cf6f63c3df80c52e9cfdea17d7",
+              "dca91f5ed5836f997712160040c26bf0a6bbd3effc5d13b072bb2f7e2b27dd5b",
+              "df6a77e5375609683aaf9a738879f6975e7f3cd8f2ea0097b1e6a4e39599453a",
+              "e52184a6a27d6b605492d4bc395e548418167dda9bc5e9d8906c8100dae0d287",
+              "e643c95f829f73e1f51d968f2c807f801847a2537c1e107cf73464524e684d86",
+              "e97fabaa34942bd62ec69e746f3cb087d26bc53040514fe1206081620be7797a",
+              "ec9dc7d2c6edaa80263729a1998c9966d8ce4b95578a0ac42b8c535b7423297e",
+              "ed7e54b906f3364eeb47ec42e6a0d6471e6c16455b280401d50ff169b544dc82",
+              "eeaf7896be1b6e43104f24ec27522c998c3d7266b383a0c6ca7936da2eb795d1",
+              "efb9a040338d1e92454611e7ad5732af92050d5157ebfbea0af6233e5f5ebe06",
+              "f0b33d35b3cf455aa7fccf1b58f70b161d4748220d96ad451fb2d2d3b7be1766",
+              "f134c844f4104231de678036401225c844eac4cbe44e5fe5499a49b0a7818b90",
+              "f171d6871b6a461e3261d23200de59776f343451b2cb644e7701bc7986e1d111",
+              "f3fc5975e1d6dc5c640e9fae0be8fe4f44c02a9c8eded0c2a0b3b2f48b972eef",
+              "f4b4ee02761007afef17741bd0bcd0ec57f540c99e4fcfc0561cb08bc8533d24",
+              "f5871dae0e3ced88f93c996dedc7789022a32619430accecf48ac322982d8f0f",
+              "f68f356f779e7a58e8d5c4f7d689029b00c724d1406796325eb89f267b5011b0",
+              "f80de6c59036436d776ae1c4ffb1ea84607b97e2c8526c1bacda767db0d3a164",
+              "f8fa244c01601f2eded2b3fb44efc01b1240242317f4a519c3755e62f38a66b8",
+              "f9313de6fb9930ca5f961a0e49af98ebed13533bf0506e6f748885e15ee08aca",
+              "fb8e381818190903e9b746ddef0c5feaa2add9702ad9b2578b96cd6f1dc22dfe",
+              "fc1847640b9e857ce43ab7fedd3009b560c52b6d0da5c5a41d0fa976834d511f",
+              "fd00df5861cd67a5ddc86c4fdd21ef2ae1088bced0eaa5cef75ad28166ee6c42",
+              "fd122cbe572d1e4dd1f97780f23df447092fc0a519934333b928dcca1c90fe1b",
+              "fd16823d48257211e16aba38beda19843bb1495eb8a90a1aa5326f12687ccab2",
+              "fe5d80d87a20dacadab49306a554bd08367ecfc9b87797f6fdd5ec50949bb320"
+            ],
+            "unique_vector_count": 116
+          },
+          "random_objective_seed": 20261729,
+          "source_model_index": 1,
+          "source_positive_inequalities": 202,
+          "source_target_id": "seeded:1",
+          "source_unique_ordered_quad_count": 202,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "05a9001a99ae9d7ff071364cf7ec110b918736ad45fb1f6593e040bb5d8f4d6d",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 2,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              15,
+              4,
+              1,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "source_unique_ordered_quad_count": 8,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 14,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:1",
+              "seeded:2"
+            ],
+            "direct_cross_target_count": 1,
+            "source_target_id": "seeded:2",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:1"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:2"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:3"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:4"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:5"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 6
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              15,
+              4,
+              1,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  2,
+                  24
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  24,
+                  20
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  16,
+                  24,
+                  15
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  15,
+                  4
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  7,
+                  12
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  15,
+                  12,
+                  17
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  4,
+                  20
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  4,
+                  20
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 8,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 8
+          },
+          "compressed_positive_inequalities": 8,
+          "compressed_unique_ordered_quad_count": 8,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 155,
+              "seed": 20262729,
+              "trial": 0,
+              "unique_ordered_quad_count": 155
+            },
+            {
+              "positive_inequalities": 136,
+              "seed": 20262732,
+              "trial": 3,
+              "unique_ordered_quad_count": 136
+            },
+            {
+              "positive_inequalities": 136,
+              "seed": 20262733,
+              "trial": 4,
+              "unique_ordered_quad_count": 135
+            },
+            {
+              "positive_inequalities": 117,
+              "seed": 20262739,
+              "trial": 10,
+              "unique_ordered_quad_count": 117
+            },
+            {
+              "positive_inequalities": 8,
+              "seed": 20262743,
+              "trial": 14,
+              "unique_ordered_quad_count": 8
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "115": 1,
+            "117": 1,
+            "122": 1,
+            "125": 2,
+            "126": 1,
+            "132": 1,
+            "136": 2,
+            "140": 1,
+            "143": 1,
+            "144": 1,
+            "148": 1,
+            "151": 2,
+            "155": 1,
+            "156": 1,
+            "158": 1,
+            "159": 2,
+            "161": 1,
+            "162": 1,
+            "163": 1,
+            "8": 1
+          },
+          "numerical_support_size_max": 163,
+          "numerical_support_size_min": 8,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            15,
+            4,
+            1,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 7,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 7,
+            "support_size": 8
+          },
+          "quad_reduction": 201,
+          "quad_reduction_fraction": 0.9617224880382775,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "028dc684ba327fa4af19c57d2cd478c4c76ff95269c479f76e45cfd4079829ed",
+              "0d8ab5c3ddf537fe6351943d2005e038cc9975f4b87a89dfacd4d1c7b69d3c33",
+              "17a1e8021af45b8e9a3a713be314c79fc133c686361122cae4137034e39913d8",
+              "55edfeb739d86463797bac154913b2cd7eb9cff44822a87df8bdb4de05f3a55c",
+              "7739879f7009befa3ef3e008d93575bf096e1924283561fd626afe6d8e3c3f87",
+              "7b4c1b9c3fe9ed3ec7375e2aa22e8fd732ad36a2020c1f5513f00a0fee306e62",
+              "8bb19f93fc15e5ddab26e3a89e6f08d27f0fb7ffb3dda1ba7058e79e85397552",
+              "cb201f9b77dbc64aa4e54e5870163d655a47b68477b694116d7ad34208907b35"
+            ],
+            "unique_vector_count": 8
+          },
+          "random_objective_seed": 20262729,
+          "source_model_index": 2,
+          "source_positive_inequalities": 209,
+          "source_target_id": "seeded:2",
+          "source_unique_ordered_quad_count": 209,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "dc2a5320661637a39687811ebdc614b9f9f17f661eefe88102068e27000d4e86",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 3,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              15,
+              1,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "source_unique_ordered_quad_count": 5,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 0,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:1",
+              "seeded:2",
+              "seeded:3",
+              "seeded:4",
+              "seeded:5",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "direct_cross_target_count": 6,
+            "source_target_id": "seeded:3",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 3,
+                "target_id": "seeded:1"
+              },
+              {
+                "matching_translation_count": 3,
+                "target_id": "seeded:2"
+              },
+              {
+                "matching_translation_count": 5,
+                "target_id": "seeded:3"
+              },
+              {
+                "matching_translation_count": 5,
+                "target_id": "seeded:4"
+              },
+              {
+                "matching_translation_count": 5,
+                "target_id": "seeded:5"
+              },
+              {
+                "matching_translation_count": 4,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 4,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 6
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              15,
+              1,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  19,
+                  9,
+                  17
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  10,
+                  23,
+                  9
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  9,
+                  6,
+                  17
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  23,
+                  9
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  4,
+                  20,
+                  6
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 5,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 5
+          },
+          "compressed_positive_inequalities": 5,
+          "compressed_unique_ordered_quad_count": 5,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 5,
+              "seed": 20263729,
+              "trial": 0,
+              "unique_ordered_quad_count": 5
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "109": 1,
+            "120": 1,
+            "126": 1,
+            "131": 1,
+            "133": 1,
+            "134": 2,
+            "136": 1,
+            "137": 1,
+            "138": 1,
+            "139": 1,
+            "143": 1,
+            "145": 2,
+            "146": 1,
+            "147": 1,
+            "148": 1,
+            "149": 1,
+            "152": 1,
+            "154": 1,
+            "155": 1,
+            "160": 1,
+            "166": 1,
+            "5": 1
+          },
+          "numerical_support_size_max": 166,
+          "numerical_support_size_min": 5,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            15,
+            1,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 4,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 4,
+            "support_size": 5
+          },
+          "quad_reduction": 203,
+          "quad_reduction_fraction": 0.9759615384615384,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "1123bc22aa1e5054650ccecb61dd0cfcfda8766214110d9bdadb1c02659900e7",
+              "1329a109fef239b87e7fec3d4bef75f1187007230634663b8243da731804d66f",
+              "8ef1cb11be11e1ac8763f2c7469c0a5e5aae391b698e2d7c452726601eb8bb95",
+              "e5b65b63bc2a4f9e37cb8d8f02cef950ad1e8b23ee773d1f08ed6089e7b5383b",
+              "ffecde3bc4d4578371394eec2af46dad40195b6cc3cbc1420370644dd77cbd3d"
+            ],
+            "unique_vector_count": 5
+          },
+          "random_objective_seed": 20263729,
+          "source_model_index": 3,
+          "source_positive_inequalities": 208,
+          "source_target_id": "seeded:3",
+          "source_unique_ordered_quad_count": 208,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "97ef3271043e2331f9b00f13b72565f87dfbbae77f999e0f12c917bca083053c",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 4,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              15,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "source_unique_ordered_quad_count": 122,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 18,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:4"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:4",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:4"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              15,
+              23,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  8,
+                  17
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  16,
+                  9
+                ],
+                "weight": 17449
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  13,
+                  18
+                ],
+                "weight": 5223
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  2,
+                  13
+                ],
+                "weight": 5223
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  2,
+                  20
+                ],
+                "weight": 12189
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  1,
+                  20
+                ],
+                "weight": 5260
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  19,
+                  5
+                ],
+                "weight": 9829
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  20
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  18,
+                  12
+                ],
+                "weight": 5223
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  9,
+                  20
+                ],
+                "weight": 9829
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  23,
+                  9
+                ],
+                "weight": 24975
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  1,
+                  12
+                ],
+                "weight": 3827
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  15,
+                  20
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  12,
+                  9
+                ],
+                "weight": 9050
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  9,
+                  3
+                ],
+                "weight": 9087
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  22,
+                  1
+                ],
+                "weight": 3917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  5,
+                  15
+                ],
+                "weight": 1960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  13,
+                  4
+                ],
+                "weight": 5737
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  22,
+                  5,
+                  1
+                ],
+                "weight": 3917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  22,
+                  9,
+                  20
+                ],
+                "weight": 3917
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  19,
+                  16,
+                  21
+                ],
+                "weight": 2843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  5,
+                  24,
+                  21
+                ],
+                "weight": 19053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  5,
+                  4,
+                  15
+                ],
+                "weight": 9402
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  16,
+                  7,
+                  23
+                ],
+                "weight": 983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  13,
+                  10,
+                  9
+                ],
+                "weight": 514
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  21,
+                  20
+                ],
+                "weight": 19053
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  1,
+                  12
+                ],
+                "weight": 514
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  21,
+                  20,
+                  17
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  1,
+                  12
+                ],
+                "weight": 5223
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  18,
+                  15,
+                  12
+                ],
+                "weight": 7697
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  23,
+                  6
+                ],
+                "weight": 983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  15,
+                  6
+                ],
+                "weight": 3665
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  20,
+                  17
+                ],
+                "weight": 1820
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  5,
+                  15
+                ],
+                "weight": 2096
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  13,
+                  10
+                ],
+                "weight": 1735
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  16,
+                  10
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  15,
+                  20
+                ],
+                "weight": 2571
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  1,
+                  6
+                ],
+                "weight": 1343
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  16,
+                  3
+                ],
+                "weight": 136
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  2,
+                  3
+                ],
+                "weight": 25243
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  10,
+                  1
+                ],
+                "weight": 3832
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  4,
+                  15,
+                  20
+                ],
+                "weight": 5737
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  20,
+                  17
+                ],
+                "weight": 8172
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  16,
+                  3
+                ],
+                "weight": 23010
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  13,
+                  10
+                ],
+                "weight": 11320
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  20
+                ],
+                "weight": 4193
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  13,
+                  12
+                ],
+                "weight": 7733
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  15,
+                  20
+                ],
+                "weight": 12932
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  13,
+                  24
+                ],
+                "weight": 27203
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  6,
+                  17
+                ],
+                "weight": 983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  13,
+                  24,
+                  1
+                ],
+                "weight": 10989
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  4,
+                  15
+                ],
+                "weight": 15028
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  4,
+                  20,
+                  6
+                ],
+                "weight": 15028
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 9177
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  18
+                ],
+                "weight": 11292
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  7
+                ],
+                "weight": 983
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  18,
+                  12
+                ],
+                "weight": 7733
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  3
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  24,
+                  20
+                ],
+                "weight": 4025
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  24,
+                  3
+                ],
+                "weight": 6153
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  12,
+                  3
+                ],
+                "weight": 7733
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 7691
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  13,
+                  3
+                ],
+                "weight": 6190
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  10,
+                  15
+                ],
+                "weight": 5594
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  18,
+                  4
+                ],
+                "weight": 3559
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  7,
+                  6
+                ],
+                "weight": 983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  1,
+                  9,
+                  17
+                ],
+                "weight": 3917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  1,
+                  6,
+                  17
+                ],
+                "weight": 6446
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  20,
+                  3
+                ],
+                "weight": 9087
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  24,
+                  15
+                ],
+                "weight": 16849
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  18,
+                  1
+                ],
+                "weight": 3917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  21,
+                  7
+                ],
+                "weight": 10544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  18
+                ],
+                "weight": 7691
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  7,
+                  1
+                ],
+                "weight": 3827
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  7,
+                  23
+                ],
+                "weight": 5734
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  18,
+                  20
+                ],
+                "weight": 5438
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  1,
+                  9
+                ],
+                "weight": 14821
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  9,
+                  3
+                ],
+                "weight": 9087
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  18,
+                  9,
+                  6
+                ],
+                "weight": 5734
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  1,
+                  23,
+                  12
+                ],
+                "weight": 5734
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  12,
+                  17,
+                  3
+                ],
+                "weight": 12956
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 4391
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  10,
+                  20
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  18,
+                  15
+                ],
+                "weight": 13319
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  23,
+                  3
+                ],
+                "weight": 19053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  24,
+                  23
+                ],
+                "weight": 19053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  7,
+                  20
+                ],
+                "weight": 21150
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  18,
+                  4,
+                  20
+                ],
+                "weight": 9402
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  7,
+                  20
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  7,
+                  12
+                ],
+                "weight": 6053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  21,
+                  4
+                ],
+                "weight": 27203
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  4,
+                  15
+                ],
+                "weight": 27203
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  6,
+                  17
+                ],
+                "weight": 983
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  23,
+                  9
+                ],
+                "weight": 1473
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  12,
+                  9
+                ],
+                "weight": 6053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  18,
+                  7,
+                  23
+                ],
+                "weight": 2456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  4,
+                  12
+                ],
+                "weight": 3827
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  15,
+                  23,
+                  6
+                ],
+                "weight": 13319
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  23
+                ],
+                "weight": 20664
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  4,
+                  9
+                ],
+                "weight": 15335
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  12,
+                  20
+                ],
+                "weight": 3827
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  18,
+                  12
+                ],
+                "weight": 9344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  15,
+                  12
+                ],
+                "weight": 2147
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  18,
+                  7,
+                  23
+                ],
+                "weight": 6053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  23,
+                  20
+                ],
+                "weight": 1611
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  9
+                ],
+                "weight": 27203
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  1,
+                  23
+                ],
+                "weight": 32104
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  1,
+                  9
+                ],
+                "weight": 17580
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  23,
+                  9
+                ],
+                "weight": 11440
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  1,
+                  9,
+                  20
+                ],
+                "weight": 22772
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  12,
+                  17,
+                  3
+                ],
+                "weight": 2934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  9,
+                  20,
+                  17
+                ],
+                "weight": 3917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  7,
+                  12,
+                  9
+                ],
+                "weight": 26689
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  1,
+                  15,
+                  12
+                ],
+                "weight": 21581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  15,
+                  9,
+                  17
+                ],
+                "weight": 2097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  1,
+                  15,
+                  20
+                ],
+                "weight": 7697
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  20,
+                  6
+                ],
+                "weight": 5734
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  12,
+                  20,
+                  17
+                ],
+                "weight": 3576
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  12,
+                  9
+                ],
+                "weight": 22772
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  1,
+                  20,
+                  6
+                ],
+                "weight": 30469
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  12,
+                  6,
+                  17
+                ],
+                "weight": 14302
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 122,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 1086200
+          },
+          "compressed_positive_inequalities": 122,
+          "compressed_unique_ordered_quad_count": 122,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 152,
+              "seed": 20264729,
+              "trial": 0,
+              "unique_ordered_quad_count": 152
+            },
+            {
+              "positive_inequalities": 148,
+              "seed": 20264730,
+              "trial": 1,
+              "unique_ordered_quad_count": 146
+            },
+            {
+              "positive_inequalities": 143,
+              "seed": 20264731,
+              "trial": 2,
+              "unique_ordered_quad_count": 143
+            },
+            {
+              "positive_inequalities": 132,
+              "seed": 20264732,
+              "trial": 3,
+              "unique_ordered_quad_count": 131
+            },
+            {
+              "positive_inequalities": 129,
+              "seed": 20264734,
+              "trial": 5,
+              "unique_ordered_quad_count": 128
+            },
+            {
+              "positive_inequalities": 124,
+              "seed": 20264737,
+              "trial": 8,
+              "unique_ordered_quad_count": 124
+            },
+            {
+              "positive_inequalities": 122,
+              "seed": 20264747,
+              "trial": 18,
+              "unique_ordered_quad_count": 122
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "122": 1,
+            "124": 1,
+            "126": 1,
+            "129": 2,
+            "132": 1,
+            "136": 1,
+            "139": 1,
+            "142": 1,
+            "143": 1,
+            "145": 3,
+            "147": 1,
+            "148": 1,
+            "149": 1,
+            "152": 1,
+            "153": 1,
+            "155": 1,
+            "157": 1,
+            "159": 1,
+            "160": 1,
+            "161": 1,
+            "166": 1
+          },
+          "numerical_support_size_max": 166,
+          "numerical_support_size_min": 122,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            15,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 121,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 121,
+            "support_size": 122
+          },
+          "quad_reduction": 82,
+          "quad_reduction_fraction": 0.4019607843137255,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "03a03951d855bf5259557702908541d3ad6753991be629a70928a4a66790b28c",
+              "08c634d03b42fd957de4b7381db61cda3b8c27f2496efd784967ac32212f83f2",
+              "0ced15ca40df5745aa10e06b2d91cd26a0e1f0e2771a2333c6eb6f4e5ea6f87e",
+              "11ed76ab0deabc8275f5e258ddcaa603f93402157b16f7944cd11b9072e45d48",
+              "14984a3f780f71c3dbbfbec47b84ec3a708df2c79f7d5df3698e72b3c4ca9d0e",
+              "155cef13e65a41585ac8072f69115cf4e8f2a4f2cfb9859a5b861441efd65b0e",
+              "15e18bc1ab1b94cc47ff909fc49e6a02d7d3d42d12afa5c37a40daac066f4f1f",
+              "1b56d165e3b780baae0b98cd4838566c800377f6c41b57d60d8675eca4480bcc",
+              "1de80fecb5470092dd92d8a90e72289d1e14425546e34ee3df475f5b1f76a285",
+              "1fa3b27fe2a6be29967c91ae4c41bfabd47ddb2e7bd92c8257c87897ca65ffbe",
+              "21daf8062e3b1c535c528f570dc8d83d9a3bf0174a690af3e7a4327944aa777b",
+              "2250ef09e8c392ed51168d2924f2c7ec18efd8ef2982ab340d623e7b3246acc3",
+              "2892e9cecd1824429d1ec981475522289a3cc298861a893f19f21826a05866bf",
+              "2ab06308f1e076660d823d83a18d751504206b6c3143ebd97d1b39105aaf3261",
+              "2b94b890e7f4b5a5174143c569806f92d2d5b3b6bf5d64bbc230eecdecc5d415",
+              "3009d9b28e17228546097fdea8c13893fc644e28c9a58590e333228bcfa51082",
+              "302295864aeef8de2be7e605cf4862f2ddd2bb59f144da695425b3a4d131184e",
+              "35841b24b1c2d46aa62986e72781ed93e8c8809e6cc1aa3993cc1f44006d3a60",
+              "3639bc19f32b0d48e2d9fbdba3d9a96633f7d0a9d0b7eab9001ede00f9ccc233",
+              "397927cb74f0c8e371225f3cb4f6fb9022247545c09aae5782f8d0c6018b86ee",
+              "3a7775b04ec0b215a5c3c079327134ea24b157139832d6e366a02c8b1e36b0a8",
+              "3c9630091ed7852443ae04a4b45a8c1a644fb8f2763c00cacdb688ecbe9f6a7e",
+              "3d407aaf90eef21f25f1f630be1460fe9cf20d4ea789dc786ac5112337b80a7b",
+              "3d7bb1efd35cd015e10bbcf954a2bf1e1b3036d2d91364555ff0d1144a849321",
+              "3dde679612cbbed64aac2ddc193f114dbf3eaace736cfc8931b5363ea5c52fd6",
+              "400a968d042a14caaed3a95991293be69730e2a212dfb41e772cf594f40b5d59",
+              "40cc777546729c9ae3cd3b334395629d6a46cf9ccc7011ab5999c106158bd0e8",
+              "415c4061e752215192141dd3d35b4d3f050faf158cdd7089966a5743fe3c2ab7",
+              "4c1c1f8c7c974f16d1cc9fd38052037ac648a9e0da2a4e9ba3f796eb0c858bfe",
+              "50e69e33414e5a962a5df9a55abcac7eb27d0b2577f6b057518f0407791d92e0",
+              "514539bc224f004044f5fb237a90c5ad2f8c021130e2c682e3f3cdff38f8480b",
+              "51a81b03ea064c542863743d1d50dab229255da3534b289a975bb6a71be067f7",
+              "5866ac9981479d200bf56514ef1b19a2df3061c44fc1e4a3702bfb57051c3b9f",
+              "58f717f61918019eaa4dbbfbab3d5d8ee1e2ee0f6ae5067b4eca5454ebc8e0a4",
+              "5ac4f856bd7e96715eeb1cff213cb77c42caf1c38c85fa9c0a0714fff88bc136",
+              "5b101285a029d5a77febd492f20d276b8d1e45e2c189e4e3ab0b505d2b97d9d5",
+              "5b8a61c12c3ba54e6fe158e0946e70e3ed8c266a1478b4f14c32f5487b16bbbf",
+              "5d2c48145ed89b00f33b36fff89cb3514c414b2a44ecbd0c0c19fa76a42216b9",
+              "5d669883adc7dd4eea81b8c753503457e8a543b0c342fb48ff76bd27e0116472",
+              "5e2071b0b1c815d538443ca0737196e6ccdda24da94f1f3d699daf466c7289dc",
+              "6021529421d73cc9692367fbe4853f27c7b8deccc14a4a7599156641705ea46a",
+              "69452e44279197df57dce93843b55aeaed6063f83a47ae2c70af552e64937ce4",
+              "6a14cc8ddf388d57fec2cf7d2c27f34aae08f72d241382caa25d23fe7f5aaf05",
+              "6b8d240aa28d23969967753b0b29ac938bc21db42bdf550351334b43b396e232",
+              "732ffaa6b3fbb13e24460d8be6e9503b62b3d76367afaa7a65614856e1f66603",
+              "7833026893de70f5424c26a00840f83fb84cb0e3744fcd662404b4e80cbde4e7",
+              "78b2579cd75432a3e3608fecae486b1c0d24cd06ff6b1d6dfe2d8430ce81629a",
+              "7bd2457ca7658f17f53017bc9b73b8ccda040dbbf45a2606434384d401ffb0e4",
+              "7c3a739b54ee8ffb582c18df1536acc53acbe4de6e4cb434bf763d1013dc9571",
+              "7c4224508729b6373c55895ee88ca6aadd69a71962e8b2b1cdb81d34167b9736",
+              "7c71e12110e5e30d037153c6f088642149420973205cd44c52699ec5695a6de0",
+              "7d6561239d86c870c2b1036acbc76e84940a638a536619bef0cc156ea3fe19f0",
+              "83b8ccfcf021a9a93cca1a06a109cb1fa97ad23567b8686537f9aaed2df8c13b",
+              "84a705309e4b7f70134a710bda92cb7f6e664b446b422ca4903b2bddd8ca2e1a",
+              "853486aea2516cbe274849774dde99a4ac9f708ed039947f5202e337a242bd57",
+              "887dfea9c16e38fc1d2d99961cd9670b925b6905339e64d9ac13be1a30459f20",
+              "89fd83f86649367c3c2ef2c61dd11bb4a4319fcedf5269d52c350ba587be5791",
+              "8ce26473130adc81c033a559b23d9506374dfb1ca549e2fc295f0c7d0506b2f9",
+              "8f5f71f83ecbc614402e6455bd6180bd1603580e946f91caac7c236d82f8bf18",
+              "91936ffd92dee4b53043502350dde217f62041cd6bc4bef77153a37b3816b7fe",
+              "9263bf3615076ce2e6b4b12bd0758df2fc7770df5f4775c1ff9410bc4140e92f",
+              "9622e176c14597a744ea9c58f15bbc7f3cac67bb921027653b2caa527f22c031",
+              "96a065cbd8aa80bbd7d2c29d291c97ca6f412e37dabfa53db073e1a03bb1b201",
+              "9788e484d68b72fccddc5f44d731f062daf5618749c03d17b57002463cc284c0",
+              "98fef2969554e4aced4363d09d5fd35e12c28dd020d7d646b7e63c60a220d98d",
+              "9979e2052c93b703407e764b356e31c45a782f746eea0a8187910206dcf69739",
+              "9d5f6ebc0550374119c984b4c757dc5e8ea70fdd181379cbb7b15657eb52ac62",
+              "a00226691993f85c150981796498fa5737d8ee0a4f0d2e83c26e4ab559cbb46a",
+              "a190c3edf875885ea715be5d674b7bb5bb7a68bfa0a6e59d10fab03dace76ad9",
+              "a490918d92cee4bf6188cb9cb3530e1c975e4be8f400878ac60117d73e3b056e",
+              "ad7d8e6b87ca2d5bf85f189fb9b9416abfa86376cc67bd5c0abcce8b715e7250",
+              "ae2902a75dff7bf4b5a6cea4b080b213b1aa4453b51051b1bc70a937e5343976",
+              "ae6b32ff0ef9e67ce2d3063d8afcf1b408481d33f600deb84d955457f54dca28",
+              "b3f38c791d81e35ecabf50588e07f5a0c1a64dfead8b8fa3fe74ff5ac0582da7",
+              "b41c204cf65e33c1fb85871cedbe7524dc493b1dcd700e0bd10582dc8f7fa02b",
+              "b621d68987cdffb5733d3469bce12df88b43a7707dd032dde3ccaeb5c9515c74",
+              "ba5bbf09a46a80a9ffee3757ae0a225d7b92941651a4467a70772f029def737d",
+              "bae9e0358e6b89f760c0b9e694b9eca7ffd2f51259da1fb52b24250555db77e3",
+              "bbc43776809e2a727025d96dd9d22addafddf1529eebefdef0657cac5681c138",
+              "bc6564d8bd8aa863e05ce11cbdbb855a9999c98e016fdda19784181d88ccc7bd",
+              "bcc78a557f046c60ef2b16365c30d46abd159af2d16dccd569f2c9b9770de04f",
+              "bfdd0f922c4bd0a184186c77a719b3610dd38348c920bc5deaa7ecd142a08482",
+              "c0bed896457af74af9a24897b3f7062fb920a89528dacc8b739fce99303a4aca",
+              "c28de2e3376d09406bffd99a8a2a25df57bb3495b57a82b7790530fec27203e1",
+              "c4992c43b12ad665a859f1ee108987136e104c81908ce8f71863a2c4837a0700",
+              "c92f8ef5e06ed11c8fcdc454807d50f419703e6da1969d042356a79e88bb661c",
+              "c9f6ca60b3323f7d26827627984b7d5d58a88f8fdf5e9887e3d3bd65975c6ea9",
+              "cb139270f76cb9116c057e13d3dee37e7a1f5aadd5d13574afc140c34bf5dfde",
+              "cdc264a05e9ed08d11637d4fd61f6bfec486d3c696f61a815d9a86bba628b7f4",
+              "d042102b622164fe77e779b259d0ffd2c3e21b9e89d0f06fb669bd1f6e4931e7",
+              "d18f2469f902338f9b8f5053528e74323676295c04e022fc90e6fccd16807026",
+              "d38ed889ae8c17524f4f87e21f4a55263c2b69ce64283ee9568ffcf9df80079d",
+              "d56b9cbc163295bd240e650b2dc65cf63e0c68f95b074fce8af603e745719f6c",
+              "d61e353d98dc6cacba31981df8c7ae16c55cbbf3f2d125d97c33e54069d2fbe4",
+              "d6f67794b018b5ab27906c2358e83ccdf93704f2c9516f31d80467fc57537ea0",
+              "d757dc0aa39d982b8b52d0e807fae71d78106632be2afe37cc1be2c4fbbb907e",
+              "d78bee571cd57e3661ef847fa4fcce75997e51dbdd9caddd9e695d61710ee2a5",
+              "da2762ce70d7b87caf27dc5ccee130537c0d31b4f6760e6fae908baf7d8ce50d",
+              "da6450fc2c53fa33481614201f8108600436c6d996ca513a71ec9b967ea83257",
+              "dac1511f9d4ce1a4196bcc8e866dda8baa9f456b804b1c8492493f08f940e129",
+              "dadeeef917b85c2ff01cdb8f2a5a800f01c1388952c79df95105842a7f942d01",
+              "dbf9b12d70b6184740db8b6f20b0d45cf71e5da13a2f45a67f4645a25ba8bbaa",
+              "de017a730da2f2d54ee364bb997692ca6ecf1ab0c556b0871b5a938b8908a1c1",
+              "e40d375425efde94e27bb6060cec8e4bc4c35bcc19e1eba8358580dbd54bbe92",
+              "e62f9b1154ffe1597212112d0a999e64db8f5f9f7c22b99201b507fcdcf7f9ea",
+              "e68732c7158c9fa8e9af5e9c2f1c58f07026a13fad4b97e30037a58c23506740",
+              "e6ae29d3b87642bce391132d64b659ef86e0c910c84c8fec314f913c4cb5e5f2",
+              "e7fc90e7d75d73c54ea37d02f9695a18117106f58875456dca5ef07f22173a31",
+              "e8ca63688eb6af3ef32c56e1b3012b1a981ff05be68da41b8c0a5bfbddd8c7a9",
+              "e9292336c4caba20290fcd5a23af3c6d0e23812a53c92327ec84bb46711e53da",
+              "e9434f72dfdbb458a192cb857b22b7b7b626b4439b101a3f7322b7f855f37941",
+              "eaf7d1f11dc4bc4ee96a94d64cfa87d8ec9c8b12a5b111b4e7a4a5ec6b68c691",
+              "eb2b65ae905e422520101b4035b0da3317bfb1dd0e5b34192ffda0471b630e74",
+              "ed89ea4f22d6c7e7c718e014fa14b58100dd8aa7da36632defe75122b848aaa8",
+              "ee72ec2ab6a1826b139febf15dd4d8e7b97ab1babbadd52c8a4af96226b120ce",
+              "efb7af3472df2a02e19f258618b63ac4e57f413822e4ae367d0c9c2a04ff10b5",
+              "efd95b36d19a27dabb440d3bd3aec45fe958715d021fa72ef46427edddcd5670",
+              "f31c59f6a7cb3ed30c825aa0777bf5a1443bda1cb831a457be623b0d7b4a10a8",
+              "f85e23206b0107bdefe2954d9dc7538fd0af4cbcb8c4f489925d9e7a4ed834ee",
+              "f992d1d5f449419b47120e6c07949134e0794c842df60e66c99b7c0a520c354c",
+              "fa03d3c471e0149ed7207164e4efcf6b1c697298a0d56f3837721ccbbfdb17ec",
+              "faeb14e2df62692ac4a493083a55acd41a51aa745e3e05c6c221313ccd23d83a"
+            ],
+            "unique_vector_count": 122
+          },
+          "random_objective_seed": 20264729,
+          "source_model_index": 4,
+          "source_positive_inequalities": 204,
+          "source_target_id": "seeded:4",
+          "source_unique_ordered_quad_count": 204,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "1055bbe9c6a92f3c23f2820aac6d449947aff85586f49ce3d5388d003a8d0b4d",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 5,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              23,
+              15,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "source_unique_ordered_quad_count": 119,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 12,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:5"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:5",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:5"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              23,
+              15,
+              12,
+              9,
+              20,
+              6,
+              17,
+              3
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  11,
+                  15
+                ],
+                "weight": 2025
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  8,
+                  18
+                ],
+                "weight": 8742
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  3
+                ],
+                "weight": 11146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  5,
+                  10
+                ],
+                "weight": 143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  24,
+                  3
+                ],
+                "weight": 7524
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  23,
+                  3
+                ],
+                "weight": 17991
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  3
+                ],
+                "weight": 19888
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  5,
+                  10
+                ],
+                "weight": 7381
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  16,
+                  2
+                ],
+                "weight": 7566
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  23,
+                  9
+                ],
+                "weight": 9079
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  10,
+                  3
+                ],
+                "weight": 7524
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  22,
+                  10
+                ],
+                "weight": 20647
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  7,
+                  20
+                ],
+                "weight": 19548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  20,
+                  17
+                ],
+                "weight": 19691
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  8,
+                  24,
+                  6
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  22,
+                  19,
+                  24
+                ],
+                "weight": 2154
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  22,
+                  5,
+                  15
+                ],
+                "weight": 9414
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  22,
+                  16,
+                  20
+                ],
+                "weight": 9079
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  5,
+                  16,
+                  20
+                ],
+                "weight": 143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  5,
+                  16,
+                  17
+                ],
+                "weight": 9528
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  16,
+                  13,
+                  4
+                ],
+                "weight": 14994
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  16,
+                  10,
+                  17
+                ],
+                "weight": 3328
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  13,
+                  10,
+                  4
+                ],
+                "weight": 14994
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  13,
+                  23,
+                  15
+                ],
+                "weight": 2025
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  10,
+                  15
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  10,
+                  6,
+                  17
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  7,
+                  23
+                ],
+                "weight": 8742
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  18,
+                  23,
+                  12
+                ],
+                "weight": 811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  18,
+                  17,
+                  3
+                ],
+                "weight": 25344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  23,
+                  3
+                ],
+                "weight": 28290
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  23,
+                  12,
+                  3
+                ],
+                "weight": 11692
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  5,
+                  17
+                ],
+                "weight": 19691
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  16,
+                  18
+                ],
+                "weight": 1633
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  2,
+                  6
+                ],
+                "weight": 3485
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  1,
+                  23
+                ],
+                "weight": 6276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  23,
+                  20
+                ],
+                "weight": 6276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  16,
+                  6
+                ],
+                "weight": 304
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  9,
+                  6
+                ],
+                "weight": 9079
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  16,
+                  20
+                ],
+                "weight": 19432
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  20,
+                  3
+                ],
+                "weight": 34930
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  16,
+                  10
+                ],
+                "weight": 22521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  2,
+                  15
+                ],
+                "weight": 7566
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  10,
+                  3
+                ],
+                "weight": 1731
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  7,
+                  3
+                ],
+                "weight": 19548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  2,
+                  18
+                ],
+                "weight": 7109
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  18,
+                  23
+                ],
+                "weight": 18333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  21,
+                  1,
+                  9
+                ],
+                "weight": 2372
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  15,
+                  20
+                ],
+                "weight": 9591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  1,
+                  6,
+                  17
+                ],
+                "weight": 8648
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  5,
+                  13
+                ],
+                "weight": 15310
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  5,
+                  3
+                ],
+                "weight": 9499
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  13,
+                  3
+                ],
+                "weight": 29
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  9,
+                  20
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  2,
+                  9
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  13,
+                  18
+                ],
+                "weight": 1226
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  24,
+                  1
+                ],
+                "weight": 4094
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  24,
+                  17
+                ],
+                "weight": 12074
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  1,
+                  20
+                ],
+                "weight": 4094
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  4
+                ],
+                "weight": 1633
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  2,
+                  4
+                ],
+                "weight": 3485
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  20,
+                  3
+                ],
+                "weight": 143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  13,
+                  23
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  13,
+                  3
+                ],
+                "weight": 19888
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  18,
+                  3
+                ],
+                "weight": 8335
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  10,
+                  1,
+                  17
+                ],
+                "weight": 6276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  21
+                ],
+                "weight": 15310
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  24,
+                  17
+                ],
+                "weight": 20514
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  7
+                ],
+                "weight": 304
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  17,
+                  3
+                ],
+                "weight": 9528
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  2,
+                  17
+                ],
+                "weight": 6200
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  2,
+                  18,
+                  4
+                ],
+                "weight": 6200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  21,
+                  18
+                ],
+                "weight": 15310
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  18,
+                  7
+                ],
+                "weight": 9110
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  7,
+                  15
+                ],
+                "weight": 9414
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  23,
+                  9,
+                  6
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  16,
+                  23
+                ],
+                "weight": 20658
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  2,
+                  23
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  18,
+                  3
+                ],
+                "weight": 1559
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  13,
+                  4
+                ],
+                "weight": 1226
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  10,
+                  18
+                ],
+                "weight": 2785
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  10,
+                  23
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  7,
+                  23
+                ],
+                "weight": 3571
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  23,
+                  9
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  7,
+                  23,
+                  9
+                ],
+                "weight": 3571
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  4,
+                  20,
+                  3
+                ],
+                "weight": 11404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  24,
+                  4
+                ],
+                "weight": 14197
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  4,
+                  9
+                ],
+                "weight": 9079
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  1,
+                  23
+                ],
+                "weight": 779
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  10,
+                  4
+                ],
+                "weight": 14197
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  7,
+                  15
+                ],
+                "weight": 12056
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  1,
+                  15,
+                  6
+                ],
+                "weight": 779
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  23,
+                  15,
+                  17
+                ],
+                "weight": 13125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  24,
+                  4
+                ],
+                "weight": 19705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  7
+                ],
+                "weight": 12056
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  21,
+                  6
+                ],
+                "weight": 5508
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  7,
+                  17
+                ],
+                "weight": 3618
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 9079
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  18,
+                  1
+                ],
+                "weight": 3618
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  4
+                ],
+                "weight": 7893
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  1
+                ],
+                "weight": 7417
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  4,
+                  9
+                ],
+                "weight": 961
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  1,
+                  12
+                ],
+                "weight": 4578
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  12,
+                  3
+                ],
+                "weight": 7524
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  12,
+                  20
+                ],
+                "weight": 811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  4,
+                  15,
+                  6
+                ],
+                "weight": 5508
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  1,
+                  15,
+                  12
+                ],
+                "weight": 8335
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  23,
+                  20,
+                  3
+                ],
+                "weight": 811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  7,
+                  1
+                ],
+                "weight": 20818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  4,
+                  17
+                ],
+                "weight": 9894
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  7,
+                  4,
+                  3
+                ],
+                "weight": 11404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 2325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  1,
+                  20,
+                  6
+                ],
+                "weight": 811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 811
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  9,
+                  6,
+                  3
+                ],
+                "weight": 5508
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  7,
+                  1,
+                  17
+                ],
+                "weight": 3618
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  23,
+                  17,
+                  3
+                ],
+                "weight": 15450
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  12,
+                  3
+                ],
+                "weight": 20146
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  12,
+                  9,
+                  17
+                ],
+                "weight": 5508
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 5508
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 119,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 1007393
+          },
+          "compressed_positive_inequalities": 119,
+          "compressed_unique_ordered_quad_count": 119,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 138,
+              "seed": 20265729,
+              "trial": 0,
+              "unique_ordered_quad_count": 138
+            },
+            {
+              "positive_inequalities": 119,
+              "seed": 20265741,
+              "trial": 12,
+              "unique_ordered_quad_count": 119
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "119": 1,
+            "126": 1,
+            "135": 2,
+            "138": 1,
+            "139": 1,
+            "141": 1,
+            "143": 2,
+            "144": 3,
+            "145": 1,
+            "147": 1,
+            "148": 2,
+            "149": 1,
+            "151": 1,
+            "153": 3,
+            "157": 2,
+            "175": 1
+          },
+          "numerical_support_size_max": 175,
+          "numerical_support_size_min": 119,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            23,
+            15,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 118,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 118,
+            "support_size": 119
+          },
+          "quad_reduction": 87,
+          "quad_reduction_fraction": 0.4223300970873786,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "00ac8a7b2f1301f2c14c383b80313089406312dfbf0fac9a22ec6e3a5da30212",
+              "00e693e3aba5435c7b4bc1333a0609ff1b895c998b10644603134584557e0b0e",
+              "01b5d5766ea6c7b9d8e9561cd220ea6ce13b6d312692e5776173f1cbb1534463",
+              "0800594b455b17462f829a444e74457c52beae09d29fd90a5968b7e4a49102e9",
+              "0879f41b9ea2909ee213ab5e75991fde0e4571b59006896fe4f8f1b118aaa83a",
+              "09a580bdea9043fc307c1f2270fa657cf7f4408159f37a8ca09e4604d49d87ea",
+              "0e65c928f3a43acf871352937a6904acf12276092d6c04c686c23f790d419c90",
+              "0f85c8dedc4e88105446823f691427aafae1ac22ac3182a318270f07ec6fbc1b",
+              "0ff4a48c646b6b51a5291bb2b7a676a31d75b882b92e306ca089ce0dcbddc8b9",
+              "14b6a2894f3f247ee388bd71f934c7b28633aaec6ed13278e389857a64c282c3",
+              "15578c743e8949c3f106afab301db7328a62942ac814319a5d5ef251ee243920",
+              "1b8048b50391a7ec7f01d66128e9528dcc0ddb0c573ed7b4e1ea98307e6c324b",
+              "1d557c344bd14883ae809d56a6aed3ce23b9b0501a9d5ad8ee04917299ac1186",
+              "1de5a42ca49f7f483481b037fb11f61e31dee13753c1c0ac1a2e3136dffdce6a",
+              "1e708151ee7020f6cfdd04c0724bb7d9305c710acc611885acedc869d7b52e53",
+              "1e8f9e495228fdd65505f457e854c7fde110407a08c150d66feda535b7b187f4",
+              "20387b65f8f9b0f520d5ffe263bbde532e9c9bbe6385aa777e54d8504fb8b209",
+              "217dd0d2a9da3ff8dc05c762a55072eff1096cb537a3f04f064e0b4bd912e2e2",
+              "2413d4f498d7e85df82c07a47c7bc31efeb3a18ddda4772a80bde1e95f6a04fb",
+              "243d8fe88f3c784be8b4a990f8518c3c972b90cb335de5042e1c0068306676b2",
+              "265b6c65a4d06c62a44953248f045edc77af809620d82b3c68dbce9ae461af0f",
+              "26620b97ac85a4df1b18ef8b7841ee1e1255ce66c8f106da7c665ba005539e58",
+              "2b419a197fc825ade5e1de14ca6ddfb7085c7afd6869da0fc3204bbd1a9653af",
+              "3089aeda0468887580e4675894892daccb03d6cfd63810916a5da390dadc3d44",
+              "3497ac66201b3d9aabdeddf1ef285a7a555c6cd0937c5692ee901511db5d8bd9",
+              "364c917a1cc42877b0bb19a6222177d6a4dc557ab0beb8769c218827e18cc09c",
+              "3745c1228347b4ed222bb1bedb35256d9e02841ac6f825f392a6933d9a116ff5",
+              "3d56399a75c806a9899f9d872769219fb7c70585e038f5dd5919a739d2cef75b",
+              "40624e41e734397455b7683cb90111270a849c284752d380b82d90fb8b900da7",
+              "40c71201ba87d91c89e00685ecfed228351d7aec19ea398298dc8ee53ce357f4",
+              "4354b04328fac0bd4883b8b6a16a933aab351a900fc9a631b4a6a7a1da62abd7",
+              "43afc59caf0e6c94ed1054967aaae28a72c965aed1122f39890ad565f9fb9ef1",
+              "442c5824e01a5fa2cc091b75a3aadee4225ed87f27b43fd2ebc975e22f3f4b78",
+              "47e36035b8c6825625c130d08923bde560cd2a8aa1d2e6020ff8d080aec0d115",
+              "49abd02158a620d2a0a99b412a02fdc24e2495396c8ef67317ee0927cbebdebe",
+              "49c558a3f4c2f9374a8aee7a5d86131901442dfe244c9f80ad8a30d6391ed7e3",
+              "4bf34a4de8dbed1d9addd5d6537baecb11a1d030a9e9703cd70cf6bc3da82edd",
+              "4c0e6991e3b87eb90752865f67093733ffe972daa2701b7bcc2a57fee05ed9fa",
+              "4cc8b55be83b1129ef6cdea10e9afbbd40e78d626d04cff0a00257a1d4f370ed",
+              "4ef811154cb09789621211defa79f1f0caa00e551887798600a42e714db83beb",
+              "4f989705db78640bd9117183ec73cb2cd93757f350d9318eda15197146d62eb5",
+              "51adc8cc57c843fbc90d7745c0cdbcca9aad3e64cd4117eb5411dd38c6dd9828",
+              "5435957556b1c93fd813cd0297ab7c34f3313745dc4c6398b3968a20b5cc23c0",
+              "57aef42beff00ab27682a496d6a4f0414dd7fa17b31229472b0831a7f7fb1a6f",
+              "580c7c1795a289378ec65d8de1eef0d236de4e265ceeaf707a01f3653261d321",
+              "5c6c6ce894a963fd3f5740b1d5956901eaaed10916601bd06fb528ae6017c3fe",
+              "5fdf55bf3421bd8c3f18ce3e89735f6d23344b68a232dd68d69ae92b0bde9d47",
+              "61c4803bd04e37c74c24b6ebe4d648de53a0c69957c815cb951194c934681eff",
+              "63794fd483f79622862d1288896a15aca633b0f92f1bc81d1c64c39a0a4998eb",
+              "6405bea868f290b41f12cb06d732844323e41e894b62914e4ab29ac5121636e4",
+              "6c23e00cf1955158f466356b98ebc3ed58f101a6166a059d1e753c48cddcdaed",
+              "709f375afc14bf4f7bbaa38707f24ffb942708eed07b27ae0e9e149c73a50612",
+              "71b39f892c642afa4613a8a0c6fde9d0adc34b4630f1e8af6f7fec6093fb5375",
+              "71d5453a7dff404860a101af8d978b3026b112562e6bc9ee9c3c379a7fdb1494",
+              "73422a104d80061d956a9b1b138db70598bb8be0d912a8d94a7da9d2204c2ddd",
+              "77134d767e760e548f0d44d16cad00aab42a2dd5d3079f55bbfe231aa95cab2f",
+              "8016333a45fcbcec00633cb0ad317ac2d6389bc7984eeb55ecfc8c3d34e61f61",
+              "813fe764173bf91e7a2537db14ce57ef3c6532748b3a1d9ecac0ee30a10a748d",
+              "83587be989fd57c39d6feebf6ea6a1b6dab6c9cb5ad7646e7efac2c699c48645",
+              "84e6d6cb5cb2073cba379c29ebaca37446ef271c67063d8ff125a8243f5a90cb",
+              "85a16c1735dc6e290efc2e7d66e0276dde91e65a553f7d6c6b70fd8267624a1b",
+              "86010c0efe773fa870877857a5a0cc392f7d969affa482a504ab54bd741a8c62",
+              "890012687d948b53a55b46eb0d7095a38d04a486f66ce46740bed3439b33d8a2",
+              "8b6a3000d8680fd2c943f279d3c5c17dcf3ff99ffef263129cb5c35b3bd363c9",
+              "8c7fbbd9da8a231c2f464b9e4389f004614ce9f08bcb175b4f681600f00f9f89",
+              "8c8d6c4d23c848f2d25e5c2bd0b23423bfe384a77147709f6075e34d8217c9de",
+              "8ed0ef964bd3bd8312c6cd525f19c39e97b5dc57a4749897e88a3b3a4edb19cf",
+              "8fbb174667a3c89518e46c26572ac1c1729f88f58409ac133c9b56193b5c9e89",
+              "90690a997b85d113da37f90ab0fab4a0d817896f087d2030ba84448627338caf",
+              "925ca8327b69f6ed92a1930506142a5cebcb98f26bab100b8113cef95c75a3a3",
+              "929653f90f1c2f368a07da91054922364a585dea78a8cac4290d11813864ffc0",
+              "933ebff3f4340395674cd3e2a6b6efa1ef3cf04821c3ab430abbac1f7e46410d",
+              "935ce11bbf6d674b85defb60ffbdbc72e9ea7027bbf2ffba821c9c8038fdf39b",
+              "9423ea16292a76c93913fff965254f469ec056f771a344597a85f2c154618044",
+              "96db1c971e7d3c948589edca4b5ae0a0e2939c094dcaa87776b00009f8b66419",
+              "97fa553366d0a8da59b1e1dae9dbfd631983b00746ce0ea80c9c196fdb1c435f",
+              "9f3054ca7bce8c51693f36987a0bfebe71132cd3f323c61a9ada5c82f6021c31",
+              "a18ba40b719433313da55d5e77279520a95e8fd418a700d393f867588aed09e9",
+              "a262e24aca2f0ad9e3b9e55a81312440580aa5f08dfcd3751fdb85902bfc46a4",
+              "a68c4c6a5b2a07b43e4467c7d2a35d4a2bf0b1ad4b86bf48f94aa0f3ce43c5ce",
+              "a924c288fa8ff6a5c7e747aa31dc3ed02f283aa59203ea6332b1b1865816d4aa",
+              "ab9c582589c6f479d6136ea086d74bf7fbb838e0ef16a48b51ab79500c972037",
+              "ac39f1e805d1d8021ee399c162d7bc43206002b0d263e46f5dbe943bdf55d0e5",
+              "aedb50fd68930fec9984e2a53be883a7b8e41fdf055745d81868560d939b65ff",
+              "b19b916498c08e29fa04bf3f6592830bd160d33797a3f4d20f34f2e6f142ce0d",
+              "b29ff95bf7293a5861bdc5167d5fa446bd6282c816a104db96ddbb1fec421042",
+              "b70ed71d7e5a161d19c865273754323adf5ad8215e488f3c578813f93699bb37",
+              "b74bab0b7625bc5b9c0bfa228ead253cba8556166c20d02e475d05e1d6af3be4",
+              "b9a13fa6d8e5ef7e047c7ca3138050c8b2c2d053020d544162941c2e42ecd662",
+              "b9a176032d8e10e003fe70475e30260956ae6dc358a905773b325c883298a1f8",
+              "bbbb872b87f86a928e1ac688f8b83c85f676d737ce9f57afb2a89df79ce9fd24",
+              "bc5ad35457281752786b8a78514f72460a0103c22e759d2e9e5d6c68e250cff0",
+              "bc5c90dce46a654b89b8a317618a9ec0232dc16b9afaa5298568a769b1875ff5",
+              "be8dc7d2935ca3a38ba38a19307c8219e527af0d3d0002f23b54412339baf4bc",
+              "bf70525f8b39bcd6c9d5d78569fd04eb655c5be908530b89b728624aab76daf1",
+              "c0c463c390f9bc6b2bf64f3d9bd4169073fca11a13bb2d27efc24351feaf6ac2",
+              "c5a748bd206f50bc34af939c53515c2cf4a30f3593d492987c84124124d1ff76",
+              "c7573b9b9719a2a81cb0957bfa60fbe972c36784e76b397d423df1df39d16458",
+              "c7e98d105e6400ab4765e9ed844a12d83c616f5e97d128474e2cfaf56930b5a5",
+              "c7efbe46b1b3ae093bd179c20570b4b485ae787c099dcfb1686074f4de91cd48",
+              "ce2cc5d8cb7f8b02a3e9f348d99fa302d513068b713bc84c1adf76f55f4f82f8",
+              "cec30f4902c1659c73e8fc1040c1e9e61ead6e27111c4d9145a5e719fd1a0a08",
+              "cf7890ec67e6bfce782aa935db8d49d5bed3e0e1031e05115ec1a3a88223738d",
+              "cfd9b16d57a130b039e6fe22f3c4021181438579f88f20d1fc43c5159f245b44",
+              "d23190da71fa87cb06def2c13a088a750ca7bb3c4a66c0b4b909161e9bde4619",
+              "d45727da7f9cec55e7c5cc33f82bc5cad4cc72ed560988954b53a1f7eeb7a84f",
+              "d773801ac4f4a7d1d22ce6fe56f9983aecff7a6d32722b435f543f03fcdd80b2",
+              "db12ef284803466373bd1cec0322860093b441585aee99e5924c1c86f8567b20",
+              "eecdf363bf203630c201a550ecc2be4202f06a540fabbfc38f58c7ee6bee898a",
+              "f0775060b7a6197429b19f789017451e1a78893bf2ca41d8728851615ed01aea",
+              "f38dd949dc11ccb5566c8ac39e7939c7c8c54ae9e5099f42064f16c37e547382",
+              "f5535054742f89717efc6638b11cbee194723293df2d282cb87580c35b50a31f",
+              "f97c34d88bfc2c944906ccb4f8096ae9704c90028f7719d2b9c5cc061635652f",
+              "f9822ceff8aca3c30e5002dbf6c0943e8eb2c339cafd17f151952be55a791169",
+              "f9d64ff6a50bb6f0164318255970a655780eaeec01dd48d950ebd29f8e1c810c",
+              "fac5af981ab5d338bd1c14ce16adc34f02cb9911b29cd455a085e3e005423805",
+              "fc41204c5609212dc17cddca97663f544636955a84fe72c88682ba800b979f93",
+              "fcec433b44369ebfe2350a504774ffbe6ad452efc824b6e0b54fa65859ecb7fd",
+              "ffdecc14eba4b51a2dd490173b5ca788b5519f7e8d365d899d6e2f806f5e30d0"
+            ],
+            "unique_vector_count": 119
+          },
+          "random_objective_seed": 20265729,
+          "source_model_index": 5,
+          "source_positive_inequalities": 206,
+          "source_target_id": "seeded:5",
+          "source_unique_ordered_quad_count": 206,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "e3996707d68fa6780edc65ce9c8369b7ddd5848662ae4859fc313432893aebfd",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 6,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              23,
+              15,
+              12,
+              9,
+              20,
+              6,
+              3,
+              17
+            ],
+            "source_unique_ordered_quad_count": 118,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 20,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:6",
+              "seeded:7"
+            ],
+            "direct_cross_target_count": 1,
+            "source_target_id": "seeded:6",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 1
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              23,
+              15,
+              12,
+              9,
+              20,
+              6,
+              3,
+              17
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  19,
+                  6
+                ],
+                "weight": 2497
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  20,
+                  6
+                ],
+                "weight": 2478
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  3
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  19,
+                  21
+                ],
+                "weight": 1208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  7,
+                  1
+                ],
+                "weight": 1684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  4,
+                  6
+                ],
+                "weight": 16825
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  2,
+                  6
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  16,
+                  4
+                ],
+                "weight": 3705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  16,
+                  10
+                ],
+                "weight": 9803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  16,
+                  3
+                ],
+                "weight": 47
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  21
+                ],
+                "weight": 7023
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  12
+                ],
+                "weight": 11700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  13,
+                  20
+                ],
+                "weight": 2661
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  24,
+                  7
+                ],
+                "weight": 1684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  10,
+                  17
+                ],
+                "weight": 9803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  23,
+                  12
+                ],
+                "weight": 1953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  4,
+                  3
+                ],
+                "weight": 2219
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  20,
+                  6
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  18,
+                  20
+                ],
+                "weight": 1684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  1,
+                  15
+                ],
+                "weight": 1684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  15,
+                  6
+                ],
+                "weight": 19044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  9,
+                  20
+                ],
+                "weight": 19044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  11,
+                  1,
+                  12
+                ],
+                "weight": 2614
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  8,
+                  22,
+                  13
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  8,
+                  12,
+                  6
+                ],
+                "weight": 8483
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  22,
+                  19,
+                  24
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  22,
+                  5,
+                  1
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  22,
+                  13,
+                  24
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  19,
+                  24,
+                  18
+                ],
+                "weight": 3508
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  5,
+                  18,
+                  6
+                ],
+                "weight": 1289
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  16,
+                  6,
+                  3
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  2,
+                  18,
+                  1
+                ],
+                "weight": 2219
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  13,
+                  10,
+                  18
+                ],
+                "weight": 5989
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  21,
+                  15
+                ],
+                "weight": 3066
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  18,
+                  4
+                ],
+                "weight": 5989
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  21,
+                  6,
+                  17
+                ],
+                "weight": 3066
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  2,
+                  13
+                ],
+                "weight": 1452
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  21,
+                  15
+                ],
+                "weight": 7221
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  21,
+                  12
+                ],
+                "weight": 2614
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  1,
+                  20
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  1,
+                  3
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  15,
+                  17
+                ],
+                "weight": 8998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  16,
+                  13
+                ],
+                "weight": 1242
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  13,
+                  21
+                ],
+                "weight": 11043
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 8627
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  13,
+                  17
+                ],
+                "weight": 210
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  7,
+                  15
+                ],
+                "weight": 1777
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  1,
+                  9
+                ],
+                "weight": 93
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  2,
+                  17
+                ],
+                "weight": 605
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  21,
+                  17
+                ],
+                "weight": 7878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  9,
+                  17
+                ],
+                "weight": 4298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  2,
+                  1
+                ],
+                "weight": 847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  10,
+                  21
+                ],
+                "weight": 657
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  4,
+                  15
+                ],
+                "weight": 11519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  12,
+                  17
+                ],
+                "weight": 9330
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  10,
+                  4
+                ],
+                "weight": 11519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  10,
+                  1,
+                  12
+                ],
+                "weight": 847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  4,
+                  15,
+                  9
+                ],
+                "weight": 4298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  12
+                ],
+                "weight": 2614
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  18,
+                  17
+                ],
+                "weight": 2614
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  13,
+                  3
+                ],
+                "weight": 2219
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  20,
+                  6
+                ],
+                "weight": 12464
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  21,
+                  18
+                ],
+                "weight": 2614
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  24,
+                  10
+                ],
+                "weight": 20625
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  16,
+                  24
+                ],
+                "weight": 1684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  2,
+                  15
+                ],
+                "weight": 27093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  13,
+                  7
+                ],
+                "weight": 3705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  6,
+                  3
+                ],
+                "weight": 13753
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  24,
+                  6
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  13,
+                  15
+                ],
+                "weight": 27093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  15
+                ],
+                "weight": 13870
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  15,
+                  12
+                ],
+                "weight": 13870
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  24,
+                  15
+                ],
+                "weight": 32040
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  7,
+                  4
+                ],
+                "weight": 3705
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  21,
+                  18,
+                  4
+                ],
+                "weight": 3404
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  18,
+                  9,
+                  20
+                ],
+                "weight": 4298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  1,
+                  12,
+                  6
+                ],
+                "weight": 11256
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  4
+                ],
+                "weight": 847
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  13,
+                  4
+                ],
+                "weight": 2858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  13,
+                  1
+                ],
+                "weight": 11890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  7,
+                  1
+                ],
+                "weight": 16256
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  20,
+                  17
+                ],
+                "weight": 9803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  21,
+                  1,
+                  12
+                ],
+                "weight": 27299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  15,
+                  12
+                ],
+                "weight": 11700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  7,
+                  4,
+                  15
+                ],
+                "weight": 847
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  3,
+                  17
+                ],
+                "weight": 38793
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  13,
+                  17
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  18,
+                  3
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  18,
+                  12
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  10,
+                  7
+                ],
+                "weight": 1777
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  10,
+                  12
+                ],
+                "weight": 4123
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  21,
+                  20
+                ],
+                "weight": 2661
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 3705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  21,
+                  7,
+                  1
+                ],
+                "weight": 30365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  6,
+                  3
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  7,
+                  4,
+                  15
+                ],
+                "weight": 29425
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  21,
+                  4
+                ],
+                "weight": 3404
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  21,
+                  12
+                ],
+                "weight": 1408
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  1,
+                  6
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  7,
+                  20
+                ],
+                "weight": 109
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  21,
+                  12,
+                  17
+                ],
+                "weight": 4812
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  4,
+                  20
+                ],
+                "weight": 109
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  1,
+                  15,
+                  20
+                ],
+                "weight": 442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  1,
+                  15,
+                  17
+                ],
+                "weight": 8725
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  12
+                ],
+                "weight": 17427
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  4,
+                  20
+                ],
+                "weight": 9694
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  21,
+                  15,
+                  20
+                ],
+                "weight": 17427
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  4,
+                  12,
+                  3
+                ],
+                "weight": 16019
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  4,
+                  20,
+                  6
+                ],
+                "weight": 3344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  15,
+                  20,
+                  6
+                ],
+                "weight": 4666
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  7,
+                  15,
+                  12
+                ],
+                "weight": 23131
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  4,
+                  15,
+                  20
+                ],
+                "weight": 14766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  1,
+                  15,
+                  6
+                ],
+                "weight": 25754
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  23,
+                  12,
+                  3
+                ],
+                "weight": 395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  15,
+                  6,
+                  17
+                ],
+                "weight": 27438
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  12,
+                  9
+                ],
+                "weight": 93
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  15,
+                  9,
+                  20
+                ],
+                "weight": 7141
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  1,
+                  6,
+                  3
+                ],
+                "weight": 13800
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 118,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 846114
+          },
+          "compressed_positive_inequalities": 118,
+          "compressed_unique_ordered_quad_count": 118,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 132,
+              "seed": 20266729,
+              "trial": 0,
+              "unique_ordered_quad_count": 132
+            },
+            {
+              "positive_inequalities": 121,
+              "seed": 20266740,
+              "trial": 11,
+              "unique_ordered_quad_count": 121
+            },
+            {
+              "positive_inequalities": 118,
+              "seed": 20266749,
+              "trial": 20,
+              "unique_ordered_quad_count": 118
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "118": 1,
+            "121": 1,
+            "127": 1,
+            "131": 1,
+            "132": 2,
+            "133": 1,
+            "135": 1,
+            "136": 2,
+            "137": 2,
+            "138": 1,
+            "143": 1,
+            "144": 1,
+            "146": 2,
+            "148": 2,
+            "153": 1,
+            "154": 2,
+            "158": 1,
+            "170": 1
+          },
+          "numerical_support_size_max": 170,
+          "numerical_support_size_min": 118,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            23,
+            15,
+            12,
+            9,
+            20,
+            6,
+            3,
+            17
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 117,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 117,
+            "support_size": 118
+          },
+          "quad_reduction": 87,
+          "quad_reduction_fraction": 0.424390243902439,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "00dfdfa0bdceb5b218487ba729b0328eeabc29cde9e13b6db85dcb17940f5170",
+              "02f1213e0b6343b0531249c14e077fbc6552fb48b21f86fd361c057677d219c0",
+              "02f1e492f0716c884a401d4920a32f84f361a73629682c5239a929c6c5bb46d4",
+              "03c7cb18bcabf3e0300e10443f1d8c39e37199696f6df2ae6a1db0a7bef83483",
+              "054cb9657726aca2348c0b040245b60678a28fa7d6fad5eb9ee21ca90fce2c79",
+              "084103766231c6e1ee6d2d7dc1484f1da19204224659650bfb33187e56d8afaa",
+              "0c756bae1000ef0e5c349f485d9cdbd4a08bdec51514bd49bfde91ace1e4d59a",
+              "0d2023589fa062d0490a4fb61970326777d39e8f2bbc1f4644da48e141b54dcf",
+              "102a4b2817d4badd0e5ab364e5b3e3b037030434d0f1674134b3bf268c39bbd6",
+              "10a7c2bad0214b4af172c38ea43e131d3f492381f95fcfb31332cea9dd4cde09",
+              "10a8dd60927e7703b266d1770ffa94676dadfc1a9eb832aeabf074f667653a5f",
+              "11fd77ef4c128a28ddb86ff83212542865f23a9f7f64f455f232aa6c7b661ec5",
+              "19511c08a664ec497c835a72eb0b72cec726c5626ce1b68a1e5878f2cd8750bb",
+              "1a27ec221d8bb3db5f1ba825ce18627b79963557264fff1476859b2390980714",
+              "1c7a0a39812d7471cbe91062cc0d71aed4518260286c8243ea694b8f1e6b1a86",
+              "1c86b1cf39619bcc75b4ab3e8834922cf65768dc5db4a5ce089d138548b4dc5e",
+              "1cce9c457d1357c44090c75078bd65de4f7cf3539d40081e23d7df3222c59424",
+              "210fa0fdba61cc7ddf0afb9cd31fff3703e613d232272644d019b7c3ec66cf91",
+              "2208f90a7b79158bab022a372acb7eff1b2a5bcb8cd76906d1dc3a14e15fa64c",
+              "24d9b7c57a0f5f7445b99205105d8520fb8c869371121849ced02f0c30d79d5a",
+              "2d6782d3fd55f27ddc6fe8848e59938ae027fc0868cb98d7ec4e5d113240439b",
+              "2f2169532a49a89b4dc1404804f11bca4aa6d563d9d4bc4d2f409f58b7e7a6f5",
+              "2f427a756e67728f1d768bdcd5213ad76beec2c75e40df91e23e45329556a364",
+              "313dad882fa23ca318fdbc2e1e5cfe5b3b79e75b7cf5f6ef740f3c42da446170",
+              "31e692b8b3a17d430e7eef618562c924b2001b858e75b6205e9509e13cf25a99",
+              "32649f410d43418c608c7c85d7df157c377ee7b9ee31041a707f733911dce9e6",
+              "326e8b39611b148c8c2f5291d7bfbf986162ad59c52c3bf23b800f76a988c4bf",
+              "35be89730e7e09fce683bbc561ff89f3007591f65e67a1c13fafb435da120de9",
+              "37623e84614a09c83b2869a49986d962c290f675b7cdb397f46e5e9e2b65608f",
+              "37b7d08bac99f9c183d382c7f2a53b44c5edc9dc611173063fd40338dd3ea26a",
+              "39ef8d9d606cbb7f4f2fefbcc9a3062ac26fb6e3b1d29166a9ef3d5b1c696ede",
+              "3cd324f5f6ad6853dab286be1a316ef3c226cb4e16b9d1826aa7ade23574dc1d",
+              "47524234fba569c53d13a50bcce8642f999f514d09705c634f077fbbe390bbce",
+              "4971923873c9be48c58db4cc8454a5cbfda5d22e25be96bb34c6405d0dfc5c09",
+              "4bf34a4de8dbed1d9addd5d6537baecb11a1d030a9e9703cd70cf6bc3da82edd",
+              "4e55d16b42ff99fcf4e9a6a5fc34086bba29d8a6c111007fec37249623e7fbac",
+              "4f32599f7bef63ec6bbb620def366f2290d9d403e51dc20c9e63d63f85351945",
+              "51d76234c96d8973b0a22c5b815d85041a06d0eafbeb73617a5e0a552f212051",
+              "51eb85725066bdaf4ec356e28abdf885a912c79a368e0d1f80e512ed08e78e1e",
+              "575a06a2a1ac69a1bb5b10c7654323423db6fe7300f11cf515474731b2c89309",
+              "5e54e4550b898016f2064ff75f84d057778c28ba28f19621bfcceb6668d38fe8",
+              "5f89f36fdf27a20c577b5acaf9c366d8aa302e13df3e12b7566fb8583ea00573",
+              "5fabbba55bf9d8f02d2e2bf985c05b7f96e32e032053f36b151e8e6bc45d71eb",
+              "6bfc9cf883e94c1b8c893a99190fc65e7131ca82f56a8d1672fb1610b943f582",
+              "6eee70647a1ed32d25d4733f2a5b3ef401b8baffef1d52aa537d25dcedcab12b",
+              "711e20a680f4d80940439c523dd9c378fd2f4771bc900048016a778c94e6b862",
+              "71b661ad0d7658ff1a35bcec601d5e3d537198ca1c0fd6f5b44a8ba081e5e0ef",
+              "73de96631d01ea7b4b7c06264ae2b3f7020ca7f5bc832bb7261adff13ac4d31f",
+              "76a838ed2474aaa395fa16e8a5078f0cb04d5a64252a71cedffde64c528ae349",
+              "76cea72f9f564beed5c6dc601154d2e0c867adcaa6562221f348c918a6e04224",
+              "79e68f2f94c2547b9a3301363c3a4e5e64e80623a39380e3aa685fec61fde883",
+              "7b788df1ce97b878b732f461c5420559abba7a9db2ce54dc9de1de99ee87ecbc",
+              "7d1637a11a529a1d40ddb3e35da23cb6fdaf12b6dcd49741ae420a6475f12225",
+              "7e7201b743efe1053862abdd37d95bb928defb5f968163576656b3118270af1c",
+              "800803f51528a6939f6c754260397b86ad6a51262e5ac2e6912c0201452dc49e",
+              "8705675a5cd2ea2c1610a7f9eef8b05471ead7bbba1f1ac1792129c6f5ab7a66",
+              "87d8c518265332532ba4e152284ed85d3fcad26e97a118fdb62ae819ec051bbf",
+              "89ba85636b7c0cc4fbe5f8e09169c344eeaf0512eb62be01804e87f4214266a0",
+              "8a89a5eec3210a93465dd33ae415e4611ce6e6dabe42dc3f1c07736f7588f7b6",
+              "8c0b741e0917256eefc25a00920fea281392490513742cc2c1f6f6fa158eb7f5",
+              "8de7c032ad021104106a6b279ebc4ae0e2d2322efa28721b90e69613beab602d",
+              "8deb551c3e7e951569e05a3354d8dec8550f73f40a30588b9fc3bbe1c241a38e",
+              "8e15fdeed169d9fef6f2b8c11d18cb977023dbc60d88d560d8cbfb590a325abd",
+              "92e7384b16752eb3f8d9b9232f6eeefab68048a604b62e5814a55a9871a7ea2b",
+              "94484ee1218f92174b78ae5888de37e0654c5b1bb98e6c8e83408de4f28d37e3",
+              "955468ae423a212bd07c130e6f5f07764241af6c064c301cf7c02f40bc1f81b2",
+              "96850c8bb7ca1ec632f386890640a4cc4cf39d0cec281d0733b4401daada9e3b",
+              "96fe9057cd072a5591d8532608dc4d0a249ecb810efe1dd8e52d1eff624909b6",
+              "99923adad72e6e70c5aa79b1e4f126d67a78a5f819bc6ac9af0d44cc06649084",
+              "9a9016e5ffa69648e0a6378300f37868fbe2d6f25106100a77998feff7b17ea7",
+              "9a983b92a1d47b78b3602e52df63746db1e596ace3224cb44e902e2d3a04a92e",
+              "9bdaa16d374cd9f4e7c6ec974b0d163bab6be77a37412e1490a4f007bce97ede",
+              "9f4b92537b3e0ea4a693b57112171c49bb2624a75de822a7c93bdc731bd1cfd1",
+              "a0ad493f09b203da51677cbd33698481f7e9c3c4581dc04979ac936c5e42a4de",
+              "a182d4e6473be75b33e5e948313fb39bfd8b059f2ed876fd26c4fb4c778598f4",
+              "a1f50bdc7f79d2b726db9d795593aaa3efd7957b3adb3f2814fd25b661baf4b8",
+              "a54da934bd92ce26fa5fd8700c1cd788d6e1527048d6be40f6705e8a404e80a6",
+              "a6d15ac423da55dd5b61e34643bbe6171ca52e973f91a5c890fca7539545d97f",
+              "a9263ff3b347659495f945bc04d1236f23f12fde0985a91deb2d12a745c748b8",
+              "a958bf88e2c8010bf82935f48cb22aa8a4b7ee2276d15c98e769c776bee445cb",
+              "acaa0765bf2112c8025465fe4512bd2ef4ef8c57bb46c35e8f64c975d81dc33c",
+              "ae32fd7d167c2ddf0287e282339edcfc74834536a3c9b76a11cc9f98d172d808",
+              "aef499a94885d385edc3ef194491e1f7ccf27ff0975f468fd54b6d3dd9e68287",
+              "afa741ab1d00bd4014dbd2bb70f4d9590bf9caa09a9d72985fd22e2235c782b1",
+              "b2c928d26f1a936d147c0c1e6de0b548d4bb059d5151c3e501e5c8eedf4b34a5",
+              "b41c204cf65e33c1fb85871cedbe7524dc493b1dcd700e0bd10582dc8f7fa02b",
+              "b83dce807ca5d2a09dd9f0a8a14a2cd3e21e3a944c6055ef0ef8e95a83a7c88f",
+              "b876c638288bb8bf65fb63a8af22dc9a6389b8ee7fd0a7aff64639e45db4abc5",
+              "ba745b8c1580ec57022c87c5eb6a783ca43d546d9559cc32e54022021082fe30",
+              "baa8d02dd564553e9e49a87bbfd9c1b34d79a6f03d915fa34e9bad47f7bc19da",
+              "bd94d0a694b34a10a09c72fee3ec2c90404d26a80ac001ba0bbd704de0926a19",
+              "bf1d865d3c2c0aaa1ee74e90c4df6551143760f71caa20e8b4e096e3812c74df",
+              "bf3de8279b23e8f3213b3ebd2b34a56b53b9c5bcd329e4416536feb8bb1807fe",
+              "bf5dbb6272400eb6e48aa2ed17909b028d08f5570a3d437a20c08349dca184b5",
+              "c05b5dd8686fbb24e9ce994723824dc716010681a0fe2e996547a8d7c70a2f21",
+              "c1672fe1030bed605a858dc252a64bf6f63a13a2d2144814bfe8280a6022bc6f",
+              "c58f45b87c23676b1d147050430187b6b85eee3f14b8e13a11f98e91fcd94f66",
+              "cab57808e749ce091549370a2e570099448566a204060b56a397b4cc31bde2cd",
+              "cbc654d2101e6113412360b0b9c1ccb4f187c1cdb6be12d6c9275c5144ef21aa",
+              "cc7e25864ac502812cb7d42faaa8f7a3396d035833a6e9b5aecea3cff1bb3a6a",
+              "cde26140b8aab02453b449e024ecc6ad6c51d49db99016f425cdee68ee8fc1ab",
+              "d07717952e6bc6243877787c7f7ade372363d7211a80e82615764646e1be7f18",
+              "d0f63a6b325ea66de63ff82a3e55ac4cdd535da9cb0695077680699d698aa5cd",
+              "d4adbb89d046f2df14a967f7bfe7f5400e20fef7b90d0184f4474c29fae1ddc8",
+              "d755af93e2e1cf084ce4b39bebc09e2b466f7795e04be40f953759c70b88a391",
+              "d8cf9b84c2c5c812dbd0c724a66f2a4cac337173c24d07acb168f994803bef9e",
+              "dbfee3ced50ceffe3effefff530def769a653ba5a790c3759b5d88b080e9d080",
+              "e2232d458c1cc7f0b8f1d3174466a6ddde2b89e227bd10178122cb99ed96402f",
+              "e9749768c5cd2e366ef2444f4944221d15897159ebea90292ae891ea061a403c",
+              "eb2a1e7bd8fedf13c22a518da294e86a86013c41f22410a642de7e14ee360e15",
+              "eef1a531ae49938bbbcf75a0c3e11856e0a0bf2fe3efb13e8c572c855d27ea80",
+              "ef2db1ac1d489d679f4567b4648d1a0db93cf70652e66b2e4a2b4cfae947cf36",
+              "f200f49f9ba6075fe40851c60fb0f9466c1aead5fcc2fef03531fa05bb046d10",
+              "f20f497a2e57056b329165eeb9f7c35a1e31d93d92b9024e63a04218765a16e4",
+              "f3850d2a7b7a3d37bb940216df5a620df437912ec984e3265dd7194d1086d4c9",
+              "f3937ad9a262f79d9bbe96fbc8c613c193302557ee8759fae3a404af15d2566b",
+              "f8ac5916f6e6cad607582df6b032f8aa0c63fc780577303655517dd3d67b2eec",
+              "fac142ca464bf150e0e47acb239a56492bef9bf4673593d7c29ef7817a9e1463"
+            ],
+            "unique_vector_count": 118
+          },
+          "random_objective_seed": 20266729,
+          "source_model_index": 6,
+          "source_positive_inequalities": 205,
+          "source_target_id": "seeded:6",
+          "source_unique_ordered_quad_count": 205,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "ef3d6069c76755ca2044029a85d4d6b498d431284a2b51380c36624f756fbef4",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 7,
+            "source_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              15,
+              23,
+              12,
+              9,
+              20,
+              6,
+              3,
+              17
+            ],
+            "source_unique_ordered_quad_count": 3,
+            "unique_orbit_clause_count": 25
+          },
+          "best_trial": 5,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:4",
+              "seeded:5",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "direct_cross_target_count": 3,
+            "source_target_id": "seeded:7",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:1"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:2"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:3"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:4"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:5"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 2,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 6
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              11,
+              8,
+              22,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              1,
+              15,
+              23,
+              12,
+              9,
+              20,
+              6,
+              3,
+              17
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  21,
+                  15
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  18,
+                  15
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  21,
+                  1,
+                  15
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 3,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 3
+          },
+          "compressed_positive_inequalities": 3,
+          "compressed_unique_ordered_quad_count": 3,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 151,
+              "seed": 20267729,
+              "trial": 0,
+              "unique_ordered_quad_count": 151
+            },
+            {
+              "positive_inequalities": 147,
+              "seed": 20267730,
+              "trial": 1,
+              "unique_ordered_quad_count": 147
+            },
+            {
+              "positive_inequalities": 138,
+              "seed": 20267731,
+              "trial": 2,
+              "unique_ordered_quad_count": 138
+            },
+            {
+              "positive_inequalities": 3,
+              "seed": 20267734,
+              "trial": 5,
+              "unique_ordered_quad_count": 3
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "106": 1,
+            "117": 2,
+            "126": 1,
+            "128": 1,
+            "131": 1,
+            "133": 1,
+            "135": 2,
+            "136": 1,
+            "138": 1,
+            "139": 1,
+            "140": 2,
+            "141": 1,
+            "142": 1,
+            "144": 1,
+            "146": 1,
+            "147": 1,
+            "149": 1,
+            "151": 2,
+            "165": 1,
+            "3": 1
+          },
+          "numerical_support_size_max": 165,
+          "numerical_support_size_min": 3,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            15,
+            23,
+            12,
+            9,
+            20,
+            6,
+            3,
+            17
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 2,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 2,
+            "support_size": 3
+          },
+          "quad_reduction": 205,
+          "quad_reduction_fraction": 0.9855769230769231,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "74a2c986e40db9cb0c080d1afeae144f10c361f408a48b39c15d5491d586fa05",
+              "b2c669d0f7f12a78bd721a83098be69c7d4e06daeccd1f52bbf0b43859eb115b",
+              "bbdbf12104df9ad58b88548537a7368c977984b464c1ff83bcaaf4a0155ac9fa"
+            ],
+            "unique_vector_count": 3
+          },
+          "random_objective_seed": 20267729,
+          "source_model_index": 7,
+          "source_positive_inequalities": 208,
+          "source_target_id": "seeded:7",
+          "source_unique_ordered_quad_count": 208,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        }
+      ],
+      "coverage_summary": {
+        "compressed_source_count": 8,
+        "direct_covered_target_count": 8,
+        "direct_cross_reuse_edge_count": 11,
+        "target_coverage": [
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:0",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:1",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:2",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:3",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:4",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:5",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:6",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:7",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:8",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:9",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:10",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:11",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:12",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:13",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:14",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:15",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": false,
+            "target_id": "seeded:0",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:1",
+              "seeded:2",
+              "seeded:3"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:1",
+            "translated_orbit_covering_source_ids": [
+              "seeded:1",
+              "seeded:2",
+              "seeded:3",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:2",
+              "seeded:3"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:2",
+            "translated_orbit_covering_source_ids": [
+              "seeded:2",
+              "seeded:3",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:3"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:3",
+            "translated_orbit_covering_source_ids": [
+              "seeded:2",
+              "seeded:3",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:3",
+              "seeded:4",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:4",
+            "translated_orbit_covering_source_ids": [
+              "seeded:2",
+              "seeded:3",
+              "seeded:4",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:3",
+              "seeded:5",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:5",
+            "translated_orbit_covering_source_ids": [
+              "seeded:2",
+              "seeded:3",
+              "seeded:5",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:3",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:6",
+            "translated_orbit_covering_source_ids": [
+              "seeded:2",
+              "seeded:3",
+              "seeded:6",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:3",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:7",
+            "translated_orbit_covering_source_ids": [
+              "seeded:2",
+              "seeded:3",
+              "seeded:6",
+              "seeded:7"
+            ]
+          }
+        ],
+        "target_order_count": 24,
+        "translated_orbit_covered_target_count": 8,
+        "translated_orbit_cross_reuse_edge_count": 19
+      },
+      "n": 25,
+      "pattern": "C25_sidon_2_5_9_14",
+      "quotient_vector_reuse": {
+        "distinct_vector_count": 492,
+        "max_certificate_frequency": 2,
+        "nonzero_pairwise_overlaps": [
+          {
+            "jaccard_fraction": 0.008130081300813009,
+            "left_source_target_id": "seeded:1",
+            "right_source_target_id": "seeded:2",
+            "shared_vector_count": 1
+          },
+          {
+            "jaccard_fraction": 0.004219409282700422,
+            "left_source_target_id": "seeded:1",
+            "right_source_target_id": "seeded:4",
+            "shared_vector_count": 1
+          },
+          {
+            "jaccard_fraction": 0.008583690987124463,
+            "left_source_target_id": "seeded:1",
+            "right_source_target_id": "seeded:5",
+            "shared_vector_count": 2
+          },
+          {
+            "jaccard_fraction": 0.0041841004184100415,
+            "left_source_target_id": "seeded:4",
+            "right_source_target_id": "seeded:6",
+            "shared_vector_count": 1
+          },
+          {
+            "jaccard_fraction": 0.00423728813559322,
+            "left_source_target_id": "seeded:5",
+            "right_source_target_id": "seeded:6",
+            "shared_vector_count": 1
+          }
+        ],
+        "per_source_max_pairwise_shared_vector_count": [
+          {
+            "max_pairwise_shared_vector_count": 0,
+            "source_target_id": "seeded:0"
+          },
+          {
+            "max_pairwise_shared_vector_count": 2,
+            "source_target_id": "seeded:1"
+          },
+          {
+            "max_pairwise_shared_vector_count": 1,
+            "source_target_id": "seeded:2"
+          },
+          {
+            "max_pairwise_shared_vector_count": 0,
+            "source_target_id": "seeded:3"
+          },
+          {
+            "max_pairwise_shared_vector_count": 1,
+            "source_target_id": "seeded:4"
+          },
+          {
+            "max_pairwise_shared_vector_count": 2,
+            "source_target_id": "seeded:5"
+          },
+          {
+            "max_pairwise_shared_vector_count": 1,
+            "source_target_id": "seeded:6"
+          },
+          {
+            "max_pairwise_shared_vector_count": 0,
+            "source_target_id": "seeded:7"
+          }
+        ],
+        "shared_vector_count": 6,
+        "shared_vectors": [
+          {
+            "certificate_count": 2,
+            "sha256": "2413d4f498d7e85df82c07a47c7bc31efeb3a18ddda4772a80bde1e95f6a04fb",
+            "source_target_ids": [
+              "seeded:1",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "43afc59caf0e6c94ed1054967aaae28a72c965aed1122f39890ad565f9fb9ef1",
+            "source_target_ids": [
+              "seeded:1",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "4bf34a4de8dbed1d9addd5d6537baecb11a1d030a9e9703cd70cf6bc3da82edd",
+            "source_target_ids": [
+              "seeded:5",
+              "seeded:6"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "89fd83f86649367c3c2ef2c61dd11bb4a4319fcedf5269d52c350ba587be5791",
+            "source_target_ids": [
+              "seeded:1",
+              "seeded:4"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "8bb19f93fc15e5ddab26e3a89e6f08d27f0fb7ffb3dda1ba7058e79e85397552",
+            "source_target_ids": [
+              "seeded:1",
+              "seeded:2"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "b41c204cf65e33c1fb85871cedbe7524dc493b1dcd700e0bd10582dc8f7fa02b",
+            "source_target_ids": [
+              "seeded:4",
+              "seeded:6"
+            ]
+          }
+        ]
+      },
+      "target_orders": [
+        {
+          "model_index": 0,
+          "order": [
+            0,
+            3,
+            6,
+            20,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11,
+            14,
+            17
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:0"
+        },
+        {
+          "model_index": 1,
+          "order": [
+            0,
+            20,
+            3,
+            6,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11,
+            14,
+            17
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:1"
+        },
+        {
+          "model_index": 2,
+          "order": [
+            0,
+            14,
+            17,
+            3,
+            6,
+            20,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:2"
+        },
+        {
+          "model_index": 3,
+          "order": [
+            0,
+            14,
+            3,
+            17,
+            6,
+            20,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:3"
+        },
+        {
+          "model_index": 4,
+          "order": [
+            0,
+            17,
+            3,
+            6,
+            20,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11,
+            14
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:4"
+        },
+        {
+          "model_index": 5,
+          "order": [
+            0,
+            3,
+            17,
+            6,
+            20,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11,
+            14
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:5"
+        },
+        {
+          "model_index": 6,
+          "order": [
+            0,
+            14,
+            3,
+            17,
+            20,
+            6,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:6"
+        },
+        {
+          "model_index": 7,
+          "order": [
+            0,
+            14,
+            17,
+            20,
+            3,
+            6,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:7"
+        },
+        {
+          "model_index": 8,
+          "order": [
+            0,
+            14,
+            17,
+            3,
+            20,
+            6,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:8"
+        },
+        {
+          "model_index": 9,
+          "order": [
+            0,
+            17,
+            3,
+            20,
+            6,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11,
+            14
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:9"
+        },
+        {
+          "model_index": 10,
+          "order": [
+            0,
+            17,
+            20,
+            3,
+            6,
+            9,
+            23,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11,
+            14
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:10"
+        },
+        {
+          "model_index": 11,
+          "order": [
+            0,
+            14,
+            17,
+            3,
+            20,
+            6,
+            23,
+            9,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:11"
+        },
+        {
+          "model_index": 12,
+          "order": [
+            0,
+            14,
+            17,
+            3,
+            20,
+            23,
+            6,
+            9,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:12"
+        },
+        {
+          "model_index": 13,
+          "order": [
+            0,
+            14,
+            17,
+            20,
+            3,
+            23,
+            6,
+            9,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:13"
+        },
+        {
+          "model_index": 14,
+          "order": [
+            0,
+            14,
+            17,
+            20,
+            3,
+            6,
+            23,
+            9,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:14"
+        },
+        {
+          "model_index": 15,
+          "order": [
+            0,
+            14,
+            3,
+            17,
+            20,
+            6,
+            23,
+            9,
+            12,
+            1,
+            15,
+            4,
+            18,
+            7,
+            21,
+            24,
+            10,
+            13,
+            16,
+            19,
+            2,
+            22,
+            5,
+            8,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:15"
+        },
+        {
+          "model_index": 0,
+          "order": [
+            0,
+            18,
+            11,
+            4,
+            22,
+            15,
+            8,
+            1,
+            19,
+            12,
+            5,
+            23,
+            16,
+            9,
+            2,
+            20,
+            13,
+            6,
+            24,
+            17,
+            10,
+            3,
+            21,
+            14,
+            7
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": false,
+          "target_id": "seeded:0"
+        },
+        {
+          "model_index": 1,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            15,
+            7,
+            4,
+            1,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:1"
+        },
+        {
+          "model_index": 2,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            15,
+            4,
+            1,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:2"
+        },
+        {
+          "model_index": 3,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            15,
+            1,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:3"
+        },
+        {
+          "model_index": 4,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            15,
+            23,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:4"
+        },
+        {
+          "model_index": 5,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            23,
+            15,
+            12,
+            9,
+            20,
+            6,
+            17,
+            3
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:5"
+        },
+        {
+          "model_index": 6,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            23,
+            15,
+            12,
+            9,
+            20,
+            6,
+            3,
+            17
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:6"
+        },
+        {
+          "model_index": 7,
+          "order": [
+            0,
+            14,
+            11,
+            8,
+            22,
+            19,
+            5,
+            16,
+            2,
+            13,
+            24,
+            10,
+            21,
+            18,
+            7,
+            4,
+            1,
+            15,
+            23,
+            12,
+            9,
+            20,
+            6,
+            3,
+            17
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:7"
+        }
+      ]
+    },
+    {
+      "circulant_offsets": [
+        1,
+        3,
+        7,
+        15
+      ],
+      "compressed_models": [
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "505c55618e2ee6884b221e43761ce4b2142c51330a83c80d52545ffc2d3de0c5",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 0,
+            "source_order": [
+              0,
+              15,
+              20,
+              4,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              27,
+              9,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 5,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 19,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:2",
+              "seeded:3",
+              "seeded:4",
+              "seeded:5",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "direct_cross_target_count": 7,
+            "source_target_id": "seeded:0",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:0"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:1"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:2"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:3"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:4"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:5"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 7
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              15,
+              20,
+              4,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              27,
+              9,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  8,
+                  1
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  8,
+                  22,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  5,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  7,
+                  1
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 5,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 5
+          },
+          "compressed_positive_inequalities": 5,
+          "compressed_unique_ordered_quad_count": 5,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 207,
+              "seed": 20360729,
+              "trial": 0,
+              "unique_ordered_quad_count": 207
+            },
+            {
+              "positive_inequalities": 205,
+              "seed": 20360730,
+              "trial": 1,
+              "unique_ordered_quad_count": 205
+            },
+            {
+              "positive_inequalities": 202,
+              "seed": 20360731,
+              "trial": 2,
+              "unique_ordered_quad_count": 202
+            },
+            {
+              "positive_inequalities": 166,
+              "seed": 20360732,
+              "trial": 3,
+              "unique_ordered_quad_count": 166
+            },
+            {
+              "positive_inequalities": 5,
+              "seed": 20360748,
+              "trial": 19,
+              "unique_ordered_quad_count": 5
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "166": 1,
+            "170": 1,
+            "187": 1,
+            "194": 1,
+            "197": 1,
+            "199": 1,
+            "202": 1,
+            "205": 3,
+            "207": 2,
+            "209": 1,
+            "210": 2,
+            "211": 1,
+            "213": 1,
+            "215": 1,
+            "216": 1,
+            "218": 1,
+            "219": 1,
+            "225": 1,
+            "234": 1,
+            "5": 1
+          },
+          "numerical_support_size_max": 234,
+          "numerical_support_size_min": 5,
+          "order": [
+            0,
+            15,
+            20,
+            4,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            27,
+            9,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 4,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 4,
+            "support_size": 5
+          },
+          "quad_reduction": 289,
+          "quad_reduction_fraction": 0.9829931972789115,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "0100fee2b5bb2d16c556ea372be175cf855ac3048dd0aa20b61a49e667d6b9dc",
+              "60aa286869cbe489bfdee943e92a4954e94c2cf4ae097f4394d47b1337c5f399",
+              "74f77857fbd3098a63e57c05c92eed270111756c514e4f9609555be83b920e72",
+              "c5b8e0a9a5ed4cb98d1c6ae7e1e32be7fa4a146c083d26270ab8bf7882ff8ed3",
+              "cee2d1462009bd382cbc11d62891ce4ddfa39587762d99cc10275fd8f9b3aeb7"
+            ],
+            "unique_vector_count": 5
+          },
+          "random_objective_seed": 20360729,
+          "source_model_index": 0,
+          "source_positive_inequalities": 294,
+          "source_target_id": "seeded:0",
+          "source_unique_ordered_quad_count": 294,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "d778c533191fb6cfe2c1fa950ae0bec2e63edf16228731b8e9714800a08294aa",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 1,
+            "source_order": [
+              0,
+              15,
+              20,
+              4,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 4,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 8,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:2",
+              "seeded:3",
+              "seeded:4",
+              "seeded:5",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "direct_cross_target_count": 7,
+            "source_target_id": "seeded:1",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:0"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:1"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:2"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:3"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:4"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:5"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 7
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              15,
+              20,
+              4,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  10,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  24,
+                  10
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  6,
+                  21
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 4,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 4
+          },
+          "compressed_positive_inequalities": 4,
+          "compressed_unique_ordered_quad_count": 4,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 201,
+              "seed": 20361729,
+              "trial": 0,
+              "unique_ordered_quad_count": 201
+            },
+            {
+              "positive_inequalities": 193,
+              "seed": 20361732,
+              "trial": 3,
+              "unique_ordered_quad_count": 193
+            },
+            {
+              "positive_inequalities": 4,
+              "seed": 20361737,
+              "trial": 8,
+              "unique_ordered_quad_count": 4
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "193": 1,
+            "196": 1,
+            "197": 1,
+            "198": 1,
+            "201": 1,
+            "204": 2,
+            "205": 3,
+            "207": 1,
+            "210": 1,
+            "211": 1,
+            "212": 1,
+            "214": 1,
+            "218": 2,
+            "220": 2,
+            "224": 1,
+            "227": 1,
+            "236": 1,
+            "244": 1,
+            "4": 1
+          },
+          "numerical_support_size_max": 244,
+          "numerical_support_size_min": 4,
+          "order": [
+            0,
+            15,
+            20,
+            4,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 3,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 3,
+            "support_size": 4
+          },
+          "quad_reduction": 290,
+          "quad_reduction_fraction": 0.9863945578231292,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "1dc7eeffe3b0c7e75aa1c8c5726bd6009e89cce7c9df3bf3ad0a1dec57df9c63",
+              "22b5014dc113333ed857ee9dccd599907b459c683092630f6edabc580f4a3da5",
+              "726a5879e49e29a68e3ff1c8000cc0fa73b3725282ceb96e5ba67ff764d8439b",
+              "7a76cdd96fbe036dd953e511cec61fdceb3d4bb4fd207dcb87da3d975e3539f1"
+            ],
+            "unique_vector_count": 4
+          },
+          "random_objective_seed": 20361729,
+          "source_model_index": 1,
+          "source_positive_inequalities": 294,
+          "source_target_id": "seeded:1",
+          "source_unique_ordered_quad_count": 294,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "f3fbdff08778fe29031e66574f037ebc53a59481692559b29500d8952b9d9fe9",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 2,
+            "source_order": [
+              0,
+              15,
+              4,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              27,
+              9,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 184,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 9,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:2"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:2",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:2"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              15,
+              4,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              27,
+              9,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  27,
+                  21
+                ],
+                "weight": 470985
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  22,
+                  2
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  16,
+                  11
+                ],
+                "weight": 965191
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  9,
+                  24
+                ],
+                "weight": 1630227
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  24,
+                  28
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  2,
+                  13
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  9,
+                  6
+                ],
+                "weight": 342776
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  28,
+                  1
+                ],
+                "weight": 965191
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  27,
+                  14,
+                  11
+                ],
+                "weight": 470985
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  24,
+                  7
+                ],
+                "weight": 1973003
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  21,
+                  14
+                ],
+                "weight": 470985
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  6,
+                  11
+                ],
+                "weight": 766654
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  13,
+                  25
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  26,
+                  10
+                ],
+                "weight": 131519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  12,
+                  14
+                ],
+                "weight": 355318
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  5,
+                  16
+                ],
+                "weight": 925001
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  27,
+                  25
+                ],
+                "weight": 229164
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  10,
+                  12
+                ],
+                "weight": 131519
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  26,
+                  8,
+                  22
+                ],
+                "weight": 131519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  24,
+                  1
+                ],
+                "weight": 1440759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  12,
+                  11
+                ],
+                "weight": 2160579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  16,
+                  27
+                ],
+                "weight": 947016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  27,
+                  13
+                ],
+                "weight": 597803
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  3,
+                  24,
+                  6
+                ],
+                "weight": 378463
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  3,
+                  13,
+                  25
+                ],
+                "weight": 597803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  8,
+                  22,
+                  7
+                ],
+                "weight": 1395218
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  8,
+                  27,
+                  11
+                ],
+                "weight": 120049
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  5,
+                  16,
+                  14
+                ],
+                "weight": 474295
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  5,
+                  14,
+                  7
+                ],
+                "weight": 450706
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  22,
+                  16,
+                  25
+                ],
+                "weight": 427632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  24,
+                  12
+                ],
+                "weight": 1359211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  28,
+                  12
+                ],
+                "weight": 832593
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  27,
+                  11,
+                  1
+                ],
+                "weight": 2160579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  9,
+                  14,
+                  1
+                ],
+                "weight": 1095786
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  24,
+                  6,
+                  11
+                ],
+                "weight": 1205430
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  24,
+                  18,
+                  7
+                ],
+                "weight": 1973003
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  6,
+                  25,
+                  11
+                ],
+                "weight": 826967
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  28,
+                  18,
+                  11
+                ],
+                "weight": 832593
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  6,
+                  11
+                ],
+                "weight": 349213
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  26,
+                  3,
+                  18
+                ],
+                "weight": 733237
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  2,
+                  25
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  2,
+                  9
+                ],
+                "weight": 320995
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  28,
+                  12
+                ],
+                "weight": 108750
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  3,
+                  8,
+                  21
+                ],
+                "weight": 166084
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  23,
+                  24
+                ],
+                "weight": 166084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  8,
+                  7,
+                  1
+                ],
+                "weight": 2588577
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  23,
+                  16,
+                  11
+                ],
+                "weight": 118977
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  23,
+                  27,
+                  1
+                ],
+                "weight": 47107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  9,
+                  13
+                ],
+                "weight": 663771
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  10,
+                  28
+                ],
+                "weight": 108750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  12,
+                  1
+                ],
+                "weight": 464068
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  5,
+                  17,
+                  13
+                ],
+                "weight": 468190
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  22,
+                  2,
+                  9
+                ],
+                "weight": 342776
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  16,
+                  24,
+                  14
+                ],
+                "weight": 118977
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  18,
+                  14
+                ],
+                "weight": 355318
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  18,
+                  11
+                ],
+                "weight": 1084168
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  2,
+                  27,
+                  25
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  2,
+                  24,
+                  1
+                ],
+                "weight": 663771
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  2,
+                  25,
+                  11
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  2,
+                  21,
+                  1
+                ],
+                "weight": 100363
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  24,
+                  6,
+                  11
+                ],
+                "weight": 782748
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  21,
+                  1
+                ],
+                "weight": 1588772
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  6,
+                  13,
+                  11
+                ],
+                "weight": 1131961
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  17,
+                  10,
+                  18
+                ],
+                "weight": 468190
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  18,
+                  11
+                ],
+                "weight": 731318
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  10,
+                  21,
+                  11
+                ],
+                "weight": 708459
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  25,
+                  18,
+                  21
+                ],
+                "weight": 4302544
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  18,
+                  21,
+                  7
+                ],
+                "weight": 1433965
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  5,
+                  11
+                ],
+                "weight": 349213
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  8,
+                  5
+                ],
+                "weight": 1408007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  23,
+                  28
+                ],
+                "weight": 229164
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  27,
+                  9
+                ],
+                "weight": 349213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  28,
+                  25
+                ],
+                "weight": 229164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  8,
+                  5,
+                  9
+                ],
+                "weight": 1408007
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  5,
+                  9,
+                  1
+                ],
+                "weight": 480732
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  16,
+                  24,
+                  28
+                ],
+                "weight": 925001
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  10,
+                  14
+                ],
+                "weight": 131519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  17,
+                  12
+                ],
+                "weight": 131519
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  17,
+                  21
+                ],
+                "weight": 925001
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  12,
+                  18
+                ],
+                "weight": 733237
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  12,
+                  1
+                ],
+                "weight": 1016881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  5,
+                  7
+                ],
+                "weight": 487177
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  22,
+                  28
+                ],
+                "weight": 292359
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  27,
+                  1
+                ],
+                "weight": 4050051
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  5,
+                  9,
+                  6
+                ],
+                "weight": 137964
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  22,
+                  24,
+                  28
+                ],
+                "weight": 395858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  16,
+                  24,
+                  6
+                ],
+                "weight": 345400
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  2,
+                  11,
+                  1
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  27,
+                  9,
+                  7
+                ],
+                "weight": 1809643
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  9,
+                  6,
+                  28
+                ],
+                "weight": 345400
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  9,
+                  28,
+                  7
+                ],
+                "weight": 317380
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  24,
+                  25,
+                  21
+                ],
+                "weight": 506848
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  2,
+                  21
+                ],
+                "weight": 1090273
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  23,
+                  7
+                ],
+                "weight": 229164
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  23,
+                  28,
+                  1
+                ],
+                "weight": 401109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  13,
+                  7
+                ],
+                "weight": 36471
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  25,
+                  12
+                ],
+                "weight": 1090273
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  9,
+                  28
+                ],
+                "weight": 345400
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  9,
+                  28,
+                  12
+                ],
+                "weight": 1015608
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  6,
+                  7,
+                  1
+                ],
+                "weight": 265635
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  28,
+                  11
+                ],
+                "weight": 1058152
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  28,
+                  12,
+                  11
+                ],
+                "weight": 2595283
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  28,
+                  18,
+                  1
+                ],
+                "weight": 350137
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  25,
+                  21,
+                  7
+                ],
+                "weight": 1090273
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  10,
+                  18
+                ],
+                "weight": 372954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  24,
+                  18
+                ],
+                "weight": 1004302
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  6,
+                  17
+                ],
+                "weight": 1227107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  13,
+                  25
+                ],
+                "weight": 431719
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  16,
+                  28,
+                  18
+                ],
+                "weight": 435184
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  28,
+                  11
+                ],
+                "weight": 625839
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  28,
+                  21
+                ],
+                "weight": 1256357
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  13,
+                  11
+                ],
+                "weight": 166084
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  28,
+                  18
+                ],
+                "weight": 73741
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  28,
+                  25,
+                  11
+                ],
+                "weight": 2161957
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 132133
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  13,
+                  10
+                ],
+                "weight": 216989
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  2,
+                  9
+                ],
+                "weight": 1408007
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  10,
+                  14
+                ],
+                "weight": 84856
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  9,
+                  17
+                ],
+                "weight": 1408007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  9,
+                  17
+                ],
+                "weight": 84856
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  27,
+                  17,
+                  13
+                ],
+                "weight": 216989
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  17,
+                  11
+                ],
+                "weight": 166084
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  6,
+                  10,
+                  25
+                ],
+                "weight": 132133
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  17,
+                  18,
+                  21
+                ],
+                "weight": 166084
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  18,
+                  21,
+                  7
+                ],
+                "weight": 166084
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  22,
+                  16,
+                  12
+                ],
+                "weight": 2082569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  6,
+                  13
+                ],
+                "weight": 719373
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  2,
+                  12,
+                  18
+                ],
+                "weight": 372954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  27,
+                  24,
+                  6
+                ],
+                "weight": 707654
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  27,
+                  24,
+                  1
+                ],
+                "weight": 780906
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  27,
+                  10,
+                  1
+                ],
+                "weight": 10547
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  27,
+                  11,
+                  7
+                ],
+                "weight": 487177
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  9,
+                  6,
+                  12
+                ],
+                "weight": 260872
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  9,
+                  10,
+                  12
+                ],
+                "weight": 254168
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 140458
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  17,
+                  13,
+                  21
+                ],
+                "weight": 272591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  28,
+                  12,
+                  11
+                ],
+                "weight": 606154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  22,
+                  6,
+                  14
+                ],
+                "weight": 342776
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  17
+                ],
+                "weight": 758917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  18
+                ],
+                "weight": 431719
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  24,
+                  18
+                ],
+                "weight": 572583
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  27,
+                  24,
+                  28
+                ],
+                "weight": 431719
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  27,
+                  6,
+                  1
+                ],
+                "weight": 1190636
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  27,
+                  6,
+                  1
+                ],
+                "weight": 480732
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  12,
+                  14
+                ],
+                "weight": 131519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  28,
+                  25
+                ],
+                "weight": 431719
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  2,
+                  28
+                ],
+                "weight": 342776
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  13,
+                  25
+                ],
+                "weight": 318397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  17,
+                  12
+                ],
+                "weight": 100363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  21,
+                  14
+                ],
+                "weight": 427632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  27,
+                  24,
+                  13
+                ],
+                "weight": 295495
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  27,
+                  10,
+                  12
+                ],
+                "weight": 216375
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  24,
+                  17
+                ],
+                "weight": 1408007
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  17,
+                  10
+                ],
+                "weight": 1307644
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  28,
+                  7
+                ],
+                "weight": 22902
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  28,
+                  14
+                ],
+                "weight": 216375
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  28,
+                  25,
+                  12
+                ],
+                "weight": 1765831
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  24,
+                  1
+                ],
+                "weight": 2277567
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  27,
+                  24,
+                  17
+                ],
+                "weight": 361058
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  24,
+                  14
+                ],
+                "weight": 12542
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  9,
+                  25,
+                  12
+                ],
+                "weight": 1199508
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  6,
+                  21
+                ],
+                "weight": 373973
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  12,
+                  21
+                ],
+                "weight": 272591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  25,
+                  21,
+                  14
+                ],
+                "weight": 800586
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  18,
+                  14,
+                  7
+                ],
+                "weight": 372954
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  6,
+                  10,
+                  7
+                ],
+                "weight": 226922
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  17,
+                  28,
+                  12
+                ],
+                "weight": 144069
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  28,
+                  25,
+                  18
+                ],
+                "weight": 423878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  25,
+                  11,
+                  7
+                ],
+                "weight": 2296820
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  6,
+                  14,
+                  7
+                ],
+                "weight": 140458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  17,
+                  12,
+                  21
+                ],
+                "weight": 144069
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  25,
+                  18
+                ],
+                "weight": 1199508
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  28,
+                  21,
+                  1
+                ],
+                "weight": 615054
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  28,
+                  14,
+                  7
+                ],
+                "weight": 340282
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  6,
+                  28,
+                  1
+                ],
+                "weight": 925001
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  6,
+                  25,
+                  11
+                ],
+                "weight": 3546755
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  25,
+                  7
+                ],
+                "weight": 3409995
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  25,
+                  11
+                ],
+                "weight": 239893
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  10,
+                  25,
+                  11
+                ],
+                "weight": 2750851
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  25,
+                  21,
+                  14
+                ],
+                "weight": 342257
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  25,
+                  18,
+                  21
+                ],
+                "weight": 7841
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  25,
+                  18,
+                  7
+                ],
+                "weight": 22902
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  18,
+                  14,
+                  11
+                ],
+                "weight": 30743
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  28,
+                  25,
+                  21,
+                  14
+                ],
+                "weight": 2660694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  28,
+                  25,
+                  14,
+                  11
+                ],
+                "weight": 3803537
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  28,
+                  21,
+                  14,
+                  11
+                ],
+                "weight": 708459
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 186,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 138794968
+          },
+          "compressed_positive_inequalities": 186,
+          "compressed_unique_ordered_quad_count": 184,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 227,
+              "seed": 20362729,
+              "trial": 0,
+              "unique_ordered_quad_count": 226
+            },
+            {
+              "positive_inequalities": 206,
+              "seed": 20362730,
+              "trial": 1,
+              "unique_ordered_quad_count": 206
+            },
+            {
+              "positive_inequalities": 186,
+              "seed": 20362738,
+              "trial": 9,
+              "unique_ordered_quad_count": 184
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "186": 2,
+            "204": 2,
+            "206": 1,
+            "207": 1,
+            "208": 1,
+            "209": 1,
+            "210": 1,
+            "212": 1,
+            "213": 1,
+            "215": 1,
+            "217": 4,
+            "218": 1,
+            "221": 1,
+            "222": 1,
+            "225": 1,
+            "227": 1,
+            "233": 2,
+            "234": 1
+          },
+          "numerical_support_size_max": 234,
+          "numerical_support_size_min": 186,
+          "order": [
+            0,
+            15,
+            4,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            27,
+            9,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 185,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 185,
+            "support_size": 186
+          },
+          "quad_reduction": 107,
+          "quad_reduction_fraction": 0.36769759450171824,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "0032b0b2ae87113777255e25f7f4a71224677279086a6d380375c83e4ee32cb2",
+              "0314c19ce4b64aee72663ba60695ec6a8e9b7dd6008fd44f5f9d4c2502cbe777",
+              "04065c1a18fcbc487058bccc5793d1c216538b0677774601bb0786764d497a9d",
+              "0438b0f32ae403599dd17a04b6db8ebd13b3570e42962da867fe78f8fcc3e9e0",
+              "06431fa77e05d13b4dbbaab1f01c3cc952834641f4d6d5dfa7590b051e69a6ef",
+              "0883e64aed8a7cdaaec8ed4b9ad3d579fb9f0096c786746861f605852e6cdc77",
+              "0aa4f4a66d8e62194ead710beefaf2f21380b3eed126da7ff588e7243a5d3906",
+              "0c06b6477cb04c05abc2d7ca2eae58ee57f4cedc8904a1af710d0c673ec109e7",
+              "0d8149ac98de7e90aae15cc78aa9a8c45dbaf2d39f6fff4dfc46e5547c03c0a2",
+              "0ea862736b66960d90d9719560a3cf121a049ec2b65b024b3f348a666b4f909a",
+              "0f5534350b8a8bb680db7b688d49c53665d806cedf197a6c740d0cf294262a62",
+              "133e74f85411b5fb98575a01bfe6fc928506fbf9e5da9f0739f5eb4b3d93faba",
+              "152f60873e750418f26fac44878e52e28515555ed1e1cf74dd10ec54eb6451f3",
+              "15864680fb17c7c8188625f48ce0014558d76977b77ed621e5574d6f96f5cda7",
+              "1844b6eb3ac4293260788cec81d0c5ea0abd0389ab49d8aa15cd78399927f594",
+              "1a96e9592e29ff979eb5cac6feefa6f81443e4b581a6bbc77f9a943f6d7827f1",
+              "1a9b3f6d380a8b40b8401175a657f4d1c701b12389ffaec11d4813c3f7d6b69a",
+              "1bd292162376fd5c114854f3cd80609bc82661ccf0de8b0587d7d9ee59b397bf",
+              "1d8dc65c586cb4e0e8ab5917dddc265a8ecc7ae54f01b4608b8b55fa71722ceb",
+              "1ec9d22f6c4e2f537e43fe9ac43636258caf8e2d6dcf9af19a0803878bb06676",
+              "20138c5813ca25197050450d7965a09d0470558eddd7b67071003e19755ecabc",
+              "20646d8a214a4fefae6d7e46fde52adfa7b4e69f25e3976b8cbcd65efa20616b",
+              "22828300acacc2f52acc9c552639359aec8268271596fe0ffd2de76a6d1a3769",
+              "24af9dfeba924c8441fa1ace4c43196a3b7795d18c9686d40a7deab661910a2b",
+              "28cd862ff80594c6b30ad19f1865d0a9a8db64e2dabe16ae055655c0757e6026",
+              "294962bc83b574b34c1807e616216cff4e90bf25f7c9bd697e185f1b464dcde6",
+              "29e86a64a3627c7992c2d82798b7876598ed1f24a851862295e0ba63c7ac483c",
+              "2ccb3ffd61cf9f7b8d376501c781a987e0c39c35ed40df876d28567b51f58eb5",
+              "2d3846edb5a0b299c630e74f512f205aaebd840dbb8a6cbd3fb4e910f8f1419d",
+              "2f10a55e0e26b1f58036859e59f46987c7f1bf17d0ce5bb1807cddff0fb8ce62",
+              "309eafaef73d8bccd37f79caf6ba63a8a1f72e42c3841ac4a3e2bcaf96c4dcc6",
+              "31c187dbf80ac7508a16dee02325dec27ddb405613b3fbaa34d9a9c796580a03",
+              "31eedccca803e9902055f14a3a8f3b015882b3671be9ab4ff969a5bed59e7c76",
+              "3389ff965b7fe5354e7d7db3b3dd7b5d7cbcb1b7947b367ac02970d1c0ccf4ef",
+              "34c51b339af43f6e7f3cadec3766ef6c5ba44d73b66510f1674653f76af0f3f1",
+              "35516f9b643657f64bbda89ebbbbcfecc606702ce12f80c8d6869a0587a6b802",
+              "3866e7d0e6390f96d9c1e5d3eb25a4627a3abeabeff175baefc25827848ffd16",
+              "39c6abc108a3ad7a11166e9d664a6452fac7d4a43de49b3d534d2c8fa14272ba",
+              "3a065434d8e3ecc940c3df2b54a2db93cb890dfea3750481deacb855a50998cd",
+              "3a482cdd5647655f9fd5504999ae04259e83f0bec08edbf9cfc975ae5ce1175c",
+              "3abc28354f1e847b88118c046086614034c560f4770328ab15b615143cf58857",
+              "3ba8f707b06b51f4932fdfcbd65d344c38dff34059cd584925b5bf1606449d03",
+              "3bb78464a1255472b1806418e8666badfe29da7fe2795b3c5b7efbbf97da8bfb",
+              "3c0057f48cce3ef0210c308ae8e2088512cbcf5c2a9f8bd404e1f552b654f40a",
+              "3e5e2c0954ebfc65ac4b4ea5d97c64be879994d2076574152ec2bafef14c72f2",
+              "424576a53f4cdf95ce882019058a19d4e01516d9d563082b8f56e440a9878495",
+              "43dd34588af934161cd3f4256f14d7ba87c5b5d7e80908a54b30b8c268cb92f1",
+              "445dd2a414f3d8853ae9d34ae9e36c5bbddb4cf4a7efa712345130fffd323dd4",
+              "44f47afa86f7a62f4fe715f24bf48c902878c75e7f8798c53faf36d9637221b1",
+              "45de76e916d4bde8634e4be9830f00af40137545708cff32867cfe8bd5a02d51",
+              "4626ba8df36f0a6a23b63b073a6567ebe3d823860f5f75e4cec85952324ed197",
+              "464041fe3335cb21673cf0b53ab99ed743613786409ae12e0e4bccf24ebbef1d",
+              "46647e290b83bbb2f27c2b53bc7ed4ecb4db8dc5e6abbc8cd3087527b35d43ed",
+              "474f3043b2d2fac801ededc687a727c4cb9a742fc4f64506f1da6b3094b17a81",
+              "4816cbd3b759b83c951067ab51d6befe34f631ab0b5954ef90d12755b7bc7192",
+              "49082c193bebcc4e5a1cb0d224747e9adb25a0fb9b6faafe0ff83a8ab4ae09eb",
+              "4ab8aed2405b7329e7fdd590f91841925391fb2aaa3bbd3118956c5b8f6398c2",
+              "4d4be86d3bcf66575d708c30ae75b3e57e9a552629e0d604b927cb492d13cb6e",
+              "51a53523d6f452278266a990adf9737cff5181e46658183a7b5023dc26d50190",
+              "52b1ff1b0a05231ca0568f39beac8c1b02c36733ad4e3ff2ff5bc27e25690fc6",
+              "544f6f572e3e4142b94d3ba3e6bf591874ea0afd96a58f955d8da5a70db4244a",
+              "54a8e719d679e64605e009c69a32c3238ee743a9a739a501b9c0784e49f22162",
+              "54c6a5d3e72eeedc0183a08b8d384b4279c09a1d401ca5354a9cd6c2b4cb862f",
+              "56dad7baa54e3a7a885de106bdd1128b4ba153fd91f19285389fe1b014fb65f9",
+              "570bd69384344975db0c90f24f11e682b5138981cbe63cb104b4d9f01970cf4e",
+              "572325e440878593d17da16aa3cb5b17deb9a94d9376e2c7f67f056ebfb2e8ad",
+              "578058cfd81f17343dcd9ec28d90ed184fab7935e49f87589eb95b78a257da1c",
+              "5b3a01a7dbba0145e896722262dd021a1d32c92904fc86af45b5f54f8afb642b",
+              "5c755c85085a261d57cd67f828e53efb5e07152b46b2c89fa5088b9fb7dd53da",
+              "5dd1072560e3f2c2a9d1a8c916654802dd6425173d1a97947beffa2f31c2e6d9",
+              "5e6670fa45d85fa531b18280428f3699569416da5cf1d4b234f4767997b98a4c",
+              "5eccae92b58a43683a0ee6129e4d622508e2357312760042d8983ab3f35ce70a",
+              "5f2a5f8a85d1d4b5f10c2e2bba78cf784343923c68ddef81b8e45a680f9a9f77",
+              "5f63550f5603fc2ae9c050de208abf7fbfa244da0cf30886d51bc79e43ad81a1",
+              "61d697b232046d33c889eb72c9bee6b64ff72d04ff4681958ed35998228e2bab",
+              "621c3410030096b45aa5ece8d85e83cd2e13cc939d3c7cd1880d086a36b99a92",
+              "66995718bd48e4d696207ff81f1e67fdd15f36b8d139912aa8e97226954ee8ed",
+              "67169f07081e94b943fc2bcf1d1352a62ed0948b3766473636127032299e069e",
+              "67670ca29f95ba368e1e33c09ee6aff40f605f3af3d6fe04da40989d865ba01c",
+              "68761d255e74d7d4a40493aa27c0fb5a427d12324c5596dad8543643516906de",
+              "696576356210b6267c9b22b32e0b97d7b7b77c93dfe509bd8e1ad48f47bb0e78",
+              "6978c3d6fa667701fd41028543828c0564c6bacd941aeb4a40e263037b899ba2",
+              "69d78f293f6e14be0d7252db4afdc195fa6b5bb7e23c3b66ea95ac9b449e49f6",
+              "6a15efb949c3816e54d80bf4785663d35cc0a0314229055a53ce32cfa8971414",
+              "6ab35a1c858fc4bae7a23bbd42b114451a4990067c9af1192af3d41d4c17bd88",
+              "6b4460b37ccdd0bc1f4f8173b2e2101f730cf3004f2ce33a6c87e73fae812582",
+              "6ba930199f6e85350ed194b21db893fbb95b3fad5cfcadcd9f6d545dba154a66",
+              "6d60255578f8ae6fd39cf7ef840f5e293f095715949faac2137fab73c5992c15",
+              "6d807d3bf37eb6304ba9baf3d82dcf8946bc856d1f97196658ca7bdaf33c6da6",
+              "6dd3a2bc59cad7d1d6a4925814d42a50dc03d5339b4cc46cbb083889248f83f3",
+              "6ec00abff1095232e7a23a8201d0cb4ae8fc2b45246dab49ed3c0e47b030bca8",
+              "6ee745146640bbcfe1e7a2f9bd78f5361927db10a672a5f9811659e0bbcf54c8",
+              "6f1297807bba61c798a4917a48fe33ff0a8f56782b06385b2574e189b58a51c4",
+              "70bb044ea2ee52cd9460f1838f12cfb882d664eb7d7d09265bf573f74babe490",
+              "70f8504e27c7cd9a93414b128b9bd6a1ee9cf45f2397f11b9f7ac5f942a2ca07",
+              "721b6ec876e7daac240a10b2f9b481595bf82f4db9581b23040cdfaa6477f24f",
+              "735d14fcea184a01c0d75a81ff634024283b37f46e0f5a29b4b11b0866581c9c",
+              "74ca78cf8ae728917a6c9747dd339b31d542fd0c69e77ee6e379c399fd3b4d79",
+              "76c3586f316bf350989e8c52092aadfbe67be7726d9b5aa37b718ab5c8441492",
+              "78e0246f48a1025197d574ea372b77044e9e78ff0c184a5d8db39f0de75c0fbf",
+              "7a22d9feeef9d8551d986857dc300e5246362e7f2d41d173946d3afcfa013c42",
+              "7d4f6d9dca0b232f66d92cea07ec4970e00d99598227629925dcf9824ee0f04b",
+              "7f8d2d4079de9a2c18942766a99e89ca34b064143350c34976155bb29a07ab7b",
+              "802df8bec7270573587567b06f11e3684629881eb256d27736991536cd7744f9",
+              "809910a05e348f9c9a9b68a2c26a31c11fdf507d3ab63adf26d14129db5c23d2",
+              "829d975100c03ec3bb792b936bfba548d0c32bec16a1b90269af661c59c64d62",
+              "8310328a0d89808c8c2f3b5f1733a25c1f2475099cca2c731d9b40451a53469c",
+              "8318725d34ae58d639b0028c7a01acaed1a3ff92820255f08d102d676351ad28",
+              "83ace3a28867670dc426b9b0ba2967cd25d0c84f0d39263fb2398a43a9926dc6",
+              "87dc4bee94d021d72b439cedc8e7b94dfd8c14d17e1151770e34dbc143a25437",
+              "887794f7fcad59b4debb7181f7b78a3a5278274ec75938640bd2c5d0db190bbe",
+              "8929a9583f49b34aea61adbc24334ea5bd65a92daddfb54f148cdf85f8eaae0e",
+              "8e852ed9f23024ddb716ac0504ca60b4bf7c513f67d41e79abb5a1d09043e4b8",
+              "8eb93e31cd6e47d44f75aa915984c72708524c1c211e932f13ad0054baa82e98",
+              "8fc3ffd903db56011a962288ced12c8bc9f9961d6ecf4daa5da9e3e283afa6f8",
+              "910229473a6e1c31698899e749b078477c4ba39d251a4e18d8bac26f3f89933a",
+              "91e34c44e04ce71a8ed27d2ae0a79793cb17b95a087694f6eaa1f75cfa6b20bb",
+              "9681740d5cc29111536c9531307f12b46b0745c320494bfd548ed4e036e754fe",
+              "985d2fb798512963fd1d0ad89f8906a95ef000b9f3db23bfc755dfebc5ae6d50",
+              "9a250131852a9c539afe8773e2406107a7adf351402c8172662f5f136a71a805",
+              "9d88712ee77dbbd8c0466f076a532bd3d388d64d3166c8b60ecc43a95f7884e1",
+              "9dd19ba99f637f7d5e085ee2283549814f4a569b698505962a59a8023df520db",
+              "a4561faf1d06cd062fc1da65310fcac9aff668267f54f4629367ecd4bd8e5ba8",
+              "a557f4add0002a5323afda8c740094168250c3a293119376f5cd3b40817bcf7e",
+              "a6a790cb7a1d58e203bcd8b6d729768ddaff38789da0f7c765b81961b7847348",
+              "a7a4a83697e3b6aa2a76524178ae98b4d09e149634a5ee2cac91d6991aebeebf",
+              "a7e5fcab3ba34ca14c713c8a3cdd17b791a7ab1a499fd00d7a4d34813c75b17c",
+              "a9da3cd11ba1dd11212e40c902f1f5b503cf7b95fa20e1b6a7d4b32ac63d4a69",
+              "aba8810fc1ec956c18c16a2d6a8b19a53a0cb99084890348bab4f8a53176087c",
+              "abc5d7beaecd2ff1b55e030b9083afcefc56989acfcc29afee92228d9140dc85",
+              "ac71951cb1bba192295503e5a08974769f3ba11231f70906313d8fd61d240871",
+              "ad9c726b776410b3b9204e7cb994b7daf2e32101293f3e8978a0cfbad63a748b",
+              "ae56ddf0bb3f67120737c00c8c6bfe2fbb745cbf96798fab7edf2972469aa0e1",
+              "aeaad30677ef9797a8a9ea56c68f9ca49cf07a2e9f1e567219996dc199d2e16f",
+              "aff770b8590acce399494ca83b7ddda5fc1b443483e61c7546f94e737a90ca3f",
+              "b3204d50d2d76b13ffbc4b43a4346425e696816f95be54d5079d5e58509e137a",
+              "b4220d7deabb72cf07aaabba9ce0bebb2139dac9238cc33bd4ed3eaa5a43ac4c",
+              "b49f572aa9a9dcc01caf86ffe418b8789521ed1b6a93485c8b2d12ae716cdafe",
+              "b4adfc10674518ce71f3e63e7faca377b32608f20a77159b3f2725c8453be671",
+              "b56b85268557ab12c8c7d6e985f26e579bd7713cb03e7614156f1fece9fceb9b",
+              "b5afce88244eb015102690a6ae43a4118d246c341c16819b7d4eefd2f2e13895",
+              "b6608b74be5ede93113d80156b328a9aa4c49712f9db61c7316b3c75bfcce968",
+              "b80580e0278a1312585247b6edf4e7797fc0ac6665858bb9d23cb51d4cd07665",
+              "b83abf36cb4bc364f36dd7df640137652189c836e4260ec01ea9dc8ef3895b30",
+              "c3f46c07d3eca44195ad0775aef0e1353801810431d7287195c9a809b40a880e",
+              "c4be7d5bbf1d4129bbd2f9473e9620904f3dfccb77bb63793758f3e39bb668d8",
+              "c64484cfd07b51ea0d35798bcce9148da5a4e1360db07ebf31b2a77b51383caa",
+              "c7ff99604d09f4a989ac350904732b695cf8128c80112a11ff973b3be967008d",
+              "c9ccc3f8125369a7151c8f711e62c660562e730068a549e00e431e3dd3944ef2",
+              "cac764a469d56bf127ce0b6ddb6b5c6aa5ce235b79ff2868ba113cb9f2a168d5",
+              "cacb80f0c0cfe09a8435b1761e2f5a9aab7129bdd57c877f5d3cf7fcfec9e479",
+              "cec3c0ab25be1fcaeda78c2a4e5bb96d4e09428612899abfed70828e17e8c5cf",
+              "cfc540627999447cc8f4577874228023d51ea2da861aae97dfcd47b5ce01fad3",
+              "d0530b4140690351dee0a27c8f84fbc9ab6aa7f96c813acf4e8f70043799ac8b",
+              "d1e0e88def122644c2a3f0dec80a6467856f6443003db21e6aa071dad3734b8d",
+              "d2ad5b9da71b0e06728420b00eb2f3be1aae371389d8c00831c2f2feeef9c8a3",
+              "d41e8e875e7420cf739b120c48ee3629624680ad6e3c8336009bf3a56cb4dea0",
+              "d5486098756ca855330d88e3dc3f6d2c801b435ab9075679bf34e45683584fbd",
+              "d6f968efd10e2532b4502a239f53db75524d34c80e7440e0187a17f338b91a17",
+              "d88d80ee4a92d27685bc533159c6331af2d7995e53dc15eb7fc448d126234d62",
+              "dbeb5ecb277e02e69bdf54ce044c64981198225c87b2464e7172aeff58a98ba9",
+              "dee1e310103cfc29595209803d902b8c3e638f62d37dbe9a1ca8409bbfa725d5",
+              "e2648eceab4036a4d75ea790c8032147e8a04752f587244caefa3a7ddd54e1ba",
+              "e3b730548686ccb4cfbfadbe7ddcc5299f51326b1dfffc9fcd8af50c0f809dec",
+              "e5349a237d2e7544f4a80effc6eeae18da9d0e01b6fcc9558cf04fe799cfd568",
+              "e595261dcbc81cb2b2e12d79f244f8440bae14748da5045c3f052664e0c798d0",
+              "e70023369ad79843871823dd3a8ab2956c2474164c84d4ec00325e9a047b4c6d",
+              "e8d7d120e120e2f8b539dd5cb17cd74193baa64abba43cd9c66aa0c0b767deb5",
+              "e98df1a0a291d043078ba38e2b043ebe7aa416276448e2bbf00b3871b7c7a142",
+              "eac2d8f2b09fcf58d6950b0aa8ffb289a4d5da9f549bd3c5555e202b19bc4ec9",
+              "ebc860b3b73f01ca19b3178c6ab544d5f56c340383e4fa5f4cc74f325357ddc7",
+              "ebcd09c022a18c33a1f53c87513cfc230f645db3c9401435e369384d446b309a",
+              "ecc452263978afacfdb0638e566c54f0105b044c41582afe8f17ecb93d8461ce",
+              "ed2d6a6907e931d8aa01bff5b65724c1644159cc181c757762560edd5f77bfdf",
+              "ef707b5c3fe4a6a2e887c6cbf26344ccae56585fa9eb8f40f22ff78300ddb735",
+              "f0a4f16362f3e4de40a8e56ba462b82ead251ac53e1a746245c75ba65ab93a42",
+              "f393fba5fbcc4f574c6a86f26e444c32d51dcccc633bb67f023a861844cf519f",
+              "f3a650bbeb897c5cd5d76ccac557b83acf9f951f77dc6718ae11c68a3a308f20",
+              "f4163312f28b28d6cef1690c1c3354bdac669db2516d7069ed7e1b7f2548ce00",
+              "f7023d8f9b7472dcb6eeb5e966beade8c62a8d1cf40a73eaff0e9b13c4654cc8",
+              "f8388edd54188636e186216700f3279c5426060bb3912d4d2abd0fec9f76a076",
+              "f9d45fc926384eb6747a65d41367b3a26a98632f1200a36290dc362fadc0c37d",
+              "fb6d455859f07968ce7c9467507925ad062a0e6105c8172511262d441122c23c",
+              "fdc314ace07e1bf1435855d97e8638056081790e6615f86a7d44b76a4bec0eb6",
+              "fe44a6b53451012b031b75f0f7329a6031b61584cb41d8c730f65b73b94e67b6",
+              "ff991086671ce638d6d6dc04f429eaea1e01664cbb36a1ca32e2013f1ab8e785"
+            ],
+            "unique_vector_count": 186
+          },
+          "random_objective_seed": 20362729,
+          "source_model_index": 2,
+          "source_positive_inequalities": 291,
+          "source_target_id": "seeded:2",
+          "source_unique_ordered_quad_count": 291,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "29d10531a4da4bc9978ffd8f44951d964994e9d89d979ac53f5947f8c3191e80",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 3,
+            "source_order": [
+              0,
+              15,
+              4,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 181,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 1,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:3"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:3",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:3"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              15,
+              4,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  22,
+                  27
+                ],
+                "weight": 74998291
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  22,
+                  25
+                ],
+                "weight": 6294540
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 80540253
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  3,
+                  27
+                ],
+                "weight": 42234774
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  23,
+                  25
+                ],
+                "weight": 31138550
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  5,
+                  25
+                ],
+                "weight": 24108593
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  10,
+                  21
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  25,
+                  12
+                ],
+                "weight": 37433090
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  23,
+                  10
+                ],
+                "weight": 42234774
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  21,
+                  14
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  5,
+                  1
+                ],
+                "weight": 59188645
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  16,
+                  11
+                ],
+                "weight": 14184679
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  9,
+                  12
+                ],
+                "weight": 42039060
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  10,
+                  12
+                ],
+                "weight": 3825088
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  12,
+                  7
+                ],
+                "weight": 41258178
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  16,
+                  28
+                ],
+                "weight": 5805812
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  9,
+                  6
+                ],
+                "weight": 62052517
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  27,
+                  12
+                ],
+                "weight": 19990491
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  17,
+                  10
+                ],
+                "weight": 35801320
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  27,
+                  10
+                ],
+                "weight": 99746733
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  14,
+                  1
+                ],
+                "weight": 4344844
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  27,
+                  17,
+                  11
+                ],
+                "weight": 44738933
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  27,
+                  10,
+                  28
+                ],
+                "weight": 11729615
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  10,
+                  11
+                ],
+                "weight": 18487736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  19,
+                  10
+                ],
+                "weight": 46780882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  16,
+                  1
+                ],
+                "weight": 184926842
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  23,
+                  5
+                ],
+                "weight": 64079163
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  16,
+                  24
+                ],
+                "weight": 210779
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  19,
+                  16,
+                  7
+                ],
+                "weight": 46780882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  22,
+                  27
+                ],
+                "weight": 23221711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  18,
+                  7
+                ],
+                "weight": 94367439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  23,
+                  5,
+                  1
+                ],
+                "weight": 64079163
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  24,
+                  10
+                ],
+                "weight": 210779
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  7,
+                  1
+                ],
+                "weight": 46612020
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  5,
+                  18,
+                  1
+                ],
+                "weight": 2864790
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  27,
+                  10,
+                  25
+                ],
+                "weight": 51776580
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  24,
+                  18,
+                  21
+                ],
+                "weight": 827082
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  6,
+                  7,
+                  1
+                ],
+                "weight": 47755419
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  10,
+                  18,
+                  11
+                ],
+                "weight": 4784919
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  21,
+                  1
+                ],
+                "weight": 827082
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  8,
+                  22
+                ],
+                "weight": 43957118
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  17,
+                  12
+                ],
+                "weight": 22066055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  23,
+                  13
+                ],
+                "weight": 827082
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  26,
+                  5,
+                  25
+                ],
+                "weight": 4896484
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  27,
+                  17
+                ],
+                "weight": 22066055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  27,
+                  13
+                ],
+                "weight": 74112370
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  13,
+                  25
+                ],
+                "weight": 78001849
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  3,
+                  8,
+                  12
+                ],
+                "weight": 100186079
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  3,
+                  2,
+                  11
+                ],
+                "weight": 37220838
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  3,
+                  27,
+                  10
+                ],
+                "weight": 49399247
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  3,
+                  11,
+                  1
+                ],
+                "weight": 49674417
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  5,
+                  28
+                ],
+                "weight": 76084555
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  8,
+                  2,
+                  13
+                ],
+                "weight": 3062397
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  9,
+                  12
+                ],
+                "weight": 34974238
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  18,
+                  11
+                ],
+                "weight": 33084404
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  23,
+                  9,
+                  24
+                ],
+                "weight": 827082
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  5,
+                  22,
+                  12
+                ],
+                "weight": 50251658
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  5,
+                  7,
+                  1
+                ],
+                "weight": 25663977
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  12,
+                  11
+                ],
+                "weight": 22066055
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  2,
+                  9,
+                  10
+                ],
+                "weight": 40283235
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  9,
+                  10,
+                  1
+                ],
+                "weight": 76084555
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  9,
+                  18,
+                  14
+                ],
+                "weight": 43410575
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  27,
+                  18,
+                  21
+                ],
+                "weight": 102167097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  27,
+                  14,
+                  1
+                ],
+                "weight": 43410575
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  10,
+                  25
+                ],
+                "weight": 95525670
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  10,
+                  25,
+                  18
+                ],
+                "weight": 168991860
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  25,
+                  18,
+                  14
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  8,
+                  27
+                ],
+                "weight": 43957118
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  23,
+                  22
+                ],
+                "weight": 92658313
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  23,
+                  16
+                ],
+                "weight": 137980754
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  17,
+                  25
+                ],
+                "weight": 16838537
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  16,
+                  1
+                ],
+                "weight": 137980754
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  10,
+                  25
+                ],
+                "weight": 89875140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  8,
+                  22,
+                  9
+                ],
+                "weight": 57707039
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  9,
+                  27
+                ],
+                "weight": 20669340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  17,
+                  11
+                ],
+                "weight": 9781494
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  5,
+                  22,
+                  11
+                ],
+                "weight": 28031855
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  22,
+                  9,
+                  18
+                ],
+                "weight": 37037699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  17,
+                  13
+                ],
+                "weight": 6423790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  13,
+                  10
+                ],
+                "weight": 1707229
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  27,
+                  25,
+                  1
+                ],
+                "weight": 18545766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  17,
+                  12
+                ],
+                "weight": 22066055
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  13,
+                  7
+                ],
+                "weight": 57145096
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  25,
+                  11
+                ],
+                "weight": 88167911
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  19,
+                  8,
+                  18
+                ],
+                "weight": 43957118
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  3,
+                  17,
+                  10
+                ],
+                "weight": 10694698
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  3,
+                  10,
+                  11
+                ],
+                "weight": 12453579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  8,
+                  25,
+                  21
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  22,
+                  16,
+                  25
+                ],
+                "weight": 85544299
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  22,
+                  2,
+                  18
+                ],
+                "weight": 7114014
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  16,
+                  9,
+                  17
+                ],
+                "weight": 38598211
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  2,
+                  27,
+                  12
+                ],
+                "weight": 7114014
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  9,
+                  24,
+                  1
+                ],
+                "weight": 38598211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  27,
+                  11,
+                  1
+                ],
+                "weight": 184926842
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  24,
+                  17,
+                  1
+                ],
+                "weight": 38598211
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  17,
+                  13,
+                  11
+                ],
+                "weight": 54520427
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  13,
+                  25,
+                  11
+                ],
+                "weight": 55347509
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  23,
+                  24
+                ],
+                "weight": 64079163
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  5,
+                  12
+                ],
+                "weight": 65211841
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  23,
+                  22,
+                  25
+                ],
+                "weight": 52646868
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  27,
+                  1
+                ],
+                "weight": 137980754
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  9,
+                  13,
+                  12
+                ],
+                "weight": 3889479
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  27,
+                  24,
+                  10
+                ],
+                "weight": 63868384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  25,
+                  12
+                ],
+                "weight": 12078109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  18,
+                  7
+                ],
+                "weight": 46780882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  27,
+                  7
+                ],
+                "weight": 49674417
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  10,
+                  14
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  16,
+                  2,
+                  27
+                ],
+                "weight": 66056712
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  16,
+                  27,
+                  17
+                ],
+                "weight": 108016316
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  6,
+                  12
+                ],
+                "weight": 100186079
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  7,
+                  1
+                ],
+                "weight": 49674417
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  21,
+                  14
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  22,
+                  9
+                ],
+                "weight": 89786875
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  2,
+                  9
+                ],
+                "weight": 3062397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  18,
+                  11
+                ],
+                "weight": 23641791
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  9,
+                  6
+                ],
+                "weight": 28042989
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  9,
+                  28
+                ],
+                "weight": 38013723
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  7,
+                  1
+                ],
+                "weight": 168862
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  9,
+                  11
+                ],
+                "weight": 19323397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  25,
+                  21
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  9,
+                  17
+                ],
+                "weight": 23722071
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  27,
+                  13
+                ],
+                "weight": 3062397
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  27,
+                  6,
+                  28
+                ],
+                "weight": 26284108
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  6,
+                  25
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  17,
+                  10
+                ],
+                "weight": 62320282
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  17,
+                  28,
+                  1
+                ],
+                "weight": 38598211
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  28,
+                  18,
+                  1
+                ],
+                "weight": 114682766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  5,
+                  2,
+                  7
+                ],
+                "weight": 3062397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  5,
+                  27,
+                  25
+                ],
+                "weight": 29005077
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  5,
+                  24,
+                  10
+                ],
+                "weight": 5583969
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  22,
+                  16,
+                  12
+                ],
+                "weight": 111565370
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  22,
+                  16,
+                  11
+                ],
+                "weight": 8708458
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  22,
+                  9,
+                  13
+                ],
+                "weight": 14344667
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  22,
+                  10,
+                  12
+                ],
+                "weight": 47607964
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  9,
+                  24,
+                  7
+                ],
+                "weight": 46780882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  24,
+                  21,
+                  11
+                ],
+                "weight": 47607964
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  6,
+                  12,
+                  21
+                ],
+                "weight": 47607964
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  25,
+                  18,
+                  1
+                ],
+                "weight": 23641791
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  22,
+                  6,
+                  28
+                ],
+                "weight": 75570102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  18
+                ],
+                "weight": 10027843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  9,
+                  18
+                ],
+                "weight": 28042989
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  28,
+                  12
+                ],
+                "weight": 113640934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  9,
+                  14,
+                  1
+                ],
+                "weight": 43410575
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  27,
+                  24,
+                  11
+                ],
+                "weight": 5583969
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  18,
+                  11
+                ],
+                "weight": 40935622
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  6,
+                  12,
+                  14
+                ],
+                "weight": 45169456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  6,
+                  11,
+                  7
+                ],
+                "weight": 18487736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  9,
+                  28
+                ],
+                "weight": 81375914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  13,
+                  7
+                ],
+                "weight": 46780882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  6,
+                  13
+                ],
+                "weight": 13517585
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  27,
+                  25,
+                  12
+                ],
+                "weight": 108921676
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  6,
+                  13,
+                  10
+                ],
+                "weight": 9537132
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  10,
+                  25
+                ],
+                "weight": 57145096
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  21,
+                  7
+                ],
+                "weight": 44151713
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  9,
+                  1
+                ],
+                "weight": 214315092
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  11,
+                  1
+                ],
+                "weight": 827082
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  27,
+                  17
+                ],
+                "weight": 45022001
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  25,
+                  1
+                ],
+                "weight": 85544299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  6,
+                  28,
+                  18
+                ],
+                "weight": 38070832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  17,
+                  12,
+                  18
+                ],
+                "weight": 34144164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  10,
+                  28,
+                  1
+                ],
+                "weight": 76084555
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  12,
+                  18,
+                  7
+                ],
+                "weight": 41258178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  21,
+                  11,
+                  1
+                ],
+                "weight": 827082
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  27,
+                  24,
+                  28
+                ],
+                "weight": 16692865
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  24,
+                  11,
+                  1
+                ],
+                "weight": 80448274
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  13,
+                  28,
+                  12
+                ],
+                "weight": 54706588
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  18,
+                  11
+                ],
+                "weight": 80448274
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  7,
+                  1
+                ],
+                "weight": 2893535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  24,
+                  17,
+                  21
+                ],
+                "weight": 45022001
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  6,
+                  10,
+                  12
+                ],
+                "weight": 47607964
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  13,
+                  25,
+                  21
+                ],
+                "weight": 57145096
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  18,
+                  11,
+                  1
+                ],
+                "weight": 134603940
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  17,
+                  10,
+                  12
+                ],
+                "weight": 34144164
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  18,
+                  11
+                ],
+                "weight": 88543586
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  25,
+                  11,
+                  1
+                ],
+                "weight": 80448274
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  10,
+                  18
+                ],
+                "weight": 38070832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  12,
+                  14
+                ],
+                "weight": 45169456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  21,
+                  7
+                ],
+                "weight": 57145096
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  28,
+                  25,
+                  14
+                ],
+                "weight": 1758881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  14,
+                  7,
+                  1
+                ],
+                "weight": 47755419
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  14,
+                  11
+                ],
+                "weight": 827082
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 181,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 8106883275
+          },
+          "compressed_positive_inequalities": 181,
+          "compressed_unique_ordered_quad_count": 181,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 209,
+              "seed": 20363729,
+              "trial": 0,
+              "unique_ordered_quad_count": 209
+            },
+            {
+              "positive_inequalities": 181,
+              "seed": 20363730,
+              "trial": 1,
+              "unique_ordered_quad_count": 181
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "181": 1,
+            "186": 1,
+            "188": 1,
+            "193": 1,
+            "199": 2,
+            "200": 1,
+            "201": 1,
+            "204": 1,
+            "205": 2,
+            "206": 1,
+            "207": 1,
+            "209": 1,
+            "211": 1,
+            "212": 1,
+            "221": 2,
+            "223": 1,
+            "224": 1,
+            "231": 1,
+            "233": 1,
+            "235": 1,
+            "240": 1
+          },
+          "numerical_support_size_max": 240,
+          "numerical_support_size_min": 181,
+          "order": [
+            0,
+            15,
+            4,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 180,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 180,
+            "support_size": 181
+          },
+          "quad_reduction": 112,
+          "quad_reduction_fraction": 0.3822525597269625,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "00c79b8776f1e92f3489a663307aaa9725b9361c2d0f33af5ea94b12266a6d6d",
+              "01e1dc4566fc40f6af428ffbe4d9dcba6a1056b5c0ea903b7188ed72a6800b82",
+              "01e2dc681b2fb9dd5e7cbe016f1985f856d5a78c02a0e3ded6463ede4ec73e6a",
+              "0240e1a0da26034680d2a09ab79c45819084b758f4e1188be6c6dc8ddf20d6a8",
+              "02603f2e6188a667ce7b7326430673c72f2db43df03a1e7cc740f3b5fecc530c",
+              "030a1a63b2c4ccb6b2e6594676e758e7111484c20ef65c67a1764cbdfd3ffbb0",
+              "0318c03304988fd7770dd5be9606b8f19397ad93dac7249c1bdf0fc9f85727ab",
+              "0abd7972a422b6cb9b7983763969d3217069544743401356a792ee2ab2c5ffe2",
+              "0c06b6477cb04c05abc2d7ca2eae58ee57f4cedc8904a1af710d0c673ec109e7",
+              "0d62b7d7f91979905dccb668c25dfc204a092e4fe5815c9e1cdfcdc8d6b54bc7",
+              "105da4ad0c15671ee5f9df073c18916fff97ccb8c990fff9583a7d7a7cbf1728",
+              "108798012e1e1c1894724458ccf6db1ae208b466637b41cb77011a0f10f67489",
+              "10d01228db418859531e3ca2bd0178b2db5ba32cf2a21e0ef547374761186275",
+              "12b58da734697ab691953e2da3d6f4cc9f13964a3ede610a5716317ae4cd29d0",
+              "1434f1c0e36ec83675d01176b693e53a88e83f2fa022e8e43bf04057e6344d63",
+              "16fb79bbb2dd43df7415e72153590e15aa2271153026cc5cd97a3af0a1707996",
+              "175c4fc6f05204d869ada434498f4a096201feebe4d7a896f11a63ada05f4ddf",
+              "17ed21cf8dc6c0f090c4898d89eee702d4f3ceab81b29f5289e873f8217877c3",
+              "1a34b2cfcc8531e7e472696ec95d05ca17c2b2f697071c981b1cf00404124063",
+              "1da92933459a241d7d29d32706c47c03bd0b9d12cdcae52e815466a02c9fc8c3",
+              "1dbedd0535252ccf49953cd9b784f20f56b951feb3b46e585ef4264c979e2568",
+              "1f8a5c2036da5c5ab92c660d42d1423b771d245da7dd1e813406de03875f901a",
+              "1fd03049dbcf16e64b86c8fbfc9ec3996f7e335de6c321a9fb6dc77b4610c64d",
+              "203179d638b2104de32edd150df295ef0e1b5ed48214ca47b05c9f157611d01a",
+              "271a703ddda90a81194b73f643f80a6448d8b05d42e95ad166df6e12a9060b8a",
+              "29a24f40ecd75f6b200c24e98e0d2feca9c0aed7dc7a499d88a5bf055e8b1c6f",
+              "2b6e109bcde527623b9c28fe9ea58b4be70975dd806dcb48b5178552b9509a8d",
+              "2fa780d1017418ca8400fd2fb3e9518a75f3bcdc79dae4bd50e413c3511a9518",
+              "328ef0264cab735ce7ca3ce86fcb73c0160b130a12e1e79b14ff868af8607b20",
+              "32def3fd4bd12b08cf75021d1e49f168d36c25f96899f2de23a86a21db3a0164",
+              "341cdc8c5cd9d0c3bf65aac82be15c7ba4623cf9bfff356cb21852498ce96be5",
+              "34e55c63209a72dbcf16e46f82a9b9675903ed6685e71d0d09fd20c4f0fb15eb",
+              "35b8a5d32b2650581b7d2d4f24fe535863df52d2443b065332ff19e698863510",
+              "35f0d5317a42b40f836cec391f0672ba6985be10796ce8e9b2a4cc4170c3e3a8",
+              "37bc0ad739adca2b58872f26b69c50c651fd1958a924932bd736a96b83355ef7",
+              "39d5e5529e663681dd4d6c8f4505b90a130b8508b2ad02baf844f4d798e1f5c1",
+              "3a482cdd5647655f9fd5504999ae04259e83f0bec08edbf9cfc975ae5ce1175c",
+              "3a986ec9188aaa14b3a8da433e107edb389e899702e3add72b4d92e42c398b2e",
+              "3bf2babb21d23f771869edfbf529c61893d87371f3edc84e8d19c4898028c6ba",
+              "3de8d6b954a47933b605cd5fa9f54f952151123247762bf5df17c027747bfd0b",
+              "4108fb8dbc07c12b03cd90ae5a2c08d4665ce69287210f31c84237ae34e4e293",
+              "41c9f031f9ef46b3a5f59494fc04a57ddf84b60790bf23420229ee32b36ea957",
+              "4274f9f905f5085db9fcfac03de8aa04afe01cb0b68ec411d7c22fa4e139339f",
+              "428d7c1f08948742220b77fd6e30fb8f931fd330082cefbb11a0599d17a26f01",
+              "42bb889b850aef9785c97a65c70f3b67437239c6e4be8bd7682e2265c2d94aea",
+              "4437d8e34b434179078e319cc1870789ef375c0696e1ead0de9cb76f9c09078b",
+              "449472db7469300cfb0084593947ea5ca4c512f72a305400424a750a6702a2b4",
+              "4499872e188d303ae0856374c5fc1adcc8b4fa0afa2d0832da90060d5205ee47",
+              "44aeba88b83cce85ce500445aa3bd3718c3bf0debd0aa15ffefaccf1f4a3077a",
+              "452da2c824cf3a5cdcca4602b211e1bdf50c80f6783b6daf59853dec1cbf58cc",
+              "45a4e7aa8e76d8bac6d3a325eece661f3255d59d98b1f1ea7f4f745f27907a6f",
+              "46999da64ec8140c687302608a08523a134afe72820ba14e592db2fa00615a8c",
+              "4719b9b054342d5860dcd217fb39562910c4413866ebf2c1cd0eab27c0a5be78",
+              "4903b20b3d8c7edfbb955fce8563bccfeb2a476b1a5ba4476e3042d338f4d5b1",
+              "4966a4e45509bb9dbcf34f81b03fecc9d9664761ac6580490d4d48c234dfbd0b",
+              "499133a2dfe92ba858cd6b451be66423886b980c9ab7cd3c3d6a8cc2cd3bfc6e",
+              "4acaf257b4852029412fe5319e42af2512270bc5f418db8d1ace6ee3e588b604",
+              "4b4285bcdf6154fb396d6209d29c2bea51ebca849afd37b373597fd6fdcff69e",
+              "4be59355bd1f99c652dc83fe9f82ee0be21467937ae89d430e402e15ba99af2e",
+              "4f83dcd952d17b944aacf59abf19bf6bed6a37543230eacbd89654492a0c3a96",
+              "51311e7bdad3c87fb53d0a28d4fb2601a778e49b4205ba8145751bc131e4b4f1",
+              "5202a6c530c30d0b498bc6a3115ad05407a66f2497a9806c2543300c6409a3e1",
+              "52560f8b070eeedac6b4d358adc2e496894d2bc4b380ccfd6aefb5cdc8aada37",
+              "5345657d5b639e5183220c0dbdd3a2a88e8712f32d136a61d9585d0da440a349",
+              "5380e5dd89491352b8d4c5603058ffd2550bf841757e6711046f678dec75e587",
+              "53d9682465a7148fcf6d554cb5a2628d3c7bd78d97fde6c63f20a01978a40dcb",
+              "53f1f92b9647a4e81913370088a2800f817f04b895e804384874034b29870f93",
+              "5424557175e1a1a8b8399721ad50713c52143fc868674556a26e02556b28d1be",
+              "550ddcc9ecac5416e0ffa9f100d645bbca1596bac588edbbededf16af367ef59",
+              "55194bfe70ebc111b869b8d054eb2181bbcd040dae0f22499a70fec4d70f5592",
+              "5690d161826ae38cdc533bf3ec4cfff473b072888615c91116e820f1da798f5f",
+              "56aaf5f208b440e963d3175da26fa1cf828401e575d5a964890cf8ee80137ef8",
+              "56d74040f27dd3315cddd069233b8b83b43d42ec25834642ec5a29bc88aa6832",
+              "5851cd739d3ef322f9cd861c2536f8e3cfc6223c717a26af33eda1eb553ddff5",
+              "596a6e05ddb0363ac5e0d1d82aa9653060f4445af678f4611fa3ed4bf829810b",
+              "5ac4545736810c30a5e400576bbfabbc15a3c809d34ea7d0fd81220380e5fdf0",
+              "5b2760c87eac8f39181c642307de8eb46efbf82a261f3c9222c97b62f25ea351",
+              "5bd676224e2d68995a895b6c162142b3bc45fce8ee31fc024dc769b1ddd27a9e",
+              "5c3b61a90c2c92ba5f8394fb3eb0f191f993bad6d28f035e3277e702bc21740c",
+              "5c3c207958ec0afb3ed34f1c31024b566504160b2eb5c008670ee69365581b9f",
+              "5cc96dc391547925522522d0b0f15272fa64a2efebb326cf11b30150c472936d",
+              "5d4d083a8ba515d1e98731e14ed5081dbe772fa9de69c57a358550f434680119",
+              "63c86cdec314b5bb71b7d71615d9307e9f3c4b8cb625e22065a26e4e8edf3654",
+              "6414458cc2c2a946252c03fc0bda65789ea9642f5c7610e505457f0e5f8e0995",
+              "64afb5ee9775ec764f8c0e6dc5a6fe94e54014341325033166f04a55c9bfd123",
+              "6547c5ddc99f970c131f83b5e07ef4facc4b24ad7b1caa4f66b3e84afd034f81",
+              "65681a125023057dbb9eb405418b1f282314321814205a3707b31e82cda07ee3",
+              "66dd664196770c13324a758c460ed67c0fdfd78ce292b99749919c832a416486",
+              "67479786cbcfb3cb62d6428d6e5e80476bc1cf37e93174eb476de40018d3b27b",
+              "6ad23dea4d4ed3e783503ada3c46ded35a3e9fc92650a61d3b84689c32e76581",
+              "6b38eb4a8ac3e3574482ecdf52be179a1929659222a42e6bfbbc0d2e4432aae3",
+              "6bc2c2859c63baf7ec088a1f685060d7eeebf5a6a863667105129b4d7067ecb2",
+              "6ccc97a058fcc3b3affdd299bd1d3619943f87385ac6589d86cc37a2bca037df",
+              "70bb044ea2ee52cd9460f1838f12cfb882d664eb7d7d09265bf573f74babe490",
+              "714846742f2e2a0a2cc2d62803194c93e1147871b6170a2aa9f1da9cbcdd73ef",
+              "7192b5a07bbc0be6d24daec3491567ad37d1e7413c79da1a487849c6b6536c0d",
+              "763f86742cea203094eaa55c9fe5dd24da2881e87338a8e5aa10b7ac3d369e28",
+              "7728210b6a29cf3215f3ca02accfaf795889f69b122871f09280489a5f7f9296",
+              "776e63f8b8df0721fc737014d10406869548a42610b1957613d79af78d2ad9f0",
+              "77880bc787364d008f729216022aabf72e61c93215e8410565b338cec00ba545",
+              "7919aabdb23473f676b40297c1baf1cc5c9cb5b1d019d6bd2b6bc38e04371924",
+              "7a619b3e775a817dee51beef2af8b33968c7e8985521522d37bdce1f20f9e9d5",
+              "7bad8adda2442c60528007c9db91a71a5ed059f85fab5af6a9a8d581d4d8771b",
+              "7bf45a47a554d5fabb4fb05e204b56115d3ac1fbcff48af99206e584acce159c",
+              "7dff553ce1fff1230c968690110cf2e1153847b5feb755e3cd8b0148a52f72e0",
+              "7ff6ee3818d20d60e8b7ca133538962cc98fb0ed6ee12e3ae050f26534476828",
+              "80553f368bd94eefbc3e49b0facdd74a569b3a25118c2245b4420cfbb3b03669",
+              "85ecfb7015c7631467a8154dc0dcaf39f895dd1d26a65c8000f510386341f92f",
+              "87b229114c66b2226c2a943376010152f62229e145846ebbfa3f39c5e7dd2e47",
+              "882ea093b60019550644adf10f37c4c1f4cde482daea12b9ffe03964c5b31d43",
+              "8e852ed9f23024ddb716ac0504ca60b4bf7c513f67d41e79abb5a1d09043e4b8",
+              "8ecacd06afb5bc95128122134d440cc36b1b379b286adfd0742ce23b2bf01d25",
+              "94b34edc9c5b4a79b51acf8ee7d0be9bd707ca0fe0f6fa8bfd73ef6203f58c5c",
+              "94e28ba895e82626f86be661045c1528cb528011d1a3429abd2ca383d807fdc1",
+              "98d987cc3383a1bcb53e38d528e9f3b08c842ebeae8822037aa6b538f1cb94b1",
+              "9923b4fcabeca0abdaf49c560d4a470513081e02debd7e4d9e67a735c6556cd0",
+              "9fafa2c6b909fb684b39dec12b4081c37952cbb45d59f9e1fd4552865a0623f6",
+              "a27a88f69149f54af8e94038eef6f9f9f0b04a2cddb032b3edf9a897993c6015",
+              "a2f68c7071c5d24df5a8a5ee4600749578b3758afdbec45cdb901312e8dea292",
+              "a4e86594b9f5005011cef8862a16dd5c96f86a0951fb0f5e297f3f42364e5235",
+              "a5461d90423a0310e14098919d5c43d19277c2a1c0cfd692823ceb32a2749445",
+              "a784d0c895ffa4e157620eaa52793ee98a9c220e696bd7ef9ccbeadc6da0e96c",
+              "aa1935c0df89cc470b7f9b42b905da4b1880ee24c59d00fc7c58eab3b71d4277",
+              "ad5dbc9b86a74b544c07f8d2d1e8a8f439c129a427f209d874a701d2f10c86be",
+              "ade105de33dda26bbb023c38712dfde85a9b85873fb119140d1c036393614d24",
+              "b0242df2013670492cd9450079b769004cab54631067880cb563e652665ee694",
+              "b1420a137d011bca3586020287388c3948667e34f1efa79ca6b91f7d5676cc20",
+              "b14bfb7bcc45b6c39bc03e9d67b134846c9c75c20def45ce671754274959379b",
+              "b22071e55e27383b4ef776601289aae1ff01729d155c1ad06d444d5b480ab4e1",
+              "b2cb4d6febf06e960e45b5561e465014671feab7c4f5b78fac011ab94c548976",
+              "b39e6554449dc4b54cb7df02ae91e0f2d2f1d156dc5de773855c686d672048fb",
+              "b58fa4bfbf1e4b4df05b4e9db0655d490d0942ad94ec5254cf5644d464416c99",
+              "b5ecc280e31d0900565cbea1b188cb898a410d9d8b087d58dd71280d88032a16",
+              "b6798175c57c933055d80bcaf1ef054ae86f3115dde75dfb0acb2e6254d91adb",
+              "b7ea8c8d19587be1beb3634f3f60ddc423af01010ac3060458d398933614a396",
+              "b9a883f3b26f663706f055f9371a6a95bb58f649b8bdd39145b7342bd45395b4",
+              "bb0f6fefe0f3ae334ab5b006e472c7ac33fd079f561701c643463e0bf3f71b11",
+              "bcf0470653d7b0e122cb20d33de4bbad3b9b514bc3ba840476f4baa47df6a8fa",
+              "be71a6a144798ab516e75cf2afc3bda9e03134b5efcdbb8037659054be280c2c",
+              "bfbc663b7252bb48062ce947d4f6305ee1a2391bc53012c9cf2488311ed9da16",
+              "c04d80f97d25e35ae90efb7176efc2f67d265f5a618c92d1415612d0f20a4b70",
+              "c0b8526bb621cc30d57c18463c8d6638de90b6224fdf2b2365c4c72da54066e3",
+              "c0bd1f380f0f2d9b267f878100a6f618b61023284469156043815ec610bd8c2e",
+              "c0f679f653bd3ff6049300da5a768a1a8d4baf2abb10e6a2d826fc175b7fe7d5",
+              "c31b22e641e0105bc22ee8cb3c27e70760fc7e243417b84185379be64bced11b",
+              "c32201de3fadc9fa3b98bfc32529e123d17e8892a727f95c599e08eaec8b49af",
+              "c480d5e45715b4bd274e5db600f77248d366b738471440330c1588ba4af990e0",
+              "c4cb64f6eb018649c6d477e7e138eb5ec2658a17bc3edb1e944ded5d38d4ff34",
+              "c50bbf4e54fd72c50b9abc2eb55605b6fc34b6b4392d96ed63a14c2f2595eca2",
+              "c5a4bd53a0e1fbf75bd4fa439b3614f4db043466670d23544f07dde2460c919b",
+              "c6719926e300122dd3c300c3a55ff2a6a8f25576b8daf9d29dd5300975ae2f31",
+              "c8316316e02b09c0ea960f9bd1d58914a20c40e3d9e01453efd27d9b4ae32100",
+              "c84f0cc352322e3cb4e7501d98d785f97180ce11c415a9646af24dbc3c760a52",
+              "cd5e1040c8b3f8b521247910729dc609c28ccfd13d99f778665d5642e54f25e3",
+              "d43a473d7ee6e29d01984ca77e0f25e3f1d7150656b74401c0d8552fd2755133",
+              "d4a179b67f4e15e20f86dae2960ae8e4b13b4a02bf5b4e5fa3b4caf065df9a1b",
+              "d8af7f765be393fc12613ffc9cd9e767dfc4b69e6269e52ec05b7c8339700fbb",
+              "db87194e1e8fe4ea75bf5a86e3e34c81182cc2542b3ea2b888cfa31e96a3f44f",
+              "dba6a3506f66fd1cdc05c83458334a3073a96dbae6c8414b7eb623ef97ea5089",
+              "dc6cc932ec9bd2d00aa18e8e145a84fbc4f3cf87f579b2b723a73a0b29e58864",
+              "de29a80179c9548bc8b69bc02e19107de8c8d6d8acda8ce646c0594e7cb41a0f",
+              "deecb2d51bbfc099f2b1b0700bce7b019e14f5e17b3f3bf808a7894fb3836c3f",
+              "e0973608acde2dbe64b8c8a58c5239fd268e00fcd3d7dc8d58163f3403e91ac1",
+              "e2fb53d8a836ab96e86fe79fd5eeb5737e897ce8c764f6e45c0132a4763dcf17",
+              "e312fae5511e3c0c05894f2a452a8ba129974bcb0dac7d3da03f41c0c41fd00b",
+              "e603c1c06f8a8802682fae63c428a20ca27da46ad6271fccc4ae756f368e56dc",
+              "e78395ac5985191772612a0a228f2c3c4be39ae66bc2c77bcd05d72deeca6a45",
+              "ea3aac34af8b8ed7b9f3019887d4a733909e7915fa602bb26f2334aa54218923",
+              "ea9c9d03313f13d815892e0ce60f2dfb19d5ef49a8307cb934c1d4372dcb0c09",
+              "eaa6bc4aa7f57a7339558f4468db24e85e7d68dbc670d4253bfcf297a97a883f",
+              "ec48527c2bfe35c3d5574953cd807393db2e0db7d9e18b1a8bf504a63ffd9a36",
+              "efece1fbe7879d723964b7f9c9ef734851a2cc795488ea167834e52ee70225b6",
+              "f05c6b1784bb630c60f5ad3c45673117352f86aec30cd4b234db0e64092a6ef4",
+              "f081935ca2ab9ab023e1d1138461d27e72f23e6e37ca6cb1cd67341bb516fc0f",
+              "f098f2b2da870aa6f0c7f15c386ac17dcd7991ab64d87f21c6751ee29ff46d20",
+              "f4ff16b088109146745676b2e010c3e38b71ff630b9ade7ab6bdc9c827740113",
+              "f9a0b8a76c4a7a59fcc09f295a454faf44003c0d8b5262407b40975fe94333f7",
+              "faa44037bc155b770a5e883dfb2fbe3e87e5144159ac3ffdf3777b7b41db42ab",
+              "fe63e469b2a4020cb78504751cce0fd8df7801a2ae61ea32d58c9abe7988a2fd",
+              "ffbf2600dc3347320e339bfbf80303327a00dafb6c30e22a4fc52fb12ec77e91",
+              "fff89ea429a8aa5255cb656aae3dbc167fcd072b701753ee2d1c3ebef5ddb56d"
+            ],
+            "unique_vector_count": 181
+          },
+          "random_objective_seed": 20363729,
+          "source_model_index": 3,
+          "source_positive_inequalities": 294,
+          "source_target_id": "seeded:3",
+          "source_unique_ordered_quad_count": 293,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "52ded422b7be86dc5391fce9f9d511578b92742dda4cf1df2a77e2c2aa7fa71b",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 4,
+            "source_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 182,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 22,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:4"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:4",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:4"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  28,
+                  25
+                ],
+                "weight": 2919271
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  5
+                ],
+                "weight": 11609746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  5,
+                  22
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  5,
+                  28
+                ],
+                "weight": 4033028
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  22,
+                  12
+                ],
+                "weight": 4986935
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  22,
+                  11
+                ],
+                "weight": 18760958
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  13,
+                  25
+                ],
+                "weight": 1542635
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  5,
+                  1
+                ],
+                "weight": 11609746
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  25,
+                  1
+                ],
+                "weight": 4461906
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  7,
+                  1
+                ],
+                "weight": 18247926
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  2,
+                  10
+                ],
+                "weight": 4928708
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  27,
+                  1
+                ],
+                "weight": 4928708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 3015346
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  28,
+                  12
+                ],
+                "weight": 1484408
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  27,
+                  10,
+                  1
+                ],
+                "weight": 4928708
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  12,
+                  7
+                ],
+                "weight": 4557981
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  12,
+                  11
+                ],
+                "weight": 1913362
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  5,
+                  27
+                ],
+                "weight": 326843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  5,
+                  12
+                ],
+                "weight": 1008764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  19,
+                  22
+                ],
+                "weight": 568339
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  26,
+                  8,
+                  27
+                ],
+                "weight": 1964816
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  19,
+                  8,
+                  12
+                ],
+                "weight": 777373
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  19,
+                  5,
+                  14
+                ],
+                "weight": 3600245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  18,
+                  7
+                ],
+                "weight": 20283782
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  3,
+                  8,
+                  24
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  3,
+                  5,
+                  27
+                ],
+                "weight": 19157209
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  3,
+                  22,
+                  27
+                ],
+                "weight": 568339
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  24,
+                  7
+                ],
+                "weight": 3484393
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  5,
+                  27,
+                  25
+                ],
+                "weight": 2919271
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  27,
+                  6,
+                  28
+                ],
+                "weight": 17788
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  27,
+                  17,
+                  28
+                ],
+                "weight": 1148161
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  27,
+                  17,
+                  11
+                ],
+                "weight": 858140
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  24,
+                  6,
+                  1
+                ],
+                "weight": 3484393
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  6,
+                  10,
+                  28
+                ],
+                "weight": 1562659
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  6,
+                  10,
+                  7
+                ],
+                "weight": 17788
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  6,
+                  28,
+                  1
+                ],
+                "weight": 3484393
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  17,
+                  28,
+                  1
+                ],
+                "weight": 997537
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  17,
+                  12,
+                  1
+                ],
+                "weight": 1008764
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  10,
+                  18,
+                  1
+                ],
+                "weight": 1580447
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  16,
+                  25
+                ],
+                "weight": 55408
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  10,
+                  25
+                ],
+                "weight": 4372502
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  3,
+                  27
+                ],
+                "weight": 12622581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  23,
+                  6
+                ],
+                "weight": 4033028
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  23,
+                  13
+                ],
+                "weight": 2284839
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  5,
+                  28
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  27,
+                  10
+                ],
+                "weight": 644029
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  3,
+                  23,
+                  27
+                ],
+                "weight": 5291879
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  3,
+                  5,
+                  11
+                ],
+                "weight": 7231583
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  3,
+                  16,
+                  14
+                ],
+                "weight": 99119
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  3,
+                  27,
+                  18
+                ],
+                "weight": 22059863
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  3,
+                  24,
+                  12
+                ],
+                "weight": 957736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  3,
+                  17,
+                  21
+                ],
+                "weight": 3600245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  22,
+                  27
+                ],
+                "weight": 2608845
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  16,
+                  1
+                ],
+                "weight": 8071962
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  17,
+                  12
+                ],
+                "weight": 777373
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  8,
+                  13,
+                  11
+                ],
+                "weight": 1148161
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  8,
+                  13,
+                  7
+                ],
+                "weight": 1136678
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  5,
+                  22,
+                  7
+                ],
+                "weight": 18247926
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  5,
+                  28,
+                  25
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  22,
+                  16,
+                  11
+                ],
+                "weight": 18662783
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  27,
+                  6,
+                  13
+                ],
+                "weight": 3075292
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  27,
+                  25,
+                  1
+                ],
+                "weight": 4724017
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  24,
+                  6,
+                  11
+                ],
+                "weight": 957736
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  17,
+                  10,
+                  21
+                ],
+                "weight": 3329053
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  17,
+                  18,
+                  11
+                ],
+                "weight": 1048565
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  10,
+                  25,
+                  18
+                ],
+                "weight": 446097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  10,
+                  14,
+                  11
+                ],
+                "weight": 6611429
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  12,
+                  21,
+                  7
+                ],
+                "weight": 3600245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  6,
+                  28
+                ],
+                "weight": 4033028
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  8,
+                  10
+                ],
+                "weight": 436293
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  16,
+                  7
+                ],
+                "weight": 55408
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  27,
+                  25
+                ],
+                "weight": 4427910
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  8,
+                  23,
+                  17
+                ],
+                "weight": 436293
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  17,
+                  1
+                ],
+                "weight": 436293
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  22,
+                  9,
+                  14
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  27,
+                  14
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  27,
+                  17,
+                  1
+                ],
+                "weight": 8889816
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  21,
+                  7
+                ],
+                "weight": 18751278
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  13,
+                  10,
+                  21
+                ],
+                "weight": 4372502
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  19,
+                  3,
+                  21
+                ],
+                "weight": 12622581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  22,
+                  16
+                ],
+                "weight": 4418596
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  25,
+                  14
+                ],
+                "weight": 4481930
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  3,
+                  17,
+                  13
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  8,
+                  5,
+                  24
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  16,
+                  9
+                ],
+                "weight": 17002123
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  22,
+                  27,
+                  10
+                ],
+                "weight": 644029
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  16,
+                  27,
+                  11
+                ],
+                "weight": 858140
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  16,
+                  25,
+                  11
+                ],
+                "weight": 11725387
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  9,
+                  24,
+                  17
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  28,
+                  12,
+                  11
+                ],
+                "weight": 293302
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  28,
+                  14,
+                  1
+                ],
+                "weight": 4481930
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  12,
+                  18
+                ],
+                "weight": 198642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  12,
+                  14
+                ],
+                "weight": 4359339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  22,
+                  2
+                ],
+                "weight": 133344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  22,
+                  7
+                ],
+                "weight": 20339190
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  2,
+                  10
+                ],
+                "weight": 777373
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  22,
+                  2,
+                  1
+                ],
+                "weight": 2371317
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  6,
+                  13
+                ],
+                "weight": 3015346
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  18,
+                  21
+                ],
+                "weight": 6843808
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  6,
+                  10,
+                  14
+                ],
+                "weight": 1620095
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  25,
+                  7
+                ],
+                "weight": 3015346
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  25,
+                  21
+                ],
+                "weight": 2586849
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  10,
+                  25,
+                  7
+                ],
+                "weight": 1279015
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  28,
+                  25,
+                  21
+                ],
+                "weight": 3191924
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  25,
+                  18,
+                  14
+                ],
+                "weight": 5591204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  25,
+                  18,
+                  14
+                ],
+                "weight": 2102741
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  8,
+                  5,
+                  11
+                ],
+                "weight": 568339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  17,
+                  13
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  5,
+                  22,
+                  12
+                ],
+                "weight": 568339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  27,
+                  25
+                ],
+                "weight": 1685878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  12,
+                  14
+                ],
+                "weight": 3600245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  16,
+                  18,
+                  11
+                ],
+                "weight": 6217147
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  9,
+                  25
+                ],
+                "weight": 1913362
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  17,
+                  25
+                ],
+                "weight": 1913362
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  27,
+                  24,
+                  17
+                ],
+                "weight": 215532
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  24,
+                  17,
+                  25
+                ],
+                "weight": 119113
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  25,
+                  14
+                ],
+                "weight": 858213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  10,
+                  18,
+                  11
+                ],
+                "weight": 446097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 4439896
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  21,
+                  14
+                ],
+                "weight": 4582440
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  11
+                ],
+                "weight": 8071962
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  2,
+                  27
+                ],
+                "weight": 644029
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  9,
+                  7
+                ],
+                "weight": 568339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  17,
+                  10
+                ],
+                "weight": 341080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  24,
+                  13
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  9,
+                  27,
+                  10
+                ],
+                "weight": 6470376
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  27,
+                  6,
+                  13
+                ],
+                "weight": 1178497
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  6,
+                  17,
+                  25
+                ],
+                "weight": 1178497
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  22,
+                  2,
+                  11
+                ],
+                "weight": 98175
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  18,
+                  11
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  6,
+                  1
+                ],
+                "weight": 11100086
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  27,
+                  24,
+                  14
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  27,
+                  6,
+                  17
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  17,
+                  25
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  10,
+                  18
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  10,
+                  28,
+                  21
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  25,
+                  12,
+                  11
+                ],
+                "weight": 5347353
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  2,
+                  28
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  17,
+                  25
+                ],
+                "weight": 1386614
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  12,
+                  7
+                ],
+                "weight": 568339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  28,
+                  25
+                ],
+                "weight": 313326
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  17,
+                  10,
+                  25
+                ],
+                "weight": 1045534
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  17,
+                  21,
+                  1
+                ],
+                "weight": 2371317
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  28,
+                  14
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  25,
+                  21
+                ],
+                "weight": 6959351
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  9,
+                  6
+                ],
+                "weight": 11100086
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  9,
+                  24,
+                  28
+                ],
+                "weight": 742204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  27,
+                  12,
+                  1
+                ],
+                "weight": 7423694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  27,
+                  7,
+                  1
+                ],
+                "weight": 55408
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  17,
+                  12
+                ],
+                "weight": 7423694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  18,
+                  14
+                ],
+                "weight": 6959351
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  10,
+                  14,
+                  11
+                ],
+                "weight": 7058470
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  25,
+                  11,
+                  1
+                ],
+                "weight": 14250337
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  24,
+                  17,
+                  1
+                ],
+                "weight": 1815187
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  6,
+                  10,
+                  25
+                ],
+                "weight": 1913362
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  27,
+                  17,
+                  28
+                ],
+                "weight": 644410
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  13,
+                  28,
+                  25
+                ],
+                "weight": 1386614
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  24,
+                  6,
+                  25
+                ],
+                "weight": 3988815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  24,
+                  7,
+                  1
+                ],
+                "weight": 55408
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  6,
+                  28,
+                  14
+                ],
+                "weight": 3559937
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  17,
+                  10,
+                  1
+                ],
+                "weight": 6763678
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  10,
+                  28,
+                  11
+                ],
+                "weight": 293302
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  6,
+                  10,
+                  7
+                ],
+                "weight": 942129
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  17,
+                  25,
+                  18
+                ],
+                "weight": 309765
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  17,
+                  21,
+                  11
+                ],
+                "weight": 957736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  13,
+                  28,
+                  12
+                ],
+                "weight": 6414930
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  13,
+                  25,
+                  1
+                ],
+                "weight": 444180
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  13,
+                  14,
+                  1
+                ],
+                "weight": 428878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  28,
+                  18,
+                  21
+                ],
+                "weight": 6101604
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  12,
+                  21,
+                  1
+                ],
+                "weight": 1008764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  14,
+                  7,
+                  1
+                ],
+                "weight": 4481930
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  10,
+                  14
+                ],
+                "weight": 6038245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  28,
+                  25
+                ],
+                "weight": 1644415
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  25,
+                  7
+                ],
+                "weight": 3399584
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  11,
+                  7
+                ],
+                "weight": 957736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  13,
+                  28,
+                  11
+                ],
+                "weight": 1148161
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  10,
+                  25,
+                  1
+                ],
+                "weight": 2475203
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  7,
+                  1
+                ],
+                "weight": 873058
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  25,
+                  18,
+                  21
+                ],
+                "weight": 6959351
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  25,
+                  14,
+                  7
+                ],
+                "weight": 7693945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  14,
+                  7
+                ],
+                "weight": 7058470
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  25,
+                  18,
+                  11,
+                  1
+                ],
+                "weight": 2589211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  14,
+                  1
+                ],
+                "weight": 1008764
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 183,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 691289610
+          },
+          "compressed_positive_inequalities": 183,
+          "compressed_unique_ordered_quad_count": 182,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 213,
+              "seed": 20364729,
+              "trial": 0,
+              "unique_ordered_quad_count": 213
+            },
+            {
+              "positive_inequalities": 200,
+              "seed": 20364730,
+              "trial": 1,
+              "unique_ordered_quad_count": 200
+            },
+            {
+              "positive_inequalities": 194,
+              "seed": 20364733,
+              "trial": 4,
+              "unique_ordered_quad_count": 194
+            },
+            {
+              "positive_inequalities": 192,
+              "seed": 20364747,
+              "trial": 18,
+              "unique_ordered_quad_count": 192
+            },
+            {
+              "positive_inequalities": 183,
+              "seed": 20364751,
+              "trial": 22,
+              "unique_ordered_quad_count": 182
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "183": 1,
+            "192": 1,
+            "194": 1,
+            "200": 2,
+            "202": 1,
+            "204": 1,
+            "206": 3,
+            "207": 2,
+            "210": 1,
+            "211": 1,
+            "212": 2,
+            "213": 1,
+            "214": 1,
+            "215": 2,
+            "217": 3,
+            "218": 1
+          },
+          "numerical_support_size_max": 218,
+          "numerical_support_size_min": 183,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 182,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 182,
+            "support_size": 183
+          },
+          "quad_reduction": 108,
+          "quad_reduction_fraction": 0.3724137931034483,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "023f432f353fde8c39c8a51564d4ea8d2a4bbefe9ba6a2001c27093dc8a50257",
+              "024456f7db8bc3a2cf2951c9c83cc060a512877667e60ef103c0c4b46520cb7b",
+              "04871e258b001cef945a9b5dc449689b1054838d8f193fb6b7ec32e19319e67e",
+              "0891627990d34fc828efe6383ef59e34f6ff72755071f3530470b96f26792da9",
+              "08f66627ce83b6fbd19643b115fd6e1ddee3ea38cdbb59b6b22a963206bcc2cd",
+              "09ed9fcbdf75d416133a30440ce66765c29536ef6aae0ebde54d6301bed8908c",
+              "0b3e1c4151be4cdea7c4b456b7dc0c79cd0d514dad881f659227eef7f4f2352f",
+              "0f482c506156fe06ec6014d2280d8fb4f326c4dc37f39b0b7843cb89e50e7600",
+              "0fd80b47ac4ed439480e838d9f5f128dbf8dc90a775ce90ef0e22855aa9304e0",
+              "103825f9671d6712f87111fbd126b1f9b4c15a1c42126142523f320c35a39044",
+              "105525cf8b13f93a994fbd23693da2ac8b4eb3dd1c8dd02de100db1bd0e60b4d",
+              "11c8d7ac6c20f20a3cadad951829b2d856b693397d6d653a0a93b1dcb64469a5",
+              "12c92abd903cb5f2e7ed5670525198b52b0c98350281e74ee0d2d2eab96a39ef",
+              "170360f7c2e95fc67d4d0dc0ab359f0207fc298f744e2be174f8fd089812c4ed",
+              "1911aa0ab285b4bcd35ea01e03702de16606eae0d0af8b02da6e4a0e7cd20321",
+              "1938113c8220074bb6697cca226a37a49dcc502f4d299854e6cc6ade7bb03257",
+              "1a647329a658529190e90b8d9b46ee7a08e4a2dc35944d50be077bdaf48dd636",
+              "1a85515758ce930b090357fffe1042fd5ef3b281273d92c61725b20cc0a59ae3",
+              "1b652b852c679311a14643abf652c2044500277e13a88d7cc8453584524db0cc",
+              "1b7dd2231df64b59a17fd823d7ab3f4960d03127f652ff8c492f45130e1e97ee",
+              "1bba44dbaab170f6fe9711954adc08b282cbbd463d18a2993228615690db455b",
+              "1d1ae31d1b6faa1524131a004e7684bf23941dd39fb28c13e4e5cf72d9958b55",
+              "1d8af77b14169cd248e5ccd76bc3f7aac0362fc0cc3f37c86d65f5dd8e535c7d",
+              "1e563c8e44e689e08e7da4b261760f2f62c17d7e166890c429a1b14cddb7e83c",
+              "1e6febea3ae94b46b93fadff976a0cd73b9af3362e087c47f6768a59b819a981",
+              "23e0561c30b53e750b698d9e4944ff6a1ad48ce839ac6df12f93604947c46de2",
+              "26f6d40599f12f66389b850bf7978d5be7ddc392ecbf9662f2a3265de24c2166",
+              "27d2d7c1483ca578236d190bbbb57137dd8326d97cae97b09daf3e2b16671669",
+              "2a8d95d041745fe5c39f192b269214ec04a2de0dd6433d9e61c23203cdbc832d",
+              "2bd815db76a6b614d57bae25c68210e7d1f1dce007765f8d3e96fd59bb94b86a",
+              "2d524b70284b6b4b6941a0b01251a91ab8269eeff03bf626cc4d5d7a9e94bc1e",
+              "2dbfaca0f14472ceb779891100640f9a5926fc71c56d956c45b960205791d724",
+              "2e83bd0daf884c685ddb72b11152a37373af3c6c416aae8b095138b6c480565e",
+              "300ec33e7af671e6609902ab0672d9ced50a3d53c41ea3e43921232691a1e309",
+              "32c387efc2ec085ab68490c9c5cca7abfa209987736a9397e7606d26b3ff926b",
+              "33a28578ec5658b48ac4e5d48ac45db8b95843480527483606ff72c1f90df4c5",
+              "3a4ee3b9b722bd83f0e1bd3728b1b5c0f40d316059e4b7899163fa1efd7eaeac",
+              "3db3367ffc982466c93b4c023b68a7567595f8aeb5fa5f4319431df9d2bb394d",
+              "3e2da520db01d2aa7efc15ccb98d03a8324be78ea273f48d1d26b33e17018135",
+              "409982b1224515c7656d4fc00285ea526d2c92a76535405fa8d6c313209b573c",
+              "41c9f031f9ef46b3a5f59494fc04a57ddf84b60790bf23420229ee32b36ea957",
+              "42b2129f6fa9531b08975ffff5e42f63a8ed5ccc77d0d1bbb7e6a24fda8a9008",
+              "42b793a1d31002624267edce83d47964e0553cca3db68ddd2703628a16a1aa66",
+              "4551fa342fd2fdf15db7af5135d15a2921326f9d49dcbd9743fcadc546365b43",
+              "45535d3339953e0885d853f1777e1d4eec5d17f442307d1a646c5dfffdcb69cf",
+              "476a9ff7811c140972b01c75aa111b326c403fcdaf7f7e4d8af92195905181b8",
+              "47e1975b8cb90463f6e41c3d8efc9122f91ff6e8a717916c1ad4ffb528e5006a",
+              "49de3cfe1bedffd447ea39b3cfaaf0a9cf81e02593bf843fe7f456298088496f",
+              "4aa98bd5b4bb6c1b8081b985e89394a61a938c77840e7037fcd25a879ef7ce33",
+              "5068e008c51323df8126c228222e73f7fc74d8847febc42039c44728406e6e70",
+              "519fb2dea2b4d69fa0ee511ea4bb8f9fc3336ca1728dae3b7a7d94101313227b",
+              "51a4c3d36f5fcef7e07a94dbe9f5216afda085b1a28687d3825708d64456f4ae",
+              "533a09fee737ee88597593e8dcd2bf589f59adf2823ddbc42708f9dbf4f2e73d",
+              "53c7d928204e81638faa2737c249606dc54aa018a3b24ea89c0edd526c98a5da",
+              "543927a8be8e037ab5083fafc942abee8e9aaa3bc7614903bff10d14e59fa9d9",
+              "544a1217ab70c8b5d316d4af9221af3ba7d58e022d019b741f7251a1bc8f8686",
+              "54c57593324bb92460e58ce35b60f6b6ce848fd1c343582bf8efbb52b96fb9e3",
+              "55ecc8682eeb08d6debaa2f2b89898d8fd8cefc739f63d462f2a748aa0cc5034",
+              "56093fd3e4d0f695abb4a60ddd0f42544c0170633db938c509359d6a38692836",
+              "57c1c4235833019f71e1e2c8447a55a45e88e7fde07f47d2cd93fa5e19caef7c",
+              "5892bb4e128412e99c2d2437047501edbb256c233b18777208c3231bb9a64d0f",
+              "5895a099784a79f48f9f222aeb5b2bfca8a25bf83b09f5444b31e54c7c9b06ca",
+              "5978f0097d72acbac5bdb4c335dc82b3991e8cdd511983ace3e2db8fe0b73658",
+              "59878e119ba8033d982cb976a271ee86db515c8f5de9ac3c2de187efea6d3cdd",
+              "5a2344808b0ac50272cf86fab67d9abe3505a37ad35b8253b74fe11b3c188e82",
+              "5c2b58b246e05450d362ebd5280c5536becf9c2a50f1d85ecb5f1de1122d5313",
+              "5c828d70d57b486e74e1dc3fe4c6e9cae4be60837fee27eda0c53fb1537166fd",
+              "5cb1c7e6b04e042a9fa948f0e29a02c1d3abd30423e1a4e27c3506e99feb3a59",
+              "5d2a7933446abcf2725e5a98b2d00a92be8e9a0c9bedb8ad6b64be72a884b0f7",
+              "602d5755177dbb637c45f2d743981f1fa47de7fc44f31a7f8f416d4e09fe6881",
+              "64a1b102c66f8826eb54a20838eda833b87f0b71dbbc7ada2ebca441e64adffd",
+              "64afb5ee9775ec764f8c0e6dc5a6fe94e54014341325033166f04a55c9bfd123",
+              "64ede2292eae66cc113f11c0b504ff7ea8514ea35a59d13f39a53ad2c0068c32",
+              "64f221c1556217bead70277caf9e203e9ec9b8c8221c120373d3a85ff483a618",
+              "64f9cb2480e96dece6e1777d910185d003e6e8a32548d3844c1994077ce0f85c",
+              "6567f64dc33ada1c41dcfd36551577d993362d8ab2843e37e1c8fe54d9ea87e8",
+              "6803e1c367fc3212aaf9109767a782d7b24e6fb4ed9737023bab2c6b0534a091",
+              "6816771b332acec0b5e117488a2f6381c589b259a6975de21b5d73c00ada1a6e",
+              "6833e5c8f66a5b58e205771c47790af9e248d068ce7a7b8c22ea53f0540de53d",
+              "68c2ff090e80494ca3471bf70d9f60fd2327b60f1a6f954e3d785e9cd3c3fbf4",
+              "69314489f6e2c332c878f16e5e0ebf7c3607d3118cfa30c6e22154575c35c760",
+              "69435bca61ed7acec1712ae9b1abea8511e2e645095a646694d29af35cff9ba4",
+              "6a11ab26ded417cd368bb0f7327caeeb9af56bcd2484e2a90a4530def5d0b1ed",
+              "6a34c6af67464f558e56b49e86743050dbe6bfe4150b722918fdd3d1b8ef0890",
+              "6d46c9dc8c5a39fb86992fb55972a4293e697cc1b5b86bf9bc2ec76ae5b1927c",
+              "6ef11e44d5ecca671c84e18d1f6a83c4f3f0627d06df5c0330c572de34097c50",
+              "6ef7b593ccd8b681ed5355f50cd670e4aae6d797f74e8cf1b0bc206c8057c4ff",
+              "6fb3acb22890e1713f39b30d3904e5538f7cb01e34f59132b7ae955d360ece34",
+              "6fc2ad33d802c5afaed1f889084c13376437c441a1908ce9b9ea54d30f5fc1fc",
+              "7142d63025700a52b7fc7fcd2d615f210223357800272210b0248035e5084dde",
+              "7290874f63afab82ddd3f2d499ff09732df0c04cada74bc479e07df0a32a9ad1",
+              "74fe59d0772093d0bd2ba90132342ee51cc2f719f647c9c06bb3b9fc138a3aee",
+              "76ba1265140e7942a031a26e532adc646f2f7fb205cbcd515b5ecdab95b399b4",
+              "789c41ff820754d9642d0257b3fe767b3c3510aa9d5dc41444f511c83456fa1f",
+              "7aaf82baab0b260d04b43547bb1797a13f4705b04743ac9848172ffd3f813385",
+              "7d07135a4c609f4fdaab75a2b767b4869681e676a7f2ffa5dca77692bce3dd81",
+              "7e28b8e2d140eb7fd683ef5ea24807aa2198e43a476733c1c17a70f42194f24a",
+              "7fe558ca5b2609b7a3ee37fa74a955a616e2676568c42397141380e2a24f81f6",
+              "8249ba2e4ebafb0cb3806ad734c9fbf68e7ee1d7970470faaac48b57d4f20a2d",
+              "8732832a370b1c8b10a7a78cadf94caf7584bdeb3a23052b4f71086c99de2138",
+              "87c4fed7b98d9bd7705f2d34d16bdb637a1478444ad779031417f775bdc2a9ca",
+              "9002f221a4365ea12b06f4625485c47410b0e860c2714a9635bfc038d4c972af",
+              "900e5547dff0423af0d759e7338f769013c3481277b40ae1a2645ae688d82092",
+              "9188775ef5547fdf5b83afeee2c1380c4b7d64f224f188fe2d257b7871fbb572",
+              "98f23ed44287f573f8f692786a1e11546143f49fe84370fd46bf7a2d70a5677b",
+              "98f8032d91e1fdf7a41dfac6cf6da028f3d1fb47e27c84c57780880695b596d5",
+              "998e6bc151b9315498ed6c8dd7080f69f7c55a8c76ab8ffed91a45ed28a1cd6b",
+              "9c53fbdca8899f63960e7118d42422126f65000c3e6b41ef6ba839f73314051b",
+              "9cdfb875af2c1452465321935883bbba4af80c0a02f62425525b952b34e3c710",
+              "a136c83ab78d5cc071fe3f0227ef589a0c2d92e6753ec748458c516d2690c18c",
+              "a2032608885f1369e48ac347dadaac277a4a4315731c3dd39890ea8c57540958",
+              "a4c850aee1df1439f10276fed6763fed2cbc8deea4b1d5fe36202aade8a02225",
+              "a77b4a3fe60a36175e75fc475c17aa9ea7b51888e4809203d6e6bd0a38b24041",
+              "a81d27b47554d5d01a5eca0242b53c76ba3058c7495aba4bbd612da079687ea5",
+              "aa407f38abb442c4004da1a148145c9d2f1e91909411a57a6fc56810f0e00c1b",
+              "aff770b8590acce399494ca83b7ddda5fc1b443483e61c7546f94e737a90ca3f",
+              "b1254a914e6849edaa5ee4feaf39b9d16f267f1f965e7f66706f095d976f61ef",
+              "b29109c5b76ec58871cc96994c4f52229eea575b2733c27d87f7a752d8b371c3",
+              "b4220d7deabb72cf07aaabba9ce0bebb2139dac9238cc33bd4ed3eaa5a43ac4c",
+              "b4338c1d60d8b6af96d8860b818a3c9228d4b7fe497a7ee066a18172f7233fe9",
+              "b51fef175ab3e260bc36f6b6d27ac69ae646508fb8d22255d7ec0e9e38436ebc",
+              "b58c21f9de6bed7d8f02268e6507949582afc9640a993899de9bf83eebfe1b55",
+              "b646d954a23e62eb0db1ccf93257625f5bde09d28832dec933439d5c9e44a153",
+              "bb1865f62b6c8bbe54e74c7e14b7f26648788d593362f048e697924b819d2baa",
+              "bb89a48fc13f2d03b3554f5a05ec5732041f1277a13c4108d96701651c744b80",
+              "bc0c3714687de3f0fd0ef3c5ea0437ae104e4a86af5db43aab54902d29d14408",
+              "be4229f258662a7a628f135263231faaa4fd4ed5d0fc2309a5f5af34eda71227",
+              "beae9b9ffc767f591ebd8753457db90f0603cf2bf62b2146e1587c9efbb36e1b",
+              "c05de4f10046c4462b500e05d22fc858f52bf172115ae556b8cbf8494644074c",
+              "c0bdd89a6a57a759d104d8963bb89d336b4fa75c54bca2545066375bcff194e0",
+              "c10ec1373a3c4bfd7aeb8fbb9f3f9fe6251f1793bf69d93a8404f7bfce7759a8",
+              "c30e89148cb5c3ba77912a58afdb5dcb5019287bdd1be9e700523db59657b7da",
+              "c39621ec57b84cb1810027da6c3c5262e6b7df137e42de1137a076d3387698ca",
+              "c47a9a45bb2c1ba6b2d1803c2c75e588ae96a077a06beba8e2a476539ccf1474",
+              "c4bbc959afd67038ab2475e4d684e9a5abf144f59558f3fbac80e78d6c24c3cf",
+              "c7c32cb29ccfdccac2d3f01f5d7103c1677a48b64be913eb71095cffaf3eb49d",
+              "c9634e9340ed1391a11869ff390a3c976d8be45acd50f3a5f5879e7d9f575279",
+              "c99ebca673e8075754efac3888a882a5dd5028361845ecb1d627c619544bfc81",
+              "cbf168db914ceb07e4a08ba81bc0751bff68262a2dfdc5582771c1dd881d588f",
+              "cbf57d43b4b6c43bd934b4fa93eb9ac22c2fa367c355d5db5dfb2dd78feee07e",
+              "cd291ed67d74f87e64bd561a79284723adfce1ab0837722c3e2211f79f93d8dd",
+              "ceac6a5d00c925e701773924588916aeb2214a40338774befd6208760d8e6b61",
+              "cead615ca8ac8f4c1fd8ac8e86cc518d23814dbc789af6ec94ae01b7acd93f35",
+              "d048729ce86f5ced67e91bca9b6eeca63439e34dd4d68e9418623c5b27992b8f",
+              "d0d7d26449ecec35e1b284b105b247cc0fc58c6d88fb0ef66a4753f40af7f84a",
+              "d2a22b4423b243f1b01b823f82d66c9ade06ead38f345e511fbaca44b00a466d",
+              "d3cb6840668646aa4536f3d93c779caf4b9874071ef670984bcc692d6abcfc40",
+              "d49597b45567d04d3b51c51571dee0a1cc0089d8491d0d11f668c7358cfdf06c",
+              "d4d5463d4e33574969a681829c8b5f07e3765316d3caa5e5653855484887ed58",
+              "d4dfd6a3079b842e045d03a5769d7caab9298f0f3a40f23ab239002cc738d936",
+              "d60b9102362b7a9a68aebcc75923db47b859bd9245e2919e3cd0a3a0a2a151a5",
+              "d8d77e7608e0b984ae86504bdc9f97360a8ed07f9110b3aa4442d4b0690cffe3",
+              "d90e864db1ccc14efed22e31f26c9cdaef6f7331891ae18761784d24081fcde3",
+              "db2ba00754548782a290e7e017fd999154a2b07d6e0531e5c81b05d0372d02cd",
+              "db8794181cda0d8058a087137e6f35dcc117cacbde6f20bb2abc9af3f7da6ce6",
+              "df3c78362883314c33f1dab3f52db5ddf5b35fd1a64e8795eb6179e79363472a",
+              "e13a8d79c9283ad1741d9ddd065cbaa7adf28e5c7122fcfdc952aa1df8e411f4",
+              "e281f161968f5c919c334e109dc57ec18e6c1983c92ad317e255c05f5ac37ddb",
+              "e323dd45faef35f3716622ee933f2bad3aa5695d5280666b6740e36cc9b42918",
+              "e3e66aa49bcd922b6c0ec795078f8a8a5962aee87917d59aeb7984e0cc9b0e3c",
+              "e477072cfb1b19c63531d8c979077c2ff61f5a38a69119cbbe54ae5f25e8de14",
+              "e587a14304125e4f141f818f6c338801bd09f6d0748e84c8cf331ce77d6ce362",
+              "e5916383aa824d5e26bb6bec2db89405fbddf936313eae8c671308f65ff09bb0",
+              "e78324accc9e51f00663b770cf27c7e7c37afb410eb77382c968ad60fdbfcfb8",
+              "e7a841b261e6b4c60797ad8ee38da6fcfb509b230f040097c39138293a5ad96e",
+              "e9a1733356e19d8ad6f39a5e28a86e3ec32d193efb1f11548c660a011056d618",
+              "e9e7d5f47d96f9c711f21721f0ecc0bc7b2795a732822a6d7c6867cf01ce1199",
+              "eabb0e44d2edfde08d99ed25328bed95c32f7978ea1b12777b2817698b4f0c6a",
+              "ebc392943aa98b7998c16cbbb4b31f8d429d30e70b744112adab042c18d04d41",
+              "ec48527c2bfe35c3d5574953cd807393db2e0db7d9e18b1a8bf504a63ffd9a36",
+              "f3e0ba57120c69d565a5df6157b0179360b65c261d0008a1f377307ac5a5810d",
+              "f47887e2a87911110a51376780a785cb8cea98389bf1ec241c2efb65f6358879",
+              "f4d9760323e7ce41873af989a9599a9a9002bbd3c057c75ebdbdc8857ad21571",
+              "f5f790534f110da7eb359c5489561308d37761df06b07edf2ac79965ea1ef345",
+              "f66c07aa84f6dd2fe88601290d3aa84b52529ebef097551f0f4c6058cc9fba30",
+              "f6cfbb160340b9e830cf60b928c1f54afb0aede47586d2ae6b5ac483fa343192",
+              "f79be64e7099fe720308a3e7a716146d514b6a622e6c6d1b1965d7994bc3eedb",
+              "f7cc1dda88ae7d4996af07b83cd90321c2085818afb9c56c0f42485a7caf83ba",
+              "f8d027c560995d684ef15732a61acacf9f1525ad42beb9a5f27c1d3d8216a828",
+              "f91bb31ffcd438cf6b4f9dfb1391781fd5e91f1d34efac4bcda8ba8f9ba88236",
+              "f972760677490803f668203af8730cac6384667de9b03a7408ada07ccbe2397e",
+              "fb5eae5b05ead5ca36e8b632475ac334fd1dc43489aa00f554f1ecf5b19f6329",
+              "ff135df7d1fc0cd44299b14abe9eac7591c0a508bd6f31cfda74caa5ea19d2e4"
+            ],
+            "unique_vector_count": 183
+          },
+          "random_objective_seed": 20364729,
+          "source_model_index": 4,
+          "source_positive_inequalities": 290,
+          "source_target_id": "seeded:4",
+          "source_unique_ordered_quad_count": 290,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "647f9b1c51b7da941f911706f7bb7fd249d91a0f77668b20688aedb186dd54d0",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 5,
+            "source_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              27,
+              9,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 183,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 0,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:5"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:5",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:5"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              27,
+              9,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              25,
+              12,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  8,
+                  5
+                ],
+                "weight": 1580363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  22,
+                  13
+                ],
+                "weight": 1580363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  9,
+                  18
+                ],
+                "weight": 338643
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  13,
+                  25
+                ],
+                "weight": 1580363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  28
+                ],
+                "weight": 3290440
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  22,
+                  27
+                ],
+                "weight": 322880
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  22,
+                  10
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  2,
+                  18
+                ],
+                "weight": 341898
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  18,
+                  11
+                ],
+                "weight": 680541
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  26,
+                  3,
+                  23
+                ],
+                "weight": 1710077
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  16,
+                  1
+                ],
+                "weight": 5145009
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  9,
+                  21
+                ],
+                "weight": 1636530
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  22,
+                  1
+                ],
+                "weight": 1029536
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  17,
+                  13
+                ],
+                "weight": 486962
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  25,
+                  7
+                ],
+                "weight": 1580363
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  5,
+                  18
+                ],
+                "weight": 1580363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  22,
+                  9
+                ],
+                "weight": 1975173
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  11,
+                  1
+                ],
+                "weight": 680541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  14,
+                  1
+                ],
+                "weight": 5145009
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  27,
+                  6
+                ],
+                "weight": 341898
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  27,
+                  10,
+                  11
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  13,
+                  1
+                ],
+                "weight": 486962
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  22,
+                  6
+                ],
+                "weight": 3252404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  9,
+                  1
+                ],
+                "weight": 3016643
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  24,
+                  25
+                ],
+                "weight": 3290440
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  25,
+                  7
+                ],
+                "weight": 1029536
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  19,
+                  9
+                ],
+                "weight": 3339523
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  3,
+                  8,
+                  7
+                ],
+                "weight": 1580363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  8,
+                  16,
+                  27
+                ],
+                "weight": 2577845
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  8,
+                  18,
+                  1
+                ],
+                "weight": 16522858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  18,
+                  1
+                ],
+                "weight": 10401602
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  5,
+                  6,
+                  1
+                ],
+                "weight": 2468855
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  5,
+                  25,
+                  11
+                ],
+                "weight": 680541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  22,
+                  16,
+                  1
+                ],
+                "weight": 1010518
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  22,
+                  9,
+                  6
+                ],
+                "weight": 661523
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  16,
+                  27,
+                  25
+                ],
+                "weight": 3588363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  28,
+                  21
+                ],
+                "weight": 3071668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  27,
+                  24,
+                  1
+                ],
+                "weight": 1010518
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  24,
+                  6,
+                  11
+                ],
+                "weight": 783549
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  24,
+                  18,
+                  21
+                ],
+                "weight": 3517409
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  21,
+                  11
+                ],
+                "weight": 740954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  18,
+                  21
+                ],
+                "weight": 1913072
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  28,
+                  21,
+                  1
+                ],
+                "weight": 3071668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  18,
+                  21,
+                  14
+                ],
+                "weight": 1172118
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  6,
+                  25
+                ],
+                "weight": 661523
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  23,
+                  7
+                ],
+                "weight": 5145009
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  9,
+                  25
+                ],
+                "weight": 4358562
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  12,
+                  21
+                ],
+                "weight": 543589
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  7,
+                  1
+                ],
+                "weight": 5145009
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  8,
+                  17,
+                  1
+                ],
+                "weight": 486962
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  23,
+                  16,
+                  25
+                ],
+                "weight": 1854569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  9,
+                  6
+                ],
+                "weight": 1366990
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  22,
+                  16,
+                  25
+                ],
+                "weight": 2882885
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  22,
+                  27,
+                  21
+                ],
+                "weight": 1042379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  22,
+                  24,
+                  18
+                ],
+                "weight": 987180
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  2,
+                  6
+                ],
+                "weight": 2292945
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  2,
+                  27,
+                  21
+                ],
+                "weight": 1426476
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  2,
+                  6,
+                  17
+                ],
+                "weight": 486962
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  2,
+                  21,
+                  1
+                ],
+                "weight": 524571
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  27,
+                  9,
+                  6
+                ],
+                "weight": 2791735
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  9,
+                  24,
+                  13
+                ],
+                "weight": 2303260
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  9,
+                  25,
+                  14
+                ],
+                "weight": 3197384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  6,
+                  28,
+                  25
+                ],
+                "weight": 4530984
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  6,
+                  28,
+                  11
+                ],
+                "weight": 740954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  13,
+                  28,
+                  14
+                ],
+                "weight": 56627
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  10,
+                  21,
+                  1
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  28,
+                  25,
+                  21
+                ],
+                "weight": 3063245
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  28,
+                  18,
+                  7
+                ],
+                "weight": 5555760
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  23,
+                  14
+                ],
+                "weight": 153887
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  2,
+                  28
+                ],
+                "weight": 899822
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  23,
+                  1
+                ],
+                "weight": 5659828
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  5,
+                  14
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  9,
+                  1
+                ],
+                "weight": 2655569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  6,
+                  21
+                ],
+                "weight": 1366990
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  25,
+                  18
+                ],
+                "weight": 348995
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  8,
+                  23,
+                  27
+                ],
+                "weight": 1649566
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  16,
+                  17,
+                  28
+                ],
+                "weight": 2829914
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  2,
+                  27,
+                  1
+                ],
+                "weight": 899822
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  17,
+                  18
+                ],
+                "weight": 2655569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  13,
+                  28
+                ],
+                "weight": 2303260
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  28,
+                  21
+                ],
+                "weight": 2115047
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  18,
+                  7
+                ],
+                "weight": 1029536
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  14,
+                  11
+                ],
+                "weight": 680541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  10,
+                  1
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  28,
+                  25
+                ],
+                "weight": 3917949
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  25,
+                  18
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  19,
+                  3,
+                  7
+                ],
+                "weight": 2609899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  27,
+                  7
+                ],
+                "weight": 2535110
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  25,
+                  1
+                ],
+                "weight": 1510734
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  3,
+                  2,
+                  21
+                ],
+                "weight": 899822
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  8,
+                  27,
+                  18
+                ],
+                "weight": 4246429
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  22,
+                  21
+                ],
+                "weight": 8084159
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  9,
+                  21
+                ],
+                "weight": 1019039
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  5,
+                  28,
+                  14
+                ],
+                "weight": 153887
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  22,
+                  25,
+                  7
+                ],
+                "weight": 8084159
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  22,
+                  11,
+                  1
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  28,
+                  25,
+                  7
+                ],
+                "weight": 1053709
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  25,
+                  18,
+                  21
+                ],
+                "weight": 4246429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  25,
+                  11,
+                  1
+                ],
+                "weight": 3615257
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  18,
+                  21,
+                  7
+                ],
+                "weight": 2609899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  5,
+                  1
+                ],
+                "weight": 14444486
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  22,
+                  18
+                ],
+                "weight": 12276429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  23,
+                  6,
+                  13
+                ],
+                "weight": 1366990
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  16,
+                  21
+                ],
+                "weight": 11929442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  27,
+                  13
+                ],
+                "weight": 3467904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  13,
+                  25
+                ],
+                "weight": 5264108
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  25,
+                  12
+                ],
+                "weight": 5264108
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  27,
+                  25
+                ],
+                "weight": 1675745
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  21,
+                  14
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  27,
+                  9,
+                  1
+                ],
+                "weight": 2608539
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  9,
+                  13,
+                  28
+                ],
+                "weight": 2608539
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  25,
+                  21
+                ],
+                "weight": 2437233
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  25,
+                  21
+                ],
+                "weight": 3037753
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  18,
+                  1
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  25,
+                  18,
+                  11
+                ],
+                "weight": 3615257
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  22,
+                  6,
+                  28
+                ],
+                "weight": 661523
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  16,
+                  18,
+                  21
+                ],
+                "weight": 899822
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  24,
+                  1
+                ],
+                "weight": 680541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  28,
+                  1
+                ],
+                "weight": 661523
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  18,
+                  11
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  24,
+                  7,
+                  1
+                ],
+                "weight": 1029536
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  23,
+                  5,
+                  18
+                ],
+                "weight": 3838542
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  21,
+                  11
+                ],
+                "weight": 6447629
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  11,
+                  1
+                ],
+                "weight": 5975070
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  22,
+                  28
+                ],
+                "weight": 3071668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  6
+                ],
+                "weight": 2577845
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  27,
+                  11
+                ],
+                "weight": 19018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  9,
+                  21
+                ],
+                "weight": 6447629
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  27,
+                  17,
+                  13
+                ],
+                "weight": 486962
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  10,
+                  28
+                ],
+                "weight": 3111078
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  10,
+                  28,
+                  7
+                ],
+                "weight": 3111078
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  14,
+                  7,
+                  1
+                ],
+                "weight": 5145009
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  5,
+                  9,
+                  1
+                ],
+                "weight": 7179362
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  27,
+                  24,
+                  13
+                ],
+                "weight": 1366990
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  9,
+                  24,
+                  7
+                ],
+                "weight": 996031
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  9,
+                  18,
+                  21
+                ],
+                "weight": 2655569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  6,
+                  18,
+                  11
+                ],
+                "weight": 472559
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  25,
+                  18,
+                  21
+                ],
+                "weight": 1854569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  1
+                ],
+                "weight": 10328758
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  9,
+                  28
+                ],
+                "weight": 7280211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  27,
+                  24,
+                  13
+                ],
+                "weight": 2195950
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  9,
+                  24,
+                  10
+                ],
+                "weight": 100849
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  9,
+                  6,
+                  10
+                ],
+                "weight": 7886850
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  13,
+                  21
+                ],
+                "weight": 2296799
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  6,
+                  13,
+                  21
+                ],
+                "weight": 11929442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  17,
+                  10,
+                  14
+                ],
+                "weight": 153887
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  13,
+                  10,
+                  25
+                ],
+                "weight": 7732963
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  13,
+                  28,
+                  11
+                ],
+                "weight": 2501124
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  28,
+                  18,
+                  21
+                ],
+                "weight": 5418905
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  13,
+                  21
+                ],
+                "weight": 2410145
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  10,
+                  18
+                ],
+                "weight": 2016716
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  28,
+                  1
+                ],
+                "weight": 2410145
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  25,
+                  11
+                ],
+                "weight": 2016716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  28,
+                  25,
+                  18
+                ],
+                "weight": 1372381
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  25,
+                  18,
+                  7
+                ],
+                "weight": 2401917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  6,
+                  28
+                ],
+                "weight": 284900
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  17,
+                  1
+                ],
+                "weight": 3381622
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  27,
+                  17,
+                  1
+                ],
+                "weight": 1816298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  6,
+                  18,
+                  21
+                ],
+                "weight": 899822
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  17,
+                  28,
+                  25
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  9,
+                  17,
+                  14
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  24,
+                  6,
+                  11
+                ],
+                "weight": 429964
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  9,
+                  25,
+                  1
+                ],
+                "weight": 5264108
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  24,
+                  17,
+                  13
+                ],
+                "weight": 2303260
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  6,
+                  13,
+                  1
+                ],
+                "weight": 2449837
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  12,
+                  21,
+                  7
+                ],
+                "weight": 2468855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  24,
+                  10,
+                  14
+                ],
+                "weight": 3724038
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  24,
+                  28,
+                  7
+                ],
+                "weight": 996031
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  6,
+                  17,
+                  25
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  6,
+                  28,
+                  18
+                ],
+                "weight": 1372381
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  13,
+                  25,
+                  12
+                ],
+                "weight": 7732963
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  25,
+                  12,
+                  7
+                ],
+                "weight": 2468855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  6,
+                  25,
+                  21
+                ],
+                "weight": 12339321
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  17,
+                  10,
+                  14
+                ],
+                "weight": 3043497
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  25,
+                  18
+                ],
+                "weight": 1894054
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  11
+                ],
+                "weight": 1913072
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  28,
+                  25,
+                  14
+                ],
+                "weight": 3363734
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  13,
+                  28,
+                  18
+                ],
+                "weight": 526654
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  28,
+                  14,
+                  11
+                ],
+                "weight": 3242078
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  25,
+                  11,
+                  7
+                ],
+                "weight": 7019577
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  28,
+                  21,
+                  14,
+                  7
+                ],
+                "weight": 3498391
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  25,
+                  18,
+                  14,
+                  7
+                ],
+                "weight": 1773743
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  25,
+                  18,
+                  14,
+                  7
+                ],
+                "weight": 1172118
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  25,
+                  21,
+                  14,
+                  1
+                ],
+                "weight": 3615257
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 184,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 502923595
+          },
+          "compressed_positive_inequalities": 184,
+          "compressed_unique_ordered_quad_count": 183,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 184,
+              "seed": 20365729,
+              "trial": 0,
+              "unique_ordered_quad_count": 183
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "184": 1,
+            "191": 1,
+            "192": 1,
+            "194": 1,
+            "195": 1,
+            "196": 1,
+            "198": 1,
+            "199": 1,
+            "202": 1,
+            "204": 1,
+            "208": 1,
+            "211": 2,
+            "218": 1,
+            "219": 1,
+            "220": 1,
+            "221": 2,
+            "222": 1,
+            "223": 1,
+            "224": 1,
+            "225": 2,
+            "227": 1
+          },
+          "numerical_support_size_max": 227,
+          "numerical_support_size_min": 184,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            27,
+            9,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 183,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 183,
+            "support_size": 184
+          },
+          "quad_reduction": 106,
+          "quad_reduction_fraction": 0.36678200692041524,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "005b81aa3b6c0850c169b9c282cf7b51608c737f8a34cc24d9a0b829e2779701",
+              "00a3009340729b49cdddc118b743809b2c73f5fc48c37dde7432153427a1f746",
+              "02de08ffa6ff9dc78ba1f810f87b1e3049e6ca2a0dc626120683f0b483132855",
+              "0473055c2c1fd86166f4d4156b345e1b4466adcd3d6359051cb94c5892d2608c",
+              "047677c69fd49e083421e4c8558a298e4e9c17c7cd886f905f38dca727bee4cd",
+              "051c1ddaa99ca25b3e647de87b5b91780baf1025beca0d0fe47c1e388c4785fc",
+              "05df3ffed703e2a0b94cd2c3b75c188bec3baf09373966f21eae8c9fa089e099",
+              "06d715ef4246d7dca771c6ca3863666b64ac38f4f5aba8b2140b3112b5ac91e7",
+              "085efb0b7c264942f795ed77e3fd4659361192194aeb0d6da33a2e6ce6389851",
+              "09448704dc44a19b19e07461f301f4074376b66c499b66eb528d459ce9b30123",
+              "0a4cc415a93d49f70424044bc4ce88765339269a7119b110bff59ca3a0ffc7b8",
+              "0baf666b22b86976c7463b45724e5a60ae5e30caa9a5464c0b582b3d920b57fb",
+              "0d27490d1bc759c7f78108ac45319b0574eb5495f6a156970cf37acc6c20a0aa",
+              "0f522a93c6d607a760a9789e5ffd1b5fb991e7f4a2fa0aae878d4a9ad24601fe",
+              "106fa8d17e5a50b5211e7f13c47ed82bd70827cc540a4e5b846a021df16fad21",
+              "1083a95a7e91fba3af11e9e0a7fdf6d2ef0f19b177d6b514c9fb9542a3ae1ff8",
+              "1090e45cc8e06c638ac00c3571809bb424b3e11036d24979d2faec0b712a62e4",
+              "11baa667f7d706a5e07cc9823a991a9f9a9c1439ed7cb3d98894c9a58810feac",
+              "1342d69b31cc5ab70cc5d5177309ca0fd83ca567a45e337943b3b6995022e0d6",
+              "1451c4cbc79b717fefd4b288d8bd63b846082781861dccd2cecdf914f08b480e",
+              "14cdc66b01de9b77fd1a2b83758e12ba202fb3ec6b3d5afeb5e9563785ea8fc6",
+              "1a2106d09f1fe1c28ad5bbf118f5741e73f1e404bd6fb936824849730d1e3d03",
+              "1c86b51289e9e7f900b0d8802b7211426d5e6e520a7cf103e186cce6a60e6680",
+              "1cfd92661f41d56c6b319fc7ce57350ba6bfc1b52bfb3d7f02a5f82ab280f57f",
+              "1f303faba31c047fda332d89fce0bca1473d000ecb8efcd9c482110e321ebd32",
+              "20c0e88b13ae5370885a8ee153bd727bcac22704ef09ce069489fc2c850d22a9",
+              "219ba86189ce3c7c859ea468bb9ac150bd7037f747f41e5680acbb3d0874c59c",
+              "23d9a6f47f7e9007872b8bdfe8d72f907508eb2006f269b4c77dffbd898a1343",
+              "246a9030cda5243444ac047f3c683a3f727ac77e7992eebe4e5d7e129c342227",
+              "252f8f463f4b6c1142bfaff178e68e34102eab992df70481390b488411c112b0",
+              "25b08e330176cd7b870954b70ef80b5cd529cae56527d674f59bf4ee67d34080",
+              "2774db048bf0e2f0d9e77b95c721dbae2ca3cca99ce2a0f9a378e4a0e3a0e5ff",
+              "279100aa232ccd95d71f36c3fe8d6fe03afbe058053eadeb5005335b2fdf901c",
+              "27bad8d127c89982654e8f1b75b675ab9d83455dc8ae3644e743690aa9c9a0a9",
+              "29bcb92c3a55a6353a052f862c97c03598e397bc923c334ae8645bdc9a840d9d",
+              "2af246c6faa7f651a88b83b44e2c08fd118b488e52566ebbf810d9ba93e3e278",
+              "2bcc5fff2590b1aec62a9065db3c73226ae94caed0313d8a753b1ef12eeb5f36",
+              "2e7f59b3e1aa216e1e3f80752c1e6e2460eb927e0d2445a03ad1b24648d5ca55",
+              "309cb91e7b2afdd7ebf87349997e9bcf37d045efca15120dd06f2f99a2872f0e",
+              "399512d326513a4c5d9a67f427acd29338f9f77d647618d2f74a9cacfb54e194",
+              "39d2b157bb38715224839aee374f928cc35f2ba03291091ef9f19a2c63a95b3c",
+              "39f08e431bb9ac61c069a11a3f2109373f5c917b4fe548177be2701a09212efb",
+              "3ac0a355c3b7093aaaac60d9a7d31d85a84c3a2452c09445436e11210ac2c9b1",
+              "3bb3fe238855c3c2cdba9f1e82acdcd666b72f2397268aa097be9ece84be3a2c",
+              "3cada0716dba9082585ba8a116f9508339abb254f26a7d148f9c5c67bccfc9bf",
+              "3d4692fcf191b3f2ac046085084cdfc35557eccd2440e15d4f3c4fd648227fc5",
+              "3f18ecd70a39ed5086daa7d93711afb1c973f491dabad11e6fe0d15f540429da",
+              "40d4d897f661345872d00ca36b33096b471dda1bda6f46f21dbabde8d2c2d111",
+              "42b062d9ff73fc2cd037f86a6c28f2d8bfff45b18cf91fdae3b4391b698496ce",
+              "4408eb810fed8c07159dee2658a324fbb9221d402b43b9ebd85334d660667e77",
+              "4468cab8b81831429a28fc0f269632f25823aa2e498ad5c9dc27cf911f0c1f4a",
+              "449ac41c533ebce7ea306e034cd3d59ad529151dbc60a3c57117919db1627e05",
+              "4729c46a910d403728501050fc0ee95ad1ce9e99467c4c71e3489d9136aa2e60",
+              "4826b87cf3f68e0c8057dc3aa6b17a4764b52d39068cbec938015b53359a3111",
+              "4875327349c97e26c22a3c3439d28e066b92fb4a4bfa7e7b53c6e60584f77d73",
+              "495dee380780b4ccd59d28e5fae5189ca03cd3c3e86c1be58989a0fef0f871bd",
+              "4a7ea55dab7d5ff3d38fa1dd521778626891771836e374a748fbbea8e4d791a1",
+              "4b33f9bf82f5cf260891fb8e727a4c3bf6fa1d1a12a95757ea8c35e9c46fc23d",
+              "5073fe98c685e15340405d3fdf2091ed1379d518a930cb96ad11bbe6afc218d8",
+              "5084b028b687e720c4aa6606cd08f59ec4874a9b2d0cafcefaf136e368536f9d",
+              "509807d4c7956316a7493b2d5668c4170b598d6d3e6d46632dcd25f405b5485e",
+              "50d87b0f12b4a74d6188f3b3bb90d54b121075561d67c3c2bdb686c94ba342f9",
+              "517e54def964920199b8f929eb3f2d32d71beff525cc166ff73dc9649f09f127",
+              "522109a3081cd40247701f43c2f4ce854cf6e0ff0bd0495cea9e748a44aaed4a",
+              "576344232c72f57c5224db0ecdb8f44bd1592628331e353e725dcddbfed75f64",
+              "58a2f3ec80e0b51ab00a82a66c70a29f95c82217389a0cf51531c24271cdbb15",
+              "5b2eb76f6c7da827efd744a75ab407033c894932c3aa1c8c5cca027463abd0e0",
+              "5c862971df1266247331f8112638aa55a3d50056a87c6e5ae8992385223ca565",
+              "601a1adb11e41063574d93488bdeec303925acb5615f3d701ffb04d3ab9f4275",
+              "60d00c1a7e8ef6ebac3397a5a397b2f77d1418dc52025e43b4123dd58f8703b1",
+              "66d2e66aa47c197ccf9f1648c26e4fa8baf07254f755581129bd282c9779f49b",
+              "6787d9ec1dc48f92ef831bc99f05919a5f7884356cac09d71f00e896b1634781",
+              "67a843fa7a19979398a6e357d495b2803a60979f477cf3000201f97786fd3d25",
+              "6843c3979c7513b742b53badc777ac5c0c66a087c2fe4cde89e9259c7ed714b5",
+              "6899aac25b05f858e8d0305107b4db09ab3be3bb7e4fee31d2c2bbf0da2b3d47",
+              "6ca3ea725dcf6443ce575657bc80785ab1d61a4d264152a3242e5350d54c2922",
+              "6e52ef399c75186729438f1ea5335e1d14ff2f8354bea2f54ca83acc2fa6fbbb",
+              "70bbec39baf0d44d0110e3cd2afa602731f6d00f55266ee89e656df699140cd6",
+              "735d14fcea184a01c0d75a81ff634024283b37f46e0f5a29b4b11b0866581c9c",
+              "73d3d9792624a09651b0dfae8de847794c91cb65ff84309f3aa72ce33856bf12",
+              "750bf66a08035c7a2642dbffaa7d6162afa23299654d0d25c9e51b553f3dee05",
+              "7561b80d83139fc3a685011c32973ed341c8819d1ec661e7bb06f7b4c45c64e8",
+              "78f55b69ac4d5085582fd1f0c86639fbc9083fcc210c439ac002dbcaabf5c52c",
+              "798d1b47b08dea3641db58a2780d5fd23d47b0f51bbf9e17c74d8566cbe1875c",
+              "7a45880fd297e426442a98458c38bc871326b7774b0d6edd304f2d6558ea905d",
+              "7cb03e21a1bbc3fc12aa2efbe118aaf9a5b0cdaf7fc10c1913054d96002d3451",
+              "7dd051f94e1e1c85b07bc0e873beea257343c118fb08e9b1675da7f336bfba52",
+              "7dfdaf9a7000a086cf4f5b432b39ac4e9f610e7f14152c3f616f10f9424296f9",
+              "7e67666f362c6fed6c1eecea6c51e50ca098c6c8a6cc4a8cd29b62593460c49c",
+              "829bf8d4dc2f69e7264bccd5f1e9231a44973621f94bddc95b6442e270e1e6be",
+              "831eb3e61c4ea90aa9eaf0f142195d6d7f2bc9cfa290325ec53d9406e641dbf1",
+              "839e0b28c62b7d748d31661ae423874861bc57d3abb0d83f4103d9f167d2b1fc",
+              "8479b4a6bed5a7038bc2b5a9831969ee0b93c72ee1769d5656ad24f88d64bcaa",
+              "862d49d857e361b2e494be6f82f977d72a9130e266af61ea3ee72a52c4765560",
+              "87046f3fd1a7f42a6b6dc0a0464231bb4200904a35bcb64e710550a9b38ff091",
+              "8796afca7e547afa353d72e67c23a4154826bc9ab681bd29ccff8eb7cae311ff",
+              "8813a09ab5224bb801ac2a400cb2b3b8419abc5c5fad07ce5638f601b3cd8725",
+              "88d1b3c4036be68b488b572113118244bd83a8abfb56075a21f02ed0f00bc958",
+              "8b83dcd10a8127f3cca43df1a980bb5b17ed4ba1e61e6263d1edef43513a46b1",
+              "8b9dce4d7fc88c26cfc19486c1ae2cbc1b7c9e715a26f5b16dce9aac51e33f20",
+              "8bf47672bfe2e857e6fda8f41975ccc0bbdb54546fa2e6100891b4ca82e43a0e",
+              "8c2d824f374b068f4cb3bb2cda4562e8b29c676d0986399faf31ca9dba619f62",
+              "8c3c8be0b1177f0e8acb6de6e6f587e3bd5a7e07c41ec67e1c0514eb678eca49",
+              "92cbfd558c252b0a90d1d29a70211ccc5c88e41a914e30ff658acedc7057de31",
+              "93aee9d9ff36168dcdd4d71f359f7e2c0542d910920ba969df887c491132d0ea",
+              "9407c6483cecbe0a8121cf005947f2bb4143a202814ebeef07aac8daf787f7e2",
+              "9576b88043360de0b4712ae6160f202d83b5d4e602d644b816ec13b3ce3e1c40",
+              "9863c37b756ef9bf90a1dd7c2323a814f19debee1597cbc673b4ebd8f52cda37",
+              "99249df33ab5c6739a8ad1fa5d51751c7023d5e0b329f984204b91e893592a20",
+              "9d88712ee77dbbd8c0466f076a532bd3d388d64d3166c8b60ecc43a95f7884e1",
+              "9eb8b7617323611d7448124ef8a1dd440202e2e5dc2dff5118feffd51c3273f8",
+              "9f76a2a50fa49f32435937b2568e339978aa8a5d34f5ff8318be4ee40aeffade",
+              "a10ac0e8d2458f72d960948fca4978e39ff1c225bbd14d0c6f0dbd87a460c225",
+              "a1721b4f9418cac025a9c2b596e1e29bd636bb39c1575c123d7c88010d3343b5",
+              "a1db2faa05171ac51c9dcefdcf3f59add3a574207f6947be64ed4c5a23205059",
+              "a20937f5dabff17d5fd52ecc70a76b84b71a0a7adff4d904aa81d0659b5c7220",
+              "a4494c5c20859c4b83d44703ea866e24cc4a0d766e7dab95e53bdcd9e154caca",
+              "a55cd2e1fc5a88d030955f6adfc793ff03973086fee39e2b73f43097130fa8c1",
+              "a5e2dc16be4530ab91c13f7fa559c128af1b160c9d55c9beb11737e713e1df50",
+              "a87a9836fb61e3e0495bf64637f1000d6f4f7d0ba8528afe9a4d2fa046042fd4",
+              "a8b3e6f0ddb25e0944f605ad8fd1adc0a9c35295cd7dbf158f4b6a17d92fb69d",
+              "a8d3749b9b67d23261e8bbb55ab87c5b969354c4649ffaff9af5c5cd0f9abe4c",
+              "aa48a69b4a85dd7a596ee9655b326b8cc8800f54cd0a4ffbd512ee14dc27825a",
+              "ac3cfe0c391767726e091b24ae8a88fec24bc58ff35e9ce0be7c374effd7182d",
+              "ad11a3b740b14db0e067833d16bf78aa5b68b588659432b1af8f043d600356ca",
+              "ae6fdd4b8d56eb9117a7cb6b402432f226eac27eea52b0074a5dbca38d921d60",
+              "b16fc37d08d0563f55195711987abd649de6c675e90e52fa592771739af67b08",
+              "b23d2f577818895d840c801fbbd7253559e2ae390ff491d14abc36bc8e0a7ff8",
+              "b317e81d81d9b24228208a66bdee71e355c936792a7f0f5ede3b7b163b770e21",
+              "b5d680aa6babc2fc8a4058fffac7a5bfe22eceb4d600631ac98953c6f649ecff",
+              "b68f3e6ad65f0252109263be43fb634156c83e38098d8892594b8c535a0a9cdc",
+              "b6c4efbab962a04521c022b26ccc55327615272bc4aae80075f585cbd3f8749f",
+              "b78de4fcb7ec5694038507e58cd5ae818bd9dbedec0646602b27b43db3f9130d",
+              "bb6e1dc86000fe3cfcdb8f22ddb47df02f948407b6e8ae7efd42d2a0f579f7fb",
+              "bd872d5ce7845b3719820ac863deb1b3b9addc434cd52073334b065a73fcf8d0",
+              "be383c7b55c6c10c459397086fd9624d1f603bac57c0681c3210943bc80b72d6",
+              "c0f302aae117f380e235b76dab61f1fe9701b4c8a06d97d6e960083cc104639e",
+              "c3a29388764fa516c44d9d2779f4bd6d052fcf6973f2fd5996edb4f702b7c79c",
+              "c48bd81e2bf9ec7537c6b6a0dd27b7e23b5de4c14953b618527dddf262e10ad8",
+              "c5611734d03f20050e3c88e5aa8bb676e3305d58c5cd1a7908a111e7f677a12c",
+              "c5f63c56cf3e1a43c12e660c9e5db3a77dcd2f64abf4d49142f8e06c611ef834",
+              "c610e20306609ddb66acf212ae5737b790ba99b2f40170b3e81eb1a3870ec8ba",
+              "c69b3534968a3c98bb247742f260d098ac093b8517426b507c7270105171268f",
+              "c8316316e02b09c0ea960f9bd1d58914a20c40e3d9e01453efd27d9b4ae32100",
+              "ca0d229378e7fc1f46fd938a64757476b91ba5eb1c6607ba29b3283dc4857472",
+              "cafabe19fa11eacad741c1b5a94a185426e4fe43e1f47e9e0a0c168ccbfd2a33",
+              "cc66845be3e19450f0625622f2c1a73003b620ce357d4e6263d6f4ae8cc7670b",
+              "cd6bd1a9c28781699979e0a9da5e1d530330b62f59d569f7f50ec004d48e86e0",
+              "cff06a38d3f2c5230f760f9e5d914c979aaacc79f60da5de368ef12b1cf51f5f",
+              "d34083123e48f97c977749426d3941abb4270fc91640d3944e028b6efbdaf82d",
+              "d38ce8ac60c06c82c9b7af6d44972ff9cd320b79e1fa593eb0599e38473b0b82",
+              "d4a179b67f4e15e20f86dae2960ae8e4b13b4a02bf5b4e5fa3b4caf065df9a1b",
+              "d73604969a31efd6883a6b7ae8bea5fd1bc0658d341ab1fd04b7a3471c8621b6",
+              "d7846849a63facee52c794c2475b2660d027bb98ed28c385bc77692f18f62d2f",
+              "d8f9d1ce911669cb9e1357426230c66257790540c8b1c84c361688c5d6ec5392",
+              "db6f11dc1f6b95c4a7d81dc410c03331cb34c404d4ac42fb911ea08036314b06",
+              "dc94681d65b87699b28ffc0d111f7d8be7eca9433478d5bccae8e358ad793d31",
+              "de8da3b43ddbd92a99cabb9b786661bcfc134759f51e39f63f8afadd0a95724e",
+              "df429b52f91ea79d8f2030bc29349bf66b1842a877888b4be1962a43c161a2e7",
+              "e079ad09874a7b06ccb5c0415e41f72d5c98f94c12f7f23cc761348ecab84896",
+              "e0973608acde2dbe64b8c8a58c5239fd268e00fcd3d7dc8d58163f3403e91ac1",
+              "e28b61861d627c990a46bd8da4eca6d36731d0c0fb2607a24192c284d31ca7fa",
+              "e3f4cc14ba3018ae06a8fd4cb4cfef7b89543408712f498fb9d63579396252c2",
+              "e49fdedbfdb98cc827d48908d2859873934362aa45d5aa701c6ea95e2be82a42",
+              "e58e4e2dcdedbeb0cd0042e69e0b4eed5c8b5ed8e05b1166f634bef4fe507f29",
+              "e626905a7b37d6be56e0db83fd1dc675adef226b6b8d5764b039489a63b96efc",
+              "e7568cdaf5d996abe508a5924fd4b8fd9f15c7e8d5db97fef144ff738739f5e2",
+              "e841a71bd32c66a6edc96b17338d97d2a23551c8940ae0f37868c388aab1aa9a",
+              "e9277f855e6d5a16624cff805d13a3531f5eee0bd3e0968779078df0acb83c04",
+              "e9f283ca83cda153cf471df43f29c786e3fc043d47e57ef5e020b742cc2c046d",
+              "eb69a0d1382b9009bd23cfc0b8a0b9d8434c16705a7f6e5569d7454c1f9a8f55",
+              "ed208afd7a69982679cc8d208ab14946afe48b978ad906edf6f3060ebb19f8fe",
+              "ed49efa21a1cbde521018aef58b09115774f02df41f0e1bfedf07f224575c330",
+              "ed52ccbb064403e7c4d9e70f17f583193d2044cf05991bcb7f3071ff9efdbda0",
+              "f0d774b28614aa265d1c23ba2cc60954e86b87ca4096389b17c65cc015aae65e",
+              "f19cde8a2b66c2c1e691fb2b351a3d5f0ad09c3aa05061b4b3d4ea0246be396a",
+              "f55ff1afae2fbc5d8bd05d5aa745dc2e8df2a5cc04c76520b472bbe238459dd9",
+              "f7023d8f9b7472dcb6eeb5e966beade8c62a8d1cf40a73eaff0e9b13c4654cc8",
+              "f731bc747497407a3f98c741c7804169c57454c98cb404084695480f802f3492",
+              "f78647ebf2288692f97d00f8a067aa24ec6a62a2144f7c7642e94ddd7eb0e77a",
+              "f81b06529d0ff85767fdd1847a518efd16b4fe96837e59a2f99f4293f5ee5804",
+              "f99cd8ce804824d8f1eae276e593943bab8c743f0a018c6b2c0e966e29a51114",
+              "fac99cc6905efd2985b25099f82072de2eee4898ff6877c3897af25b46121943",
+              "fe1128f1d0ef0fb387c4723a09b622a4101fe73042c52f0c4d02f1b802d529fe"
+            ],
+            "unique_vector_count": 184
+          },
+          "random_objective_seed": 20365729,
+          "source_model_index": 5,
+          "source_positive_inequalities": 289,
+          "source_target_id": "seeded:5",
+          "source_unique_ordered_quad_count": 289,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "5a4473d32ea5b479b03b6ff883faafcbfc962913f488517491e3d405c3f9a8c1",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 6,
+            "source_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              12,
+              28,
+              25,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 190,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 21,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:6"
+            ],
+            "direct_cross_target_count": 0,
+            "source_target_id": "seeded:6",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:6"
+              }
+            ],
+            "translated_orbit_cross_target_count": 0
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              12,
+              28,
+              25,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  2,
+                  12
+                ],
+                "weight": 1276385
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  19,
+                  28
+                ],
+                "weight": 480731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  22,
+                  14
+                ],
+                "weight": 17256270
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  19,
+                  11
+                ],
+                "weight": 43859700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  26,
+                  12,
+                  1
+                ],
+                "weight": 1276385
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  3,
+                  12
+                ],
+                "weight": 480731
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  22,
+                  1
+                ],
+                "weight": 43859700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  28,
+                  1
+                ],
+                "weight": 1276385
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  8,
+                  24
+                ],
+                "weight": 1975841
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  5,
+                  22
+                ],
+                "weight": 15992821
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  5,
+                  9
+                ],
+                "weight": 17183044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  16,
+                  1
+                ],
+                "weight": 24775298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  2,
+                  17
+                ],
+                "weight": 4613378
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  2,
+                  12
+                ],
+                "weight": 3978144
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  19,
+                  28
+                ],
+                "weight": 22067425
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  27,
+                  12
+                ],
+                "weight": 3722967
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  26,
+                  24,
+                  1
+                ],
+                "weight": 1975841
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  19,
+                  3,
+                  9
+                ],
+                "weight": 2147323
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  19,
+                  5,
+                  28
+                ],
+                "weight": 62639347
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  6,
+                  11
+                ],
+                "weight": 43333655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  16,
+                  11
+                ],
+                "weight": 1975841
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  8,
+                  12,
+                  7
+                ],
+                "weight": 9762312
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  8,
+                  28,
+                  14
+                ],
+                "weight": 4630911
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  22,
+                  16
+                ],
+                "weight": 20606199
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  12,
+                  28
+                ],
+                "weight": 15902900
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  22,
+                  17,
+                  25
+                ],
+                "weight": 4613378
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  16,
+                  2,
+                  25
+                ],
+                "weight": 1276385
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  9,
+                  27
+                ],
+                "weight": 17183044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  16,
+                  27,
+                  14
+                ],
+                "weight": 4868555
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  18,
+                  1
+                ],
+                "weight": 63477025
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  2,
+                  27,
+                  7
+                ],
+                "weight": 8591522
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  6,
+                  12,
+                  25
+                ],
+                "weight": 43333655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  12,
+                  28,
+                  25
+                ],
+                "weight": 43333655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  12,
+                  18,
+                  21
+                ],
+                "weight": 19240486
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  28,
+                  14,
+                  11
+                ],
+                "weight": 9994241
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  25,
+                  18,
+                  14
+                ],
+                "weight": 5363330
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  27,
+                  6
+                ],
+                "weight": 18768029
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  16,
+                  1
+                ],
+                "weight": 16514734
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  26,
+                  24,
+                  7
+                ],
+                "weight": 16300366
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  24,
+                  17
+                ],
+                "weight": 626376
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  8,
+                  12,
+                  1
+                ],
+                "weight": 39569347
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  8,
+                  28,
+                  21
+                ],
+                "weight": 145645
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  21,
+                  7
+                ],
+                "weight": 145645
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  22,
+                  17,
+                  28
+                ],
+                "weight": 15751046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  22,
+                  12,
+                  18
+                ],
+                "weight": 163178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  6,
+                  17
+                ],
+                "weight": 15124670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  9,
+                  28,
+                  25
+                ],
+                "weight": 15124670
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  27,
+                  6,
+                  1
+                ],
+                "weight": 18768029
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  24,
+                  18,
+                  11
+                ],
+                "weight": 18902583
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  6,
+                  25,
+                  1
+                ],
+                "weight": 15124670
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  12,
+                  18,
+                  1
+                ],
+                "weight": 31101925
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  14,
+                  1
+                ],
+                "weight": 16139049
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  7,
+                  1
+                ],
+                "weight": 306962
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  14,
+                  7,
+                  1
+                ],
+                "weight": 16139049
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  24,
+                  12
+                ],
+                "weight": 3978144
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  26,
+                  17,
+                  28
+                ],
+                "weight": 8898484
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  23,
+                  13
+                ],
+                "weight": 4423855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  19,
+                  16,
+                  13
+                ],
+                "weight": 5822387
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  17,
+                  21
+                ],
+                "weight": 24775298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  21,
+                  14
+                ],
+                "weight": 24775298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  14,
+                  1
+                ],
+                "weight": 24775298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  8,
+                  22,
+                  6
+                ],
+                "weight": 2960090
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  8,
+                  2,
+                  9
+                ],
+                "weight": 8591522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  5,
+                  27,
+                  24
+                ],
+                "weight": 64649064
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  5,
+                  24,
+                  10
+                ],
+                "weight": 20465326
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  22,
+                  16,
+                  10
+                ],
+                "weight": 18952911
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  22,
+                  28,
+                  25
+                ],
+                "weight": 15751046
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  25,
+                  7
+                ],
+                "weight": 8591522
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  27,
+                  24,
+                  10
+                ],
+                "weight": 45340541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  27,
+                  13,
+                  11
+                ],
+                "weight": 306962
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  17,
+                  14
+                ],
+                "weight": 5134947
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  10,
+                  7
+                ],
+                "weight": 58702334
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  13,
+                  28,
+                  7
+                ],
+                "weight": 306962
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 38237008
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  28,
+                  25,
+                  18
+                ],
+                "weight": 7159524
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  19,
+                  8,
+                  12
+                ],
+                "weight": 9293455
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  16,
+                  28
+                ],
+                "weight": 2590368
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  19,
+                  12,
+                  7
+                ],
+                "weight": 2501886
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  3,
+                  5,
+                  17
+                ],
+                "weight": 626376
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  8,
+                  22,
+                  16
+                ],
+                "weight": 38975917
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  8,
+                  22,
+                  7
+                ],
+                "weight": 9293455
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  8,
+                  27,
+                  18
+                ],
+                "weight": 13798480
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  8,
+                  17,
+                  12
+                ],
+                "weight": 14424856
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  5,
+                  12
+                ],
+                "weight": 28467874
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  22,
+                  9
+                ],
+                "weight": 4630911
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  23,
+                  27,
+                  21
+                ],
+                "weight": 10188181
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  23,
+                  18,
+                  7
+                ],
+                "weight": 13798480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  5,
+                  27,
+                  14
+                ],
+                "weight": 29094250
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  5,
+                  24,
+                  28
+                ],
+                "weight": 28375541
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  5,
+                  25,
+                  21
+                ],
+                "weight": 9453445
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  22,
+                  16,
+                  1
+                ],
+                "weight": 52900283
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  22,
+                  25,
+                  21
+                ],
+                "weight": 10313515
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  26,
+                  2,
+                  21,
+                  1
+                ],
+                "weight": 19766960
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  24,
+                  25,
+                  14
+                ],
+                "weight": 6121190
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  26,
+                  17,
+                  25,
+                  21
+                ],
+                "weight": 4899996
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  22,
+                  9
+                ],
+                "weight": 4123164
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  22,
+                  24
+                ],
+                "weight": 27237716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  24,
+                  10
+                ],
+                "weight": 40804056
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  3,
+                  6,
+                  28
+                ],
+                "weight": 36730772
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  23,
+                  25
+                ],
+                "weight": 4423855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  16,
+                  1
+                ],
+                "weight": 43859700
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  8,
+                  10,
+                  25
+                ],
+                "weight": 12785844
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  10,
+                  28
+                ],
+                "weight": 34263806
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  22,
+                  6,
+                  13
+                ],
+                "weight": 10246242
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  9,
+                  11
+                ],
+                "weight": 1975841
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  24,
+                  17,
+                  21
+                ],
+                "weight": 13566340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  25,
+                  1
+                ],
+                "weight": 3643359
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  17,
+                  25,
+                  18
+                ],
+                "weight": 13566340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  10,
+                  28,
+                  18
+                ],
+                "weight": 6245594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  11,
+                  7
+                ],
+                "weight": 2501886
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  8,
+                  5,
+                  24
+                ],
+                "weight": 626376
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  8,
+                  22,
+                  10
+                ],
+                "weight": 31360880
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  8,
+                  25,
+                  7
+                ],
+                "weight": 9743807
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  17,
+                  18
+                ],
+                "weight": 14669394
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  5,
+                  24,
+                  1
+                ],
+                "weight": 14192716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  22,
+                  6,
+                  17
+                ],
+                "weight": 15751046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  22,
+                  12,
+                  1
+                ],
+                "weight": 838775
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  9,
+                  17
+                ],
+                "weight": 109960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  6,
+                  12
+                ],
+                "weight": 358044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  17,
+                  14
+                ],
+                "weight": 2085801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  27,
+                  10,
+                  28
+                ],
+                "weight": 23700577
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  7,
+                  1
+                ],
+                "weight": 9743807
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  28,
+                  25,
+                  18
+                ],
+                "weight": 13030195
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  23,
+                  17,
+                  18
+                ],
+                "weight": 13798480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  25
+                ],
+                "weight": 29713836
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  27,
+                  10
+                ],
+                "weight": 13798480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  22,
+                  2,
+                  7
+                ],
+                "weight": 8591522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  6,
+                  25
+                ],
+                "weight": 7611537
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  22,
+                  12,
+                  14
+                ],
+                "weight": 4630911
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  9,
+                  6
+                ],
+                "weight": 24830053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  9,
+                  6
+                ],
+                "weight": 10571627
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  25,
+                  21
+                ],
+                "weight": 5804200
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  10,
+                  28,
+                  1
+                ],
+                "weight": 4776556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  25,
+                  21,
+                  11
+                ],
+                "weight": 5658555
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  5,
+                  17,
+                  13
+                ],
+                "weight": 28467874
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  5,
+                  13,
+                  12
+                ],
+                "weight": 28467874
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  27,
+                  18
+                ],
+                "weight": 38656055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  2,
+                  18,
+                  21
+                ],
+                "weight": 10042536
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  27,
+                  24,
+                  14
+                ],
+                "weight": 38656055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  27,
+                  12,
+                  28
+                ],
+                "weight": 15902900
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  28,
+                  18,
+                  7
+                ],
+                "weight": 13944125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  27,
+                  17
+                ],
+                "weight": 6642032
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  27,
+                  21
+                ],
+                "weight": 9453445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  24,
+                  25
+                ],
+                "weight": 28437451
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  27,
+                  24,
+                  7
+                ],
+                "weight": 33463145
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  27,
+                  14,
+                  1
+                ],
+                "weight": 14192716
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  6,
+                  1
+                ],
+                "weight": 63516077
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  17,
+                  25
+                ],
+                "weight": 7709988
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  17,
+                  14
+                ],
+                "weight": 27399918
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  28,
+                  25,
+                  14
+                ],
+                "weight": 15887048
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  9,
+                  14
+                ],
+                "weight": 4630911
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  10,
+                  18
+                ],
+                "weight": 10042536
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  6,
+                  10
+                ],
+                "weight": 33608825
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  25,
+                  21
+                ],
+                "weight": 23716192
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  17,
+                  10,
+                  12
+                ],
+                "weight": 4613378
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  12,
+                  14
+                ],
+                "weight": 10246242
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  18,
+                  1
+                ],
+                "weight": 9879358
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  9,
+                  24
+                ],
+                "weight": 56776501
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  27,
+                  11
+                ],
+                "weight": 21043345
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  27,
+                  24
+                ],
+                "weight": 16525143
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  9,
+                  24,
+                  6
+                ],
+                "weight": 20277010
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  24,
+                  11
+                ],
+                "weight": 8160441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  9,
+                  10,
+                  21
+                ],
+                "weight": 9453445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  27,
+                  10,
+                  14
+                ],
+                "weight": 9499466
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  25,
+                  18,
+                  1
+                ],
+                "weight": 24820970
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  27,
+                  24,
+                  28
+                ],
+                "weight": 17163433
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  17,
+                  10,
+                  21
+                ],
+                "weight": 10042536
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  25,
+                  11
+                ],
+                "weight": 21043345
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  25,
+                  21,
+                  7
+                ],
+                "weight": 13962760
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  27,
+                  25,
+                  7
+                ],
+                "weight": 8591522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  24,
+                  10,
+                  21
+                ],
+                "weight": 43415879
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  24,
+                  12,
+                  21
+                ],
+                "weight": 8994244
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  6,
+                  17,
+                  21
+                ],
+                "weight": 109960
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  6,
+                  28,
+                  11
+                ],
+                "weight": 9994241
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  12,
+                  28,
+                  7
+                ],
+                "weight": 5130429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  21,
+                  14
+                ],
+                "weight": 10246242
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  14,
+                  11
+                ],
+                "weight": 8160441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  24,
+                  11,
+                  7
+                ],
+                "weight": 33463145
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  6,
+                  25,
+                  21
+                ],
+                "weight": 2538581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  27,
+                  6,
+                  21,
+                  11
+                ],
+                "weight": 12726762
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  10,
+                  28,
+                  7
+                ],
+                "weight": 12140498
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  27,
+                  28,
+                  25,
+                  1
+                ],
+                "weight": 6052941
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  6,
+                  25,
+                  1
+                ],
+                "weight": 40795074
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  6,
+                  11,
+                  1
+                ],
+                "weight": 22721003
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  10,
+                  18,
+                  21
+                ],
+                "weight": 1266232
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  25,
+                  7
+                ],
+                "weight": 4613378
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  11,
+                  7
+                ],
+                "weight": 306962
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  28,
+                  21,
+                  7
+                ],
+                "weight": 3633764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  25,
+                  18,
+                  21
+                ],
+                "weight": 4899996
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  11,
+                  1
+                ],
+                "weight": 14655914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  25,
+                  21,
+                  14,
+                  7
+                ],
+                "weight": 757860
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 191,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 3028686519
+          },
+          "compressed_positive_inequalities": 191,
+          "compressed_unique_ordered_quad_count": 190,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 212,
+              "seed": 20366729,
+              "trial": 0,
+              "unique_ordered_quad_count": 211
+            },
+            {
+              "positive_inequalities": 204,
+              "seed": 20366731,
+              "trial": 2,
+              "unique_ordered_quad_count": 204
+            },
+            {
+              "positive_inequalities": 202,
+              "seed": 20366736,
+              "trial": 7,
+              "unique_ordered_quad_count": 202
+            },
+            {
+              "positive_inequalities": 199,
+              "seed": 20366740,
+              "trial": 11,
+              "unique_ordered_quad_count": 199
+            },
+            {
+              "positive_inequalities": 191,
+              "seed": 20366750,
+              "trial": 21,
+              "unique_ordered_quad_count": 190
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "191": 1,
+            "198": 1,
+            "199": 1,
+            "201": 1,
+            "202": 2,
+            "203": 1,
+            "204": 2,
+            "205": 1,
+            "207": 1,
+            "208": 2,
+            "210": 1,
+            "212": 2,
+            "213": 1,
+            "216": 1,
+            "223": 2,
+            "227": 2,
+            "230": 1,
+            "234": 1
+          },
+          "numerical_support_size_max": 234,
+          "numerical_support_size_min": 191,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            12,
+            28,
+            25,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 190,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 190,
+            "support_size": 191
+          },
+          "quad_reduction": 99,
+          "quad_reduction_fraction": 0.34256055363321797,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "010cb2138e96c90882338cda2b6ed065f68e4979a10da631c86de7fc3f755fb0",
+              "04c8dbb81d197e2f78498615f11c818f8556c0e6f1c7b4f8da2863a20311f9cb",
+              "069ee5de86afe599d7758931d64e2de83391b7e82230aeeb1ab1bde1d0fa1a6a",
+              "072dd2adedcbb442446f2dea59b4bb176bd01cc4bf97418f9f3712bccd292bc0",
+              "0733436ea8c931cb8ab90bc16842288d63204a0e6f7b43dff906ffad95d81a0e",
+              "085baacc227e70fe3cf1f7de9404bef74c8e9b614f8c116cbf248a90c23ed4c0",
+              "08c93951e1ee785b3d4656bced92a7382ba43d63616364e5e1dcd8102ed07128",
+              "08f270772f89c76cf7ec9cf51595eec93fa4a80086e65ff2788ef0722b9bc68d",
+              "090dae6bbe3a79057f6b3171da689fea54a77d0e629554b0c1f02b5b232f6118",
+              "09ef2cbf5c89f07f36a750b6db6c4d89b23057200d0363f999e6c550920f129e",
+              "0a00c1229f8897edf955d848aa66afd8a21f06d3d2cdddcb3180884fb8a5af61",
+              "0a571a1f3f2b0b68d95ecfd5d4aab926fa0617dd34783b51e582da5be1fb279f",
+              "0a6409e868a6f1cc84a00dabf915bb0cf08a9cefdfb8f92d10d056c9aa2ba8c5",
+              "0dbd25b47ccacba5955c5b076b5fced2aeefe6a7a6bf67eef1654f38bd7b39b6",
+              "0e5ea199ea2be0a1fe442d2c814ed577acc1530d0a8890998dd9d17c794704ef",
+              "101759b18133fd7d48f70c6f75a24a8c60e458857f8fd91355e0f14be9a40240",
+              "104a3f41364d39c124af1f934d37e393bca72a7ab9129c9ba99371cb4354da07",
+              "10870c4031cc6c3fd0c9e0406c0ae1b46870979f9bfc85c69dd07cd079747b43",
+              "1107e1e7a3503ba73170f0baf810739256cc534d06e51082f9d7725fd6e4db69",
+              "11878f4314d6e46b2dae420bc866ae1aeee1e0796cbec4b14d1caf2f237b389e",
+              "16c9cacd8e5e4c1d4d2200835b621b201fa759871ef97ad56a01218ba65f0d28",
+              "17b88cda4c9b93c61d574e04a6f9f877f4a6cc0f37124c559b0fab6e429423ae",
+              "19571bf8116f9375a0b89b25db1324c9130191a139bf6b92a9c785db0f6ffe8b",
+              "1a0c85a45bd0f56617e1277b6ff92655ce3fcdcd184228b7f00a9f1e58f50bc3",
+              "1c02382bc70498ee392c5cdc6cb59e918b5f3cd47318b73f05ca58b729493cf3",
+              "1c3f0eeafe0afe650c0987fc5050b6f6c31ac84af239eb7eb763741d173fbc4d",
+              "1c6512b761ea2113c70d3086e35f9ea52c0dbe8540954dc70e6e66f99b2e3e7f",
+              "1cde6f92766e30860a2484e5637a8263d0448ec942e6db3f71aff4a5bb810a57",
+              "1d9c76272112cee86151bfa733349368b55ee71e9e3be98d8f29d1e95eb960ec",
+              "1dc7eeffe3b0c7e75aa1c8c5726bd6009e89cce7c9df3bf3ad0a1dec57df9c63",
+              "1e7e285f683001b4b5d2a1a017ec005172021118fcc4752528ccc21046764f1f",
+              "2027fb877232ff12ce61b2724493a658117afc1189910d316365a2c6c87d1446",
+              "215cb0df484fa7389c6f5bbb24130b6321fa0f8310accb5afa35126cfddfae41",
+              "2245dff61b2af2485c7299bbf24d3095f0f3ec66df4a1e62365b19383fc99876",
+              "22b5014dc113333ed857ee9dccd599907b459c683092630f6edabc580f4a3da5",
+              "23d5bcc1f4cbe36a7ac2964295838def59a3930db8e0d7bdb4425abeb16080fe",
+              "266f1bcd412963dad0433a7d6a36f597967997d3e44c961ddda40aa41656c359",
+              "27920dcf774b672b1022b934232b5957df77920383d9dc489953a4decaf19270",
+              "29900055d2c50451d438c0424b66745d372c555bbe8b7bf5128c9e93e291fec0",
+              "2dfde09fbb815d759f679c9c0638536e4e7b45532a7cd98fd7e1cede7fe5681d",
+              "30022f33d03be047b9135d846119d628c2c13ee945a5eba9ceff28149d271be9",
+              "30806dee42883ec903ff4c366064eb03aceba0f5200facae94a53f1a2df6ac10",
+              "30e69a51b861311064cd1299d91d463e94a088d8a7679bf4f32df597d97b2c58",
+              "3130808b10d4a7e0ebecc51df998bc3c75d603cee8b64487b1ac8db06e830018",
+              "3157402c7e9faf69740736dede552c35f30a8da30bca34f8b6e0acde94472d14",
+              "33bdaa4c2b1d988e4bb6a70c0056d4649ac138be78c0e03293720546f6a6794d",
+              "34b627510beee9895ef9639ef02123c9b883ec066402160284b0c17163b56934",
+              "34efcc6620f31fcdd0683efd8cee97c88b506503f122cc3a9092f18b618d40d4",
+              "35be4f4e462e255e1031d5ba919891519c1cdb3cdfbebd5c1c08edce3b698f35",
+              "3632153d3b1879db761a684999efdafb1ae66fbb31f22959b4ee5c60e314c1c0",
+              "372569f63d03dedfe4c74529b8b093735c5d79692ff8d12ce3bf1c3117090c28",
+              "376371e96641ead6e870e7d05179a4b6a4bfecffdd6d5f26eecf8ab2cb840444",
+              "38ffe492cb88ea03b38f1df30f783638e3cbd6a5f058deb86eba79884078c205",
+              "395fa92299ec1e70afe64eb841adc889355680b9d4ce52cb21073a7bc48e5d20",
+              "39a66d6ac78f16e746697277187200656a30da8c3692fcb82f689e6560031f2f",
+              "3d45de36dfb1883fa8ce75e46a5b03d7b330733a1e808fc85437c575b8657483",
+              "4343b1b930721fbc0243e39c23d9b7cb787611bcfabff51dd5743c829ec25f63",
+              "4385d62f18646238c255f79ebec8e90fb6d745cfed4124bf27683b86d9b8716a",
+              "43e409eb8f320c85f3c4a359a1c6e5618bed8728145a0cce1d78946223566842",
+              "44310bb58b033677ba5819882962df1f2da69c7d47ab5c7bf167080ca45180fa",
+              "460528ce2321a9aa0f6223700478d8f05833441cd334372ce4af3869424ad50a",
+              "47d0ee3274511d5be5af5585a8a7656ba2b754abfba3825db80e7988435cab02",
+              "49d485c5a9b2252fd4946e2ebe9e2f0306c7e1156f86feba79799c465fef2d1e",
+              "49de1b7fc720654b693e4bbe467dfaaf836180ff347bfc20f1232116f45fca1d",
+              "4b54cdaa910022e5fedf066f4a42be5a599c5c9ba42aa07edf60703c9ead1943",
+              "51e301fcfc99263767ac6fc00baa75ba6b2b648c806c7c9f5b6b23d3044147e4",
+              "522dd42ccc0380f9e9c3d7d10a76f9c9699febb1d9c20327b26812928a0494a9",
+              "526aa21b7d3b55417588247b9a62bdeb8b1d3d5f0a2fb07c10140f36b149c64f",
+              "52ff7188ddb0509a9095bd27329434d84d12cfce78f3e5a036a535a388071f70",
+              "558ff910057ea4ae85b8f60ee04b40825aed7a178809266f182dc782362c12ed",
+              "58925f7977e7cd5f4b15e7a1a07ac4784124351622cacc6f69bd468b75dfb99a",
+              "5a673f13fe4844c576754475fdf015c9b9e8a7237562c9ec7709bc729c0a1f03",
+              "5ad7030fccf9d1f5ec7877788922448b6bc0c9fd9139c631a88f14034443e8f4",
+              "5b2eb76f6c7da827efd744a75ab407033c894932c3aa1c8c5cca027463abd0e0",
+              "5dd46c04acf4d541e68c9a6b1cccbb17c180a7132b5165896f6c3c1b47b9c245",
+              "5f6279ed0d93a53aa2c0c126fd2c596e521c1f3912eb014affb473f8968d0a7e",
+              "5fada5dbf0fdc794a42a1f30632270288eebaf3e6d7ed0a5501a9d1b4f010c73",
+              "6519671de19b6b6975db033ef62053afad96edc46eae09bacb5139c987198f7f",
+              "672717419d46ce4fec06993383381804253d9dd59d8113a9530f3a243ac23d6a",
+              "680e464cf0be35c28938bd8cb9449849e228c7a54b80cf1dd0a2c8af962971c1",
+              "69f96bf263db11cd3bd61acf27f6c50a0c608865f086b86f8947b959e8f30f0f",
+              "6b2d11db703108251abe937acc3f3142e65447c5e724a223390818892967953f",
+              "6c14d558089b85a02de3e9c29891d40a216b35cff051eeb3136361c1dbcae127",
+              "6c69fe335fc956234bad56e2a68c3497f7cde0e0b0a9c9c613908d81094a1f4d",
+              "6ce6eed7700030cf9a79466d86c03a291c0c26cea84d0b2aa1871d1658ca8283",
+              "6d7c1baf4ae6aecc1b6c70e0a051222358e4281a633ae56b5e7639f07b8ccbf7",
+              "6f543e346dd64d9b74a0d9a85f43e8436e5087b4c4f3c2b5fee015f6a4cbf877",
+              "734e805ab84518ce97b75477111707738a461acae60b5c4a63331cbc2c8b57d5",
+              "745a94822ba16cfa62fabd657d12ca6f44c6912f8a8710bb12bc75cf857381ce",
+              "74bf6afdcbc010a7ba3d1afe0065f9eb9df0b1d7dc560d0d933de93e4cd5e80a",
+              "750fbe68904ad95ab7655d7e0e7ef6de60abe214eadb12ef90ffe748ac682cd8",
+              "7759d8dbf2e20dbc70c6ba97ae3cad733dab34d026d196cd1fe4c5480100fb63",
+              "77f4f02f77aa71e5726a04afb9ef740c3124c1d51bae12e14c5cf2f8d44f9c50",
+              "7b4b7febcb10d5bc4919e6765e041eadc41c77f5783ecdbaed23e968f37b8f6a",
+              "7ba9d1861b4a2e6ff0b7aa8278e97337369a79dd13deefd69c465c3713d5a2e2",
+              "7d0cd27eb015d0a523384d1a779549f484dd35fd4771659b84c278f3ce9d015c",
+              "7d5a8c45c378a5dffd4fdb1dcef3f18b468ddf82c5cdea045dd1798e04ebc644",
+              "7df201fce1a74b9fedacd2487dc0cb129c34706c5e8fce95508444d8c0ed6e4e",
+              "7ed92e801d6b3dca68af9efb09d63a5a91f6b82d97127d3bbeb27349fb500474",
+              "80e82d115229c8dd778b2e637e90e75af83df76a4f77b981412412f32bf70917",
+              "851e362614368e0f991d83f185470a5ad7ca54395281789bb4981b8a8d16f98f",
+              "86c228b0228607d1d796f7d9b36780b40303f4692cb41b673307f826bb0baaf7",
+              "86caecaee0bf099aae8abcb02eadeec82ef3746de7b292314113026046779664",
+              "87718f95cdad3f946e8cc723b871a57c94868467958c0fa032c892b6fd03b14e",
+              "87d7aee47da881c5a4883e09263d91b1dce561d88053acb0609bd6201a561bd4",
+              "8c8c69eec2f42d5e7cd2b22bbbf2b5660ec9f4303bebd695e4ff890999232247",
+              "8dc92da4698d6f798835132b076d8e9a5935a94ca8d9278a787772abbbc9fe2c",
+              "8fd7a5966c0d6d9a6404cfba01a4a6df31b9891853692d8c15d310f939e9040b",
+              "934281ec0e7c7aa39ae7d6eb6b5b22c66c6d849c894c26ab93184c40d74eafc3",
+              "95529381d3ff4a27f55bb5e1ad016c675dfdc9f5917786ad67427f97db91ab96",
+              "97e86db297b224a057a76eddf34369434a0ca84782add52c9c6d24cdb1c7b121",
+              "9923f404c73e175b720abf4849f32766c1b788e5b3a46efe71dc973411b718a7",
+              "995956789406a725aaeaf9187a1cb71967384c9faaf4ec7ad020d707b73adc0e",
+              "99fae2edcf2a0ad7bbf4114634e5dc0726c77fb2a210133d2aa428bf1bafe9c9",
+              "9aa86f4485d4f793fd7ca7293683edd5cf6c49a244b60bf9361c83432b6acb40",
+              "9cedaeb3bee5488e1c1ae6047e81197ee39ac6f54fdad55c2cb01ffab4ff879c",
+              "9f4bdba8745340e5cc3fc21d2284e9fd7b890ac5cc29c8d52620a5583b9d81e0",
+              "9f6e6571b7fe7492236cc88b0658d3dc24a56002c6f0472b0b5ca7179d3a394e",
+              "a06e86c2c73459095ce12298cad76a2f6fb3fcbcdd9c91edd7fc80b69208a93a",
+              "a0b97ab9ce06cd33818c4ec460a7dab3c834cc8dbee4bcaa01827bb1790952b9",
+              "a3b6264034edf09f8bf04c2328d8af18b0f044944c6953cf2c6370f26f47ab95",
+              "a5aa1082365216588263f5e36735a4f2a62e311a838a4ce8c90db987f65e9696",
+              "a5b904fe9e970ea560f86817a6dccd9636652a88b3d95b96418c8773d715501e",
+              "a64f01ba4c2788ff2da38bf4ffe6744c0fbf957f7f7bd7f23b23bf737788755a",
+              "a6cabd8702b3590cfad6a0ec5b90daebc9a9099ff603bd746f43912a48e52bcb",
+              "a7bf47520b198bb63942af0cf4a13acb1f5a2f42779ee02afaf7be6326fab9bf",
+              "a842cc1e287f9fa400095e56fa0ed3c84e97e7e876d4f06120850d59d2f4a1a9",
+              "a8c3b1c5a18850436d5fece1a98ebb43c503bfc5e7bb0639283ab8e9ff3ded02",
+              "aa1e842b5ff0ac94b2fd8255fe61bca063305bb21ce9ef7139d800466c06fe57",
+              "abf68bd096b204b82f344045132340e5290e9017270b9943dd8e252b83292dd4",
+              "ae0c7270ceb63c59297824fcf143d663da8e7f368e5574f6f8d2425fc2df791f",
+              "af428f93781f9dc6b28ca69523cfb814aabec5712869ece7595f429748bddb2d",
+              "afcbb0f0a380c73c306ea8270bb60554253357a39fce356f70b080baf0278b38",
+              "b3613bba51c54d6206d152e9e95c83a22294ebb383981ef12c175f241e6dff7b",
+              "b60f806cdca5330c8de6de78d32d12b38b4006af8d45d588a09aa5cf37829e14",
+              "b6ac060280783f1c00b42dcac7ff5d21ef59d4995c499a501d684ade11311726",
+              "b8d5fa4268c739b6bd77c0cceadc63f0c64c9b06b354158d44289f358c5e8279",
+              "b9bf9d2c7943b0ecac1f9dd0548d653bf6ef1ed1b29bbbb52c2d935975b6716d",
+              "bd34e341f29a3bbcf1b2f9d084d866c70ff8e29c73f05e7312bc3ea4bc35378c",
+              "bf89e88291ef148c9687cbd456fa6d59a52b241a70d68c6f8f00a19dbc8fff56",
+              "c3306b409c954667f916bcca0f5e00a9d1abc5abc849b1860e678a684bbbb7f2",
+              "c60e8e9ccefe4c35bbbbc1d788cc25e6813fae6a9d47107a3edef32dabc1f701",
+              "c7401a4637d57eed4d5bb40bed6340d0b4376f8164214cb13c02e84551bdc1b7",
+              "cbf431d9f8d095dd25bc2ee8a0fa1fc5f6a7a102b0d3fdd130ebe93615658b70",
+              "cc7ae820943b4884b86ff8b445ce82bbbb3c7f998bcc0ac7052f37bffe2ff403",
+              "cc891773a5c1b254566b67b3e4338a6ea114ddeeefef938c28f2a625d17e0261",
+              "cea42f482e95e63f925bb458cd6ed1d7098ed28bdb4cc8fc70f9060dde5d8e37",
+              "cf99872f94d879149d25a00fd3297975af6fa83395c32c4a258e3fae2a141d54",
+              "d0ede65aeececb15ca5b7c9c7153789f3d935ddd971f3794768177833148f55f",
+              "d132726c888c8eb531a916a4c53d8b57131b13ec53a96e91e9c026f776836222",
+              "d3121fa47d74b1eb28fd81e75941d1fec8f3137d36d849f609ed5f9fcb9949c7",
+              "d58d825214b6c0b5d4bd65e981c816ad110561863fd14790ca42a65d59abea99",
+              "d5f9852dace024e81d9c1955653eaeb1e796e821e8ad3f2a1a8d93269aeaa386",
+              "d8178d8e2fb13fd462ebd6387c1afdc32876e49b0c3fb726b0062516eea981aa",
+              "dafb18d8ba55fd302c7ff09d411db1ae470d30e33a8a56c035fcec091a53224c",
+              "dbfe94c9e9ec437f72034c2a15a78dae53f91a43603e34646506e5abb23101cd",
+              "dc7eb02602d00d64bcd5447f3ecd4be7b021c6b6dd23f74c1c0defaef3c34a34",
+              "dcb555ccfcb2ad4282e4eac8273b1799ee45aac48298c808708229c43ce70f5b",
+              "dd24f1d59de04fe06b4c00b956ed2c78c26b10138e8b5a6c2ccab4b077fa6085",
+              "dd330a882ef3767f3216999c89a8f883199e520b327a356d42c24fd79f33ac45",
+              "e036bf8696b8c04e53c250cb7529d15d404275b226d75697cc13430160c89eb9",
+              "e488ab7206a2a5e96b83fe8eaf3afac9d870368a21e14056ce8f0b309f1035ec",
+              "e5219fa75db6016300cb5f3d8af75aa0d16492cd0e691d83564ec7e026015f86",
+              "e5b546d970b181acf5d97506ac95dba679e1e40f6d65341031bca004c3586fa1",
+              "e6c38a24813d779aa29312261f74597cafb3d71dd18b768aca27fca73c30cbb8",
+              "e8bbccdc613663b68512226ccf2cd297b6be6762e95f1511257b9c4235730300",
+              "e9dcabe68182ddae3a2c596d0c58c18ec2d5a6a2c483136fded4a1a76c56839c",
+              "ea5fde547a8f8b6e7950c326d0dda0eda0978f7d60d9c6f8d28b54d98693e3ad",
+              "ecb0d58f9915712564593bd98d1b3b2507c8106f179b2d7e74edc43b30821b4b",
+              "ee633d722df41793fa40e452013a14592efd2b0ac5b4a730843b27124fad8ed1",
+              "ef05cae9013e68382ee9221d032090ca8a6dae9dcb754c4521f1d9a2f60edec4",
+              "ef5d06e8e6984e8b385dcaf10a4fdb6e51ea5ab61d97d2cafff55ce8ebaf0086",
+              "ef7e2db26df983abf0abf86085a72893c43e284f72c6a0ca5b5266a9132ce0c0",
+              "f05c6b1784bb630c60f5ad3c45673117352f86aec30cd4b234db0e64092a6ef4",
+              "f1c2a90f00e5855afe115ce4db407005e7a22ed450348968c0f36746bbd5210e",
+              "f227c313f7e753eb79a8db892c56f9cc5abd71577501000e70142f9749fc4232",
+              "f2adf2a31d78663784e17d3cb237fb307595889391683e0eac42ca12337b6d3e",
+              "f4f73e98c903182cb7183e5a9e921dde880b799513ee203f305e8431af27d81d",
+              "f615d3341e04bb32a97bb534d52d9aaa8f2dc159df9623ad7854ef73318870cf",
+              "f6186efa5daa9d52ef9eeebd16ddd2d60b1e5098d441f072d14ea4360b57c01c",
+              "f650d02cb3d728e201443171912b93b23d465a0497132e119456e243cf459aee",
+              "f7305be4d3bb79feb79040e01559f93b09e3d29b77f53ccd052b8efeeefeb7ef",
+              "f807db2d46d7bb2584d1b75ed0e63147b31e9bfb64874cfc2518a42938f87107",
+              "f8cb063726f7c0a1755eaca2f7d6297b669088a08d2e6635038084d33bea44a7",
+              "f91094bb83f50b1dac7b33470d0c449c9d4e4150f2579444b26549ee1cc443eb",
+              "f98c0865c30247787fa9ae787d8116aa1802a2d92d14b43fef9aa4c4f0164c89",
+              "fa0ad2a7f69649c744dcf7b95302addcdb1ac175ce6d9ce36ccc8316e8236241",
+              "fc2ef3846c31e4649f9c781bd12a0ad473665e3f2c752628794ab6b89a1aeb34",
+              "fd451de76dc9f46cd3dee64aede7f2db7e8aff1ad31e478f6c0fab3f73ebcd1d",
+              "fe63e469b2a4020cb78504751cce0fd8df7801a2ae61ea32d58c9abe7988a2fd",
+              "ff911511da6aec2ba699e07c9b4bce58e00f45ff40e5a4988b4a17dc88e67e32"
+            ],
+            "unique_vector_count": 191
+          },
+          "random_objective_seed": 20366729,
+          "source_model_index": 6,
+          "source_positive_inequalities": 289,
+          "source_target_id": "seeded:6",
+          "source_unique_ordered_quad_count": 289,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        },
+        {
+          "affine_clause_orbit": {
+            "affine_map_count": 29,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "498805ab96dac466e4ab9a1ddd823882d847599fb36b5c5cdaee6a260e97d010",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 7,
+            "source_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              12,
+              25,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "source_unique_ordered_quad_count": 4,
+            "unique_orbit_clause_count": 29
+          },
+          "best_trial": 23,
+          "clause_coverage": {
+            "direct_covered_target_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:2",
+              "seeded:3",
+              "seeded:4",
+              "seeded:5",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "direct_cross_target_count": 7,
+            "source_target_id": "seeded:7",
+            "translated_orbit_covered_targets": [
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:0"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:1"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:2"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:3"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:4"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:5"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:6"
+              },
+              {
+                "matching_translation_count": 1,
+                "target_id": "seeded:7"
+              }
+            ],
+            "translated_orbit_cross_target_count": 7
+          },
+          "compressed_certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              4,
+              15,
+              20,
+              26,
+              19,
+              3,
+              8,
+              23,
+              5,
+              22,
+              16,
+              2,
+              9,
+              27,
+              24,
+              6,
+              17,
+              13,
+              10,
+              28,
+              12,
+              25,
+              18,
+              21,
+              14,
+              11,
+              7,
+              1
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  2,
+                  25
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  28,
+                  25
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  25,
+                  1
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  25,
+                  18,
+                  1
+                ],
+                "weight": 1
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 4,
+            "pattern": {
+              "circulant_offsets": [
+                1,
+                3,
+                7,
+                15
+              ],
+              "n": 29,
+              "name": "C29_sidon_1_3_7_15"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 4
+          },
+          "compressed_positive_inequalities": 4,
+          "compressed_unique_ordered_quad_count": 4,
+          "exact_improvements": [
+            {
+              "positive_inequalities": 210,
+              "seed": 20367729,
+              "trial": 0,
+              "unique_ordered_quad_count": 209
+            },
+            {
+              "positive_inequalities": 208,
+              "seed": 20367731,
+              "trial": 2,
+              "unique_ordered_quad_count": 208
+            },
+            {
+              "positive_inequalities": 206,
+              "seed": 20367732,
+              "trial": 3,
+              "unique_ordered_quad_count": 206
+            },
+            {
+              "positive_inequalities": 179,
+              "seed": 20367736,
+              "trial": 7,
+              "unique_ordered_quad_count": 179
+            },
+            {
+              "positive_inequalities": 4,
+              "seed": 20367752,
+              "trial": 23,
+              "unique_ordered_quad_count": 4
+            }
+          ],
+          "numerical_support_size_histogram": {
+            "179": 1,
+            "186": 1,
+            "198": 1,
+            "205": 1,
+            "206": 2,
+            "208": 1,
+            "210": 2,
+            "211": 2,
+            "213": 1,
+            "215": 1,
+            "216": 3,
+            "218": 1,
+            "224": 2,
+            "225": 1,
+            "226": 1,
+            "227": 1,
+            "232": 1,
+            "4": 1
+          },
+          "numerical_support_size_max": 232,
+          "numerical_support_size_min": 4,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            12,
+            25,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "positive_circuit_audit": {
+            "all_weights_positive": true,
+            "exact_zero_sum_gives_nullity_at_least": 1,
+            "modular_rank_gives_rational_rank_at_least": 3,
+            "positive_circuit_verified": true,
+            "rank_mod_1000000007": 3,
+            "support_size": 4
+          },
+          "quad_reduction": 288,
+          "quad_reduction_fraction": 0.9863013698630136,
+          "quotient_vector_support": {
+            "duplicate_inequality_vector_count": 0,
+            "hashes": [
+              "8dc2c486d7e6cb8dee938aa31ecfa2cb14f2f79e73d7f1ce03524d4d1d85524a",
+              "b3695a615f827d1b161d249901fa982c1d44796dcaed6b214bd40322c11835d5",
+              "c16368bc342bf4790c2399a37fa9483f3c1ec8e0f912cadbd530a1c0871c019b",
+              "e35ec6df8423c0053e646005e35bf4360a847763353ec18e29745d44a320f29f"
+            ],
+            "unique_vector_count": 4
+          },
+          "random_objective_seed": 20367729,
+          "source_model_index": 7,
+          "source_positive_inequalities": 292,
+          "source_target_id": "seeded:7",
+          "source_unique_ordered_quad_count": 292,
+          "successful_numerical_trials": 24,
+          "support_is_exact_positive_circuit": true,
+          "trial_count": 24
+        }
+      ],
+      "coverage_summary": {
+        "compressed_source_count": 8,
+        "direct_covered_target_count": 8,
+        "direct_cross_reuse_edge_count": 21,
+        "target_coverage": [
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:0",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:1",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:2",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:3",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:4",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:5",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:6",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:7",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:8",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:9",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:10",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:11",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:12",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:13",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:14",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [],
+            "stream": "probe",
+            "strong_lightweight_survivor": true,
+            "target_id": "probe:15",
+            "translated_orbit_covering_source_ids": []
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:0",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:1",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:2",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:2",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:2",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:3",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:3",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:3",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:4",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:4",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:4",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:5",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:5",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:5",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:6",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:6",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:6",
+              "seeded:7"
+            ]
+          },
+          {
+            "direct_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:7"
+            ],
+            "stream": "seeded",
+            "strong_lightweight_survivor": true,
+            "target_id": "seeded:7",
+            "translated_orbit_covering_source_ids": [
+              "seeded:0",
+              "seeded:1",
+              "seeded:7"
+            ]
+          }
+        ],
+        "target_order_count": 24,
+        "translated_orbit_covered_target_count": 8,
+        "translated_orbit_cross_reuse_edge_count": 21
+      },
+      "n": 29,
+      "pattern": "C29_sidon_1_3_7_15",
+      "quotient_vector_reuse": {
+        "distinct_vector_count": 918,
+        "max_certificate_frequency": 2,
+        "nonzero_pairwise_overlaps": [
+          {
+            "jaccard_fraction": 0.010362694300518135,
+            "left_source_target_id": "seeded:1",
+            "right_source_target_id": "seeded:6",
+            "shared_vector_count": 2
+          },
+          {
+            "jaccard_fraction": 0.011019283746556474,
+            "left_source_target_id": "seeded:2",
+            "right_source_target_id": "seeded:3",
+            "shared_vector_count": 4
+          },
+          {
+            "jaccard_fraction": 0.005449591280653951,
+            "left_source_target_id": "seeded:2",
+            "right_source_target_id": "seeded:4",
+            "shared_vector_count": 2
+          },
+          {
+            "jaccard_fraction": 0.008174386920980926,
+            "left_source_target_id": "seeded:2",
+            "right_source_target_id": "seeded:5",
+            "shared_vector_count": 3
+          },
+          {
+            "jaccard_fraction": 0.008310249307479225,
+            "left_source_target_id": "seeded:3",
+            "right_source_target_id": "seeded:4",
+            "shared_vector_count": 3
+          },
+          {
+            "jaccard_fraction": 0.008287292817679558,
+            "left_source_target_id": "seeded:3",
+            "right_source_target_id": "seeded:5",
+            "shared_vector_count": 3
+          },
+          {
+            "jaccard_fraction": 0.005405405405405406,
+            "left_source_target_id": "seeded:3",
+            "right_source_target_id": "seeded:6",
+            "shared_vector_count": 2
+          },
+          {
+            "jaccard_fraction": 0.00267379679144385,
+            "left_source_target_id": "seeded:5",
+            "right_source_target_id": "seeded:6",
+            "shared_vector_count": 1
+          }
+        ],
+        "per_source_max_pairwise_shared_vector_count": [
+          {
+            "max_pairwise_shared_vector_count": 0,
+            "source_target_id": "seeded:0"
+          },
+          {
+            "max_pairwise_shared_vector_count": 2,
+            "source_target_id": "seeded:1"
+          },
+          {
+            "max_pairwise_shared_vector_count": 4,
+            "source_target_id": "seeded:2"
+          },
+          {
+            "max_pairwise_shared_vector_count": 4,
+            "source_target_id": "seeded:3"
+          },
+          {
+            "max_pairwise_shared_vector_count": 3,
+            "source_target_id": "seeded:4"
+          },
+          {
+            "max_pairwise_shared_vector_count": 3,
+            "source_target_id": "seeded:5"
+          },
+          {
+            "max_pairwise_shared_vector_count": 2,
+            "source_target_id": "seeded:6"
+          },
+          {
+            "max_pairwise_shared_vector_count": 0,
+            "source_target_id": "seeded:7"
+          }
+        ],
+        "shared_vector_count": 20,
+        "shared_vectors": [
+          {
+            "certificate_count": 2,
+            "sha256": "0c06b6477cb04c05abc2d7ca2eae58ee57f4cedc8904a1af710d0c673ec109e7",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:3"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "1dc7eeffe3b0c7e75aa1c8c5726bd6009e89cce7c9df3bf3ad0a1dec57df9c63",
+            "source_target_ids": [
+              "seeded:1",
+              "seeded:6"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "22b5014dc113333ed857ee9dccd599907b459c683092630f6edabc580f4a3da5",
+            "source_target_ids": [
+              "seeded:1",
+              "seeded:6"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "3a482cdd5647655f9fd5504999ae04259e83f0bec08edbf9cfc975ae5ce1175c",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:3"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "41c9f031f9ef46b3a5f59494fc04a57ddf84b60790bf23420229ee32b36ea957",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:4"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "5b2eb76f6c7da827efd744a75ab407033c894932c3aa1c8c5cca027463abd0e0",
+            "source_target_ids": [
+              "seeded:5",
+              "seeded:6"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "64afb5ee9775ec764f8c0e6dc5a6fe94e54014341325033166f04a55c9bfd123",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:4"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "70bb044ea2ee52cd9460f1838f12cfb882d664eb7d7d09265bf573f74babe490",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:3"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "735d14fcea184a01c0d75a81ff634024283b37f46e0f5a29b4b11b0866581c9c",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "8e852ed9f23024ddb716ac0504ca60b4bf7c513f67d41e79abb5a1d09043e4b8",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:3"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "9d88712ee77dbbd8c0466f076a532bd3d388d64d3166c8b60ecc43a95f7884e1",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "aff770b8590acce399494ca83b7ddda5fc1b443483e61c7546f94e737a90ca3f",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:4"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "b4220d7deabb72cf07aaabba9ce0bebb2139dac9238cc33bd4ed3eaa5a43ac4c",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:4"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "c8316316e02b09c0ea960f9bd1d58914a20c40e3d9e01453efd27d9b4ae32100",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "d4a179b67f4e15e20f86dae2960ae8e4b13b4a02bf5b4e5fa3b4caf065df9a1b",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "e0973608acde2dbe64b8c8a58c5239fd268e00fcd3d7dc8d58163f3403e91ac1",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "ec48527c2bfe35c3d5574953cd807393db2e0db7d9e18b1a8bf504a63ffd9a36",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:4"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "f05c6b1784bb630c60f5ad3c45673117352f86aec30cd4b234db0e64092a6ef4",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:6"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "f7023d8f9b7472dcb6eeb5e966beade8c62a8d1cf40a73eaff0e9b13c4654cc8",
+            "source_target_ids": [
+              "seeded:2",
+              "seeded:5"
+            ]
+          },
+          {
+            "certificate_count": 2,
+            "sha256": "fe63e469b2a4020cb78504751cce0fd8df7801a2ae61ea32d58c9abe7988a2fd",
+            "source_target_ids": [
+              "seeded:3",
+              "seeded:6"
+            ]
+          }
+        ]
+      },
+      "target_orders": [
+        {
+          "model_index": 0,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            13,
+            24,
+            17,
+            10,
+            26,
+            3,
+            25,
+            18,
+            11,
+            2
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:0"
+        },
+        {
+          "model_index": 1,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            3,
+            25,
+            18,
+            11,
+            2
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:1"
+        },
+        {
+          "model_index": 2,
+          "order": [
+            0,
+            18,
+            11,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            3,
+            25,
+            2
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:2"
+        },
+        {
+          "model_index": 3,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            3,
+            25,
+            18,
+            2,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:3"
+        },
+        {
+          "model_index": 4,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            3,
+            25,
+            2,
+            18,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:4"
+        },
+        {
+          "model_index": 5,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            3,
+            25,
+            18,
+            2,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:5"
+        },
+        {
+          "model_index": 6,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            2,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:6"
+        },
+        {
+          "model_index": 7,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            2,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:7"
+        },
+        {
+          "model_index": 8,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            11,
+            2
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:8"
+        },
+        {
+          "model_index": 9,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            11,
+            2
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:9"
+        },
+        {
+          "model_index": 10,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            25,
+            3,
+            2,
+            18,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:10"
+        },
+        {
+          "model_index": 11,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            13,
+            24,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            11,
+            2
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:11"
+        },
+        {
+          "model_index": 12,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            13,
+            24,
+            17,
+            10,
+            26,
+            25,
+            3,
+            2,
+            18,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:12"
+        },
+        {
+          "model_index": 13,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            22,
+            4,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            13,
+            24,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            2,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:13"
+        },
+        {
+          "model_index": 14,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            24,
+            13,
+            17,
+            10,
+            26,
+            25,
+            3,
+            2,
+            18,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:14"
+        },
+        {
+          "model_index": 15,
+          "order": [
+            0,
+            28,
+            14,
+            6,
+            21,
+            7,
+            4,
+            22,
+            19,
+            5,
+            20,
+            12,
+            27,
+            15,
+            1,
+            16,
+            8,
+            23,
+            9,
+            13,
+            24,
+            17,
+            10,
+            26,
+            25,
+            3,
+            18,
+            2,
+            11
+          ],
+          "stream": "probe",
+          "strong_lightweight_survivor": true,
+          "target_id": "probe:15"
+        },
+        {
+          "model_index": 0,
+          "order": [
+            0,
+            15,
+            20,
+            4,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            27,
+            9,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:0"
+        },
+        {
+          "model_index": 1,
+          "order": [
+            0,
+            15,
+            20,
+            4,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:1"
+        },
+        {
+          "model_index": 2,
+          "order": [
+            0,
+            15,
+            4,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            27,
+            9,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:2"
+        },
+        {
+          "model_index": 3,
+          "order": [
+            0,
+            15,
+            4,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:3"
+        },
+        {
+          "model_index": 4,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:4"
+        },
+        {
+          "model_index": 5,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            27,
+            9,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            25,
+            12,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:5"
+        },
+        {
+          "model_index": 6,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            12,
+            28,
+            25,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:6"
+        },
+        {
+          "model_index": 7,
+          "order": [
+            0,
+            4,
+            15,
+            20,
+            26,
+            19,
+            3,
+            8,
+            23,
+            5,
+            22,
+            16,
+            2,
+            9,
+            27,
+            24,
+            6,
+            17,
+            13,
+            10,
+            28,
+            12,
+            25,
+            18,
+            21,
+            14,
+            11,
+            7,
+            1
+          ],
+          "stream": "seeded",
+          "strong_lightweight_survivor": true,
+          "target_id": "seeded:7"
+        }
+      ]
+    }
+  ],
+  "source_artifact": "data/runs/sparse_full_cone_seeded_cegar_2026-07-23/summary.json",
+  "source_sha256": "4a4bce42f5cdef3a90c4cd596e817fca26fe81e97be457549e78e2787a02f214",
+  "status": "BOUNDED_CROSS_ORDER_CLAUSE_REUSE_DIAGNOSTIC",
+  "trust": "EXACT_COMPRESSED_CERTIFICATES_IN_BOUNDED_RANDOMIZED_SEARCH",
+  "type": "sparse_full_cone_seeded_clause_compression_v1"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -701,9 +701,14 @@ and must not assume that the finite `n=9` pivot census generalizes.
    quotient-preserving translations: reflection is invalid for both
    quotients. None of 32 fresh strong inverse-pair escape orders hits a seed
    orbit. Separate seeded searches learn eight new exact certificate orbits
-   per pattern before bounded limits. The next target is to compress those 16
-   certificates and test shared small circuits across all 48 fresh stored
-   orders. The current clauses are not an all-order obstruction.
+   per pattern before bounded limits. The compression follow-up in
+   `docs/sparse-full-cone-seeded-certificate-compression.md` finds seven exact
+   `3`--`8`-quad circuits among those 16 certificates. Across all 48 stored
+   orders they produce 19 C25 and 21 C29 translated cross-coverage edges
+   inside the seeded clusters, but zero probe-order coverage; quotient-vector
+   frequency never exceeds two certificates. The next target is a fresh
+   independent order stream seeded by canonical small-circuit templates. The
+   current clauses are not an all-order obstruction.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external

--- a/docs/index.md
+++ b/docs/index.md
@@ -968,6 +968,10 @@ put detailed reconciliation in the canonical synthesis.
   longer exact C25/C29 CEGAR seeded by all quotient-preserving translations of
   the compressed clauses; 32 fresh probe orders have zero seed hits, while 16
   new exact certificate orbits are learned before bounded limits.
+- [`sparse-full-cone-seeded-certificate-compression.md`](sparse-full-cone-seeded-certificate-compression.md):
+  exact compression of those 16 learned certificates and coverage over all 48
+  stored orders; seven 3--8-quad circuits reuse inside seeded clusters but
+  cover none of the counterfactual probe orders.
 - [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
   cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
   numerical evidence only, not an exact coordinate certificate.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -697,6 +697,10 @@ benchmarks for the larger frontier:
   the two-inequality inverse-pair filter;
 - try to turn full-cone fixed-order certificates into reusable order-search
   clauses for larger sparse/Sidon patterns;
+- use `docs/sparse-full-cone-seeded-certificate-compression.md` as the bounded
+  C25/C29 reuse diagnostic: seven exact 3--8-quad circuits cover seeded-order
+  clusters but none of 32 counterfactual probe orders, so transfer beyond that
+  cluster remains open;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 

--- a/docs/sparse-full-cone-certificate-compression.md
+++ b/docs/sparse-full-cone-certificate-compression.md
@@ -59,6 +59,12 @@ escape orders, so the earlier C29 cross-model reuse did not persist in that
 bounded stream. The seeded solvers learned eight new exact certificate orbits
 per pattern and again stopped at a certificate limit.
 
+The second-generation compression of those sixteen newly learned
+certificates is recorded in
+`docs/sparse-full-cone-seeded-certificate-compression.md`. Seven compress to
+exact `3`--`8`-quad circuits. They show substantial reuse inside the seeded
+order clusters but zero coverage of the 32 counterfactual probe orders.
+
 Replay:
 
 ```bash

--- a/docs/sparse-full-cone-seeded-cegar.md
+++ b/docs/sparse-full-cone-seeded-cegar.md
@@ -56,13 +56,15 @@ size (`25` or `29`), and all `16` new canonical orbit hashes are distinct.
 Both searches stopped at the configured eight-certificate limit, not at
 UNSAT.
 
-## Next target
+## Compression follow-up
 
-Compress the `16` new certificates, then measure the compressed clauses across
-all `48` stored fresh orders (the `32` probe orders plus `16` seeded models).
-Because raw seed reuse was zero in the fresh probe, prioritize shared
-quotient-vector supports and unions of small circuits instead of assuming that
-one large certificate orbit will recur.
+That target is completed in
+`docs/sparse-full-cone-seeded-certificate-compression.md`. Seven of the sixteen
+new certificates compress to exact `3`--`8`-quad circuits. Those small clauses
+produce `19` C25 and `21` C29 translation-orbit cross-coverage edges inside
+the seeded model packets, but still cover none of the 32 counterfactual probe
+orders. Quotient-vector overlap is sparse and has maximum certificate
+frequency two.
 
 Replay:
 

--- a/docs/sparse-full-cone-seeded-certificate-compression.md
+++ b/docs/sparse-full-cone-seeded-certificate-compression.md
@@ -1,0 +1,104 @@
+# Sparse full-cone seeded certificate compression
+
+Status: bounded randomized search with exact fixed-pattern, fixed-order
+outputs. No general proof, all-order C25/C29 obstruction, geometric
+counterexample, or official-status change is claimed.
+
+## Method
+
+The source packet
+`data/runs/sparse_full_cone_seeded_cegar_2026-07-23/summary.json` contains
+eight newly learned exact full-cone certificates for each sparse pattern,
+together with sixteen counterfactual probe orders per pattern.
+
+For each of the sixteen certificates,
+`scripts/exploration/compress_sparse_full_cone_seeded_certificates.py` sampled
+24 deterministic pseudorandom LP objectives over all fixed-order Kalmanson
+rows. A numerical support was retained only after exact positive integer
+weights were recovered, its quotient-vector sum checked as zero, and modular
+rank certified it as a positive circuit.
+
+Each retained circuit was then expanded through every exact
+quotient-preserving affine image. As in the seeded run, only translations are
+valid for these two quotients. Coverage was measured both for the direct
+compressed clause and for its full translation orbit over all 48 stored fresh
+orders: 32 probe orders and 16 seeded models.
+
+## Exact compression result
+
+| Pattern | Source model | Original width | Compressed width | Best trial |
+|---|---:|---:|---:|---:|
+| `C25_sidon_2_5_9_14` | 0 | 188 | 7 | 20 |
+| `C25_sidon_2_5_9_14` | 1 | 202 | 116 | 14 |
+| `C25_sidon_2_5_9_14` | 2 | 209 | 8 | 14 |
+| `C25_sidon_2_5_9_14` | 3 | 208 | 5 | 0 |
+| `C25_sidon_2_5_9_14` | 4 | 204 | 122 | 18 |
+| `C25_sidon_2_5_9_14` | 5 | 206 | 119 | 12 |
+| `C25_sidon_2_5_9_14` | 6 | 205 | 118 | 20 |
+| `C25_sidon_2_5_9_14` | 7 | 208 | 3 | 5 |
+| `C29_sidon_1_3_7_15` | 0 | 294 | 5 | 19 |
+| `C29_sidon_1_3_7_15` | 1 | 294 | 4 | 8 |
+| `C29_sidon_1_3_7_15` | 2 | 291 | 184 | 9 |
+| `C29_sidon_1_3_7_15` | 3 | 293 | 181 | 1 |
+| `C29_sidon_1_3_7_15` | 4 | 290 | 182 | 22 |
+| `C29_sidon_1_3_7_15` | 5 | 289 | 183 | 0 |
+| `C29_sidon_1_3_7_15` | 6 | 289 | 190 | 21 |
+| `C29_sidon_1_3_7_15` | 7 | 292 | 4 | 23 |
+
+Seven of the sixteen exact circuits have only `3` through `8` ordered
+quadrilaterals. The other nine retain widths `116` through `190`. This sharp
+split was not assumed by the search.
+
+## Exact cross-order coverage
+
+| Pattern | Stored targets | Probe targets covered | Seeded targets covered | Direct cross-edges | Translation-orbit cross-edges |
+|---|---:|---:|---:|---:|---:|
+| `C25_sidon_2_5_9_14` | 24 | 0/16 | 8/8 | 11 | 19 |
+| `C29_sidon_1_3_7_15` | 24 | 0/16 | 8/8 | 21 | 21 |
+
+No compressed circuit, even after all exact translations, covers any fresh
+probe order. Reuse is concentrated inside the seeded-model packets:
+
+- the C25 5-quad circuit from model 3 directly covers seeded models 1 through
+  7;
+- the C25 3-quad circuit from model 7 covers seeded models 1 through 7 after
+  translation expansion;
+- the three C29 circuits of widths `5`, `4`, and `4` each directly cover all
+  eight seeded models.
+
+Thus small exact circuits recover substantial bounded reuse that was invisible
+to the original 188--294-quad clauses. They still do not bridge to the
+counterfactual probe stream.
+
+## Quotient-vector reuse
+
+The C25 circuits contain 492 distinct quotient vectors. Only 6 occur in more
+than one certificate, no vector occurs in three certificates, and the largest
+pairwise overlap is 2 vectors.
+
+The C29 circuits contain 918 distinct quotient vectors. Only 20 occur in more
+than one certificate, no vector occurs in three certificates, and the largest
+pairwise overlap is 4 vectors.
+
+The observed clause reuse therefore does not come from a large common
+quotient-vector core. It comes from a few very small positive circuits whose
+ordered-quadrilateral supports recur across the seeded order cluster.
+
+## Scope and next target
+
+The 24-objective search is not exhaustive, and the coverage matrix contains
+only the 48 stored orders. The result does not imply all-order coverage for
+either abstract pattern.
+
+The next useful step is to canonicalize the seven `3`--`8`-quad circuits as
+explicit small templates, seed a fresh independent order stream with those
+templates, and measure whether they transfer beyond the current seeded
+cluster. If they still record zero probe/fresh-stream hits, treat them as
+cluster-specific diagnostics rather than prospective all-order clauses.
+
+Replay:
+
+```bash
+python scripts/exploration/compress_sparse_full_cone_seeded_certificates.py \
+  --check data/runs/sparse_full_cone_seeded_compression_2026-07-29/summary.json
+```

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -3063,6 +3063,16 @@
         "data/runs/sparse_full_cone_seeded_cegar_2026-07-23/summary.json"
       ],
       "claim_scope": "Replay 32 counterfactual inverse-pair escape orders, 16 new exact full-cone certificates, and 544 exact quotient-preserving affine certificate images from bounded fixed-pattern C25/C29 seeded CEGAR runs. Both runs stopped at certificate limits, not UNSAT; not an all-order obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
+    },
+    {
+      "id": "sparse_full_cone_seeded_compressed_certificates",
+      "command": [
+        "python",
+        "scripts/exploration/compress_sparse_full_cone_seeded_certificates.py",
+        "--check",
+        "data/runs/sparse_full_cone_seeded_compression_2026-07-29/summary.json"
+      ],
+      "claim_scope": "Replay 16 exact compressed positive-circuit certificates, 432 exact quotient-preserving affine images, and their direct/translation-orbit coverage over 48 stored fixed C25/C29 orders. Randomized compression is not exhaustive; not an all-order obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
     }
   ],
   "make_targets": {

--- a/scripts/exploration/compress_sparse_full_cone_seeded_certificates.py
+++ b/scripts/exploration/compress_sparse_full_cone_seeded_certificates.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Compress the seeded C25/C29 certificates and measure exact cross-coverage.
+
+The source packet contains eight newly learned exact full-cone certificates
+for each sparse pattern, plus sixteen counterfactual probe orders per pattern.
+This bounded follow-up samples alternative LP extreme points for each of the
+sixteen certificates, exactifies every retained improvement, expands each
+compressed circuit through all quotient-preserving translations, and measures
+direct and translated-clause coverage across all forty-eight stored orders.
+
+Randomized objective sampling is not exhaustive.  Every retained certificate
+and every translated image is exact, but all conclusions remain fixed-pattern,
+fixed-order diagnostics rather than an all-order obstruction, counterexample,
+or proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter, defaultdict
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+EXPLORATION = Path(__file__).resolve().parent
+for path in (SCRIPTS, EXPLORATION):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_kalmanson_certificate import (  # noqa: E402
+    build_distance_classes,
+    check_certificate_dict,
+    inequality_terms,
+)
+from compress_sparse_full_cone_certificates import (  # noqa: E402
+    compress_model,
+    order_satisfies_quads,
+    positive_circuit_audit,
+)
+from pilot_sparse_full_cone_order_cegar import (  # noqa: E402
+    PATTERNS,
+    certificate_order_quads,
+)
+from run_sparse_full_cone_seeded_cegar import (  # noqa: E402
+    ClauseOrbit,
+    build_clause_orbit,
+    file_sha256,
+)
+
+
+DEFAULT_SOURCE = (
+    ROOT / "data" / "runs" / "sparse_full_cone_seeded_cegar_2026-07-23" / "summary.json"
+)
+
+
+def target_orders(run: Mapping[str, Any]) -> list[dict[str, object]]:
+    """Return the 16 probe and 8 seeded orders for one pattern."""
+
+    targets = []
+    streams = (
+        ("probe", run["counterfactual_probe"]["models"]),
+        ("seeded", run["seeded_cegar"]["models"]),
+    )
+    for stream, models in streams:
+        for model in models:
+            index_key = "probe_model_index" if stream == "probe" else "model_index"
+            index = int(model[index_key])
+            targets.append(
+                {
+                    "target_id": f"{stream}:{index}",
+                    "stream": stream,
+                    "model_index": index,
+                    "order": [int(label) for label in model["order"]],
+                    "strong_lightweight_survivor": bool(
+                        model["lightweight_filters"]["survives"]
+                    ),
+                }
+            )
+    ids = [str(target["target_id"]) for target in targets]
+    if len(ids) != len(set(ids)):
+        raise AssertionError("target order identifiers are not unique")
+    return targets
+
+
+def quotient_vector_hashes(
+    certificate: Mapping[str, Any],
+) -> list[str]:
+    """Hash the distinct exact quotient vectors used by one certificate."""
+
+    pattern = certificate["pattern"]
+    n = int(pattern["n"])
+    offsets = [int(value) for value in pattern["circulant_offsets"]]
+    classes = build_distance_classes(n, offsets)
+    class_count = len(set(classes.values()))
+    hashes = set()
+    for inequality in certificate["inequalities"]:
+        vector = [0] * class_count
+        for pair, coefficient in inequality_terms(
+            str(inequality["kind"]), inequality["quad"]
+        ):
+            vector[classes[pair]] += coefficient
+        encoded = json.dumps(vector, separators=(",", ":")).encode("ascii")
+        hashes.add(hashlib.sha256(encoded).hexdigest())
+    return sorted(hashes)
+
+
+def clause_coverage(
+    certificate: Mapping[str, Any],
+    orbit: ClauseOrbit,
+    targets: Sequence[Mapping[str, Any]],
+    *,
+    source_target_id: str,
+) -> dict[str, object]:
+    order = [int(label) for label in certificate["cyclic_order"]]
+    direct_quads = certificate_order_quads(certificate, order)
+    direct = [
+        str(target["target_id"])
+        for target in targets
+        if order_satisfies_quads(target["order"], direct_quads)
+    ]
+    translated = []
+    for target in targets:
+        matching = sum(
+            order_satisfies_quads(target["order"], clause) for clause in orbit.clauses
+        )
+        if matching:
+            translated.append(
+                {
+                    "target_id": str(target["target_id"]),
+                    "matching_translation_count": matching,
+                }
+            )
+    translated_ids = [str(row["target_id"]) for row in translated]
+    if source_target_id not in direct or source_target_id not in translated_ids:
+        raise AssertionError("compressed clause does not cover its source order")
+    return {
+        "source_target_id": source_target_id,
+        "direct_covered_target_ids": direct,
+        "direct_cross_target_count": sum(
+            target_id != source_target_id for target_id in direct
+        ),
+        "translated_orbit_covered_targets": translated,
+        "translated_orbit_cross_target_count": sum(
+            target_id != source_target_id for target_id in translated_ids
+        ),
+    }
+
+
+def aggregate_coverage(
+    rows: Sequence[Mapping[str, Any]],
+    targets: Sequence[Mapping[str, Any]],
+) -> dict[str, object]:
+    direct_sources: dict[str, list[str]] = defaultdict(list)
+    translated_sources: dict[str, list[str]] = defaultdict(list)
+    direct_cross_edges = 0
+    translated_cross_edges = 0
+    for row in rows:
+        source = str(row["source_target_id"])
+        coverage = row["clause_coverage"]
+        for target_id in coverage["direct_covered_target_ids"]:
+            target_id = str(target_id)
+            direct_sources[target_id].append(source)
+            direct_cross_edges += int(target_id != source)
+        for target in coverage["translated_orbit_covered_targets"]:
+            target_id = str(target["target_id"])
+            translated_sources[target_id].append(source)
+            translated_cross_edges += int(target_id != source)
+
+    target_rows = []
+    for target in targets:
+        target_id = str(target["target_id"])
+        target_rows.append(
+            {
+                "target_id": target_id,
+                "stream": str(target["stream"]),
+                "strong_lightweight_survivor": bool(
+                    target["strong_lightweight_survivor"]
+                ),
+                "direct_covering_source_ids": sorted(direct_sources[target_id]),
+                "translated_orbit_covering_source_ids": sorted(
+                    translated_sources[target_id]
+                ),
+            }
+        )
+    return {
+        "target_order_count": len(targets),
+        "compressed_source_count": len(rows),
+        "direct_covered_target_count": sum(
+            bool(row["direct_covering_source_ids"]) for row in target_rows
+        ),
+        "translated_orbit_covered_target_count": sum(
+            bool(row["translated_orbit_covering_source_ids"]) for row in target_rows
+        ),
+        "direct_cross_reuse_edge_count": direct_cross_edges,
+        "translated_orbit_cross_reuse_edge_count": translated_cross_edges,
+        "target_coverage": target_rows,
+    }
+
+
+def quotient_vector_reuse(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, object]:
+    supports = {
+        str(row["source_target_id"]): set(
+            str(value) for value in row["quotient_vector_support"]["hashes"]
+        )
+        for row in rows
+    }
+    frequency: Counter[str] = Counter()
+    sources_by_hash: dict[str, list[str]] = defaultdict(list)
+    for source, hashes in supports.items():
+        for vector_hash in hashes:
+            frequency[vector_hash] += 1
+            sources_by_hash[vector_hash].append(source)
+
+    pairwise = []
+    per_source_best: dict[str, int] = {source: 0 for source in supports}
+    for left, right in combinations(sorted(supports), 2):
+        intersection = len(supports[left] & supports[right])
+        union = len(supports[left] | supports[right])
+        per_source_best[left] = max(per_source_best[left], intersection)
+        per_source_best[right] = max(per_source_best[right], intersection)
+        if intersection:
+            pairwise.append(
+                {
+                    "left_source_target_id": left,
+                    "right_source_target_id": right,
+                    "shared_vector_count": intersection,
+                    "jaccard_fraction": intersection / union,
+                }
+            )
+
+    shared = [
+        {
+            "sha256": vector_hash,
+            "certificate_count": frequency[vector_hash],
+            "source_target_ids": sorted(sources_by_hash[vector_hash]),
+        }
+        for vector_hash in sorted(frequency)
+        if frequency[vector_hash] >= 2
+    ]
+    return {
+        "distinct_vector_count": len(frequency),
+        "shared_vector_count": len(shared),
+        "max_certificate_frequency": max(frequency.values(), default=0),
+        "shared_vectors": shared,
+        "nonzero_pairwise_overlaps": pairwise,
+        "per_source_max_pairwise_shared_vector_count": [
+            {
+                "source_target_id": source,
+                "max_pairwise_shared_vector_count": per_source_best[source],
+            }
+            for source in sorted(per_source_best)
+        ],
+    }
+
+
+def compress_run(
+    run: Mapping[str, Any],
+    *,
+    pattern_index: int,
+    trials: int,
+    seed: int,
+    tolerance: float,
+) -> dict[str, object]:
+    name = str(run["pattern"])
+    n, offsets = PATTERNS[name]
+    targets = target_orders(run)
+    compressed_rows = []
+    for model in run["seeded_cegar"]["models"]:
+        model_index = int(model["model_index"])
+        if model["full_kalmanson"].get("certificate") is None:
+            raise AssertionError("seeded source model lacks an exact certificate")
+        model_seed = seed + pattern_index * 100_000 + model_index * 1_000
+        compressed = compress_model(
+            name,
+            n,
+            offsets,
+            model,
+            trials=trials,
+            seed=model_seed,
+            tolerance=tolerance,
+        )
+        certificate = compressed["compressed_certificate"]
+        orbit = build_clause_orbit(name, model_index, certificate)
+        source_target_id = f"seeded:{model_index}"
+        compressed["source_target_id"] = source_target_id
+        compressed["random_objective_seed"] = model_seed
+        compressed["affine_clause_orbit"] = orbit.summary()
+        hashes = quotient_vector_hashes(certificate)
+        compressed["quotient_vector_support"] = {
+            "unique_vector_count": len(hashes),
+            "duplicate_inequality_vector_count": (
+                int(compressed["compressed_positive_inequalities"]) - len(hashes)
+            ),
+            "hashes": hashes,
+        }
+        compressed["clause_coverage"] = clause_coverage(
+            certificate,
+            orbit,
+            targets,
+            source_target_id=source_target_id,
+        )
+        compressed_rows.append(compressed)
+
+    return {
+        "pattern": name,
+        "n": n,
+        "circulant_offsets": offsets,
+        "target_orders": targets,
+        "compressed_models": compressed_rows,
+        "coverage_summary": aggregate_coverage(compressed_rows, targets),
+        "quotient_vector_reuse": quotient_vector_reuse(compressed_rows),
+    }
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    selected_runs = [
+        (index, run)
+        for index, run in enumerate(source["runs"])
+        if not args.pattern or str(run["pattern"]) in args.pattern
+    ]
+    runs = [
+        compress_run(
+            run,
+            pattern_index=index,
+            trials=args.trials,
+            seed=args.seed,
+            tolerance=args.tolerance,
+        )
+        for index, run in selected_runs
+    ]
+    return {
+        "type": "sparse_full_cone_seeded_clause_compression_v1",
+        "trust": "EXACT_COMPRESSED_CERTIFICATES_IN_BOUNDED_RANDOMIZED_SEARCH",
+        "status": "BOUNDED_CROSS_ORDER_CLAUSE_REUSE_DIAGNOSTIC",
+        "claim_scope": (
+            "Randomized alternative-circuit search for sixteen fixed C25/C29 "
+            "patterns and orders, followed by exact direct and translation-orbit "
+            "coverage over forty-eight stored orders. Retained certificates and "
+            "images are exact, but the search is not exhaustive and does not prove "
+            "an all-order obstruction, geometric realizability, a counterexample, "
+            "or Erdos Problem #97."
+        ),
+        "source_artifact": source_path.relative_to(ROOT).as_posix(),
+        "source_sha256": file_sha256(source_path),
+        "configuration": {
+            "trials_per_model": args.trials,
+            "seed": args.seed,
+            "per_model_seed_stride": 1_000,
+            "per_pattern_seed_stride": 100_000,
+            "tolerance": args.tolerance,
+            "target_order_selection": (
+                "all counterfactual probe and seeded CEGAR models"
+            ),
+        },
+        "runs": runs,
+    }
+
+
+def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    source_path = ROOT / str(payload["source_artifact"])
+    if file_sha256(source_path) != str(payload["source_sha256"]):
+        raise AssertionError("source seeded-CEGAR artifact hash drifted")
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    source_by_pattern = {str(run["pattern"]): run for run in source["runs"]}
+    verified_certificates = 0
+    verified_affine_images = 0
+    verified_target_orders = 0
+
+    for run in payload["runs"]:
+        name = str(run["pattern"])
+        source_run = source_by_pattern[name]
+        expected_targets = target_orders(source_run)
+        if run["target_orders"] != expected_targets:
+            raise AssertionError(f"{name} target-order packet drifted")
+        verified_target_orders += len(expected_targets)
+        source_models = {
+            int(model["model_index"]): model
+            for model in source_run["seeded_cegar"]["models"]
+        }
+        checked_rows = []
+        for row in run["compressed_models"]:
+            model_index = int(row["source_model_index"])
+            source_model = source_models[model_index]
+            order = [int(label) for label in row["order"]]
+            if order != [int(label) for label in source_model["order"]]:
+                raise AssertionError(f"{name} compression source order drifted")
+            certificate = row["compressed_certificate"]
+            checked = check_certificate_dict(certificate)
+            if not checked.zero_sum_verified:
+                raise AssertionError(f"{name} compressed certificate failed")
+            quads = certificate_order_quads(certificate, order)
+            if len(quads) != int(row["compressed_unique_ordered_quad_count"]):
+                raise AssertionError(f"{name} compressed width drifted")
+            source_width = int(row["source_unique_ordered_quad_count"])
+            if source_width - len(quads) != int(row["quad_reduction"]):
+                raise AssertionError(f"{name} compression reduction drifted")
+            circuit_audit = positive_circuit_audit(certificate)
+            if circuit_audit != row["positive_circuit_audit"]:
+                raise AssertionError(f"{name} positive-circuit audit drifted")
+            if not circuit_audit["positive_circuit_verified"]:
+                raise AssertionError(f"{name} compressed support is not a circuit")
+
+            hashes = quotient_vector_hashes(certificate)
+            expected_vector_support = {
+                "unique_vector_count": len(hashes),
+                "duplicate_inequality_vector_count": (
+                    checked.positive_inequalities - len(hashes)
+                ),
+                "hashes": hashes,
+            }
+            if row["quotient_vector_support"] != expected_vector_support:
+                raise AssertionError(f"{name} quotient-vector support drifted")
+
+            orbit = build_clause_orbit(name, model_index, certificate)
+            if row["affine_clause_orbit"] != orbit.summary():
+                raise AssertionError(f"{name} compressed affine orbit drifted")
+            source_target_id = f"seeded:{model_index}"
+            expected_coverage = clause_coverage(
+                certificate,
+                orbit,
+                expected_targets,
+                source_target_id=source_target_id,
+            )
+            if row["clause_coverage"] != expected_coverage:
+                raise AssertionError(f"{name} compressed clause coverage drifted")
+            checked_rows.append(row)
+            verified_certificates += 1
+            verified_affine_images += orbit.affine_map_count
+
+        if run["coverage_summary"] != aggregate_coverage(
+            checked_rows, expected_targets
+        ):
+            raise AssertionError(f"{name} aggregate coverage drifted")
+        if run["quotient_vector_reuse"] != quotient_vector_reuse(checked_rows):
+            raise AssertionError(f"{name} quotient-vector reuse drifted")
+
+    return {
+        "status": "OK",
+        "verified_target_orders": verified_target_orders,
+        "verified_compressed_exact_certificates": verified_certificates,
+        "verified_exact_affine_certificate_images": verified_affine_images,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--pattern", action="append", choices=sorted(PATTERNS))
+    parser.add_argument("--trials", type=int, default=24)
+    parser.add_argument("--seed", type=int, default=20260729)
+    parser.add_argument("--tolerance", type=float, default=1.0e-9)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.trials <= 0 or args.tolerance <= 0:
+        raise SystemExit("trials and tolerance must be positive")
+    if args.check is not None:
+        payload = json.loads(args.check.read_text(encoding="utf-8"))
+        print(json.dumps(check_payload(payload), indent=2, sort_keys=True))
+        return 0
+
+    payload = build_payload(args)
+
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8", newline="\n")
+    if args.json or args.out is None:
+        print(text, end="")
+    else:
+        for run in payload["runs"]:
+            sizes = [
+                f"{row['source_unique_ordered_quad_count']}->"
+                f"{row['compressed_unique_ordered_quad_count']}"
+                for row in run["compressed_models"]
+            ]
+            coverage = run["coverage_summary"]
+            print(
+                f"{run['pattern']}: {', '.join(sizes)} "
+                f"direct_cross={coverage['direct_cross_reuse_edge_count']} "
+                f"translated_cross="
+                f"{coverage['translated_orbit_cross_reuse_edge_count']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/exploration/compress_sparse_full_cone_seeded_certificates.py
+++ b/scripts/exploration/compress_sparse_full_cone_seeded_certificates.py
@@ -367,17 +367,30 @@ def build_payload(args: argparse.Namespace) -> dict[str, object]:
 
 
 def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    if payload["type"] != "sparse_full_cone_seeded_clause_compression_v1":
+        raise AssertionError("seeded compression artifact type drifted")
     source_path = ROOT / str(payload["source_artifact"])
     if file_sha256(source_path) != str(payload["source_sha256"]):
         raise AssertionError("source seeded-CEGAR artifact hash drifted")
     source = json.loads(source_path.read_text(encoding="utf-8"))
     source_by_pattern = {str(run["pattern"]): run for run in source["runs"]}
+    source_pattern_indices = {
+        str(run["pattern"]): index for index, run in enumerate(source["runs"])
+    }
+    configuration = payload["configuration"]
+    base_seed = int(configuration["seed"])
+    pattern_stride = int(configuration["per_pattern_seed_stride"])
+    model_stride = int(configuration["per_model_seed_stride"])
     verified_certificates = 0
     verified_affine_images = 0
     verified_target_orders = 0
+    seen_patterns: set[str] = set()
 
     for run in payload["runs"]:
         name = str(run["pattern"])
+        if name in seen_patterns or name not in source_by_pattern:
+            raise AssertionError(f"invalid or duplicate compression pattern: {name}")
+        seen_patterns.add(name)
         source_run = source_by_pattern[name]
         expected_targets = target_orders(source_run)
         if run["target_orders"] != expected_targets:
@@ -387,13 +400,40 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
             int(model["model_index"]): model
             for model in source_run["seeded_cegar"]["models"]
         }
+        rows = run["compressed_models"]
+        if len(rows) != len(source_models):
+            raise AssertionError(f"{name} compressed source count drifted")
+        seen_model_indices: set[int] = set()
         checked_rows = []
-        for row in run["compressed_models"]:
+        for row in rows:
             model_index = int(row["source_model_index"])
+            if model_index in seen_model_indices or model_index not in source_models:
+                raise AssertionError(f"{name} invalid or duplicate source model index")
+            seen_model_indices.add(model_index)
             source_model = source_models[model_index]
             order = [int(label) for label in row["order"]]
             if order != [int(label) for label in source_model["order"]]:
                 raise AssertionError(f"{name} compression source order drifted")
+            source_target_id = f"seeded:{model_index}"
+            if row["source_target_id"] != source_target_id:
+                raise AssertionError(f"{name} source target id drifted")
+            expected_seed = (
+                base_seed
+                + source_pattern_indices[name] * pattern_stride
+                + model_index * model_stride
+            )
+            if int(row["random_objective_seed"]) != expected_seed:
+                raise AssertionError(f"{name} random objective seed drifted")
+
+            source_certificate = source_model["full_kalmanson"]["certificate"]
+            source_quads = certificate_order_quads(source_certificate, order)
+            if int(source_model["full_kalmanson"]["positive_inequalities"]) != int(
+                row["source_positive_inequalities"]
+            ):
+                raise AssertionError(f"{name} source certificate support drifted")
+            if len(source_quads) != int(row["source_unique_ordered_quad_count"]):
+                raise AssertionError(f"{name} source certificate width drifted")
+
             certificate = row["compressed_certificate"]
             checked = check_certificate_dict(certificate)
             if not checked.zero_sum_verified:
@@ -424,7 +464,6 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
             orbit = build_clause_orbit(name, model_index, certificate)
             if row["affine_clause_orbit"] != orbit.summary():
                 raise AssertionError(f"{name} compressed affine orbit drifted")
-            source_target_id = f"seeded:{model_index}"
             expected_coverage = clause_coverage(
                 certificate,
                 orbit,
@@ -437,6 +476,8 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
             verified_certificates += 1
             verified_affine_images += orbit.affine_map_count
 
+        if seen_model_indices != set(source_models):
+            raise AssertionError(f"{name} compressed source set drifted")
         if run["coverage_summary"] != aggregate_coverage(
             checked_rows, expected_targets
         ):
@@ -450,8 +491,6 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
         "verified_compressed_exact_certificates": verified_certificates,
         "verified_exact_affine_certificate_images": verified_affine_images,
     }
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)

--- a/tests/test_sparse_full_cone_seeded_certificate_compression.py
+++ b/tests/test_sparse_full_cone_seeded_certificate_compression.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "exploration"
+    / "compress_sparse_full_cone_seeded_certificates.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_full_cone_seeded_compression", SCRIPT
+)
+assert SPEC is not None and SPEC.loader is not None
+COMPRESSION = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = COMPRESSION
+SPEC.loader.exec_module(COMPRESSION)
+
+SOURCE = (
+    ROOT / "data" / "runs" / "sparse_full_cone_seeded_cegar_2026-07-23" / "summary.json"
+)
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_seeded_compression_2026-07-29"
+    / "summary.json"
+)
+
+
+def source_payload() -> dict[str, object]:
+    return json.loads(SOURCE.read_text(encoding="utf-8"))
+
+
+def test_target_orders_collect_all_48_fresh_orders() -> None:
+    payload = source_payload()
+    targets = [COMPRESSION.target_orders(run) for run in payload["runs"]]
+
+    assert [len(rows) for rows in targets] == [24, 24]
+    assert sum(len(rows) for rows in targets) == 48
+    for rows in targets:
+        assert [row["target_id"] for row in rows[:2]] == ["probe:0", "probe:1"]
+        assert [row["target_id"] for row in rows[-2:]] == [
+            "seeded:6",
+            "seeded:7",
+        ]
+
+
+def test_quotient_vector_hashes_are_stable_and_deduplicated() -> None:
+    payload = source_payload()
+    model = payload["runs"][0]["seeded_cegar"]["models"][0]
+    certificate = model["full_kalmanson"]["certificate"]
+
+    first = COMPRESSION.quotient_vector_hashes(certificate)
+    second = COMPRESSION.quotient_vector_hashes(certificate)
+
+    assert first == second
+    assert first == sorted(set(first))
+    assert all(len(value) == 64 for value in first)
+    assert len(first) <= len(certificate["inequalities"])
+
+
+def test_clause_coverage_contains_its_source_order() -> None:
+    payload = source_payload()
+    run = payload["runs"][0]
+    model = run["seeded_cegar"]["models"][0]
+    certificate = model["full_kalmanson"]["certificate"]
+    orbit = COMPRESSION.build_clause_orbit(
+        str(run["pattern"]),
+        int(model["model_index"]),
+        certificate,
+    )
+
+    coverage = COMPRESSION.clause_coverage(
+        certificate,
+        orbit,
+        COMPRESSION.target_orders(run),
+        source_target_id="seeded:0",
+    )
+
+    assert "seeded:0" in coverage["direct_covered_target_ids"]
+    assert "seeded:0" in {
+        row["target_id"] for row in coverage["translated_orbit_covered_targets"]
+    }
+
+
+def test_quotient_vector_reuse_records_pairwise_overlap() -> None:
+    rows = [
+        {
+            "source_target_id": "seeded:0",
+            "quotient_vector_support": {"hashes": ["a", "b"]},
+        },
+        {
+            "source_target_id": "seeded:1",
+            "quotient_vector_support": {"hashes": ["b", "c"]},
+        },
+    ]
+
+    summary = COMPRESSION.quotient_vector_reuse(rows)
+
+    assert summary["distinct_vector_count"] == 3
+    assert summary["shared_vector_count"] == 1
+    assert summary["max_certificate_frequency"] == 2
+    assert summary["nonzero_pairwise_overlaps"] == [
+        {
+            "left_source_target_id": "seeded:0",
+            "right_source_target_id": "seeded:1",
+            "shared_vector_count": 1,
+            "jaccard_fraction": 1 / 3,
+        }
+    ]
+
+
+def test_stored_seeded_compression_packet_replays_exactly() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    assert COMPRESSION.check_payload(payload) == {
+        "status": "OK",
+        "verified_target_orders": 48,
+        "verified_compressed_exact_certificates": 16,
+        "verified_exact_affine_certificate_images": 432,
+    }

--- a/tests/test_sparse_full_cone_seeded_certificate_compression.py
+++ b/tests/test_sparse_full_cone_seeded_certificate_compression.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -125,3 +128,13 @@ def test_stored_seeded_compression_packet_replays_exactly() -> None:
         "verified_compressed_exact_certificates": 16,
         "verified_exact_affine_certificate_images": 432,
     }
+
+
+def test_checker_rejects_duplicate_source_model() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    mutated = copy.deepcopy(payload)
+    rows = mutated["runs"][0]["compressed_models"]
+    rows[1] = copy.deepcopy(rows[0])
+
+    with pytest.raises(AssertionError, match="duplicate source model index"):
+        COMPRESSION.check_payload(mutated)


### PR DESCRIPTION
## Summary

- deterministically compress all 16 exact C25/C29 seeded full-cone certificates
- exact-replay the compressed positive circuits and all 432 quotient-preserving translation images
- measure direct and translation-orbit clause coverage over all 48 stored probe/seeded orders
- record exact quotient-vector overlap, tests, documentation, and an audit-registry replay target

## Bounded findings

- seven certificates compress to 3–8 quadrilateral clauses
- no compressed certificate or translation image covers any of the 32 probe orders
- among seeded orders, C25 has 19 translated cross-certificate coverage edges and C29 has 21
- exact quotient-vector reuse is sparse (6 shared vectors for C25; 20 for C29; maximum frequency 2)

This is fixed-pattern, fixed-order sampled evidence only. It is not an all-order obstruction, geometric realizability result, counterexample, proof of Erdos Problem #97, or official/global status update.

## Validation

- required text/status/provenance/Makefile-generator/diff/Ruff checks: pass
- focused compression tests: 6 passed, including duplicate/omitted source-row rejection
- full tracked pytest suite: 1,772 passed across two non-overlapping clean shards
- all required artifact-tier commands: pass
- new exact replay: 16 compressed certificates, 432 affine images, 48 target orders: pass