### PR TITLE
Compare C25 residual seed augmentation

### DIFF
--- a/data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/README.md
+++ b/data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/README.md
@@ -1,0 +1,44 @@
+# C25 residual-seed augmentation probe
+
+Status: bounded history-disjoint exact-clause coverage diagnostic. No
+all-order obstruction, geometric counterexample, general proof, or
+official-status update is claimed.
+
+This packet blocks all 112 previously stored C25 orders under rotation and
+reversal, generates 32 fresh inverse-pair-escape orders without activating
+full-cone seed clauses, and compares three nested exact seed packets.
+
+## Result
+
+- Blocked history: `112` dihedral order classes.
+- Fresh probe: `32` orders, all lightweight-filter survivors.
+- Probe search: `563` Z3 iterations and `14,901` inverse-pair clauses.
+- Transferred-only packet: 3 orbits, 75 exact affine images, coverage `32/32`.
+- Transferred plus residual width 3: 4 orbits, 100 exact affine images,
+  coverage `32/32`.
+- Transferred plus all residuals: 11 orbits, 275 exact affine images,
+  coverage `32/32`.
+- Width-3 marginal over transferred seeds: `0`.
+- Other residual marginal over width-3 augmentation: `0`.
+- The transferred width-3 and width-14 orbits each individually cover all 32
+  probe orders.
+- Decision:
+  `STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE`.
+
+Generate:
+
+```bash
+python scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py \
+  --out data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json
+```
+
+Replay without rerunning Z3:
+
+```bash
+python scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py \
+  --check data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json
+```
+
+SHA-256 of `summary.json`:
+
+`a58f1f8caa7df997b16b225b12cd8622ef498759d3c9f43d6f0d8dda7d496502`

