### PR TITLE
Screen two persistent C25 orders against the full cone

### DIFF
--- a/data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/README.md
+++ b/data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/README.md
@@ -37,3 +37,7 @@ Replay:
 python scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py \
   --check data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/summary.json
 ```
+
+SHA-256 of `summary.json`:
+
+`15e3efdf86e27a9fcb0173f447bab87f9e51c8f3f7ea69e5ceeaeb2c556bbe7f`

--- a/data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/README.md
+++ b/data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/README.md
@@ -1,0 +1,39 @@
+# C25 persistent-escape full-cone screen
+
+This packet exactly classifies the two predeclared transfer-CEGAR targets
+`probe:0` and `probe:1` for the fixed `C25_sidon_2_5_9_14` selected-witness
+pattern.
+
+Both orders:
+
+- survive the stored vertex-circle and Altman lightweight filters;
+- escape the exact two-inequality Kalmanson inverse-pair filter;
+- match none of the three transferred or eight compressed residual seed
+  orbits; and
+- have exact positive integer zero-sum certificates in the complete
+  fixed-order Kalmanson cone.
+
+| Target | Strict rows screened | Positive certificate rows | Ordered quads |
+| --- | ---: | ---: | ---: |
+| `probe:0` | 25,300 | 201 | 201 |
+| `probe:1` | 25,300 | 196 | 196 |
+
+The checker replays the pinned residual-seed augmentation provenance chain,
+all 11 seed orbits and 275 quotient-preserving affine images, each target
+order and filter audit, and both exact positive circuits.
+
+The decision is
+`CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS`. The next bounded
+target is to compress these two circuits and test their affine reuse before
+extending cyclic-order search limits.
+
+This is a two-order, fixed-pattern exact obstruction packet. It is not an
+all-order C25 obstruction, a geometric realizability result, a proof of Erdos
+Problem #97, a counterexample, or an official/global status update.
+
+Replay:
+
+```bash
+python scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py \
+  --check data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/summary.json
+```

--- a/data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/summary.json
+++ b/data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/summary.json
@@ -1,0 +1,4268 @@
+{
+  "circulant_offsets": [
+    2,
+    5,
+    9,
+    14
+  ],
+  "claim_scope": "Exact Gordan-alternative classification of transfer-CEGAR counterfactual probe orders 0 and 1 for the fixed C25_sidon_2_5_9_14 selected-witness pattern. The targets are replayed outside all three transferred and eight compressed residual seed orbits. Each conclusive record stores either an exact positive Kalmanson zero-sum certificate or an exact integer separating potential. This is not an all-order obstruction, a geometric realizability result, a proof of Erdos Problem #97, a counterexample, or an official/global status update.",
+  "configuration": {
+    "max_separator_denominator": 1000000,
+    "retry_count": 16,
+    "retry_seed": 20260730,
+    "selection": "the two predeclared original transfer-CEGAR probe escapes outside all eleven stored seed orbits",
+    "target_probe_model_indices": [
+      0,
+      1
+    ],
+    "target_seed_stride": 1000,
+    "tolerance": 1e-09
+  },
+  "decision": "CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS",
+  "n": 25,
+  "next_target": "Compress the two new exact positive circuits and test their quotient-preserving affine orbits before extending C25 cyclic-order search limits.",
+  "pattern": "C25_sidon_2_5_9_14",
+  "records": [
+    {
+      "all_eleven_seed_orbit_match_count": 0,
+      "certificate": {
+        "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+        "certificate_type": "kalmanson_strict_inequality_farkas",
+        "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+        "cyclic_order": [
+          0,
+          22,
+          14,
+          11,
+          8,
+          19,
+          5,
+          2,
+          24,
+          16,
+          13,
+          10,
+          21,
+          7,
+          4,
+          1,
+          18,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3
+        ],
+        "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+        "inequalities": [
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              14,
+              7,
+              6
+            ],
+            "weight": 413209878042317819
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              14,
+              4,
+              1
+            ],
+            "weight": 245460979634608784
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              14,
+              6,
+              17
+            ],
+            "weight": 1061619812728895477
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              11,
+              8,
+              2
+            ],
+            "weight": 230391779606417786
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              11,
+              5,
+              20
+            ],
+            "weight": 391598987386524353
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              11,
+              2,
+              9
+            ],
+            "weight": 1528179291738494166
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              11,
+              18,
+              20
+            ],
+            "weight": 343273811883487230
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              8,
+              19,
+              2
+            ],
+            "weight": 2761870410221250343
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              8,
+              19,
+              23
+            ],
+            "weight": 230391779606417786
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              8,
+              24,
+              10
+            ],
+            "weight": 252547031438386864
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              8,
+              4,
+              12
+            ],
+            "weight": 88008340801534279
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              19,
+              5,
+              15
+            ],
+            "weight": 230391779606417786
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              19,
+              1,
+              3
+            ],
+            "weight": 2992262189827668129
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              5,
+              13,
+              4
+            ],
+            "weight": 333469320436143063
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              5,
+              7,
+              15
+            ],
+            "weight": 267429521923028078
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              5,
+              18,
+              17
+            ],
+            "weight": 207674806831352305
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              24,
+              10,
+              1
+            ],
+            "weight": 252547031438386864
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              24,
+              21,
+              1
+            ],
+            "weight": 252547031438386864
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              24,
+              6,
+              17
+            ],
+            "weight": 239879286857426741
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              16,
+              15,
+              9
+            ],
+            "weight": 164351981093302801
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              13,
+              15,
+              9
+            ],
+            "weight": 333469320436143063
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              21,
+              23,
+              3
+            ],
+            "weight": 252547031438386864
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              7,
+              23,
+              20
+            ],
+            "weight": 391766952872620347
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              7,
+              9,
+              3
+            ],
+            "weight": 288872447092725550
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              1,
+              12,
+              3
+            ],
+            "weight": 2494254178754672481
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              18,
+              9,
+              20
+            ],
+            "weight": 550948618714839535
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              12,
+              23,
+              6
+            ],
+            "weight": 960840664759911925
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              12,
+              9,
+              17
+            ],
+            "weight": 1205525886335799536
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              12,
+              17,
+              3
+            ],
+            "weight": 239879286857426741
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              9,
+              20,
+              6
+            ],
+            "weight": 888289221544004399
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              14,
+              16,
+              21
+            ],
+            "weight": 353443406651105120
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              14,
+              13,
+              15
+            ],
+            "weight": 46539179676577490
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              11,
+              8,
+              1
+            ],
+            "weight": 406961997822322528
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              11,
+              19,
+              3
+            ],
+            "weight": 1388008879221049309
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              11,
+              24,
+              18
+            ],
+            "weight": 519556024141938079
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              11,
+              10,
+              4
+            ],
+            "weight": 46897457779534484
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              11,
+              10,
+              18
+            ],
+            "weight": 107033667969151339
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              11,
+              10,
+              17
+            ],
+            "weight": 698190328652852334
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              8,
+              24,
+              23
+            ],
+            "weight": 716892987391187892
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              8,
+              7,
+              3
+            ],
+            "weight": 955577651491841215
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              8,
+              4,
+              15
+            ],
+            "weight": 46897457779534484
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              8,
+              18,
+              17
+            ],
+            "weight": 417480863299501062
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              19,
+              5,
+              2
+            ],
+            "weight": 388681534253897827
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              19,
+              2,
+              12
+            ],
+            "weight": 1285933718378612292
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              19,
+              13,
+              7
+            ],
+            "weight": 955577651491841215
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              19,
+              18,
+              6
+            ],
+            "weight": 102075160842437017
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              5,
+              16,
+              9
+            ],
+            "weight": 131591329782690818
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              5,
+              13,
+              3
+            ],
+            "weight": 158752115879317896
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              5,
+              10,
+              23
+            ],
+            "weight": 75008351530190662
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              5,
+              9,
+              6
+            ],
+            "weight": 154921066844389269
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              2,
+              1,
+              12
+            ],
+            "weight": 93436637456111974
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              24,
+              13,
+              10
+            ],
+            "weight": 927129805931728819
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              24,
+              21,
+              23
+            ],
+            "weight": 316061352272921172
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              24,
+              9,
+              20
+            ],
+            "weight": 194314596267133312
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              16,
+              21,
+              6
+            ],
+            "weight": 37382054378183948
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              16,
+              12,
+              17
+            ],
+            "weight": 191853656400201383
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              16,
+              20,
+              6
+            ],
+            "weight": 485034736433795938
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              1,
+              15,
+              23
+            ],
+            "weight": 93436637456111974
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              1,
+              12,
+              9
+            ],
+            "weight": 217644333328831763
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              12,
+              23,
+              9
+            ],
+            "weight": 316061352272921172
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              11,
+              19,
+              21
+            ],
+            "weight": 552635027017255410
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              11,
+              4,
+              15
+            ],
+            "weight": 140334095235646458
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              11,
+              23,
+              6
+            ],
+            "weight": 1160750956596003713
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              19,
+              2,
+              13
+            ],
+            "weight": 224175946865261923
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              5,
+              24,
+              9
+            ],
+            "weight": 314761331484694963
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              5,
+              10,
+              21
+            ],
+            "weight": 118301675827832136
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              5,
+              1,
+              20
+            ],
+            "weight": 45357368778419441
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              5,
+              12,
+              3
+            ],
+            "weight": 860061314777558884
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              2,
+              13,
+              4
+            ],
+            "weight": 205420648493301228
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              2,
+              21,
+              23
+            ],
+            "weight": 371530708188616858
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              2,
+              4,
+              12
+            ],
+            "weight": 146888488286011977
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              2,
+              20,
+              17
+            ],
+            "weight": 77287458579249946
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              24,
+              13,
+              4
+            ],
+            "weight": 269403962706275522
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              24,
+              10,
+              3
+            ],
+            "weight": 45357368778419441
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              16,
+              7,
+              20
+            ],
+            "weight": 155062981389946050
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              13,
+              21,
+              3
+            ],
+            "weight": 204109484657737337
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              13,
+              6,
+              17
+            ],
+            "weight": 747541078553685894
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              10,
+              4,
+              18
+            ],
+            "weight": 163659044606251577
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              10,
+              18,
+              17
+            ],
+            "weight": 163659044606251577
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              21,
+              7,
+              18
+            ],
+            "weight": 258146896652371769
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              21,
+              15,
+              12
+            ],
+            "weight": 93794915559068968
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              1,
+              9,
+              17
+            ],
+            "weight": 290818348413028225
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              18,
+              23,
+              17
+            ],
+            "weight": 190945842586094038
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              23,
+              9,
+              6
+            ],
+            "weight": 319296396582072299
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              23,
+              20,
+              17
+            ],
+            "weight": 123132891589115545
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              8,
+              19,
+              3
+            ],
+            "weight": 559086758673241130
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              8,
+              2,
+              21
+            ],
+            "weight": 1223159672337330968
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              8,
+              15,
+              17
+            ],
+            "weight": 272924855148544826
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              19,
+              5,
+              1
+            ],
+            "weight": 413413729478308248
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              19,
+              4,
+              3
+            ],
+            "weight": 93436637456111974
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              19,
+              1,
+              6
+            ],
+            "weight": 6451731655985720
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              19,
+              12,
+              6
+            ],
+            "weight": 719037601140668904
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              5,
+              13,
+              17
+            ],
+            "weight": 413413729478308248
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              2,
+              24,
+              12
+            ],
+            "weight": 1045608592636488341
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              2,
+              16,
+              3
+            ],
+            "weight": 475830961488566212
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              2,
+              10,
+              18
+            ],
+            "weight": 745087786432386818
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              24,
+              16,
+              18
+            ],
+            "weight": 526052568494550262
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              24,
+              21,
+              12
+            ],
+            "weight": 670524645320075558
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              24,
+              23,
+              17
+            ],
+            "weight": 1160750956596003713
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              16,
+              17,
+              3
+            ],
+            "weight": 735485483091696205
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              13,
+              7,
+              12
+            ],
+            "weight": 461771906204784630
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              7,
+              18,
+              9
+            ],
+            "weight": 461771906204784630
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              15,
+              12,
+              9
+            ],
+            "weight": 413258950384191284
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              19,
+              5,
+              17
+            ],
+            "weight": 2953582011107589239
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              19,
+              16,
+              12
+            ],
+            "weight": 45845433009865599
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              19,
+              18,
+              20
+            ],
+            "weight": 33833630272905678
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              5,
+              24,
+              13
+            ],
+            "weight": 1254796096526912736
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              5,
+              13,
+              21
+            ],
+            "weight": 1698785914580676503
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              5,
+              4,
+              20
+            ],
+            "weight": 346241618608104912
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              5,
+              18,
+              23
+            ],
+            "weight": 172311412999559235
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              2,
+              24,
+              18
+            ],
+            "weight": 1308318958277501589
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              2,
+              15,
+              9
+            ],
+            "weight": 226027397369010342
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              24,
+              10,
+              21
+            ],
+            "weight": 1223159672337330968
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              16,
+              20,
+              17
+            ],
+            "weight": 45845433009865599
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              13,
+              1,
+              12
+            ],
+            "weight": 146888488286011977
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              10,
+              20,
+              3
+            ],
+            "weight": 45357368778419441
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              21,
+              7,
+              23
+            ],
+            "weight": 260073509536310551
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              21,
+              12,
+              6
+            ],
+            "weight": 104725580494343297
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              7,
+              1,
+              15
+            ],
+            "weight": 260073509536310551
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              4,
+              18,
+              23
+            ],
+            "weight": 211335820027036149
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              23,
+              9,
+              20
+            ],
+            "weight": 514899844461735892
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              9,
+              20,
+              3
+            ],
+            "weight": 288872447092725550
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              6,
+              17,
+              3
+            ],
+            "weight": 354192315363855595
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              5,
+              13,
+              12
+            ],
+            "weight": 612741550247808987
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              2,
+              16,
+              23
+            ],
+            "weight": 164505587388635904
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              2,
+              10,
+              20
+            ],
+            "weight": 33833630272905678
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              2,
+              4,
+              1
+            ],
+            "weight": 93436637456111974
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              24,
+              10,
+              1
+            ],
+            "weight": 446018386048462773
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              24,
+              18,
+              3
+            ],
+            "weight": 33833630272905678
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              16,
+              13,
+              12
+            ],
+            "weight": 118660154378770305
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              13,
+              21,
+              7
+            ],
+            "weight": 955577651491841215
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              10,
+              21,
+              6
+            ],
+            "weight": 1147541585661287915
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              1,
+              6,
+              3
+            ],
+            "weight": 319977092022196274
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              15,
+              23,
+              6
+            ],
+            "weight": 230391779606417786
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              2,
+              16,
+              18
+            ],
+            "weight": 82345810751506994
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              2,
+              13,
+              9
+            ],
+            "weight": 1222362264421435603
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              24,
+              4,
+              15
+            ],
+            "weight": 267429521923028078
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              16,
+              10,
+              18
+            ],
+            "weight": 4036349277065765107
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              13,
+              7,
+              15
+            ],
+            "weight": 1530947490264396289
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              10,
+              21,
+              6
+            ],
+            "weight": 880735183648393119
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              21,
+              1,
+              20
+            ],
+            "weight": 45357368778419441
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              21,
+              9,
+              6
+            ],
+            "weight": 776009603154049822
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              7,
+              12,
+              23
+            ],
+            "weight": 247319764529749897
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              7,
+              6,
+              17
+            ],
+            "weight": 621088536309660553
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              4,
+              18,
+              3
+            ],
+            "weight": 254657223751066229
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              24,
+              10,
+              3
+            ],
+            "weight": 281135023023663273
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              24,
+              7,
+              23
+            ],
+            "weight": 536036295577252762
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              2,
+              16,
+              10,
+              17
+            ],
+            "weight": 497786393681629223
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              2,
+              13,
+              21,
+              12
+            ],
+            "weight": 371530708188616858
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              7,
+              15,
+              6
+            ],
+            "weight": 75395821271043464
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              4,
+              15,
+              20
+            ],
+            "weight": 150631576097966878
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              4,
+              6,
+              17
+            ],
+            "weight": 271983397044152885
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              18,
+              17,
+              3
+            ],
+            "weight": 194695938464902939
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              15,
+              9,
+              20
+            ],
+            "weight": 79789629948048221
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              15,
+              20,
+              6
+            ],
+            "weight": 196587575773109421
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              21,
+              7,
+              4
+            ],
+            "weight": 1081729010615869851
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              24,
+              21,
+              18,
+              17
+            ],
+            "weight": 236573674744334238
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              21,
+              12,
+              17
+            ],
+            "weight": 375083947316412783
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              24,
+              7,
+              18,
+              6
+            ],
+            "weight": 545692715038617089
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              4,
+              9,
+              20
+            ],
+            "weight": 194314596267133312
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              12,
+              23,
+              17
+            ],
+            "weight": 1025546296137017671
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              12,
+              9,
+              6
+            ],
+            "weight": 120446735217561651
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              12,
+              6,
+              3
+            ],
+            "weight": 360326022074988392
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              13,
+              21,
+              4
+            ],
+            "weight": 33610657817539190
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              10,
+              7,
+              1
+            ],
+            "weight": 86755062491070913
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              10,
+              4,
+              23
+            ],
+            "weight": 120365720308610103
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              21,
+              18,
+              9
+            ],
+            "weight": 164351981093302801
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              7,
+              15,
+              23
+            ],
+            "weight": 237545483114733879
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              7,
+              20,
+              3
+            ],
+            "weight": 259654521603129993
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              16,
+              4,
+              1,
+              20
+            ],
+            "weight": 86755062491070913
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              4,
+              18,
+              20
+            ],
+            "weight": 414717502993076043
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              4,
+              23,
+              6
+            ],
+            "weight": 522416790811979886
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              16,
+              15,
+              12,
+              6
+            ],
+            "weight": 73193502021431078
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              10,
+              21,
+              7
+            ],
+            "weight": 86755062491070913
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              10,
+              21,
+              18
+            ],
+            "weight": 2601219161398985995
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              10,
+              12,
+              17
+            ],
+            "weight": 334127349075377646
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              10,
+              23,
+              20
+            ],
+            "weight": 45357368778419441
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              21,
+              4,
+              23
+            ],
+            "weight": 452408051574405113
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              21,
+              20,
+              3
+            ],
+            "weight": 45357368778419441
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              7,
+              15,
+              12
+            ],
+            "weight": 1195658297376020806
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              7,
+              23,
+              3
+            ],
+            "weight": 407050682795985672
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              4,
+              1,
+              12
+            ],
+            "weight": 146888488286011977
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              15,
+              9,
+              6
+            ],
+            "weight": 414071758117542831
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              9,
+              6,
+              17
+            ],
+            "weight": 747541078553685894
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              21,
+              4,
+              1
+            ],
+            "weight": 629320959041464738
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              7,
+              18,
+              15
+            ],
+            "weight": 2026272614910732980
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              10,
+              4,
+              1,
+              23
+            ],
+            "weight": 311080970784943737
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              10,
+              4,
+              6,
+              3
+            ],
+            "weight": 34215223341659321
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              1,
+              12,
+              6
+            ],
+            "weight": 2062491992651340355
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              10,
+              18,
+              12,
+              6
+            ],
+            "weight": 647767875881054106
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              21,
+              18,
+              15,
+              3
+            ],
+            "weight": 93794915559068968
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              21,
+              18,
+              9,
+              17
+            ],
+            "weight": 611657622060747021
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              21,
+              15,
+              23,
+              3
+            ],
+            "weight": 93794915559068968
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              7,
+              1,
+              15,
+              20
+            ],
+            "weight": 132112431269490354
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              7,
+              1,
+              15,
+              17
+            ],
+            "weight": 621088536309660553
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              4,
+              15,
+              20,
+              17
+            ],
+            "weight": 271983397044152885
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              4,
+              20,
+              6,
+              3
+            ],
+            "weight": 288872447092725550
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              1,
+              15,
+              12,
+              23
+            ],
+            "weight": 187231553015180942
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              1,
+              12,
+              23,
+              9
+            ],
+            "weight": 217644333328831763
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              23,
+              9,
+              6,
+              17
+            ],
+            "weight": 748803156195141867
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              23,
+              20,
+              6,
+              17
+            ],
+            "weight": 123132891589115545
+          }
+        ],
+        "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+        "num_inequalities": 201,
+        "pattern": {
+          "circulant_offsets": [
+            2,
+            5,
+            9,
+            14
+          ],
+          "n": 25,
+          "name": "C25_sidon_2_5_9_14"
+        },
+        "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+        "weight_sum": 99350014738666548712
+      },
+      "certificate_search": {
+        "exactification_method": "zero_objective_basic_support",
+        "primary_numerical_support_size": 201,
+        "retry_index": null
+      },
+      "certificate_sha256": "a0b0cc198e8a030a4f8111530914a06cffc6207b69cc2ceae3d1c0b0ab7b8101",
+      "classification": "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE",
+      "dihedral_order_sha256": "21af0fdceaa2c7b6d6fd444590571ed04a48bd7e0dce5aeafecf86e80e6b2081",
+      "distance_class_count": 225,
+      "max_weight": 4036349277065765107,
+      "order": [
+        0,
+        22,
+        14,
+        11,
+        8,
+        19,
+        5,
+        2,
+        24,
+        16,
+        13,
+        10,
+        21,
+        7,
+        4,
+        1,
+        18,
+        15,
+        12,
+        23,
+        9,
+        20,
+        6,
+        17,
+        3
+      ],
+      "order_sha256": "01e5595550dc1a887be1e0a5745e1ea9ab38070460f5afa569ad45df8ae3a32c",
+      "positive_circuit_audit": {
+        "all_weights_positive": true,
+        "exact_zero_sum_gives_nullity_at_least": 1,
+        "modular_rank_gives_rational_rank_at_least": 200,
+        "positive_circuit_verified": true,
+        "rank_mod_1000000007": 200,
+        "support_size": 201
+      },
+      "positive_inequalities": 201,
+      "probe_model_index": 0,
+      "seed_packet_matches": {
+        "transferred_only": [],
+        "transferred_plus_all_residuals": [],
+        "transferred_plus_width3": []
+      },
+      "source_transferred_seed_orbit_matches": [],
+      "strict_row_count": 25300,
+      "target_id": "probe:0",
+      "unique_ordered_quad_count": 201,
+      "weight_sum": 99350014738666548712
+    },
+    {
+      "all_eleven_seed_orbit_match_count": 0,
+      "certificate": {
+        "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+        "certificate_type": "kalmanson_strict_inequality_farkas",
+        "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+        "cyclic_order": [
+          0,
+          22,
+          14,
+          11,
+          8,
+          19,
+          5,
+          2,
+          24,
+          16,
+          13,
+          10,
+          21,
+          7,
+          4,
+          1,
+          18,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17
+        ],
+        "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+        "inequalities": [
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              22,
+              8,
+              15
+            ],
+            "weight": 59037445220637246
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              22,
+              5,
+              3
+            ],
+            "weight": 41377813403191988
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              22,
+              4,
+              1
+            ],
+            "weight": 13978836246832730
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              14,
+              8,
+              2
+            ],
+            "weight": 85297139204070589
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              14,
+              13,
+              7
+            ],
+            "weight": 85673746957891398
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              14,
+              7,
+              4
+            ],
+            "weight": 33275592205311267
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              14,
+              15,
+              9
+            ],
+            "weight": 4633157064817928
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              14,
+              3,
+              17
+            ],
+            "weight": 119274564498717199
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              11,
+              2,
+              20
+            ],
+            "weight": 93287605249867304
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              11,
+              2,
+              3
+            ],
+            "weight": 34702868148879318
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              11,
+              10,
+              7
+            ],
+            "weight": 19296755958478537
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              11,
+              21,
+              18
+            ],
+            "weight": 18635028914314633
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              11,
+              7,
+              3
+            ],
+            "weight": 77896751095525211
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              11,
+              15,
+              23
+            ],
+            "weight": 27202144077909659
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              11,
+              15,
+              6
+            ],
+            "weight": 27202144077909659
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              8,
+              19,
+              5
+            ],
+            "weight": 20479807529884443
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              8,
+              24,
+              1
+            ],
+            "weight": 42350775328588051
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              8,
+              21,
+              17
+            ],
+            "weight": 31571656857364814
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              8,
+              7,
+              9
+            ],
+            "weight": 70412152238754970
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              19,
+              5,
+              2
+            ],
+            "weight": 421489695390744733
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              19,
+              2,
+              9
+            ],
+            "weight": 20479807529884443
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              5,
+              6,
+              17
+            ],
+            "weight": 27202144077909659
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              2,
+              16,
+              21
+            ],
+            "weight": 50206685771679447
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              2,
+              18,
+              3
+            ],
+            "weight": 18635028914314633
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              24,
+              16,
+              6
+            ],
+            "weight": 27339314490107218
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              24,
+              12,
+              17
+            ],
+            "weight": 15011460838480833
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              13,
+              9,
+              3
+            ],
+            "weight": 85673746957891398
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              10,
+              4,
+              15
+            ],
+            "weight": 19296755958478537
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              7,
+              1,
+              23
+            ],
+            "weight": 95910748581700050
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              1,
+              23,
+              6
+            ],
+            "weight": 81931912334867320
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              12,
+              23,
+              20
+            ],
+            "weight": 15011460838480833
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              14,
+              2,
+              15
+            ],
+            "weight": 4633157064817928
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              14,
+              1,
+              12
+            ],
+            "weight": 8202148549880204
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              14,
+              6,
+              17
+            ],
+            "weight": 52313458994117908
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              11,
+              8,
+              24
+            ],
+            "weight": 1262900625983877
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              11,
+              19,
+              5
+            ],
+            "weight": 8081803249877807
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              11,
+              5,
+              17
+            ],
+            "weight": 99848836129104830
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              8,
+              13,
+              7
+            ],
+            "weight": 253003322401953080
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              8,
+              10,
+              18
+            ],
+            "weight": 182784405795050886
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              8,
+              23,
+              17
+            ],
+            "weight": 383792754290556390
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              19,
+              16,
+              9
+            ],
+            "weight": 7415735947984652
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              19,
+              13,
+              1
+            ],
+            "weight": 666067301893155
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              19,
+              7,
+              15
+            ],
+            "weight": 60078555356452557
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              19,
+              18,
+              23
+            ],
+            "weight": 90197327659729662
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              5,
+              24,
+              9
+            ],
+            "weight": 40248858225585398
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              5,
+              13,
+              4
+            ],
+            "weight": 9606298935278342
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              5,
+              10,
+              4
+            ],
+            "weight": 10140361250449637
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              5,
+              12,
+              3
+            ],
+            "weight": 37461550932624515
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              2,
+              21,
+              23
+            ],
+            "weight": 293595426630826728
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              16,
+              21,
+              12
+            ],
+            "weight": 7415735947984652
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              16,
+              4,
+              12
+            ],
+            "weight": 29259402382744311
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              22,
+              13,
+              6,
+              3
+            ],
+            "weight": 3916262470567473
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              10,
+              7,
+              15
+            ],
+            "weight": 192924767045500523
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              21,
+              18,
+              23
+            ],
+            "weight": 92587078135321224
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              21,
+              20,
+              17
+            ],
+            "weight": 208424084443490156
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              4,
+              15,
+              3
+            ],
+            "weight": 5674267200633239
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              22,
+              1,
+              20,
+              3
+            ],
+            "weight": 22180984796712934
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              11,
+              19,
+              7
+            ],
+            "weight": 112331850905866534
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              11,
+              24,
+              4
+            ],
+            "weight": 1262900625983877
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              11,
+              13,
+              21
+            ],
+            "weight": 20167640314477597
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              8,
+              24,
+              17
+            ],
+            "weight": 99851295180365761
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              8,
+              16,
+              12
+            ],
+            "weight": 255095900639774371
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              8,
+              1,
+              6
+            ],
+            "weight": 5554134489576632
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              19,
+              7,
+              4
+            ],
+            "weight": 32012691579327390
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              19,
+              1,
+              18
+            ],
+            "weight": 2648014060303572
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              19,
+              18,
+              6
+            ],
+            "weight": 2648014060303572
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              5,
+              13,
+              17
+            ],
+            "weight": 909963738725825
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              5,
+              9,
+              17
+            ],
+            "weight": 71736728312469346
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              2,
+              13,
+              6
+            ],
+            "weight": 64596142904687976
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              2,
+              21,
+              3
+            ],
+            "weight": 16067839234564685
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              24,
+              7,
+              6
+            ],
+            "weight": 27921004573959013
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              14,
+              24,
+              23,
+              3
+            ],
+            "weight": 73193191232390625
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              13,
+              21,
+              20
+            ],
+            "weight": 4099801079912912
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              21,
+              20,
+              3
+            ],
+            "weight": 4099801079912912
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              7,
+              12,
+              23
+            ],
+            "weight": 376005534154120506
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              14,
+              12,
+              6,
+              3
+            ],
+            "weight": 57867593483694540
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              8,
+              19,
+              4
+            ],
+            "weight": 120413654155744341
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              8,
+              1,
+              17
+            ],
+            "weight": 36796640839011419
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              8,
+              12,
+              3
+            ],
+            "weight": 175651814534497940
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              19,
+              2,
+              6
+            ],
+            "weight": 76042664285424064
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              5,
+              16,
+              21
+            ],
+            "weight": 8081803249877807
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              5,
+              7,
+              1
+            ],
+            "weight": 38329252239174383
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              2,
+              7,
+              17
+            ],
+            "weight": 5009764818638737
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              2,
+              4,
+              12
+            ],
+            "weight": 119150753529760464
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              16,
+              15,
+              23
+            ],
+            "weight": 27202144077909659
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              21,
+              1,
+              9
+            ],
+            "weight": 1532611400162964
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              7,
+              18,
+              12
+            ],
+            "weight": 272722687361130920
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              7,
+              12,
+              9
+            ],
+            "weight": 97070872826632980
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              11,
+              18,
+              9,
+              3
+            ],
+            "weight": 291357716275445553
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              11,
+              9,
+              3,
+              17
+            ],
+            "weight": 63052195290093411
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              19,
+              2,
+              7
+            ],
+            "weight": 92091246935779947
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              19,
+              16,
+              10
+            ],
+            "weight": 58450074375641049
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              19,
+              13,
+              17
+            ],
+            "weight": 551668948770138247
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              5,
+              2,
+              9
+            ],
+            "weight": 12450961862713307
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              5,
+              16,
+              21
+            ],
+            "weight": 238202465137614507
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              5,
+              4,
+              18
+            ],
+            "weight": 19746660185727979
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              5,
+              15,
+              23
+            ],
+            "weight": 8028845667171136
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              2,
+              16,
+              21
+            ],
+            "weight": 19245069594422665
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              2,
+              21,
+              18
+            ],
+            "weight": 331978666742667176
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              24,
+              7,
+              15
+            ],
+            "weight": 8028845667171136
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              16,
+              23,
+              9
+            ],
+            "weight": 47664594173570050
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              16,
+              20,
+              6
+            ],
+            "weight": 60801708467903850
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              16,
+              20,
+              3
+            ],
+            "weight": 140409312211072659
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              8,
+              10,
+              4,
+              9
+            ],
+            "weight": 102191644170461351
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              21,
+              4,
+              17
+            ],
+            "weight": 93776201605052669
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              7,
+              18,
+              9
+            ],
+            "weight": 168940921133344269
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              4,
+              23,
+              17
+            ],
+            "weight": 336128160116986340
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              12,
+              9,
+              17
+            ],
+            "weight": 79444086105276431
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              8,
+              20,
+              6,
+              17
+            ],
+            "weight": 201211020678976509
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              5,
+              18,
+              6
+            ],
+            "weight": 87549313599426090
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              5,
+              15,
+              9
+            ],
+            "weight": 19036908224170641
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              2,
+              16,
+              23
+            ],
+            "weight": 13818339407968220
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              2,
+              13,
+              10
+            ],
+            "weight": 298313164600597525
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              2,
+              13,
+              18
+            ],
+            "weight": 253355784169540722
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              24,
+              16,
+              4
+            ],
+            "weight": 44631734967672829
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              24,
+              21,
+              1
+            ],
+            "weight": 110016988370650408
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              24,
+              21,
+              12
+            ],
+            "weight": 75508208282651205
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              13,
+              12,
+              20
+            ],
+            "weight": 63237603709488036
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              21,
+              1,
+              15
+            ],
+            "weight": 117727971526472440
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              4,
+              15,
+              17
+            ],
+            "weight": 19742087006164221
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              4,
+              12,
+              6
+            ],
+            "weight": 12270604573163169
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              19,
+              1,
+              15,
+              23
+            ],
+            "weight": 82108024649173057
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              1,
+              23,
+              9
+            ],
+            "weight": 5729036397411615
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              15,
+              20,
+              17
+            ],
+            "weight": 63237603709488036
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              19,
+              9,
+              6,
+              17
+            ],
+            "weight": 8858635253698454
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              24,
+              13,
+              23
+            ],
+            "weight": 9606298935278342
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              16,
+              10,
+              18
+            ],
+            "weight": 450505312469568069
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              16,
+              7,
+              3
+            ],
+            "weight": 10223598899076872
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              13,
+              12,
+              6
+            ],
+            "weight": 66934952107148243
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              10,
+              1,
+              20
+            ],
+            "weight": 29473401174523728
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              10,
+              23,
+              6
+            ],
+            "weight": 1577453268107206
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              1,
+              18,
+              6
+            ],
+            "weight": 67802653413698111
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              5,
+              1,
+              15,
+              6
+            ],
+            "weight": 19036908224170641
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              5,
+              12,
+              20,
+              6
+            ],
+            "weight": 29473401174523728
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              16,
+              4,
+              1
+            ],
+            "weight": 49604592632000681
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              16,
+              12,
+              6
+            ],
+            "weight": 36675138330728963
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              13,
+              7,
+              12
+            ],
+            "weight": 155825891860489427
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              13,
+              1,
+              23
+            ],
+            "weight": 307413766038794948
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              13,
+              20,
+              17
+            ],
+            "weight": 5009764818638737
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              10,
+              21,
+              1
+            ],
+            "weight": 257809173406794267
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              2,
+              10,
+              21,
+              18
+            ],
+            "weight": 298313164600597525
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              10,
+              9,
+              20
+            ],
+            "weight": 90414028400646271
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              7,
+              9,
+              6
+            ],
+            "weight": 27921004573959013
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              2,
+              9,
+              20,
+              3
+            ],
+            "weight": 85404263582007534
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              16,
+              21,
+              3
+            ],
+            "weight": 73193191232390625
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              16,
+              15,
+              20
+            ],
+            "weight": 30022921676961666
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              16,
+              9,
+              6
+            ],
+            "weight": 40248858225585398
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              24,
+              13,
+              10,
+              6
+            ],
+            "weight": 1577453268107206
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              24,
+              10,
+              21,
+              4
+            ],
+            "weight": 112332005420910988
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              24,
+              10,
+              7,
+              20
+            ],
+            "weight": 47316179132281378
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              10,
+              20,
+              17
+            ],
+            "weight": 15011460838480833
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              21,
+              15,
+              12
+            ],
+            "weight": 75508208282651205
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              24,
+              7,
+              15,
+              3
+            ],
+            "weight": 39287333465110242
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              1,
+              15,
+              23
+            ],
+            "weight": 9606298935278342
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              24,
+              12,
+              20,
+              6
+            ],
+            "weight": 15011460838480833
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              13,
+              15,
+              3
+            ],
+            "weight": 57225065754871325
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              10,
+              23,
+              3
+            ],
+            "weight": 166601036587668831
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              21,
+              1,
+              23
+            ],
+            "weight": 146138586492008440
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              16,
+              7,
+              4,
+              12
+            ],
+            "weight": 188929079810927639
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              16,
+              4,
+              18,
+              3
+            ],
+            "weight": 65433349828509818
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              16,
+              1,
+              18,
+              17
+            ],
+            "weight": 195743179124009121
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              16,
+              15,
+              20,
+              6
+            ],
+            "weight": 110386390534110993
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              10,
+              21,
+              17
+            ],
+            "weight": 4099801079912912
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              10,
+              7,
+              9
+            ],
+            "weight": 156400874085960957
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              21,
+              4,
+              23
+            ],
+            "weight": 40765599490366081
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              21,
+              18,
+              9
+            ],
+            "weight": 6000644161321602
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              7,
+              15,
+              20
+            ],
+            "weight": 47316179132281378
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              7,
+              3,
+              17
+            ],
+            "weight": 574982225471530
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              4,
+              1,
+              12
+            ],
+            "weight": 308079833340688103
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              4,
+              15,
+              23
+            ],
+            "weight": 292301502592282015
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              18,
+              9,
+              3
+            ],
+            "weight": 147390057408801726
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              13,
+              12,
+              23,
+              6
+            ],
+            "weight": 25653336043853148
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              13,
+              23,
+              9,
+              20
+            ],
+            "weight": 15011460838480833
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              10,
+              21,
+              7,
+              23
+            ],
+            "weight": 175697630044439494
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              4,
+              18,
+              20
+            ],
+            "weight": 152192147868970544
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              1,
+              12,
+              3
+            ],
+            "weight": 185712298506062576
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              15,
+              23,
+              9
+            ],
+            "weight": 168178489855776037
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              10,
+              15,
+              3,
+              17
+            ],
+            "weight": 19111261918393745
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              21,
+              7,
+              4,
+              23
+            ],
+            "weight": 153097604911277069
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              21,
+              7,
+              18,
+              15
+            ],
+            "weight": 304313808761919127
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              21,
+              7,
+              3,
+              17
+            ],
+            "weight": 4434782593167207
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              21,
+              1,
+              15,
+              20
+            ],
+            "weight": 262094045518097892
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              21,
+              18,
+              20,
+              17
+            ],
+            "weight": 266193846598010804
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              21,
+              9,
+              3,
+              17
+            ],
+            "weight": 7533255561484566
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              7,
+              15,
+              12,
+              3
+            ],
+            "weight": 64072862584137226
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              7,
+              23,
+              9,
+              3
+            ],
+            "weight": 34852550871943035
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              4,
+              1,
+              20,
+              17
+            ],
+            "weight": 262094045518097892
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              4,
+              15,
+              23,
+              20
+            ],
+            "weight": 196924262435981394
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              4,
+              12,
+              9,
+              3
+            ],
+            "weight": 71107617029143057
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              4,
+              23,
+              6,
+              17
+            ],
+            "weight": 336128160116986340
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              1,
+              18,
+              23,
+              9
+            ],
+            "weight": 4196424997248651
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              1,
+              15,
+              12,
+              23
+            ],
+            "weight": 232155252181062189
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              18,
+              9,
+              20,
+              3
+            ],
+            "weight": 354679394941422828
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              18,
+              20,
+              6,
+              17
+            ],
+            "weight": 70450667474001683
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              15,
+              12,
+              23,
+              9
+            ],
+            "weight": 168178489855776037
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              23,
+              20,
+              6,
+              3
+            ],
+            "weight": 107585248378720468
+          }
+        ],
+        "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+        "num_inequalities": 196,
+        "pattern": {
+          "circulant_offsets": [
+            2,
+            5,
+            9,
+            14
+          ],
+          "n": 25,
+          "name": "C25_sidon_2_5_9_14"
+        },
+        "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+        "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+        "weight_sum": 18328751602592595684
+      },
+      "certificate_search": {
+        "exactification_method": "zero_objective_basic_support",
+        "primary_numerical_support_size": 196,
+        "retry_index": null
+      },
+      "certificate_sha256": "6672eead7fe08d256529334c99d49beb48c380a1474d7b174172ed050c5024d7",
+      "classification": "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE",
+      "dihedral_order_sha256": "2ec108f7f3fbc4f5b9dbc523095b381676452797aa2384d5d4e65eb375b22f3c",
+      "distance_class_count": 225,
+      "max_weight": 551668948770138247,
+      "order": [
+        0,
+        22,
+        14,
+        11,
+        8,
+        19,
+        5,
+        2,
+        24,
+        16,
+        13,
+        10,
+        21,
+        7,
+        4,
+        1,
+        18,
+        15,
+        12,
+        23,
+        9,
+        20,
+        6,
+        3,
+        17
+      ],
+      "order_sha256": "793e8e7d2770941c399debc6a5e57e4c903561f826f10991922fb616d14081c4",
+      "positive_circuit_audit": {
+        "all_weights_positive": true,
+        "exact_zero_sum_gives_nullity_at_least": 1,
+        "modular_rank_gives_rational_rank_at_least": 195,
+        "positive_circuit_verified": true,
+        "rank_mod_1000000007": 195,
+        "support_size": 196
+      },
+      "positive_inequalities": 196,
+      "probe_model_index": 1,
+      "seed_packet_matches": {
+        "transferred_only": [],
+        "transferred_plus_all_residuals": [],
+        "transferred_plus_width3": []
+      },
+      "source_transferred_seed_orbit_matches": [],
+      "strict_row_count": 25300,
+      "target_id": "probe:1",
+      "unique_ordered_quad_count": 196,
+      "weight_sum": 18328751602592595684
+    }
+  ],
+  "seed_packet_summary": {
+    "all_seed_exact_affine_image_count": 275,
+    "all_seed_orbit_count": 11,
+    "compressed_residual_seed_orbit_count": 8,
+    "compressed_residual_seed_widths": [
+      7,
+      9,
+      5,
+      3,
+      7,
+      4,
+      6,
+      4
+    ],
+    "transferred_seed_orbit_count": 3,
+    "transferred_seed_widths": [
+      3,
+      5,
+      14
+    ]
+  },
+  "source_augmentation_artifact": "data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json",
+  "source_augmentation_sha256": "a58f1f8caa7df997b16b225b12cd8622ef498759d3c9f43d6f0d8dda7d496502",
+  "source_cegar_artifact": "data/runs/sparse_full_cone_c25_transfer_cegar_2026-07-29/summary.json",
+  "source_cegar_sha256": "7d61f34c8bc0e96b9ce70a9021f735f0cbdbe93647574239c0234aa5bb48e5c4",
+  "status": "BOUNDED_TWO_ORDER_C25_FULL_CONE_SCREEN",
+  "summary": {
+    "certificate_positive_inequality_count_histogram": {
+      "196": 1,
+      "201": 1
+    },
+    "certificate_unique_quad_count_histogram": {
+      "196": 1,
+      "201": 1
+    },
+    "classification_histogram": {
+      "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE": 2
+    },
+    "exact_positive_certificate_count": 2,
+    "exact_separating_potential_count": 0,
+    "maximum_certificate_positive_inequality_count": 201,
+    "maximum_certificate_unique_quad_count": 201,
+    "minimum_certificate_positive_inequality_count": 196,
+    "minimum_certificate_unique_quad_count": 196,
+    "selected_target_order_count": 2,
+    "unresolved_numerical_screen_count": 0
+  },
+  "trust": "EXACT_FIXED_ORDER_FULL_CONE_CLASSIFICATION_FOR_TWO_C25_TARGETS",
+  "type": "sparse_full_cone_c25_persistent_escape_screen_v1"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -737,10 +737,14 @@ and must not assume that the finite `n=9` pivot census generalizes.
    in `docs/sparse-full-cone-c25-residual-seed-augmentation.md` then blocks all
    112 known orders and finds 32/32 transferred-seed coverage on a new probe;
    adding the residual width-`3` orbit or all eight residual orbits adds zero
-   covered orders. Stop residual seed augmentation and screen the two original
-   probe escapes `probe:0` and `probe:1` against the full Kalmanson cone before
-   extending order-search limits. Stop the current C29 template-mining route.
-   This is still not an all-order obstruction.
+   covered orders. The completed exact screen in
+   `docs/sparse-full-cone-c25-persistent-escape-screen.md` then verifies that
+   the two original probe escapes `probe:0` and `probe:1` remain outside all
+   11 stored seed orbits but have exact positive full-cone circuits of widths
+   `201` and `196`. Neither is a coordinate target. Compress those two
+   circuits and test their affine reuse before extending order-search limits.
+   Stop the current C29 template-mining route. This is still not an all-order
+   obstruction.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external

--- a/docs/index.md
+++ b/docs/index.md
@@ -995,6 +995,10 @@ put detailed reconciliation in the canonical synthesis.
   exact comparison of three nested C25 seed packets on 32 orders disjoint from
   112-order history; transferred seeds cover all 32, so residual augmentation
   adds no marginal order coverage and stops.
+- [`sparse-full-cone-c25-persistent-escape-screen.md`](sparse-full-cone-c25-persistent-escape-screen.md):
+  exact full-cone classification of the two original C25 probe escapes; both
+  remain outside all 11 seed orbits but have positive circuits of widths 201
+  and 196, so the bounded clause route continues.
 - [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
   cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
   numerical evidence only, not an exact coordinate certificate.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -728,9 +728,12 @@ benchmarks for the larger frontier:
 - use `docs/sparse-full-cone-c25-residual-seed-augmentation.md` as the
   marginal-coverage decision: after 112 history blocks the transferred seeds
   cover all 32 new probe orders, while width-`3`-only and all-eight residual
-  augmentation add zero covered orders. Stop residual augmentation and screen
-  the two original probe escapes exactly before more order-search budget; keep
-  the current C29 template family stopped;
+  augmentation add zero covered orders. Stop residual augmentation;
+- use `docs/sparse-full-cone-c25-persistent-escape-screen.md` as the exact
+  disposition of the two original probe escapes: both remain outside all 11
+  seed orbits but have exact positive full-cone circuits of widths `201` and
+  `196`. Compress those two circuits and audit affine reuse before more
+  order-search budget; keep the current C29 template family stopped;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 

--- a/docs/sparse-full-cone-c25-persistent-escape-screen.md
+++ b/docs/sparse-full-cone-c25-persistent-escape-screen.md
@@ -1,0 +1,76 @@
+# C25 persistent-escape full-cone screen
+
+Status: exact full-cone obstructions for two fixed C25 cyclic orders. No
+general proof, all-order C25 obstruction, geometric counterexample, or
+official-status change is claimed.
+
+## Target
+
+The residual-seed augmentation in
+`docs/sparse-full-cone-c25-residual-seed-augmentation.md` stopped after the
+original transferred seeds covered all 32 new probe orders and residual
+augmentation added no marginal coverage. It predeclared the two original
+transfer-CEGAR orders `probe:0` and `probe:1` as the next targets because both:
+
+- survive the vertex-circle and both Altman lightweight filters;
+- escape the two-inequality Kalmanson inverse-pair filter; and
+- remain outside all three transferred and eight compressed residual seed
+  orbits.
+
+The remaining question was whether either order escapes the full fixed-order
+Kalmanson cone.
+
+## Exact protocol
+
+`scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py`
+reconstructs the complete provenance chain from the residual-seed augmentation
+artifact. It replays all 11 exact seed orbits and their 275
+quotient-preserving affine images, verifies that both targets match none of
+them, and screens all 25,300 strict fixed-order Kalmanson rows for each target.
+
+The numerical LP is only a witness finder. A conclusive record must contain
+one side of Gordan's theorem of alternatives:
+
+1. an exact positive integer combination of strict row vectors summing to
+   zero; or
+2. an exact integer potential having strictly positive dot product with every
+   row.
+
+The stored checker uses exact integer arithmetic for the zero sum or every
+separator dot product. It also checks the positive-circuit rank audit and
+pins every source artifact by SHA-256.
+
+## Result
+
+| Target | Distance classes | Strict rows | Classification | Certificate rows | Ordered quads |
+| --- | ---: | ---: | --- | ---: | ---: |
+| `probe:0` | 225 | 25,300 | exact positive zero sum | 201 | 201 |
+| `probe:1` | 225 | 25,300 | exact positive zero sum | 196 | 196 |
+
+Both zero-objective LP supports exactify directly. There are no separator and
+no unresolved records.
+
+Therefore neither target is a fixed-order full-cone escape. Each fixed
+selected-witness quotient and cyclic order is exactly inconsistent with the
+strict Kalmanson inequalities, despite escaping all 11 previously stored seed
+orbits.
+
+## Decision and next target
+
+The exact alternative returns
+`CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS`. These two orders are
+not coordinate-search targets.
+
+The certificates are still wide, at 201 and 196 ordered quadrilaterals. Before
+extending the C25 cyclic-order search budget, compress both certificates with
+the established deterministic alternative-objective protocol, construct their
+quotient-preserving affine orbits, and measure direct and affine reuse against
+the current C25 packets. This remains a bounded clause-engineering diagnostic,
+not evidence of an all-order obstruction.
+
+Replay:
+
+```bash
+python scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py \
+  --check data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/summary.json
+```

--- a/docs/sparse-full-cone-c25-residual-seed-augmentation.md
+++ b/docs/sparse-full-cone-c25-residual-seed-augmentation.md
@@ -81,13 +81,14 @@ The predeclared marginal-coverage rule returns
 residual orbits to the next CEGAR merely because they create more matching
 clause occurrences.
 
-The most informative remaining fixed-order targets are the two original
-transfer-CEGAR probe orders `probe:0` and `probe:1`. They survive the
-lightweight filters and remain outside all three transferred and eight
-compressed residual seed orbits. Screen those two orders against the full
-Kalmanson cone exactly before extending order-search limits: an exact positive
-circuit continues the clause route, while an exact Gordan separator would
-identify a genuine fixed-order cone escape for later geometric investigation.
+The predeclared follow-up is now completed in
+`docs/sparse-full-cone-c25-persistent-escape-screen.md`. The two original
+transfer-CEGAR probe orders `probe:0` and `probe:1` survive the lightweight
+filters and remain outside all three transferred and eight compressed residual
+seed orbits, but exact positive circuits of widths `201` and `196` obstruct
+them in the full Kalmanson cone. Neither is a coordinate target. Compress those
+two new circuits and test their affine reuse before extending order-search
+limits.
 
 Replay:
 

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -3143,6 +3143,16 @@
         "data/runs/sparse_full_cone_c25_residual_seed_probe_2026-07-29/summary.json"
       ],
       "claim_scope": "Replay three transferred and eight compressed residual exact C25 seed certificates, 275 exact quotient-preserving affine images, 112 blocked historical order identities, 32 history-disjoint inverse-pair-escape probe orders, and exact coverage for three nested seed packets. The bounded probe finds zero marginal order coverage from residual augmentation; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
+    },
+    {
+      "id": "sparse_full_cone_c25_persistent_escape_screen",
+      "command": [
+        "python",
+        "scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py",
+        "--check",
+        "data/runs/sparse_full_cone_c25_persistent_escape_screen_2026-07-30/summary.json"
+      ],
+      "claim_scope": "Replay two exact positive full-Kalmanson-cone certificates for the fixed C25 transfer-CEGAR probe orders 0 and 1, together with their absence from three transferred and eight compressed residual seed orbits comprising 275 exact affine images. Fixed pattern and two fixed orders only; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
     }
   ],
   "make_targets": {

--- a/scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py
+++ b/scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Exactly screen the two persistent C25 transfer-CEGAR probe escapes.
+
+The residual-seed augmentation packet leaves the original transfer-CEGAR
+``probe:0`` and ``probe:1`` orders outside all three transferred and eight
+compressed residual seed orbits.  This script classifies exactly those two
+fixed orders against the complete fixed-order Kalmanson row family.
+
+The LP is used only to find candidate witnesses.  Stored results are accepted
+only when the checker replays either an exact positive integer zero-sum
+certificate or an exact integer Gordan separating potential.  Every claim is
+therefore bounded to the fixed C25 selected-witness pattern and the two listed
+cyclic orders; no all-order obstruction, geometric realizability result,
+counterexample, or proof of Erdos Problem #97 is claimed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+EXPLORATION = Path(__file__).resolve().parent
+for path in (SCRIPTS, EXPLORATION):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_kalmanson_certificate import check_certificate_dict  # noqa: E402
+from compress_sparse_full_cone_certificates import (  # noqa: E402
+    positive_circuit_audit,
+)
+from kalmanson_order_utils import all_kalmanson_rows  # noqa: E402
+from pilot_sparse_full_cone_order_cegar import (  # noqa: E402
+    PATTERNS,
+    certificate_order_quads,
+)
+from probe_sparse_full_cone_c25_residual_seed_augmentation import (  # noqa: E402
+    check_payload as check_augmentation_payload,
+    check_source_chain_references,
+    model_packet_matches,
+    packet_definitions,
+    seed_packets,
+)
+from run_sparse_full_cone_c25_transfer_cegar import (  # noqa: E402
+    PATTERN,
+    check_order_record,
+)
+from run_sparse_full_cone_seeded_cegar import (  # noqa: E402
+    file_sha256,
+)
+from screen_sparse_full_cone_fresh_orders import (  # noqa: E402
+    classify_order,
+    separator_audit,
+    stable_json_sha256,
+)
+
+
+DEFAULT_SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_residual_seed_probe_2026-07-29"
+    / "summary.json"
+)
+DEFAULT_TARGET_INDICES = (0, 1)
+
+
+def load_source(
+    source_path: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    """Replay the augmentation artifact and return its direct source chain."""
+
+    augmentation = json.loads(source_path.read_text(encoding="utf-8"))
+    check_augmentation_payload(augmentation)
+    compression, cegar, transfer, first = check_source_chain_references(augmentation)
+    return augmentation, compression, cegar, transfer
+
+
+def target_models(
+    cegar: Mapping[str, Any],
+    target_indices: Sequence[int],
+) -> list[dict[str, Any]]:
+    """Select the requested transfer-CEGAR counterfactual probe models."""
+
+    by_index = {
+        int(model["probe_model_index"]): model
+        for model in cegar["counterfactual_probe"]["models"]
+    }
+    if len(by_index) != len(cegar["counterfactual_probe"]["models"]):
+        raise AssertionError("C25 transfer-CEGAR probe indices are duplicated")
+    requested = [int(index) for index in target_indices]
+    if len(set(requested)) != len(requested):
+        raise ValueError("target probe indices must be distinct")
+    missing = [index for index in requested if index not in by_index]
+    if missing:
+        raise ValueError(f"unknown C25 transfer-CEGAR probe indices: {missing}")
+    return [by_index[index] for index in requested]
+
+
+def reconstruct_seed_packets(
+    compression: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+) -> tuple[
+    list[dict[str, object]],
+    list[dict[str, object]],
+    dict[str, list[Any]],
+]:
+    """Replay the three transferred and eight residual exact seed orbits."""
+
+    (
+        transferred_records,
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    ) = seed_packets(compression, transfer)
+    packets = packet_definitions(
+        transferred_orbits,
+        residual_records,
+        residual_orbits,
+    )
+    return transferred_records, residual_records, packets
+
+
+def target_seed_audit(
+    model: Mapping[str, Any],
+    packets: Mapping[str, Sequence[Any]],
+) -> dict[str, object]:
+    """Replay the target order and its exact absence from every seed packet."""
+
+    n, offsets = PATTERNS[PATTERN]
+    order = check_order_record(model, n=n, offsets=offsets)
+    if not bool(model["lightweight_filters"]["survives"]):
+        raise AssertionError("persistent C25 target no longer survives light filters")
+    if model["seed_orbit_matches"]:
+        raise AssertionError("persistent C25 target matches a transferred source seed")
+    matches = model_packet_matches(order, packets)
+    all_matches = matches["transferred_plus_all_residuals"]
+    if all_matches:
+        raise AssertionError("persistent C25 target matches an augmented seed orbit")
+    return {
+        "source_transferred_seed_orbit_matches": model["seed_orbit_matches"],
+        "seed_packet_matches": matches,
+        "all_eleven_seed_orbit_match_count": len(all_matches),
+    }
+
+
+def classify_target(
+    model: Mapping[str, Any],
+    packets: Mapping[str, Sequence[Any]],
+    *,
+    tolerance: float,
+    retry_count: int,
+    retry_seed: int,
+    max_separator_denominator: int,
+) -> dict[str, object]:
+    """Run the established exact Gordan-alternative classifier on one target."""
+
+    adapted = dict(model)
+    adapted["fresh_model_index"] = int(model["probe_model_index"])
+    record = classify_order(
+        PATTERN,
+        adapted,
+        tolerance=tolerance,
+        retry_count=retry_count,
+        retry_seed=retry_seed,
+        max_separator_denominator=max_separator_denominator,
+    )
+    probe_model_index = int(record.pop("fresh_model_index"))
+    return {
+        "target_id": f"probe:{probe_model_index}",
+        "probe_model_index": probe_model_index,
+        **target_seed_audit(model, packets),
+        **record,
+    }
+
+
+def classification_decision(records: Sequence[Mapping[str, Any]]) -> str:
+    classifications = Counter(str(record["classification"]) for record in records)
+    if classifications["UNRESOLVED_NUMERICAL_SCREEN"]:
+        return "STOP_FOR_UNRESOLVED_EXACT_CLASSIFICATION"
+    if classifications["EXACT_INTEGER_SEPARATING_POTENTIAL"]:
+        return "INVESTIGATE_EXACT_FIXED_ORDER_CONE_ESCAPE"
+    if classifications["EXACT_POSITIVE_ZERO_SUM_CERTIFICATE"] == len(records):
+        return "CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS"
+    raise AssertionError("unexpected persistent-escape classification mix")
+
+
+def screen_summary(records: Sequence[Mapping[str, Any]]) -> dict[str, object]:
+    classifications = Counter(str(record["classification"]) for record in records)
+    widths = Counter(
+        int(record["unique_ordered_quad_count"])
+        for record in records
+        if record["classification"] == "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE"
+    )
+    supports = Counter(
+        int(record["positive_inequalities"])
+        for record in records
+        if record["classification"] == "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE"
+    )
+    return {
+        "selected_target_order_count": len(records),
+        "exact_positive_certificate_count": classifications[
+            "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE"
+        ],
+        "exact_separating_potential_count": classifications[
+            "EXACT_INTEGER_SEPARATING_POTENTIAL"
+        ],
+        "unresolved_numerical_screen_count": classifications[
+            "UNRESOLVED_NUMERICAL_SCREEN"
+        ],
+        "classification_histogram": {
+            key: classifications[key] for key in sorted(classifications)
+        },
+        "certificate_unique_quad_count_histogram": {
+            str(key): widths[key] for key in sorted(widths)
+        },
+        "certificate_positive_inequality_count_histogram": {
+            str(key): supports[key] for key in sorted(supports)
+        },
+        "minimum_certificate_unique_quad_count": min(widths, default=None),
+        "maximum_certificate_unique_quad_count": max(widths, default=None),
+        "minimum_certificate_positive_inequality_count": min(supports, default=None),
+        "maximum_certificate_positive_inequality_count": max(supports, default=None),
+    }
+
+
+def seed_summary(
+    transferred_records: Sequence[Mapping[str, Any]],
+    residual_records: Sequence[Mapping[str, Any]],
+    packets: Mapping[str, Sequence[Any]],
+) -> dict[str, object]:
+    all_orbits = packets["transferred_plus_all_residuals"]
+    return {
+        "transferred_seed_orbit_count": len(transferred_records),
+        "compressed_residual_seed_orbit_count": len(residual_records),
+        "all_seed_orbit_count": len(all_orbits),
+        "all_seed_exact_affine_image_count": sum(
+            int(orbit.affine_map_count) for orbit in all_orbits
+        ),
+        "transferred_seed_widths": [
+            int(record["ordered_quad_count"]) for record in transferred_records
+        ],
+        "compressed_residual_seed_widths": [
+            int(record["ordered_quad_count"]) for record in residual_records
+        ],
+    }
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    augmentation, compression, cegar, transfer = load_source(source_path)
+    selected = target_models(cegar, args.target_index)
+    transferred_records, residual_records, packets = reconstruct_seed_packets(
+        compression,
+        transfer,
+    )
+    records = []
+    for ordinal, model in enumerate(selected):
+        retry_seed = args.retry_seed + ordinal * args.target_seed_stride
+        records.append(
+            classify_target(
+                model,
+                packets,
+                tolerance=args.tolerance,
+                retry_count=args.retry_count,
+                retry_seed=retry_seed,
+                max_separator_denominator=args.max_separator_denominator,
+            )
+        )
+    n, offsets = PATTERNS[PATTERN]
+    return {
+        "type": "sparse_full_cone_c25_persistent_escape_screen_v1",
+        "trust": "EXACT_FIXED_ORDER_FULL_CONE_CLASSIFICATION_FOR_TWO_C25_TARGETS",
+        "status": "BOUNDED_TWO_ORDER_C25_FULL_CONE_SCREEN",
+        "claim_scope": (
+            "Exact Gordan-alternative classification of transfer-CEGAR "
+            "counterfactual probe orders 0 and 1 for the fixed "
+            "C25_sidon_2_5_9_14 selected-witness pattern. The targets are "
+            "replayed outside all three transferred and eight compressed "
+            "residual seed orbits. Each conclusive record stores either an "
+            "exact positive Kalmanson zero-sum certificate or an exact integer "
+            "separating potential. This is not an all-order obstruction, a "
+            "geometric realizability result, a proof of Erdos Problem #97, a "
+            "counterexample, or an official/global status update."
+        ),
+        "source_augmentation_artifact": source_path.relative_to(ROOT).as_posix(),
+        "source_augmentation_sha256": file_sha256(source_path),
+        "source_cegar_artifact": str(augmentation["source_cegar_artifact"]),
+        "source_cegar_sha256": str(augmentation["source_cegar_sha256"]),
+        "pattern": PATTERN,
+        "n": n,
+        "circulant_offsets": list(offsets),
+        "configuration": {
+            "target_probe_model_indices": [
+                int(index) for index in args.target_index
+            ],
+            "selection": (
+                "the two predeclared original transfer-CEGAR probe escapes "
+                "outside all eleven stored seed orbits"
+            ),
+            "tolerance": args.tolerance,
+            "retry_count": args.retry_count,
+            "retry_seed": args.retry_seed,
+            "target_seed_stride": args.target_seed_stride,
+            "max_separator_denominator": args.max_separator_denominator,
+        },
+        "seed_packet_summary": seed_summary(
+            transferred_records,
+            residual_records,
+            packets,
+        ),
+        "records": records,
+        "summary": screen_summary(records),
+        "decision": classification_decision(records),
+        "next_target": (
+            "Compress the two new exact positive circuits and test their "
+            "quotient-preserving affine orbits before extending C25 cyclic-order "
+            "search limits."
+        ),
+    }
+
+
+def check_positive_record(
+    record: Mapping[str, Any],
+    order: Sequence[int],
+) -> None:
+    certificate = record["certificate"]
+    checked = check_certificate_dict(certificate)
+    if not checked.zero_sum_verified:
+        raise AssertionError("persistent C25 positive certificate failed")
+    if certificate["cyclic_order"] != list(order):
+        raise AssertionError("persistent C25 certificate order drifted")
+    if stable_json_sha256(certificate) != record["certificate_sha256"]:
+        raise AssertionError("persistent C25 certificate hash drifted")
+    quads = certificate_order_quads(certificate, order)
+    if len(quads) != int(record["unique_ordered_quad_count"]):
+        raise AssertionError("persistent C25 certificate width drifted")
+    if checked.positive_inequalities != int(record["positive_inequalities"]):
+        raise AssertionError("persistent C25 certificate support drifted")
+    if checked.weight_sum != int(record["weight_sum"]):
+        raise AssertionError("persistent C25 certificate weight sum drifted")
+    if checked.max_weight != int(record["max_weight"]):
+        raise AssertionError("persistent C25 certificate max weight drifted")
+    circuit_audit = positive_circuit_audit(certificate)
+    if circuit_audit != record["positive_circuit_audit"]:
+        raise AssertionError("persistent C25 circuit audit drifted")
+    if not bool(circuit_audit["positive_circuit_verified"]):
+        raise AssertionError("persistent C25 certificate is not a circuit")
+
+
+def check_separator_record(
+    record: Mapping[str, Any],
+    order: Sequence[int],
+) -> None:
+    n, offsets = PATTERNS[PATTERN]
+    rows = all_kalmanson_rows(n, offsets, order)
+    potential = [int(value) for value in record["separating_potential"]]
+    if stable_json_sha256(potential) != record["separator_sha256"]:
+        raise AssertionError("persistent C25 separator hash drifted")
+    audit = separator_audit(rows, potential)
+    if audit != record["separator_audit"]:
+        raise AssertionError("persistent C25 separator audit drifted")
+    if not bool(audit["all_row_dots_strictly_positive"]):
+        raise AssertionError("persistent C25 separator is not strict")
+
+
+def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    if payload["type"] != "sparse_full_cone_c25_persistent_escape_screen_v1":
+        raise AssertionError("persistent C25 screen artifact type drifted")
+    source_path = ROOT / str(payload["source_augmentation_artifact"])
+    if file_sha256(source_path) != str(payload["source_augmentation_sha256"]):
+        raise AssertionError("persistent C25 augmentation source hash drifted")
+    augmentation, compression, cegar, transfer = load_source(source_path)
+    if payload["source_cegar_artifact"] != augmentation["source_cegar_artifact"]:
+        raise AssertionError("persistent C25 CEGAR source path drifted")
+    if payload["source_cegar_sha256"] != augmentation["source_cegar_sha256"]:
+        raise AssertionError("persistent C25 CEGAR source hash drifted")
+
+    n, offsets = PATTERNS[PATTERN]
+    if payload["pattern"] != PATTERN or int(payload["n"]) != n:
+        raise AssertionError("persistent C25 pattern metadata drifted")
+    if payload["circulant_offsets"] != list(offsets):
+        raise AssertionError("persistent C25 offsets drifted")
+
+    configuration = payload["configuration"]
+    indices = [int(index) for index in configuration["target_probe_model_indices"]]
+    if indices != list(DEFAULT_TARGET_INDICES):
+        raise AssertionError("persistent C25 target selection drifted")
+    selected = target_models(cegar, indices)
+    transferred_records, residual_records, packets = reconstruct_seed_packets(
+        compression,
+        transfer,
+    )
+    expected_seed_summary = seed_summary(
+        transferred_records,
+        residual_records,
+        packets,
+    )
+    if payload["seed_packet_summary"] != expected_seed_summary:
+        raise AssertionError("persistent C25 seed summary drifted")
+
+    records = payload["records"]
+    if len(records) != len(selected):
+        raise AssertionError("persistent C25 record count drifted")
+    verified_certificates = 0
+    verified_separators = 0
+    verified_unresolved = 0
+    for record, model in zip(records, selected, strict=True):
+        model_index = int(model["probe_model_index"])
+        if int(record["probe_model_index"]) != model_index:
+            raise AssertionError("persistent C25 target index drifted")
+        if record["target_id"] != f"probe:{model_index}":
+            raise AssertionError("persistent C25 target id drifted")
+        order = check_order_record(model, n=n, offsets=offsets)
+        if record["order"] != order:
+            raise AssertionError("persistent C25 target order drifted")
+        for field in ("order_sha256", "dihedral_order_sha256"):
+            if record[field] != model[field]:
+                raise AssertionError(f"persistent C25 {field} drifted")
+        expected_seed_audit = target_seed_audit(model, packets)
+        for field, value in expected_seed_audit.items():
+            if record[field] != value:
+                raise AssertionError(f"persistent C25 {field} drifted")
+
+        classification = str(record["classification"])
+        if classification == "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE":
+            check_positive_record(record, order)
+            verified_certificates += 1
+        elif classification == "EXACT_INTEGER_SEPARATING_POTENTIAL":
+            check_separator_record(record, order)
+            verified_separators += 1
+        elif classification == "UNRESOLVED_NUMERICAL_SCREEN":
+            verified_unresolved += 1
+        else:
+            raise AssertionError("persistent C25 classification drifted")
+
+    if payload["summary"] != screen_summary(records):
+        raise AssertionError("persistent C25 screen summary drifted")
+    decision = classification_decision(records)
+    if payload["decision"] != decision:
+        raise AssertionError("persistent C25 screen decision drifted")
+    return {
+        "status": "OK",
+        "verified_target_orders": len(records),
+        "verified_exact_positive_certificates": verified_certificates,
+        "verified_exact_integer_separators": verified_separators,
+        "recorded_unresolved_numerical_screens": verified_unresolved,
+        "verified_seed_orbits": int(expected_seed_summary["all_seed_orbit_count"]),
+        "verified_exact_affine_seed_images": int(
+            expected_seed_summary["all_seed_exact_affine_image_count"]
+        ),
+        "decision": decision,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument(
+        "--target-index",
+        type=int,
+        action="append",
+        default=None,
+        help="transfer-CEGAR counterfactual probe index; defaults to 0 and 1",
+    )
+    parser.add_argument("--tolerance", type=float, default=1.0e-9)
+    parser.add_argument("--retry-count", type=int, default=16)
+    parser.add_argument("--retry-seed", type=int, default=20260730)
+    parser.add_argument("--target-seed-stride", type=int, default=1_000)
+    parser.add_argument("--max-separator-denominator", type=int, default=1_000_000)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    if args.target_index is None:
+        args.target_index = list(DEFAULT_TARGET_INDICES)
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    positive = (
+        args.tolerance,
+        args.retry_count,
+        args.target_seed_stride,
+        args.max_separator_denominator,
+    )
+    if any(value <= 0 for value in positive):
+        raise SystemExit(
+            "tolerance, retries, seed stride, and denominator must be positive"
+        )
+    if args.check is not None:
+        payload = json.loads(args.check.read_text(encoding="utf-8"))
+        print(json.dumps(check_payload(payload), indent=2, sort_keys=True))
+        return 0
+
+    payload = build_payload(args)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8", newline="\n")
+    if args.json or args.out is None:
+        print(text, end="")
+    else:
+        summary = payload["summary"]
+        print(
+            f"selected={summary['selected_target_order_count']} "
+            f"certificates={summary['exact_positive_certificate_count']} "
+            f"separators={summary['exact_separating_potential_count']} "
+            f"unresolved={summary['unresolved_numerical_screen_count']} "
+            f"decision={payload['decision']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py
+++ b/scripts/exploration/screen_sparse_full_cone_c25_persistent_escapes.py
@@ -69,6 +69,15 @@ DEFAULT_SOURCE = (
     / "summary.json"
 )
 DEFAULT_TARGET_INDICES = (0, 1)
+DEFAULT_TOLERANCE = 1.0e-9
+DEFAULT_RETRY_COUNT = 16
+DEFAULT_RETRY_SEED = 20_260_730
+DEFAULT_TARGET_SEED_STRIDE = 1_000
+DEFAULT_MAX_SEPARATOR_DENOMINATOR = 1_000_000
+TARGET_SELECTION = (
+    "the two predeclared original transfer-CEGAR probe escapes "
+    "outside all eleven stored seed orbits"
+)
 
 
 def load_source(
@@ -305,10 +314,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, object]:
             "target_probe_model_indices": [
                 int(index) for index in args.target_index
             ],
-            "selection": (
-                "the two predeclared original transfer-CEGAR probe escapes "
-                "outside all eleven stored seed orbits"
-            ),
+            "selection": TARGET_SELECTION,
             "tolerance": args.tolerance,
             "retry_count": args.retry_count,
             "retry_seed": args.retry_seed,
@@ -379,6 +385,20 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     if payload["type"] != "sparse_full_cone_c25_persistent_escape_screen_v1":
         raise AssertionError("persistent C25 screen artifact type drifted")
     source_path = ROOT / str(payload["source_augmentation_artifact"])
+    if source_path.resolve() != DEFAULT_SOURCE.resolve():
+        raise AssertionError("persistent C25 augmentation source artifact drifted")
+    configuration = payload["configuration"]
+    expected_configuration = {
+        "target_probe_model_indices": list(DEFAULT_TARGET_INDICES),
+        "selection": TARGET_SELECTION,
+        "tolerance": DEFAULT_TOLERANCE,
+        "retry_count": DEFAULT_RETRY_COUNT,
+        "retry_seed": DEFAULT_RETRY_SEED,
+        "target_seed_stride": DEFAULT_TARGET_SEED_STRIDE,
+        "max_separator_denominator": DEFAULT_MAX_SEPARATOR_DENOMINATOR,
+    }
+    if configuration != expected_configuration:
+        raise AssertionError("persistent C25 screen configuration drifted")
     if file_sha256(source_path) != str(payload["source_augmentation_sha256"]):
         raise AssertionError("persistent C25 augmentation source hash drifted")
     augmentation, compression, cegar, transfer = load_source(source_path)
@@ -393,8 +413,7 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     if payload["circulant_offsets"] != list(offsets):
         raise AssertionError("persistent C25 offsets drifted")
 
-    configuration = payload["configuration"]
-    indices = [int(index) for index in configuration["target_probe_model_indices"]]
+    indices = list(DEFAULT_TARGET_INDICES)
     if indices != list(DEFAULT_TARGET_INDICES):
         raise AssertionError("persistent C25 target selection drifted")
     selected = target_models(cegar, indices)
@@ -474,11 +493,19 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="transfer-CEGAR counterfactual probe index; defaults to 0 and 1",
     )
-    parser.add_argument("--tolerance", type=float, default=1.0e-9)
-    parser.add_argument("--retry-count", type=int, default=16)
-    parser.add_argument("--retry-seed", type=int, default=20260730)
-    parser.add_argument("--target-seed-stride", type=int, default=1_000)
-    parser.add_argument("--max-separator-denominator", type=int, default=1_000_000)
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    parser.add_argument("--retry-count", type=int, default=DEFAULT_RETRY_COUNT)
+    parser.add_argument("--retry-seed", type=int, default=DEFAULT_RETRY_SEED)
+    parser.add_argument(
+        "--target-seed-stride",
+        type=int,
+        default=DEFAULT_TARGET_SEED_STRIDE,
+    )
+    parser.add_argument(
+        "--max-separator-denominator",
+        type=int,
+        default=DEFAULT_MAX_SEPARATOR_DENOMINATOR,
+    )
     parser.add_argument("--out", type=Path)
     parser.add_argument("--check", type=Path)
     parser.add_argument("--json", action="store_true")

--- a/tests/test_sparse_full_cone_c25_persistent_escape_screen.py
+++ b/tests/test_sparse_full_cone_c25_persistent_escape_screen.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
@@ -94,3 +96,21 @@ def test_stored_persistent_escape_screen_replays_exactly() -> None:
         "verified_exact_affine_seed_images": 275,
         "decision": "CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS",
     }
+
+def test_checker_rejects_fabricated_screen_configuration() -> None:
+    payload = artifact_payload()
+    payload["configuration"]["retry_seed"] += 1
+
+    with pytest.raises(AssertionError, match="screen configuration drifted"):
+        SCREEN.check_payload(payload)
+
+
+def test_checker_rejects_substituted_source_artifact(tmp_path: Path) -> None:
+    substitute = tmp_path / "summary.json"
+    substitute.write_bytes(SOURCE.read_bytes())
+    payload = artifact_payload()
+    payload["source_augmentation_artifact"] = str(substitute)
+    payload["source_augmentation_sha256"] = SCREEN.file_sha256(substitute)
+
+    with pytest.raises(AssertionError, match="source artifact drifted"):
+        SCREEN.check_payload(payload)

--- a/tests/test_sparse_full_cone_c25_persistent_escape_screen.py
+++ b/tests/test_sparse_full_cone_c25_persistent_escape_screen.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "exploration"
+    / "screen_sparse_full_cone_c25_persistent_escapes.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_full_cone_c25_persistent_escape_screen",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+SCREEN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SCREEN
+SPEC.loader.exec_module(SCREEN)
+
+SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_residual_seed_probe_2026-07-29"
+    / "summary.json"
+)
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_persistent_escape_screen_2026-07-30"
+    / "summary.json"
+)
+
+
+def artifact_payload() -> dict[str, object]:
+    return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def test_selects_the_two_predeclared_transfer_cegar_targets() -> None:
+    _, _, cegar, _ = SCREEN.load_source(SOURCE)
+    models = SCREEN.target_models(cegar, SCREEN.DEFAULT_TARGET_INDICES)
+
+    assert [model["probe_model_index"] for model in models] == [0, 1]
+    assert all(model["lightweight_filters"]["survives"] for model in models)
+    assert all(not model["seed_orbit_matches"] for model in models)
+
+
+def test_targets_match_none_of_the_eleven_exact_seed_orbits() -> None:
+    _, compression, cegar, transfer = SCREEN.load_source(SOURCE)
+    _, _, packets = SCREEN.reconstruct_seed_packets(compression, transfer)
+    models = SCREEN.target_models(cegar, SCREEN.DEFAULT_TARGET_INDICES)
+
+    assert {name: len(orbits) for name, orbits in packets.items()} == {
+        "transferred_only": 3,
+        "transferred_plus_width3": 4,
+        "transferred_plus_all_residuals": 11,
+    }
+    for model in models:
+        audit = SCREEN.target_seed_audit(model, packets)
+        assert audit["all_eleven_seed_orbit_match_count"] == 0
+        assert all(not matches for matches in audit["seed_packet_matches"].values())
+
+
+def test_stored_targets_have_two_exact_positive_circuits() -> None:
+    payload = artifact_payload()
+    records = payload["records"]
+
+    assert [record["target_id"] for record in records] == ["probe:0", "probe:1"]
+    assert [record["classification"] for record in records] == [
+        "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE",
+        "EXACT_POSITIVE_ZERO_SUM_CERTIFICATE",
+    ]
+    assert [record["positive_inequalities"] for record in records] == [201, 196]
+    assert [record["unique_ordered_quad_count"] for record in records] == [201, 196]
+    assert payload["decision"] == (
+        "CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS"
+    )
+
+
+def test_stored_persistent_escape_screen_replays_exactly() -> None:
+    assert SCREEN.check_payload(artifact_payload()) == {
+        "status": "OK",
+        "verified_target_orders": 2,
+        "verified_exact_positive_certificates": 2,
+        "verified_exact_integer_separators": 0,
+        "recorded_unresolved_numerical_screens": 0,
+        "verified_seed_orbits": 11,
+        "verified_exact_affine_seed_images": 275,
+        "decision": "CONTINUE_C25_CLAUSE_ROUTE_WITH_EXACT_POSITIVE_CIRCUITS",
+    }


### PR DESCRIPTION
## Result

This packet exactly screens the two predeclared C25 transfer-CEGAR targets, `probe:0` and `probe:1`, against all 25,300 strict fixed-order Kalmanson rows.

- Both orders still survive the stored lightweight filters and match none of the three transferred or eight compressed residual seed orbits (275 exact affine images total).
- `probe:0` has an exact positive zero-sum circuit with 201 inequalities and 201 ordered quadrilaterals.
- `probe:1` has an exact positive zero-sum circuit with 196 inequalities and 196 ordered quadrilaterals.
- There are no Gordan separators and no unresolved records, so neither order is a fixed-order full-cone escape or a coordinate-search target.

The bounded decision is to continue the clause route by compressing these two circuits and testing their quotient-preserving affine reuse before extending C25 order-search limits.

## Scope

The prerequisite residual-seed probe from PR #907 is merged, and this PR now targets `main`.

The result concerns one fixed selected-witness pattern and two fixed cyclic orders. It is not an all-order C25 obstruction, a geometric realizability result, a proof of Erdos Problem #97, a counterexample, or an official/global status update.

## Review hardening

- pins the exact augmentation source and the numerical-classifier configuration
- adds regressions rejecting substituted sources and fabricated retry-seed provenance
- records the previously omitted SHA-256 in the run README
- leaves the mathematical summary artifact unchanged

## Validation

- fast text/status/provenance/generator/diff checks and Ruff: passed
- focused packet tests: `6 passed`
- cumulative corrected stack: `1,828 passed` across four non-overlapping tracked-test shards
- complete required artifact tier and all seven C25 packet replays: passed
- exact-head GitHub tests and artifact audit: passed