--- a/data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json
+++ b/data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json
@@ -1,0 +1,7316 @@
+{
+  "blocked_history": {
+    "dihedral_order_count": 112,
+    "identities": [
+      {
+        "dihedral_order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "history_id": "prior:probe:0",
+        "order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "e47ce1873ef7df7855de6ac947539b6b8cb08f69fe551b55db4dacd8594de6fa",
+        "history_id": "prior:probe:1",
+        "order_sha256": "efc4a292c226cfc11e313d0c4404977f0e4d67f8b6f44f92009cfc421b5fd29c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8a17cf46dc234917d8cfe36ff788438c4f49bf137c67a6edf37c6f305c1063df",
+        "history_id": "prior:probe:2",
+        "order_sha256": "c95c42099fef5ebc90a4037cad6d101892b494c64604c119a628293f7bf2331d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "82db3aad7af4566f9bf5624f50133b7cbe34e22b3cc2a81981c4777199a73adf",
+        "history_id": "prior:probe:3",
+        "order_sha256": "666ea584ade30a2e1f2c73701e959a53a5f62313940e4908b36c432228be554f",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "02ed07cd34ac32b87a770c4ef50acbaa24091fe89c0fed35a5d52989e08d6367",
+        "history_id": "prior:probe:4",
+        "order_sha256": "0e6cd6f07b0e787550f167b7b2618c093798a7daf6532ed7034883102e630f6a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "history_id": "prior:probe:5",
+        "order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "79babcff39c14382587e9985c2a7f29e9f235ec820f9be660d4a5b389a80c157",
+        "history_id": "prior:probe:6",
+        "order_sha256": "fff3141a6a0cb083c0c47caa9d503962f2e8df7d09b0cb7bd7feb48749db91cc",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "58ca3889b456993b7269bc29f804db9ae48ab1f1cba6e3b32fffc551643f18f2",
+        "history_id": "prior:probe:7",
+        "order_sha256": "4f1bd2dba49c94c3347c1f8d305a64c63909a7c554fb8dcae8d30043d81ff5f2",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ef45651dea4eb7f0dd109be674abd64408952f633702ede41bc2fde02d1cae72",
+        "history_id": "prior:probe:8",
+        "order_sha256": "e20270d7c562e00367c52995549417843bcef3d8603184d207639c904148c571",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "12332dd76c249041d5a28b9c81dbe613f45a41c5a2685910daa3517ad4b34027",
+        "history_id": "prior:probe:9",
+        "order_sha256": "dc61176ac8c0097851f2854c265eb7583663b5a6a2f66126bf5a03846d56e63e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "0f6cc8e662af54f44907d245f9adbd6cca93dbdbb8c14ef9a99adfcb9ac1ed0d",
+        "history_id": "prior:probe:10",
+        "order_sha256": "754426e7bc885a0f2e8fb1c853807baed5351586254e29bb8c92b0d0f7cd25ef",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "15e5a1a1fea1a5c4c47229faa4ebc023063d8e2802139a23bd754d30c5c851ea",
+        "history_id": "prior:probe:11",
+        "order_sha256": "060fe21eab6ec94f7825cfb799fd2d022cee8a3f0db90f73fd69e6154d7da5fd",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "141cf222b3b0697645027b016fa45231adbca52849dc3f7d9523cb32061d7665",
+        "history_id": "prior:probe:12",
+        "order_sha256": "d09f13e9829115f310886304f784cb62e2385fd9dcf291bd1b0db6670624e40d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "086627559e7a75648d34ad8dc52bd10baba93dabd028de442ad497dcc3c34818",
+        "history_id": "prior:probe:13",
+        "order_sha256": "2bc81b26171354d28295d62241623aadd68a98cff34fee7b7e0ec47465187abb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "bb962a4708e2b29db9d7ed570225b789a34ccca8a14ce7121ba8f514dcecb481",
+        "history_id": "prior:probe:14",
+        "order_sha256": "581f88dbcd0fe62dd4b80be4521d5ba21399a400fd50945694dc2c01287cc430",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "74e24135b5924adfadf007c806b6aa922dd473ca0b82512b9699e83ee4395b8b",
+        "history_id": "prior:probe:15",
+        "order_sha256": "6ca9c08de031a639defe03c7f5aee697b8142cc1884460d9aa314df76e2d13ec",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "cf586c61dd9f421f025969fd3dc6342bd632daf4221e035c00af56f422f07b6a",
+        "history_id": "prior:seeded:0",
+        "order_sha256": "3d9f6fafb2bdc898aaefab174932d060919b4992440954d03266ac0c4c3a8c54",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2a2374e7b829f31f5a3afc50a6115620f53894bd7b47689f9ce838591a7d3145",
+        "history_id": "prior:seeded:1",
+        "order_sha256": "b143a0412b3d7179d2dfa5ab7056fc86f0f61678f29463343201cd3755310912",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2664a62fd1f2df2ceb8c350104fbc18f01fb918c919f345a51234f0fc080a765",
+        "history_id": "prior:seeded:2",
+        "order_sha256": "7ddc43a26c71be6f9226d86a4094064ea2a56f1f87af69c787c9b50e7285fc18",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "87025881b3c0d75c80505a291d7206657e7cf8267543f6b1f4c9bfd897d402ac",
+        "history_id": "prior:seeded:3",
+        "order_sha256": "62af9cce7d384bb07a18bee0a5666e752f08ab91ff6cb8f28d94bdaec6de126a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f9be89d8cca62869c2d7500e4d75ae8a28d5cd90e8315cc711ecdc6a76899523",
+        "history_id": "prior:seeded:4",
+        "order_sha256": "e7ff334e2ba96bd7861442773e354845c776db61d2723a7fe9229928c2af8a95",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "6198d5cd8e6689d0af6250c76d076db6606ff85eaaf14a9ca1125944ecbb0f8f",
+        "history_id": "prior:seeded:5",
+        "order_sha256": "9ca9bcb9f7ac3012eddcd1faa95a2e41c5c2062ac1b662d828938d902ba81902",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "history_id": "prior:seeded:6",
+        "order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "history_id": "prior:seeded:7",
+        "order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f65bb867cbc8532d2c2c89682895ae8999d75de687ef6d03e8122039b88a60c1",
+        "history_id": "first_fresh:fresh:0",
+        "order_sha256": "b3fb01c68d5763b9f7e1145de43d85fa10593e255de1664502289aba9f2c18d5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1495f18db025b31993978b203d9884065a466f27754cbb6930c0349d027d6837",
+        "history_id": "first_fresh:fresh:1",
+        "order_sha256": "e5bbf6b4fe5c23b4d8660b0ee114ae5197a9d92f8b8a7817c809d66c67b6bc7f",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "14e2003e2113af6086da7654e7dad616e2b5b87fb06dfa1826f5e27d276da60a",
+        "history_id": "first_fresh:fresh:2",
+        "order_sha256": "fffc543b5fe7bd806e59be736acb34787451c354d733cb00cbc0d3e1d4a17ceb",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0b7138c621548805e187aa1d5f0b70c169765362a98c21535a3b7797b62c9fe",
+        "history_id": "first_fresh:fresh:3",
+        "order_sha256": "f1f588b6a76fe0727293f263ff3d40bbfe537e40293f68a9e14b7745d23a419c",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "120335beb6c2273c2f30312e297cd69ae2316e1a273044a0959d79f824424a5c",
+        "history_id": "first_fresh:fresh:4",
+        "order_sha256": "6bb23677f914747186d71bf861bd525e7f3788e608396f106b27bf70524c4637",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "history_id": "first_fresh:fresh:5",
+        "order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "history_id": "first_fresh:fresh:6",
+        "order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "history_id": "first_fresh:fresh:7",
+        "order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "history_id": "first_fresh:fresh:8",
+        "order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "history_id": "first_fresh:fresh:9",
+        "order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "history_id": "first_fresh:fresh:10",
+        "order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "history_id": "first_fresh:fresh:11",
+        "order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "169cb63c511b5342437e41bab670aca22fa1a8dd49197596a5b400c0df9aad93",
+        "history_id": "first_fresh:fresh:12",
+        "order_sha256": "7d26dac32a4f49b310623dc118741fd3eae62a98fddc3fc02343cda28982e0d2",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "history_id": "first_fresh:fresh:13",
+        "order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "history_id": "first_fresh:fresh:14",
+        "order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "history_id": "first_fresh:fresh:15",
+        "order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "history_id": "first_fresh:fresh:16",
+        "order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "history_id": "first_fresh:fresh:17",
+        "order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b2ea5b6ee6ac796d5383ae7260006a43c9ef172de728ce355103ad818c011870",
+        "history_id": "first_fresh:fresh:18",
+        "order_sha256": "ad2c330339c8d008ca9dddebd31e6e72a92f3a882529ef6afe1eb15687ac3a92",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "39344073585252f9a0c4b427237efa9eaff37765c4aebfeba914b69695fc05b3",
+        "history_id": "first_fresh:fresh:19",
+        "order_sha256": "f3ff2b091996877bb676eb68b61bd8740b052aa0b0cc11bf737b7921f33ce237",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "history_id": "first_fresh:fresh:20",
+        "order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ec5946bf2f40dc5430e51e9490586f5672dce0247712e3725efa519a53aca7de",
+        "history_id": "first_fresh:fresh:21",
+        "order_sha256": "9bca3aac19a02dae679142542a99e8f2691b6b621620d71a97ab7ae9cc651128",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "history_id": "first_fresh:fresh:22",
+        "order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "history_id": "first_fresh:fresh:23",
+        "order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "history_id": "first_fresh:fresh:24",
+        "order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "history_id": "first_fresh:fresh:25",
+        "order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "history_id": "first_fresh:fresh:26",
+        "order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "history_id": "first_fresh:fresh:27",
+        "order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "history_id": "first_fresh:fresh:28",
+        "order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "history_id": "first_fresh:fresh:29",
+        "order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "history_id": "first_fresh:fresh:30",
+        "order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "history_id": "first_fresh:fresh:31",
+        "order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "history_id": "second_fresh:fresh:0",
+        "order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "79992c5f6bd66f15584ce60b9059f4f9adf6d6c3bbfe13a6c7e985e4cc98e934",
+        "history_id": "second_fresh:fresh:1",
+        "order_sha256": "813b0573bbb49d2ec6fdd5850c98a09faf809b8d202f75b9b5039304d45fc12a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "history_id": "second_fresh:fresh:2",
+        "order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "history_id": "second_fresh:fresh:3",
+        "order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "history_id": "second_fresh:fresh:4",
+        "order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "history_id": "second_fresh:fresh:5",
+        "order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "history_id": "second_fresh:fresh:6",
+        "order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "history_id": "second_fresh:fresh:7",
+        "order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "history_id": "second_fresh:fresh:8",
+        "order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "history_id": "second_fresh:fresh:9",
+        "order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "history_id": "second_fresh:fresh:10",
+        "order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "history_id": "second_fresh:fresh:11",
+        "order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "history_id": "second_fresh:fresh:12",
+        "order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "history_id": "second_fresh:fresh:13",
+        "order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "history_id": "second_fresh:fresh:14",
+        "order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "history_id": "second_fresh:fresh:15",
+        "order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "history_id": "second_fresh:fresh:16",
+        "order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "history_id": "second_fresh:fresh:17",
+        "order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2210ce735dc632ef83e03e7b2d4a3634375c2de67696f6a365b902a9b4bc3f86",
+        "history_id": "second_fresh:fresh:18",
+        "order_sha256": "fe45925710e246345dc057ea7c935ae9c3070ad9544efd0b19be6b546fa64220",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "194f3fd7909ff96ed4d2f5e2dfd692d275d2133f0855cd649b6d759e5aab8643",
+        "history_id": "second_fresh:fresh:19",
+        "order_sha256": "ec5c74f9b07ef5d4a791ebd149abe20ec81a42ebfc23d8121afcacd22fe5fe66",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "41c5ce250a21087b96de0cd9afe6e772afe256bfba0efb86dc4b9cd866ba1775",
+        "history_id": "second_fresh:fresh:20",
+        "order_sha256": "e5bfda8732de5ace04841e34b1683f96d951c7b3c720e01ae8fbca8252cee2e2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1f94d235621cb6118fbcec853d4ce051fbc0da58aac1f6536f86c1a07a7c8ce3",
+        "history_id": "second_fresh:fresh:21",
+        "order_sha256": "f10f76dcdd591f5c4d36be49cea8e7b063f8aad6880f227da5b1541bd2fc65e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "91c0adb00ca0fc2c9c95e0a6231d9ee98bb106fd4e4be71d22321a23dd713102",
+        "history_id": "second_fresh:fresh:22",
+        "order_sha256": "c7c0cf5c2af1ee6ab12519d404279ed36f2b3c63a3f047b2f34208670ffa6a33",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "history_id": "second_fresh:fresh:23",
+        "order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "history_id": "second_fresh:fresh:24",
+        "order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "history_id": "second_fresh:fresh:25",
+        "order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "history_id": "second_fresh:fresh:26",
+        "order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "history_id": "second_fresh:fresh:27",
+        "order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "history_id": "second_fresh:fresh:28",
+        "order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "history_id": "second_fresh:fresh:29",
+        "order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "history_id": "second_fresh:fresh:30",
+        "order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "history_id": "second_fresh:fresh:31",
+        "order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "21af0fdceaa2c7b6d6fd444590571ed04a48bd7e0dce5aeafecf86e80e6b2081",
+        "history_id": "transfer_cegar_probe:0",
+        "order_sha256": "01e5595550dc1a887be1e0a5745e1ea9ab38070460f5afa569ad45df8ae3a32c",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "2ec108f7f3fbc4f5b9dbc523095b381676452797aa2384d5d4e65eb375b22f3c",
+        "history_id": "transfer_cegar_probe:1",
+        "order_sha256": "793e8e7d2770941c399debc6a5e57e4c903561f826f10991922fb616d14081c4",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "892d53605b57f7e885514c3bc240208a75c949cd05d38d6b869f9a52a222fbda",
+        "history_id": "transfer_cegar_probe:2",
+        "order_sha256": "8477beb967b9eb08f3528689ba26bed083a58f98b3aa384414b5b625d0ed28f5",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "history_id": "transfer_cegar_probe:3",
+        "order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "history_id": "transfer_cegar_probe:4",
+        "order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "history_id": "transfer_cegar_probe:5",
+        "order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "11bec0ac6af6f23f784eb87a4829063a3fcafa5afe5f0312d6f596981dd16623",
+        "history_id": "transfer_cegar_probe:6",
+        "order_sha256": "c2be4b0fce6eeeab8dff1f8c2569d23305b998bdf248f09edb0c16adcbd739a1",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "history_id": "transfer_cegar_probe:7",
+        "order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "3f394554dde1776db09fd7018a91729b93c154520d599454bb8c00b9aaf6e7f4",
+        "history_id": "transfer_cegar_probe:8",
+        "order_sha256": "c60c083264a78b314734ec064a7dfc0d27f62cf6954b1652613439d313b74f00",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "history_id": "transfer_cegar_probe:9",
+        "order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "b62b485b3882d8da27d08d57d4f9623cec3e06fb0cbab1100ef51f7d58af5760",
+        "history_id": "transfer_cegar_probe:10",
+        "order_sha256": "443391e50babb2e418cf3acce0b958bf584bbfbdd5d30cf538e5c5ed299f388e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "history_id": "transfer_cegar_probe:11",
+        "order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5198401fb43886093718c4425e1cba2cd6ba7bc36a1e43ca52f68acb1467822",
+        "history_id": "transfer_cegar_probe:12",
+        "order_sha256": "918febc87d6907cc754ee5cfd79b8a5c258ab2c0d3045606b310f3a5e076e3cc",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "history_id": "transfer_cegar_probe:13",
+        "order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "history_id": "transfer_cegar_probe:14",
+        "order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "history_id": "transfer_cegar_probe:15",
+        "order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "518976209920025e367b9beb159b8cdc524e485ef40fff87460cdc2959476cab",
+        "history_id": "transfer_cegar_residual:0",
+        "order_sha256": "e24c65ad7cd685c73d1cb969841fd4c72ecd0d56957a03239f4033de180555c6",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "5846cfb91ddf84cfda808e3f4c44d58a8cbb429d53db50f4e303fbada897be4f",
+        "history_id": "transfer_cegar_residual:1",
+        "order_sha256": "4ab9d66bab68c96f6804a8acbbb80d5e865a4e4cccbe628661f47c89878ae8cd",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "history_id": "transfer_cegar_residual:2",
+        "order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "history_id": "transfer_cegar_residual:3",
+        "order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "history_id": "transfer_cegar_residual:4",
+        "order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "history_id": "transfer_cegar_residual:5",
+        "order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "history_id": "transfer_cegar_residual:6",
+        "order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "history_id": "transfer_cegar_residual:7",
+        "order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "packet": "transfer_cegar_residual"
+      }
+    ],
+    "order_count": 112,
+    "packet_histogram": {
+      "first_fresh": 32,
+      "prior": 24,
+      "second_fresh": 32,
+      "transfer_cegar_probe": 16,
+      "transfer_cegar_residual": 8
+    }
+  },
+  "circulant_offsets": [
+    2,
+    5,
+    9,
+    14
+  ],
+  "claim_scope": "Exact coverage comparison for three nested C25 seed packets over one bounded inverse-pair-escape probe after 112 stored orders are blocked under rotation and reversal. Seed certificates and affine images are exact, but history blocking and finite limits preclude any all-order obstruction, geometric realizability result, counterexample, proof of Erdos Problem #97, or official/global status update.",
+  "comparison": {
+    "decision": "STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE",
+    "full_packet_uncovered_probe_model_indices": [],
+    "other_residuals_marginal_over_width3_order_count": 0,
+    "other_residuals_marginal_over_width3_probe_model_indices": [],
+    "width3_marginal_over_transferred_order_count": 0,
+    "width3_marginal_over_transferred_probe_model_indices": []
+  },
+  "compressed_residual_seed_templates": [
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "2a1134337269121a8b4079afa9888294b5c6529a6ddd902656d6ac01f6058a01",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 0,
+        "source_order": [
+          0,
+          14,
+          3,
+          6,
+          9,
+          17,
+          12,
+          20,
+          23,
+          1,
+          4,
+          15,
+          18,
+          7,
+          10,
+          21,
+          24,
+          2,
+          5,
+          13,
+          8,
+          16,
+          19,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 7,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "f8362079fc6ea9df386ca8b3cc210f3758db59850e2f108ad6c63017cc5b774a",
+      "max_weight": 1,
+      "ordered_quad_count": 7,
+      "positive_inequalities": 7,
+      "seed_id": "residual:0",
+      "source_model_index": 0,
+      "source_target_id": "seeded:0",
+      "weight_sum": 7
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "688754a4f2259235dee0ce04f4b92bf61a6318b4eb02aa8e6bc4d8af6171d985",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 1,
+        "source_order": [
+          0,
+          14,
+          3,
+          6,
+          9,
+          17,
+          12,
+          20,
+          23,
+          1,
+          4,
+          15,
+          18,
+          7,
+          10,
+          21,
+          24,
+          2,
+          13,
+          5,
+          8,
+          16,
+          19,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 9,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "e9efcb62532b22e33a1488b4087ed4fc29d3c763b47293de7331b909113dd98d",
+      "max_weight": 1,
+      "ordered_quad_count": 9,
+      "positive_inequalities": 9,
+      "seed_id": "residual:1",
+      "source_model_index": 1,
+      "source_target_id": "seeded:1",
+      "weight_sum": 9
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "30e4470c4e78617f43f5a3dad6cb61d5ef815069dc51cfb6ed0851cac4ac8867",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 2,
+        "source_order": [
+          0,
+          3,
+          6,
+          14,
+          9,
+          17,
+          20,
+          23,
+          1,
+          4,
+          12,
+          15,
+          7,
+          18,
+          21,
+          24,
+          10,
+          2,
+          5,
+          13,
+          16,
+          19,
+          8,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 5,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "3a3abbda9514b96acaf4ad09c589c2b1a087e08924456ca6fcf33eb9d8d35ef8",
+      "max_weight": 1,
+      "ordered_quad_count": 5,
+      "positive_inequalities": 5,
+      "seed_id": "residual:2",
+      "source_model_index": 2,
+      "source_target_id": "seeded:2",
+      "weight_sum": 5
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "08c7e636bc3eefd93c58b8f58a864916e9f84975e4ad67dab4ecae3402e8fc32",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 3,
+        "source_order": [
+          0,
+          3,
+          6,
+          14,
+          17,
+          9,
+          20,
+          23,
+          1,
+          4,
+          12,
+          15,
+          7,
+          18,
+          21,
+          24,
+          10,
+          2,
+          5,
+          13,
+          16,
+          19,
+          8,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 3,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "721ded29b8624d830c7ed6ff2c15ec544b8c8662701e03f7aadcb1863b96ccae",
+      "max_weight": 1,
+      "ordered_quad_count": 3,
+      "positive_inequalities": 3,
+      "seed_id": "residual:3",
+      "source_model_index": 3,
+      "source_target_id": "seeded:3",
+      "weight_sum": 3
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "844f79396e7613092e180c74a09acabf7ea09e34faeea3525a7846b5dedf37c2",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 4,
+        "source_order": [
+          0,
+          3,
+          11,
+          6,
+          14,
+          17,
+          20,
+          9,
+          23,
+          1,
+          4,
+          12,
+          15,
+          7,
+          18,
+          21,
+          24,
+          10,
+          2,
+          5,
+          13,
+          16,
+          19,
+          8,
+          22
+        ],
+        "source_unique_ordered_quad_count": 7,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "58873106a85fd064758c92dab5ed86e479b6de082e9964e0d939e3f7617c36c3",
+      "max_weight": 1,
+      "ordered_quad_count": 7,
+      "positive_inequalities": 7,
+      "seed_id": "residual:4",
+      "source_model_index": 4,
+      "source_target_id": "seeded:4",
+      "weight_sum": 7
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "9443f651b1c48564f709c3a3f6b31982163e24554d34cb161368838e8f0a82bc",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 5,
+        "source_order": [
+          0,
+          3,
+          6,
+          14,
+          9,
+          17,
+          20,
+          23,
+          1,
+          12,
+          4,
+          7,
+          15,
+          18,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          11,
+          19,
+          22
+        ],
+        "source_unique_ordered_quad_count": 4,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "fc724cd90b08c77c9e596e081bf5de1b03fb9f34fe32486a7daddf39eebb9cb9",
+      "max_weight": 1,
+      "ordered_quad_count": 4,
+      "positive_inequalities": 4,
+      "seed_id": "residual:5",
+      "source_model_index": 5,
+      "source_target_id": "seeded:5",
+      "weight_sum": 4
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "b0a00925436f41f730b62d9d038110d3d2f378b6bc7a315cd89e28915b934e68",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 6,
+        "source_order": [
+          0,
+          3,
+          6,
+          14,
+          9,
+          17,
+          20,
+          23,
+          1,
+          12,
+          4,
+          7,
+          15,
+          18,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          19,
+          11,
+          22
+        ],
+        "source_unique_ordered_quad_count": 6,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "1b589e8f5a2740c1ffb0244713b246e8cb9d48bc72d3caf358a280528f1b9805",
+      "max_weight": 1,
+      "ordered_quad_count": 6,
+      "positive_inequalities": 6,
+      "seed_id": "residual:6",
+      "source_model_index": 6,
+      "source_target_id": "seeded:6",
+      "weight_sum": 6
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "46e63bc7b5da9b7781532a95387b53cee9065d4becae5aa8409b1a102cc9b4aa",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 7,
+        "source_order": [
+          0,
+          3,
+          14,
+          6,
+          9,
+          17,
+          20,
+          23,
+          1,
+          12,
+          4,
+          7,
+          15,
+          18,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          11,
+          19,
+          22
+        ],
+        "source_unique_ordered_quad_count": 4,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "75509de4030d9b89c00358503d3ed00f9d1733e07666eb1c2035f7cfbbae9814",
+      "max_weight": 1,
+      "ordered_quad_count": 4,
+      "positive_inequalities": 4,
+      "seed_id": "residual:7",
+      "source_model_index": 7,
+      "source_target_id": "seeded:7",
+      "weight_sum": 4
+    }
+  ],
+  "configuration": {
+    "conflict_cap": 1024,
+    "history_equivalence": "cyclic rotation and reversal",
+    "history_order_count": 112,
+    "packet_comparison": [
+      "transferred_only",
+      "transferred_plus_width3",
+      "transferred_plus_all_residuals"
+    ],
+    "pattern": "C25_sidon_2_5_9_14",
+    "probe_max_iterations": 12000,
+    "probe_order_limit": 32,
+    "random_seed": 20260729
+  },
+  "first_fresh_stream_artifact": "data/runs/sparse_full_cone_small_template_fresh_stream_2026-07-29/summary.json",
+  "first_fresh_stream_sha256": "4f1f444405a1316e0acf6fbd1da850a32932c2c6477bfe3e90b4aa62b3a1aa3c",
+  "n": 25,
+  "packet_coverage": [
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 75,
+      "matching_orbit_clause_occurrences": 280,
+      "packet_id": "transferred_only",
+      "probe_order_count": 32,
+      "seed_orbit_count": 3,
+      "unique_clause_count": 75
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 100,
+      "matching_orbit_clause_occurrences": 417,
+      "packet_id": "transferred_plus_width3",
+      "probe_order_count": 32,
+      "seed_orbit_count": 4,
+      "unique_clause_count": 100
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 275,
+      "matching_orbit_clause_occurrences": 809,
+      "packet_id": "transferred_plus_all_residuals",
+      "probe_order_count": 32,
+      "seed_orbit_count": 11,
+      "unique_clause_count": 275
+    }
+  ],
+  "pattern": "C25_sidon_2_5_9_14",
+  "per_seed_coverage": [
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 206,
+      "ordered_quad_count": 3,
+      "seed_family": "transferred",
+      "seed_id": "C25_sidon_2_5_9_14:fresh-28:w3:6459e9d4dd618172",
+      "source_model_index": 28,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10,
+        13,
+        14,
+        15,
+        22,
+        23,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 22,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10,
+        13,
+        14,
+        15,
+        22,
+        23,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 22,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 26,
+      "ordered_quad_count": 5,
+      "seed_family": "transferred",
+      "seed_id": "C25_sidon_2_5_9_14:fresh-19:w5:e0b19b1c4bee1919",
+      "source_model_index": 19,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 48,
+      "ordered_quad_count": 14,
+      "seed_family": "transferred",
+      "seed_id": "C25_sidon_2_5_9_14:fresh-15:w14:0b360a662009eea4",
+      "source_model_index": 15,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 44,
+      "ordered_quad_count": 7,
+      "seed_family": "residual",
+      "seed_id": "residual:0",
+      "source_model_index": 0,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        3,
+        16,
+        17,
+        18,
+        19,
+        20,
+        26,
+        27,
+        28,
+        29,
+        30
+      ],
+      "covered_probe_order_count": 13,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        3,
+        16,
+        17,
+        18,
+        19,
+        20,
+        26,
+        27,
+        28,
+        29,
+        30
+      ],
+      "covered_strong_probe_order_count": 13,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 13,
+      "ordered_quad_count": 9,
+      "seed_family": "residual",
+      "seed_id": "residual:1",
+      "source_model_index": 1,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 30,
+      "covered_strong_probe_model_indices": [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 30,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 81,
+      "ordered_quad_count": 5,
+      "seed_family": "residual",
+      "seed_id": "residual:2",
+      "source_model_index": 2,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 137,
+      "ordered_quad_count": 3,
+      "seed_family": "residual",
+      "seed_id": "residual:3",
+      "source_model_index": 3,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        12,
+        13,
+        14,
+        15,
+        16,
+        18,
+        20,
+        21,
+        23,
+        25,
+        27,
+        28,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 18,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        12,
+        13,
+        14,
+        15,
+        16,
+        18,
+        20,
+        21,
+        23,
+        25,
+        27,
+        28,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 18,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 20,
+      "ordered_quad_count": 7,
+      "seed_family": "residual",
+      "seed_id": "residual:4",
+      "source_model_index": 4,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 83,
+      "ordered_quad_count": 4,
+      "seed_family": "residual",
+      "seed_id": "residual:5",
+      "source_model_index": 5,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 32,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 32,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 69,
+      "ordered_quad_count": 6,
+      "seed_family": "residual",
+      "seed_id": "residual:6",
+      "source_model_index": 6,
+      "unique_clause_count": 25
+    },
+    {
+      "covered_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_probe_order_count": 31,
+      "covered_strong_probe_model_indices": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31
+      ],
+      "covered_strong_probe_order_count": 31,
+      "exact_affine_image_count": 25,
+      "matching_orbit_clause_occurrences": 82,
+      "ordered_quad_count": 4,
+      "seed_family": "residual",
+      "seed_id": "residual:7",
+      "source_model_index": 7,
+      "unique_clause_count": 25
+    }
+  ],
+  "probe": {
+    "blocked_history_dihedral_order_count": 112,
+    "inverse_pair_clause_count": 14901,
+    "inverse_pair_escape_order_count": 32,
+    "iterations": 563,
+    "models": [
+      {
+        "dihedral_order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          14,
+          17,
+          20,
+          6,
+          23,
+          9,
+          12,
+          1,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          13,
+          24,
+          2,
+          5,
+          16,
+          19,
+          8,
+          22,
+          11
+        ],
+        "order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "probe_model_index": 0,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 412
+      },
+      {
+        "dihedral_order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          14,
+          17,
+          20,
+          23,
+          6,
+          9,
+          12,
+          1,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          13,
+          24,
+          2,
+          5,
+          16,
+          19,
+          8,
+          22,
+          11
+        ],
+        "order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "probe_model_index": 1,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 413
+      },
+      {
+        "dihedral_order_sha256": "1c386c157cf50020135c32b97b2bd1252a10e0a76acc05739ebd1f79813cab0b",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          20,
+          23,
+          6,
+          9,
+          12,
+          1,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          13,
+          24,
+          2,
+          5,
+          16,
+          19,
+          8,
+          22,
+          11
+        ],
+        "order_sha256": "2968b0a163e6b15c9a4fd3ae309091089b864290224eff954088809fea1786aa",
+        "probe_model_index": 2,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 9,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 414
+      },
+      {
+        "dihedral_order_sha256": "6dc35b1d65c62e2042ff2f2274085bb0d5e54b8f93048bdcb02beff769356f7e",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          20,
+          23,
+          6,
+          9,
+          12,
+          15,
+          1,
+          4,
+          18,
+          7,
+          21,
+          10,
+          13,
+          24,
+          2,
+          5,
+          16,
+          19,
+          8,
+          22,
+          11
+        ],
+        "order_sha256": "c98f9fda4a774c274f83baf63ad5fe0be5e64d5110323e63decf1b243e42b4a6",
+        "probe_model_index": 3,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 415
+      },
+      {
+        "dihedral_order_sha256": "f8f07b4dfa0c7b5b1cdb5e52ec58e09f720179fe9c2bd6e15132f3adf1e94023",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "9cfffb312b0cbe7074847072c804ef7890f0de69cd2a3475901941885ef11098",
+        "probe_model_index": 4,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 9,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 536
+      },
+      {
+        "dihedral_order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          11,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "probe_model_index": 5,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 537
+      },
+      {
+        "dihedral_order_sha256": "ba04e21c82460534a05f784da7af74b5db4579daf575969d2f3664c64527d8c2",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          3,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "58ef1145544aba90699ee3949e67dac9f93ee20e108de7a7ed81c3a50ce1f882",
+        "probe_model_index": 6,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 538
+      },
+      {
+        "dihedral_order_sha256": "eaff5f7030f3780b3ac105f0031dab52a5aa483dc42d156895a227713fd3d357",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          8,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          19,
+          22,
+          5
+        ],
+        "order_sha256": "aa82c870cdec719876a50964d030d7c13da82a632c3a0f16ce05efaa8a41a6aa",
+        "probe_model_index": 7,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 539
+      },
+      {
+        "dihedral_order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          8,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          19,
+          5,
+          22
+        ],
+        "order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "probe_model_index": 8,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 540
+      },
+      {
+        "dihedral_order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "probe_model_index": 9,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 11,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 11,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 11,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 11,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 541
+      },
+      {
+        "dihedral_order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          3,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "probe_model_index": 10,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 542
+      },
+      {
+        "dihedral_order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          11,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "probe_model_index": 11,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 543
+      },
+      {
+        "dihedral_order_sha256": "30f362230bc2ecc4c569923228b5a4ce003220f93c3869bcd57bad5a6f8240fe",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          8,
+          11,
+          14,
+          17,
+          3,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          19,
+          22,
+          5
+        ],
+        "order_sha256": "fd1d0c8af17efe869c2a5eaa37f44d2ff196df14e2f4e2b5d645d1fa3f7ebf2e",
+        "probe_model_index": 12,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 544
+      },
+      {
+        "dihedral_order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          8,
+          11,
+          14,
+          17,
+          3,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          19,
+          5,
+          22
+        ],
+        "order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "probe_model_index": 13,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 545
+      },
+      {
+        "dihedral_order_sha256": "4a99c5a82c42e9253460d4e3612a3b4d30d567e71749a417bb9378be8a3ebc52",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          3,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "a343ff07c8321bf23451fe9b7cefad97adaa8f48e9557f25187f4cab5d732760",
+        "probe_model_index": 14,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 546
+      },
+      {
+        "dihedral_order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          3,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "probe_model_index": 15,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 8,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 8,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 8,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 8,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 547
+      },
+      {
+        "dihedral_order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          11,
+          14,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "probe_model_index": 16,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 548
+      },
+      {
+        "dihedral_order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "probe_model_index": 17,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 9,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 549
+      },
+      {
+        "dihedral_order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          3,
+          14,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "probe_model_index": 18,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 550
+      },
+      {
+        "dihedral_order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          20,
+          3,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "probe_model_index": 19,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 551
+      },
+      {
+        "dihedral_order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          3,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "probe_model_index": 20,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 552
+      },
+      {
+        "dihedral_order_sha256": "e71b60f92693ae63a66e0e0805134f1436381cd85e61e4cfcf0fb9c7843d4fd3",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          3,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "383b5131a68b22240a74ec5281be3ba01a372dc02241d9b706d11a80e66bae0c",
+        "probe_model_index": 21,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 553
+      },
+      {
+        "dihedral_order_sha256": "7ae8308d62d26f3fbefa7a9862f88a26c3a1aa2cc4a51f07c5e2cfd0fd7b67e2",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "47cbe888ff88b45b833d8fd1f8dc89bca00656bf9795ef484a3a481345b027f3",
+        "probe_model_index": 22,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 7,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 554
+      },
+      {
+        "dihedral_order_sha256": "8ccd5b799ffa1e43f5b47f14a140bb0a6484ff859f9621f0a41bfb294c9a6869",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          3,
+          14,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "4c6f5a3aea2e6afe78c2ae409b429cd35c9c06ea7cc1ac23a355ac50f97ca0bd",
+        "probe_model_index": 23,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 555
+      },
+      {
+        "dihedral_order_sha256": "715ff051ef4e9563096c2798eaa5894890379a3089e5875874e624b9799cabb7",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          20,
+          3,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "e4706b5d6ecbd1b1f03ae78cf2f130f9b962e32236ada16185baf6b25f4d40f7",
+        "probe_model_index": 24,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 556
+      },
+      {
+        "dihedral_order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          11,
+          14,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          21,
+          4,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "probe_model_index": 25,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 557
+      },
+      {
+        "dihedral_order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          20,
+          3,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "probe_model_index": 26,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 558
+      },
+      {
+        "dihedral_order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          3,
+          11,
+          14,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "probe_model_index": 27,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 559
+      },
+      {
+        "dihedral_order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          3,
+          14,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "probe_model_index": 28,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 560
+      },
+      {
+        "dihedral_order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "probe_model_index": 29,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 9,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 9,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 561
+      },
+      {
+        "dihedral_order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          3,
+          20,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "probe_model_index": 30,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 6,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 1
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 5,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 1
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 6,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 5,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 562
+      },
+      {
+        "dihedral_order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          17,
+          3,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          7,
+          10,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "probe_model_index": 31,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 8,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 15
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 3
+          },
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 4
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 5
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 6
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 7
+          }
+        ],
+        "seed_packet_matches": {
+          "transferred_only": [
+            {
+              "matching_orbit_clause_count": 8,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            }
+          ],
+          "transferred_plus_all_residuals": [
+            {
+              "matching_orbit_clause_count": 8,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 0
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 2
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 4
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 5
+            },
+            {
+              "matching_orbit_clause_count": 3,
+              "source_model_index": 6
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 7
+            }
+          ],
+          "transferred_plus_width3": [
+            {
+              "matching_orbit_clause_count": 8,
+              "source_model_index": 28
+            },
+            {
+              "matching_orbit_clause_count": 2,
+              "source_model_index": 19
+            },
+            {
+              "matching_orbit_clause_count": 1,
+              "source_model_index": 15
+            },
+            {
+              "matching_orbit_clause_count": 4,
+              "source_model_index": 3
+            }
+          ]
+        },
+        "z3_iteration": 563
+      }
+    ],
+    "solver_result": "bounded_after_inverse_pair_escape_models",
+    "status": "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+  },
+  "source_cegar_artifact": "data/runs/sparse_full_cone_c25_transfer_cegar_2026-07-29/summary.json",
+  "source_cegar_sha256": "7d61f34c8bc0e96b9ce70a9021f735f0cbdbe93647574239c0234aa5bb48e5c4",
+  "source_compression_artifact": "data/runs/sparse_full_cone_c25_transfer_residual_compression_2026-07-29/summary.json",
+  "source_compression_sha256": "e90b7af7af1bac40d61606b6e9f7d400232bbe6d648860e5cc0d8519b2536dea",
+  "source_transfer_artifact": "data/runs/sparse_full_cone_fresh_template_transfer_2026-07-29/summary.json",
+  "source_transfer_sha256": "fe2af90c417640f32e5c91cba539bea85cc1441721f81b3d0e4e7c97e566d308",
+  "status": "BOUNDED_C25_RESIDUAL_SEED_PACKET_COMPARISON",
+  "transferred_seed_templates": [
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 28,
+        "source_order": [
+          0,
+          14,
+          17,
+          3,
+          6,
+          9,
+          20,
+          23,
+          12,
+          15,
+          1,
+          4,
+          7,
+          18,
+          10,
+          21,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 3,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "208e5267b8492857aee1419ecfe360c84ef365b86496726caed2e6f832aee6db",
+      "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+      "max_weight": 1,
+      "ordered_quad_count": 3,
+      "positive_inequalities": 3,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 28,
+      "source_target_id": "fresh:28",
+      "template_id": "C25_sidon_2_5_9_14:fresh-28:w3:6459e9d4dd618172",
+      "weight_sum": 3
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 19,
+        "source_order": [
+          0,
+          3,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          1,
+          12,
+          4,
+          15,
+          18,
+          7,
+          21,
+          10,
+          24,
+          2,
+          13,
+          5,
+          16,
+          19,
+          22,
+          8,
+          11
+        ],
+        "source_unique_ordered_quad_count": 5,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f68d46d4978292392c65fda379bf7ab80d51230f1aaa0b03f856506902b3399e",
+      "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+      "max_weight": 1,
+      "ordered_quad_count": 5,
+      "positive_inequalities": 5,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 19,
+      "source_target_id": "fresh:19",
+      "template_id": "C25_sidon_2_5_9_14:fresh-19:w5:e0b19b1c4bee1919",
+      "weight_sum": 5
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 15,
+        "source_order": [
+          0,
+          14,
+          3,
+          6,
+          17,
+          20,
+          23,
+          1,
+          9,
+          12,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          19,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 14,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f22b31f1c564b1456c9f0882bcedee26fe51161cdd64141ff4f96f06f79e71f1",
+      "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+      "max_weight": 1,
+      "ordered_quad_count": 14,
+      "positive_inequalities": 14,
+      "seed_role": "SECONDARY_PRIOR_PACKET_TRANSFER",
+      "source_model_index": 15,
+      "source_target_id": "fresh:15",
+      "template_id": "C25_sidon_2_5_9_14:fresh-15:w14:0b360a662009eea4",
+      "weight_sum": 14
+    }
+  ],
+  "trust": "EXACT_CLAUSE_COVERAGE_IN_BOUNDED_HISTORY_DISJOINT_C25_PROBE",
+  "type": "sparse_full_cone_c25_residual_seed_augmentation_probe_v1"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -733,10 +733,14 @@ and must not assume that the finite `n=9` pivot census generalizes.
    eight to exact widths `3`--`9`, verifies 150 affine cross-edges, and finds
    that the new width-`3` orbit alone covers all eight residual orders plus
    the same 14/16 probe orders reached by the transferred seeds. The two
-   original probe escapes remain uncovered. Next compare width-`3`-only and
-   all-eight residual augmentation on a new history-disjoint C25 probe before
-   extending certificate learning. Stop the current C29 template-mining
-   route. This is still not an all-order obstruction.
+   original probe escapes remain uncovered. The completed augmentation audit
+   in `docs/sparse-full-cone-c25-residual-seed-augmentation.md` then blocks all
+   112 known orders and finds 32/32 transferred-seed coverage on a new probe;
+   adding the residual width-`3` orbit or all eight residual orbits adds zero
+   covered orders. Stop residual seed augmentation and screen the two original
+   probe escapes `probe:0` and `probe:1` against the full Kalmanson cone before
+   extending order-search limits. Stop the current C29 template-mining route.
+   This is still not an all-order obstruction.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external

--- a/docs/index.md
+++ b/docs/index.md
@@ -991,6 +991,10 @@ put detailed reconciliation in the canonical synthesis.
   exact compression of all eight C25 residual certificates to widths 3--9;
   one new width-3 orbit covers the full residual packet while the two original
   probe escapes remain outside all stored seed orbits.
+- [`sparse-full-cone-c25-residual-seed-augmentation.md`](sparse-full-cone-c25-residual-seed-augmentation.md):
+  exact comparison of three nested C25 seed packets on 32 orders disjoint from
+  112-order history; transferred seeds cover all 32, so residual augmentation
+  adds no marginal order coverage and stops.
 - [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
   cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
   numerical evidence only, not an exact coordinate certificate.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -724,9 +724,13 @@ benchmarks for the larger frontier:
   exact continuation decision: all eight residuals compress to widths
   `3`--`9`, the width-`3` orbit alone covers the residual packet and 14/16
   probe orders, and the same two probe orders remain outside every stored
-  seed orbit. Compare width-`3`-only and all-eight residual augmentation on a
-  new C25 probe before more certificate learning; keep the current C29
-  template family stopped;
+  seed orbit;
+- use `docs/sparse-full-cone-c25-residual-seed-augmentation.md` as the
+  marginal-coverage decision: after 112 history blocks the transferred seeds
+  cover all 32 new probe orders, while width-`3`-only and all-eight residual
+  augmentation add zero covered orders. Stop residual augmentation and screen
+  the two original probe escapes exactly before more order-search budget; keep
+  the current C29 template family stopped;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 

--- a/docs/sparse-full-cone-c25-residual-seed-augmentation.md
+++ b/docs/sparse-full-cone-c25-residual-seed-augmentation.md
@@ -1,0 +1,97 @@
+# C25 residual-seed augmentation probe
+
+Status: bounded exact-clause coverage comparison for one fixed C25 quotient.
+No general proof, all-order C25 obstruction, geometric counterexample, or
+official-status change is claimed.
+
+## Target
+
+The residual compression in
+`docs/sparse-full-cone-c25-transfer-residual-compression.md` found eight exact
+circuits of widths `3`--`9`. Its predeclared continuation rule called for a
+fresh order probe comparing the original three transferred seed orbits,
+width-3-only residual augmentation, and augmentation by all eight residual
+orbits before spending another certificate-learning budget.
+
+`scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py`
+performs that comparison without activating any full-cone clauses during order
+generation. This makes coverage counterfactual: all measured seed hits are
+evaluated only after each inverse-pair-escape order is found.
+
+## Exact history and seed packets
+
+All 112 previously stored C25 orders are blocked under cyclic rotation and
+reversal:
+
+| History packet | Orders |
+| --- | ---: |
+| Prior probe/seeded packet | 24 |
+| First fresh stream | 32 |
+| Second fresh stream | 32 |
+| Transfer-CEGAR probe | 16 |
+| Transfer-CEGAR residuals | 8 |
+| **Total** | **112** |
+
+The 112 orders are pairwise distinct under the same dihedral equivalence.
+History blocking is a novelty device, not an all-order proof rule.
+
+The comparison uses three nested exact packets:
+
+| Packet | Seed orbits | Exact affine images | Unique clauses |
+| --- | ---: | ---: | ---: |
+| Transferred only | 3 | 75 | 75 |
+| Transferred plus residual width 3 | 4 | 100 | 100 |
+| Transferred plus all residuals | 11 | 275 | 275 |
+
+Every certificate and affine image is replayed exactly through the pinned
+compression, CEGAR, transfer, and fresh-stream provenance chain.
+
+## Fresh-probe result
+
+The order probe reaches its 32-order limit after 563 Z3 iterations and 14,901
+learned inverse-pair clauses. All 32 orders survive the vertex-circle and both
+Altman lightweight filters.
+
+| Packet | Covered orders | Matching affine-clause occurrences |
+| --- | ---: | ---: |
+| Transferred only | 32/32 | 280 |
+| Transferred plus residual width 3 | 32/32 | 417 |
+| Transferred plus all residuals | 32/32 | 809 |
+
+The residual circuits increase the number of matching clauses but add no
+covered order. The width-3 residual has zero marginal coverage over the
+transferred packet, and the other seven residuals have zero marginal coverage
+over width-3 augmentation.
+
+Individual transferred-seed coverage is:
+
+| Transferred width | Covered orders | Matching occurrences |
+| ---: | ---: | ---: |
+| 3 | 32/32 | 206 |
+| 5 | 22/32 | 26 |
+| 14 | 32/32 | 48 |
+
+Thus the original width-3 and width-14 orbits each independently cover the
+entire new probe.
+
+## Decision and next target
+
+The predeclared marginal-coverage rule returns
+`STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE`. Do not add the eight
+residual orbits to the next CEGAR merely because they create more matching
+clause occurrences.
+
+The most informative remaining fixed-order targets are the two original
+transfer-CEGAR probe orders `probe:0` and `probe:1`. They survive the
+lightweight filters and remain outside all three transferred and eight
+compressed residual seed orbits. Screen those two orders against the full
+Kalmanson cone exactly before extending order-search limits: an exact positive
+circuit continues the clause route, while an exact Gordan separator would
+identify a genuine fixed-order cone escape for later geometric investigation.
+
+Replay:
+
+```bash
+python scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py \
+  --check data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json
+```

--- a/docs/sparse-full-cone-c25-transfer-residual-compression.md
+++ b/docs/sparse-full-cone-c25-transfer-residual-compression.md
@@ -76,17 +76,16 @@ complete clause geometry, not literal reuse of quotient vectors.
 
 The predeclared continuation rule fires: all eight residual circuits have
 width at most 9, all eight reuse affinely across residual orders, and every
-orbit reaches probe orders. The next bounded experiment should extend the C25
-history-disjoint order search, while preserving the two probe escapes as a
-counterfactual control:
+orbit reaches probe orders. The completed comparison in
+`docs/sparse-full-cone-c25-residual-seed-augmentation.md` blocks all 112 known
+orders and finds that the original transferred seeds already cover all 32 new
+probe orders. The width-3 residual and the other seven residuals add zero
+marginally covered orders, so residual seed augmentation stops.
 
-1. block all 112 known C25 orders under rotation and reversal;
-2. compare the original three transferred seeds plus the new width-3 orbit
-   against the full augmentation by all eight compressed residual orbits;
-3. measure marginal seed coverage on a new probe before learning more
-   full-cone certificates;
-4. stop on any unresolved full-cone model, and never interpret a bounded or
-   history-blocked solver result as an all-order conclusion.
+The next exact targets are the two original probe escapes `probe:0` and
+`probe:1`, which remain outside all 11 stored seed orbits. Screen those two
+fixed orders against the full Kalmanson cone before extending order-search
+limits.
 
 Replay:
 

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -3133,6 +3133,16 @@
         "data/runs/sparse_full_cone_c25_transfer_residual_compression_2026-07-29/summary.json"
       ],
       "claim_scope": "Replay eight exact compressed C25 positive-circuit certificates of widths 3 through 9, 200 exact quotient-preserving affine images, exact coverage over 16 probe and eight residual orders, 16 direct plus 150 affine cross-order reuse edges, and exhaustive minimum-source covers inside that finite packet. The objective search is deterministic-budget but non-exhaustive; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
+    },
+    {
+      "id": "sparse_full_cone_c25_residual_seed_augmentation_probe",
+      "command": [
+        "python",
+        "scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py",
+        "--check",
+        "data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json"
+      ],
+      "claim_scope": "Replay three transferred and eight compressed residual exact C25 seed certificates, 275 exact quotient-preserving affine images, 112 blocked historical order identities, 32 history-disjoint inverse-pair-escape probe orders, and exact coverage for three nested seed packets. The bounded probe finds zero marginal order coverage from residual augmentation; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
     }
   ],
   "make_targets": {

--- a/scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py
+++ b/scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py
@@ -68,6 +68,17 @@ DEFAULT_SOURCE = (
     / "sparse_full_cone_c25_transfer_residual_compression_2026-07-29"
     / "summary.json"
 )
+DEFAULT_PROBE_ORDER_LIMIT = 32
+DEFAULT_PROBE_MAX_ITERATIONS = 12_000
+DEFAULT_CONFLICT_CAP = 1_024
+DEFAULT_RANDOM_SEED = 20_260_729
+DEFAULT_HISTORY_ORDER_COUNT = 112
+HISTORY_EQUIVALENCE = "cyclic rotation and reversal"
+PACKET_COMPARISON = (
+    "transferred_only",
+    "transferred_plus_width3",
+    "transferred_plus_all_residuals",
+)
 
 
 def load_source_chain(
@@ -150,7 +161,7 @@ def augmented_history(
                     **hashes,
                 }
             )
-    if len(history) != 112:
+    if len(history) != DEFAULT_HISTORY_ORDER_COUNT:
         raise AssertionError("C25 augmented history must contain 112 orders")
     return history
 
@@ -453,13 +464,9 @@ def build_payload(args: argparse.Namespace) -> dict[str, object]:
             "probe_max_iterations": args.probe_max_iterations,
             "conflict_cap": args.conflict_cap,
             "random_seed": args.random_seed,
-            "history_equivalence": "cyclic rotation and reversal",
+            "history_equivalence": HISTORY_EQUIVALENCE,
             "history_order_count": len(history),
-            "packet_comparison": [
-                "transferred_only",
-                "transferred_plus_width3",
-                "transferred_plus_all_residuals",
-            ],
+            "packet_comparison": list(PACKET_COMPARISON),
         },
         "pattern": PATTERN,
         "n": n,
@@ -523,15 +530,28 @@ def check_source_chain_references(
 def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     if payload["type"] != "sparse_full_cone_c25_residual_seed_augmentation_probe_v1":
         raise AssertionError("C25 augmentation artifact type drifted")
-    compression, cegar, transfer, first = check_source_chain_references(payload)
+    source_path = ROOT / str(payload["source_compression_artifact"])
+    if source_path.resolve() != DEFAULT_SOURCE.resolve():
+        raise AssertionError("C25 augmentation source artifact drifted")
     configuration = payload["configuration"]
+    expected_configuration = {
+        "pattern": PATTERN,
+        "probe_order_limit": DEFAULT_PROBE_ORDER_LIMIT,
+        "probe_max_iterations": DEFAULT_PROBE_MAX_ITERATIONS,
+        "conflict_cap": DEFAULT_CONFLICT_CAP,
+        "random_seed": DEFAULT_RANDOM_SEED,
+        "history_equivalence": HISTORY_EQUIVALENCE,
+        "history_order_count": DEFAULT_HISTORY_ORDER_COUNT,
+        "packet_comparison": list(PACKET_COMPARISON),
+    }
+    if configuration != expected_configuration:
+        raise AssertionError("C25 augmentation configuration drifted")
+    compression, cegar, transfer, first = check_source_chain_references(payload)
     n, offsets = PATTERNS[PATTERN]
     if payload["pattern"] != PATTERN or configuration["pattern"] != PATTERN:
         raise AssertionError("C25 augmentation pattern drifted")
     if int(payload["n"]) != n or payload["circulant_offsets"] != list(offsets):
         raise AssertionError("C25 augmentation circulant metadata drifted")
-    if configuration["history_equivalence"] != "cyclic rotation and reversal":
-        raise AssertionError("C25 augmentation history equivalence drifted")
 
     history = augmented_history(transfer, first, cegar)
     history_keys = {dihedral_order_key(record["order"]) for record in history}
@@ -568,9 +588,9 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
 
     probe = payload["probe"]
     models = probe["models"]
-    probe_order_limit = int(configuration["probe_order_limit"])
-    probe_max_iterations = int(configuration["probe_max_iterations"])
-    conflict_cap = int(configuration["conflict_cap"])
+    probe_order_limit = DEFAULT_PROBE_ORDER_LIMIT
+    probe_max_iterations = DEFAULT_PROBE_MAX_ITERATIONS
+    conflict_cap = DEFAULT_CONFLICT_CAP
     iterations = int(probe["iterations"])
     if not 1 <= iterations <= probe_max_iterations:
         raise AssertionError("C25 augmentation probe iteration count drifted")
@@ -656,10 +676,18 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
-    parser.add_argument("--probe-order-limit", type=int, default=32)
-    parser.add_argument("--probe-max-iterations", type=int, default=12_000)
-    parser.add_argument("--conflict-cap", type=int, default=1_024)
-    parser.add_argument("--random-seed", type=int, default=20260729)
+    parser.add_argument(
+        "--probe-order-limit",
+        type=int,
+        default=DEFAULT_PROBE_ORDER_LIMIT,
+    )
+    parser.add_argument(
+        "--probe-max-iterations",
+        type=int,
+        default=DEFAULT_PROBE_MAX_ITERATIONS,
+    )
+    parser.add_argument("--conflict-cap", type=int, default=DEFAULT_CONFLICT_CAP)
+    parser.add_argument("--random-seed", type=int, default=DEFAULT_RANDOM_SEED)
     parser.add_argument("--out", type=Path)
     parser.add_argument("--check", type=Path)
     parser.add_argument("--json", action="store_true")

--- a/scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py
+++ b/scripts/exploration/probe_sparse_full_cone_c25_residual_seed_augmentation.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Compare compressed C25 residual seed packets on a fresh order probe.
+
+The source compression packet supplies eight exact residual circuits of widths
+three through nine.  This bounded experiment blocks all 112 previously stored
+C25 orders under rotation and reversal, generates a new inverse-pair-escape
+probe without activating any full-cone seed clauses, and compares:
+
+* the three transferred seed orbits;
+* those three seeds plus the unique width-three residual orbit; and
+* those three seeds plus all eight compressed residual orbits.
+
+Every seed certificate and affine image is exact.  The Z3 order probe is
+finite, history-blocked, and bounded, so no all-order obstruction, geometric
+realizability result, counterexample, or proof of Erdos Problem #97 is claimed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+EXPLORATION = Path(__file__).resolve().parent
+for path in (SCRIPTS, EXPLORATION):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_kalmanson_certificate import check_certificate_dict  # noqa: E402
+from compress_sparse_full_cone_c25_transfer_residuals import (  # noqa: E402
+    check_payload as check_compression_payload,
+    stable_json_sha256,
+)
+from pilot_sparse_full_cone_order_cegar import PATTERNS  # noqa: E402
+from probe_sparse_full_cone_small_templates import (  # noqa: E402
+    dihedral_order_key,
+    order_record_hashes,
+)
+from run_sparse_full_cone_c25_transfer_cegar import (  # noqa: E402
+    PATTERN,
+    c25_history,
+    c25_seed_packet,
+    check_order_record,
+    check_payload as check_cegar_payload,
+    collect_history_disjoint_probe,
+    first_fresh_stream_path,
+    history_identity,
+)
+from run_sparse_full_cone_seeded_cegar import (  # noqa: E402
+    ClauseOrbit,
+    build_clause_orbit,
+    clause_matches,
+    file_sha256,
+    unique_clauses,
+)
+
+
+DEFAULT_SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_transfer_residual_compression_2026-07-29"
+    / "summary.json"
+)
+
+
+def load_source_chain(
+    source_path: Path,
+) -> tuple[
+    dict[str, Any],
+    Path,
+    dict[str, Any],
+    Path,
+    dict[str, Any],
+    Path,
+    dict[str, Any],
+]:
+    """Load and validate the compression, CEGAR, transfer, and first stream."""
+
+    compression = json.loads(source_path.read_text(encoding="utf-8"))
+    check_compression_payload(compression)
+
+    cegar_path = ROOT / str(compression["source_artifact"])
+    if file_sha256(cegar_path) != str(compression["source_sha256"]):
+        raise AssertionError("C25 augmentation CEGAR source hash drifted")
+    cegar = json.loads(cegar_path.read_text(encoding="utf-8"))
+    check_cegar_payload(cegar)
+
+    transfer_path = ROOT / str(cegar["source_transfer_artifact"])
+    if file_sha256(transfer_path) != str(cegar["source_transfer_sha256"]):
+        raise AssertionError("C25 augmentation transfer source hash drifted")
+    transfer = json.loads(transfer_path.read_text(encoding="utf-8"))
+
+    first_path = first_fresh_stream_path(transfer)
+    first = json.loads(first_path.read_text(encoding="utf-8"))
+    return (
+        compression,
+        cegar_path,
+        cegar,
+        transfer_path,
+        transfer,
+        first_path,
+        first,
+    )
+
+
+def augmented_history(
+    transfer: Mapping[str, Any],
+    first: Mapping[str, Any],
+    cegar: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    """Return the 88 prior orders plus 16 probe and 8 residual orders."""
+
+    history = c25_history(transfer, first)
+    additions = (
+        (
+            "transfer_cegar_probe",
+            "probe_model_index",
+            cegar["counterfactual_probe"]["models"],
+        ),
+        (
+            "transfer_cegar_residual",
+            "model_index",
+            cegar["seeded_cegar"]["models"],
+        ),
+    )
+    seen = {dihedral_order_key(record["order"]) for record in history}
+    for packet, index_key, models in additions:
+        for model in models:
+            index = int(model[index_key])
+            order = [int(label) for label in model["order"]]
+            key = dihedral_order_key(order)
+            if key in seen:
+                raise AssertionError("C25 augmented history has a dihedral duplicate")
+            seen.add(key)
+            hashes = order_record_hashes(order)
+            if any(model[field] != value for field, value in hashes.items()):
+                raise AssertionError("C25 augmented history order hash drifted")
+            history.append(
+                {
+                    "history_id": f"{packet}:{index}",
+                    "packet": packet,
+                    "order": order,
+                    **hashes,
+                }
+            )
+    if len(history) != 112:
+        raise AssertionError("C25 augmented history must contain 112 orders")
+    return history
+
+
+def seed_packets(
+    compression: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+) -> tuple[
+    list[dict[str, object]],
+    list[ClauseOrbit],
+    list[dict[str, object]],
+    list[ClauseOrbit],
+]:
+    """Reconstruct the three transferred and eight compressed residual seeds."""
+
+    transferred_records, transferred_orbits = c25_seed_packet(transfer)
+    residual_records = []
+    residual_orbits = []
+    seen_hashes = {orbit.canonical_clause_sha256 for orbit in transferred_orbits}
+    for row in compression["run"]["compressed_models"]:
+        model_index = int(row["source_model_index"])
+        certificate = row["compressed_certificate"]
+        checked = check_certificate_dict(certificate)
+        if not checked.zero_sum_verified:
+            raise AssertionError("C25 residual augmentation seed failed exact replay")
+        orbit = build_clause_orbit(PATTERN, model_index, certificate)
+        if orbit.summary() != row["affine_clause_orbit"]:
+            raise AssertionError("C25 residual augmentation orbit drifted")
+        if orbit.canonical_clause_sha256 in seen_hashes:
+            raise AssertionError("C25 augmentation seed orbit is duplicated")
+        seen_hashes.add(orbit.canonical_clause_sha256)
+        width = int(row["compressed_unique_ordered_quad_count"])
+        residual_records.append(
+            {
+                "seed_id": f"residual:{model_index}",
+                "source_target_id": str(row["source_target_id"]),
+                "source_model_index": model_index,
+                "ordered_quad_count": width,
+                "compressed_certificate_sha256": stable_json_sha256(certificate),
+                "positive_inequalities": checked.positive_inequalities,
+                "weight_sum": checked.weight_sum,
+                "max_weight": checked.max_weight,
+                "affine_clause_orbit": orbit.summary(),
+            }
+        )
+        residual_orbits.append(orbit)
+
+    if len(transferred_orbits) != 3 or len(residual_orbits) != 8:
+        raise AssertionError("unexpected C25 augmentation seed packet size")
+    width_three = [
+        record for record in residual_records if int(record["ordered_quad_count"]) == 3
+    ]
+    if len(width_three) != 1:
+        raise AssertionError("C25 augmentation requires one width-three residual")
+    return (
+        transferred_records,
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+
+
+def packet_definitions(
+    transferred_orbits: Sequence[ClauseOrbit],
+    residual_records: Sequence[Mapping[str, Any]],
+    residual_orbits: Sequence[ClauseOrbit],
+) -> dict[str, list[ClauseOrbit]]:
+    width_three_indices = [
+        index
+        for index, record in enumerate(residual_records)
+        if int(record["ordered_quad_count"]) == 3
+    ]
+    if len(width_three_indices) != 1:
+        raise AssertionError("C25 width-three packet selection drifted")
+    width_three_orbit = residual_orbits[width_three_indices[0]]
+    return {
+        "transferred_only": list(transferred_orbits),
+        "transferred_plus_width3": [*transferred_orbits, width_three_orbit],
+        "transferred_plus_all_residuals": [
+            *transferred_orbits,
+            *residual_orbits,
+        ],
+    }
+
+
+def model_packet_matches(
+    order: Sequence[int],
+    packets: Mapping[str, Sequence[ClauseOrbit]],
+) -> dict[str, list[dict[str, object]]]:
+    return {
+        packet_id: clause_matches(order, orbits)
+        for packet_id, orbits in packets.items()
+    }
+
+
+def packet_coverage(
+    models: Sequence[Mapping[str, Any]],
+    packets: Mapping[str, Sequence[ClauseOrbit]],
+) -> list[dict[str, object]]:
+    result = []
+    for packet_id, orbits in packets.items():
+        covered = []
+        strong_covered = []
+        occurrences = 0
+        for model in models:
+            matches = model["seed_packet_matches"][packet_id]
+            if matches:
+                index = int(model["probe_model_index"])
+                covered.append(index)
+                if bool(model["lightweight_filters"]["survives"]):
+                    strong_covered.append(index)
+                occurrences += sum(
+                    int(match["matching_orbit_clause_count"]) for match in matches
+                )
+        result.append(
+            {
+                "packet_id": packet_id,
+                "probe_order_count": len(models),
+                "seed_orbit_count": len(orbits),
+                "exact_affine_image_count": sum(
+                    orbit.affine_map_count for orbit in orbits
+                ),
+                "unique_clause_count": len(unique_clauses(orbits)),
+                "covered_probe_model_indices": covered,
+                "covered_probe_order_count": len(covered),
+                "covered_strong_probe_model_indices": strong_covered,
+                "covered_strong_probe_order_count": len(strong_covered),
+                "matching_orbit_clause_occurrences": occurrences,
+            }
+        )
+    return result
+
+
+def per_seed_coverage(
+    models: Sequence[Mapping[str, Any]],
+    transferred_records: Sequence[Mapping[str, Any]],
+    transferred_orbits: Sequence[ClauseOrbit],
+    residual_records: Sequence[Mapping[str, Any]],
+    residual_orbits: Sequence[ClauseOrbit],
+) -> list[dict[str, object]]:
+    """Return exact individual-orbit coverage inside the fresh probe."""
+
+    result = []
+    families = (
+        ("transferred", transferred_records, transferred_orbits),
+        ("residual", residual_records, residual_orbits),
+    )
+    for family, records, orbits in families:
+        for record, orbit in zip(records, orbits):
+            covered = []
+            strong_covered = []
+            occurrences = 0
+            for model in models:
+                matches = clause_matches(model["order"], [orbit])
+                if matches:
+                    index = int(model["probe_model_index"])
+                    covered.append(index)
+                    if bool(model["lightweight_filters"]["survives"]):
+                        strong_covered.append(index)
+                    occurrences += int(matches[0]["matching_orbit_clause_count"])
+            seed_id = (
+                str(record["template_id"])
+                if family == "transferred"
+                else str(record["seed_id"])
+            )
+            result.append(
+                {
+                    "seed_family": family,
+                    "seed_id": seed_id,
+                    "source_model_index": orbit.source_model_index,
+                    "ordered_quad_count": int(record["ordered_quad_count"]),
+                    "exact_affine_image_count": orbit.affine_map_count,
+                    "unique_clause_count": len(orbit.clauses),
+                    "covered_probe_model_indices": covered,
+                    "covered_probe_order_count": len(covered),
+                    "covered_strong_probe_model_indices": strong_covered,
+                    "covered_strong_probe_order_count": len(strong_covered),
+                    "matching_orbit_clause_occurrences": occurrences,
+                }
+            )
+    return result
+
+
+def comparison_summary(
+    coverage: Sequence[Mapping[str, Any]],
+) -> dict[str, object]:
+    by_packet = {str(record["packet_id"]): record for record in coverage}
+    transferred = set(
+        int(value)
+        for value in by_packet["transferred_only"]["covered_probe_model_indices"]
+    )
+    width_three = set(
+        int(value)
+        for value in by_packet["transferred_plus_width3"]["covered_probe_model_indices"]
+    )
+    all_residuals = set(
+        int(value)
+        for value in by_packet["transferred_plus_all_residuals"][
+            "covered_probe_model_indices"
+        ]
+    )
+    if not transferred <= width_three <= all_residuals:
+        raise AssertionError("C25 seed packet coverage is not monotone")
+    probe_counts = {int(record["probe_order_count"]) for record in coverage}
+    if len(probe_counts) != 1:
+        raise AssertionError("C25 seed packet probe counts drifted")
+    probe_order_count = probe_counts.pop()
+    width_three_marginal = sorted(width_three - transferred)
+    remaining_residual_marginal = sorted(all_residuals - width_three)
+    if remaining_residual_marginal:
+        decision = "CONTINUE_C25_CEGAR_WITH_ALL_RESIDUAL_ORBITS"
+    elif width_three_marginal:
+        decision = "CONTINUE_C25_CEGAR_WITH_WIDTH3_RESIDUAL_ORBIT_ONLY"
+    else:
+        decision = "STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE"
+    return {
+        "width3_marginal_over_transferred_probe_model_indices": (width_three_marginal),
+        "width3_marginal_over_transferred_order_count": len(width_three_marginal),
+        "other_residuals_marginal_over_width3_probe_model_indices": (
+            remaining_residual_marginal
+        ),
+        "other_residuals_marginal_over_width3_order_count": len(
+            remaining_residual_marginal
+        ),
+        "full_packet_uncovered_probe_model_indices": sorted(
+            set(range(probe_order_count)) - all_residuals
+        ),
+        "decision": decision,
+    }
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    (
+        compression,
+        cegar_path,
+        cegar,
+        transfer_path,
+        transfer,
+        first_path,
+        first,
+    ) = load_source_chain(source_path)
+    history = augmented_history(transfer, first, cegar)
+    (
+        transferred_records,
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    ) = seed_packets(compression, transfer)
+    packets = packet_definitions(
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+    all_orbits = packets["transferred_plus_all_residuals"]
+    probe, _inverse_clauses = collect_history_disjoint_probe(
+        all_orbits,
+        history,
+        order_limit=args.probe_order_limit,
+        max_iterations=args.probe_max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+    )
+    for model in probe["models"]:
+        model["seed_packet_matches"] = model_packet_matches(model["order"], packets)
+    coverage = packet_coverage(probe["models"], packets)
+    comparison = comparison_summary(coverage)
+    individual_coverage = per_seed_coverage(
+        probe["models"],
+        transferred_records,
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+    n, offsets = PATTERNS[PATTERN]
+    return {
+        "type": "sparse_full_cone_c25_residual_seed_augmentation_probe_v1",
+        "trust": "EXACT_CLAUSE_COVERAGE_IN_BOUNDED_HISTORY_DISJOINT_C25_PROBE",
+        "status": "BOUNDED_C25_RESIDUAL_SEED_PACKET_COMPARISON",
+        "claim_scope": (
+            "Exact coverage comparison for three nested C25 seed packets over "
+            "one bounded inverse-pair-escape probe after 112 stored orders are "
+            "blocked under rotation and reversal. Seed certificates and affine "
+            "images are exact, but history blocking and finite limits preclude "
+            "any all-order obstruction, geometric realizability result, "
+            "counterexample, proof of Erdos Problem #97, or official/global "
+            "status update."
+        ),
+        "source_compression_artifact": source_path.relative_to(ROOT).as_posix(),
+        "source_compression_sha256": file_sha256(source_path),
+        "source_cegar_artifact": cegar_path.relative_to(ROOT).as_posix(),
+        "source_cegar_sha256": file_sha256(cegar_path),
+        "source_transfer_artifact": transfer_path.relative_to(ROOT).as_posix(),
+        "source_transfer_sha256": file_sha256(transfer_path),
+        "first_fresh_stream_artifact": first_path.relative_to(ROOT).as_posix(),
+        "first_fresh_stream_sha256": file_sha256(first_path),
+        "configuration": {
+            "pattern": PATTERN,
+            "probe_order_limit": args.probe_order_limit,
+            "probe_max_iterations": args.probe_max_iterations,
+            "conflict_cap": args.conflict_cap,
+            "random_seed": args.random_seed,
+            "history_equivalence": "cyclic rotation and reversal",
+            "history_order_count": len(history),
+            "packet_comparison": [
+                "transferred_only",
+                "transferred_plus_width3",
+                "transferred_plus_all_residuals",
+            ],
+        },
+        "pattern": PATTERN,
+        "n": n,
+        "circulant_offsets": list(offsets),
+        "transferred_seed_templates": transferred_records,
+        "compressed_residual_seed_templates": residual_records,
+        "blocked_history": {
+            "order_count": len(history),
+            "dihedral_order_count": len(
+                {dihedral_order_key(record["order"]) for record in history}
+            ),
+            "packet_histogram": dict(
+                sorted(Counter(str(record["packet"]) for record in history).items())
+            ),
+            "identities": history_identity(history),
+        },
+        "probe": probe,
+        "packet_coverage": coverage,
+        "per_seed_coverage": individual_coverage,
+        "comparison": comparison,
+    }
+
+
+def check_source_chain_references(
+    payload: Mapping[str, Any],
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    source_path = ROOT / str(payload["source_compression_artifact"])
+    if file_sha256(source_path) != str(payload["source_compression_sha256"]):
+        raise AssertionError("C25 augmentation compression hash drifted")
+    (
+        compression,
+        cegar_path,
+        cegar,
+        transfer_path,
+        transfer,
+        first_path,
+        first,
+    ) = load_source_chain(source_path)
+    expected = (
+        (cegar_path, "source_cegar_artifact", "source_cegar_sha256"),
+        (transfer_path, "source_transfer_artifact", "source_transfer_sha256"),
+        (
+            first_path,
+            "first_fresh_stream_artifact",
+            "first_fresh_stream_sha256",
+        ),
+    )
+    for path, artifact_field, hash_field in expected:
+        if payload[artifact_field] != path.relative_to(ROOT).as_posix():
+            raise AssertionError(f"C25 augmentation {artifact_field} drifted")
+        if payload[hash_field] != file_sha256(path):
+            raise AssertionError(f"C25 augmentation {hash_field} drifted")
+    return compression, cegar, transfer, first
+
+
+def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    if payload["type"] != "sparse_full_cone_c25_residual_seed_augmentation_probe_v1":
+        raise AssertionError("C25 augmentation artifact type drifted")
+    compression, cegar, transfer, first = check_source_chain_references(payload)
+    configuration = payload["configuration"]
+    n, offsets = PATTERNS[PATTERN]
+    if payload["pattern"] != PATTERN or configuration["pattern"] != PATTERN:
+        raise AssertionError("C25 augmentation pattern drifted")
+    if int(payload["n"]) != n or payload["circulant_offsets"] != list(offsets):
+        raise AssertionError("C25 augmentation circulant metadata drifted")
+    if configuration["history_equivalence"] != "cyclic rotation and reversal":
+        raise AssertionError("C25 augmentation history equivalence drifted")
+
+    history = augmented_history(transfer, first, cegar)
+    history_keys = {dihedral_order_key(record["order"]) for record in history}
+    expected_history = {
+        "order_count": len(history),
+        "dihedral_order_count": len(history_keys),
+        "packet_histogram": dict(
+            sorted(Counter(str(record["packet"]) for record in history).items())
+        ),
+        "identities": history_identity(history),
+    }
+    if payload["blocked_history"] != expected_history:
+        raise AssertionError("C25 augmentation history drifted")
+    if int(configuration["history_order_count"]) != len(history):
+        raise AssertionError("C25 augmentation history configuration drifted")
+
+    (
+        transferred_records,
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    ) = seed_packets(compression, transfer)
+    if payload["transferred_seed_templates"] != transferred_records:
+        raise AssertionError("C25 transferred augmentation seeds drifted")
+    if payload["compressed_residual_seed_templates"] != residual_records:
+        raise AssertionError("C25 residual augmentation seeds drifted")
+    packets = packet_definitions(
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+    if configuration["packet_comparison"] != list(packets):
+        raise AssertionError("C25 augmentation packet comparison drifted")
+
+    probe = payload["probe"]
+    models = probe["models"]
+    probe_order_limit = int(configuration["probe_order_limit"])
+    probe_max_iterations = int(configuration["probe_max_iterations"])
+    conflict_cap = int(configuration["conflict_cap"])
+    iterations = int(probe["iterations"])
+    if not 1 <= iterations <= probe_max_iterations:
+        raise AssertionError("C25 augmentation probe iteration count drifted")
+    inverse_count = int(probe["inverse_pair_clause_count"])
+    if not 0 <= inverse_count <= iterations * conflict_cap:
+        raise AssertionError("C25 augmentation inverse clause count drifted")
+    if int(probe["blocked_history_dihedral_order_count"]) != len(history_keys):
+        raise AssertionError("C25 augmentation blocked history count drifted")
+
+    seen = set(history_keys)
+    previous_iteration = 0
+    verified_orders = 0
+    all_orbits = packets["transferred_plus_all_residuals"]
+    for expected_index, model in enumerate(models):
+        if int(model["probe_model_index"]) != expected_index:
+            raise AssertionError("C25 augmentation probe model index drifted")
+        z3_iteration = int(model["z3_iteration"])
+        if not previous_iteration < z3_iteration <= iterations:
+            raise AssertionError("C25 augmentation probe iteration drifted")
+        previous_iteration = z3_iteration
+        order = check_order_record(model, n=n, offsets=offsets)
+        key = dihedral_order_key(order)
+        if key in seen:
+            raise AssertionError("C25 augmentation probe is not history-disjoint")
+        seen.add(key)
+        if model["seed_orbit_matches"] != clause_matches(order, all_orbits):
+            raise AssertionError("C25 augmentation all-seed matches drifted")
+        expected_matches = model_packet_matches(order, packets)
+        if model["seed_packet_matches"] != expected_matches:
+            raise AssertionError("C25 augmentation packet matches drifted")
+        verified_orders += 1
+
+    if int(probe["inverse_pair_escape_order_count"]) != len(models):
+        raise AssertionError("C25 augmentation probe order count drifted")
+    if len(models) >= probe_order_limit:
+        if len(models) != probe_order_limit:
+            raise AssertionError("C25 augmentation probe limit drifted")
+        if probe["status"] != "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED":
+            raise AssertionError("C25 augmentation bounded status drifted")
+        if probe["solver_result"] != "bounded_after_inverse_pair_escape_models":
+            raise AssertionError("C25 augmentation bounded result drifted")
+        if iterations != previous_iteration:
+            raise AssertionError("C25 augmentation terminal iteration drifted")
+    elif iterations == probe_max_iterations:
+        if probe["status"] != "BOUNDED_HISTORY_DISJOINT_PROBE_ITERATION_LIMIT":
+            raise AssertionError("C25 augmentation iteration-limit status drifted")
+        if probe["solver_result"] != "iteration_limit":
+            raise AssertionError("C25 augmentation iteration-limit result drifted")
+    elif probe["status"] == "HISTORY_DISJOINT_PROBE_SOLVER_UNSAT":
+        if probe["solver_result"] != "unsat":
+            raise AssertionError("C25 augmentation unsat result drifted")
+    elif probe["status"] != "UNKNOWN_HISTORY_DISJOINT_PROBE_SMT_RESULT":
+        raise AssertionError("C25 augmentation termination status drifted")
+
+    expected_coverage = packet_coverage(models, packets)
+    if payload["packet_coverage"] != expected_coverage:
+        raise AssertionError("C25 augmentation packet coverage drifted")
+    expected_individual_coverage = per_seed_coverage(
+        models,
+        transferred_records,
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+    if payload["per_seed_coverage"] != expected_individual_coverage:
+        raise AssertionError("C25 augmentation individual seed coverage drifted")
+    expected_comparison = comparison_summary(expected_coverage)
+    if payload["comparison"] != expected_comparison:
+        raise AssertionError("C25 augmentation comparison drifted")
+    return {
+        "status": "OK",
+        "verified_blocked_history_orders": len(history),
+        "verified_probe_orders": verified_orders,
+        "verified_transferred_seed_certificates": len(transferred_orbits),
+        "verified_residual_seed_certificates": len(residual_orbits),
+        "verified_exact_affine_seed_images": sum(
+            orbit.affine_map_count for orbit in all_orbits
+        ),
+        "decision": str(expected_comparison["decision"]),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--probe-order-limit", type=int, default=32)
+    parser.add_argument("--probe-max-iterations", type=int, default=12_000)
+    parser.add_argument("--conflict-cap", type=int, default=1_024)
+    parser.add_argument("--random-seed", type=int, default=20260729)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    limits = (
+        args.probe_order_limit,
+        args.probe_max_iterations,
+        args.conflict_cap,
+    )
+    if any(value <= 0 for value in limits):
+        raise SystemExit("all probe limits and conflict cap must be positive")
+    if args.check is not None:
+        path = args.check if args.check.is_absolute() else ROOT / args.check
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        print(json.dumps(check_payload(payload), indent=2, sort_keys=True))
+        return 0
+
+    payload = build_payload(args)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        path = args.out if args.out.is_absolute() else ROOT / args.out
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+    if args.json or args.out is None:
+        print(text, end="")
+    else:
+        coverage = {
+            str(record["packet_id"]): int(record["covered_probe_order_count"])
+            for record in payload["packet_coverage"]
+        }
+        print(
+            f"{PATTERN}: "
+            f"history={payload['blocked_history']['order_count']} "
+            f"probe={payload['probe']['inverse_pair_escape_order_count']} "
+            f"coverage={coverage} "
+            f"decision={payload['comparison']['decision']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sparse_full_cone_c25_residual_seed_augmentation.py
+++ b/tests/test_sparse_full_cone_c25_residual_seed_augmentation.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "exploration"
+    / "probe_sparse_full_cone_c25_residual_seed_augmentation.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_full_cone_c25_residual_seed_augmentation",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+PROBE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PROBE
+SPEC.loader.exec_module(PROBE)
+
+SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_transfer_residual_compression_2026-07-29"
+    / "summary.json"
+)
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_residual_seed_probe_2026-07-29"
+    / "summary.json"
+)
+
+
+def source_chain() -> tuple[object, ...]:
+    return PROBE.load_source_chain(SOURCE)
+
+
+def artifact_payload() -> dict[str, object]:
+    return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def test_augmented_history_has_112_distinct_dihedral_orders() -> None:
+    compression, cegar_path, cegar, transfer_path, transfer, first_path, first = (
+        source_chain()
+    )
+    del compression, cegar_path, transfer_path, first_path
+
+    history = PROBE.augmented_history(transfer, first, cegar)
+
+    assert len(history) == 112
+    assert Counter(record["packet"] for record in history) == {
+        "prior": 24,
+        "first_fresh": 32,
+        "second_fresh": 32,
+        "transfer_cegar_probe": 16,
+        "transfer_cegar_residual": 8,
+    }
+    assert len({PROBE.dihedral_order_key(record["order"]) for record in history}) == 112
+
+
+def test_seed_packets_have_three_transferred_and_eight_residual_orbits() -> None:
+    compression, _, _, _, transfer, _, _ = source_chain()
+    transferred_records, transferred_orbits, residual_records, residual_orbits = (
+        PROBE.seed_packets(compression, transfer)
+    )
+    packets = PROBE.packet_definitions(
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+
+    assert [record["ordered_quad_count"] for record in transferred_records] == [
+        3,
+        5,
+        14,
+    ]
+    assert [record["ordered_quad_count"] for record in residual_records] == [
+        7,
+        9,
+        5,
+        3,
+        7,
+        4,
+        6,
+        4,
+    ]
+    assert {name: len(orbits) for name, orbits in packets.items()} == {
+        "transferred_only": 3,
+        "transferred_plus_width3": 4,
+        "transferred_plus_all_residuals": 11,
+    }
+    assert sum(orbit.affine_map_count for orbit in packets["transferred_only"]) == 75
+    assert (
+        sum(
+            orbit.affine_map_count
+            for orbit in packets["transferred_plus_all_residuals"]
+        )
+        == 275
+    )
+
+
+def test_stored_probe_has_no_residual_seed_coverage_marginal() -> None:
+    payload = artifact_payload()
+    by_packet = {record["packet_id"]: record for record in payload["packet_coverage"]}
+    by_seed = {
+        (record["seed_family"], record["ordered_quad_count"], record["seed_id"]): record
+        for record in payload["per_seed_coverage"]
+    }
+
+    assert {
+        packet_id: record["covered_probe_order_count"]
+        for packet_id, record in by_packet.items()
+    } == {
+        "transferred_only": 32,
+        "transferred_plus_width3": 32,
+        "transferred_plus_all_residuals": 32,
+    }
+    assert by_packet["transferred_only"]["matching_orbit_clause_occurrences"] == 280
+    assert (
+        by_packet["transferred_plus_width3"]["matching_orbit_clause_occurrences"] == 417
+    )
+    assert (
+        by_packet["transferred_plus_all_residuals"]["matching_orbit_clause_occurrences"]
+        == 809
+    )
+    assert sorted(
+        record["covered_probe_order_count"]
+        for (family, width, _), record in by_seed.items()
+        if family == "transferred" and width in (3, 14)
+    ) == [32, 32]
+    assert payload["comparison"] == {
+        "width3_marginal_over_transferred_probe_model_indices": [],
+        "width3_marginal_over_transferred_order_count": 0,
+        "other_residuals_marginal_over_width3_probe_model_indices": [],
+        "other_residuals_marginal_over_width3_order_count": 0,
+        "full_packet_uncovered_probe_model_indices": [],
+        "decision": "STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE",
+    }
+
+
+def test_stored_c25_residual_seed_probe_replays_exactly() -> None:
+    assert PROBE.check_payload(artifact_payload()) == {
+        "status": "OK",
+        "verified_blocked_history_orders": 112,
+        "verified_probe_orders": 32,
+        "verified_transferred_seed_certificates": 3,
+        "verified_residual_seed_certificates": 8,
+        "verified_exact_affine_seed_images": 275,
+        "decision": "STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE",
+    }

--- a/tests/test_sparse_full_cone_c25_residual_seed_augmentation.py
+++ b/tests/test_sparse_full_cone_c25_residual_seed_augmentation.py
@@ -6,6 +6,8 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
@@ -156,3 +158,21 @@ def test_stored_c25_residual_seed_probe_replays_exactly() -> None:
         "verified_exact_affine_seed_images": 275,
         "decision": "STOP_C25_RESIDUAL_SEED_AUGMENTATION_AFTER_BOUNDED_PROBE",
     }
+
+def test_checker_rejects_fabricated_probe_configuration() -> None:
+    payload = artifact_payload()
+    payload["configuration"]["random_seed"] += 1
+
+    with pytest.raises(AssertionError, match="configuration drifted"):
+        PROBE.check_payload(payload)
+
+
+def test_checker_rejects_substituted_source_artifact(tmp_path: Path) -> None:
+    substitute = tmp_path / "summary.json"
+    substitute.write_bytes(SOURCE.read_bytes())
+    payload = artifact_payload()
+    payload["source_compression_artifact"] = str(substitute)
+    payload["source_compression_sha256"] = PROBE.file_sha256(substitute)
+
+    with pytest.raises(AssertionError, match="source artifact drifted"):
+        PROBE.check_payload(payload)


### PR DESCRIPTION
## Result

This packet compares three exact nested C25 seed sets on a new 32-order history-disjoint inverse-pair-escape probe:

- the original three transferred seed orbits (75 affine images),
- those seeds plus the width-3 compressed residual orbit (100 images), and
- those seeds plus all eight compressed residual orbits (275 images).

The original transferred packet already covers all 32 probe orders. Both residual augmentations add clause occurrences but zero marginal covered orders, so the bounded stopping decision is to avoid adding residual seed orbits merely for redundancy.

The artifact records the complete provenance chain, all 112 blocked-history orders, exact seed certificates and affine images, per-seed coverage, packet comparisons, and a replaying checker. Documentation, audit registration, and focused tests are included.

## Why

This closes the residual-seed-augmentation branch with an exact bounded comparison instead of carrying extra seed clauses into another CEGAR round without demonstrated coverage benefit. The next research target is an exact full-Kalmanson-cone screen of the two original persistent escapes, probe:0 and probe:1.

This is a local finite computational result only. It does not claim a general proof or counterexample for Erdos Problem #97.

## Review hardening

- pins the exact source artifact and all stored probe/search configuration
- adds regressions rejecting substituted sources and fabricated random-seed provenance
- leaves the mathematical artifact and its SHA-256 unchanged

## Validation

- fast text/status/provenance/generator/diff checks and Ruff: passed
- focused packet tests: `6 passed`
- cumulative corrected stack: `1,828 passed` across four non-overlapping tracked-test shards
- complete required artifact tier and all seven C25 packet replays: passed
- exact-head GitHub tests and artifact audit: passed