### PR TITLE
Run 144-history C25 augmented CEGAR

### DIFF
--- a/data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/README.md
+++ b/data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/README.md
@@ -1,0 +1,39 @@
+# C25 persistent width-4 augmented CEGAR
+
+This packet blocks the complete current 144-order C25 history and activates
+only the three transferred exact seed orbits plus the selected persistent
+width-4 orbit. The dominated persistent width-5 orbit and all eight
+zero-marginal compressed residual orbits remain explicitly inactive.
+
+On a deterministic 16-order history-disjoint probe:
+
+- the three transferred seeds cover `0/16`;
+- the selected width-4 orbit covers `16/16`;
+- all 16 orders are strong lightweight survivors.
+
+After activating the four seed orbits, bounded CEGAR learns eight further exact
+full-Kalmanson-cone certificates of widths:
+
+`197, 197, 193, 194, 192, 200, 191, 195`
+
+The run stops at its eight-certificate limit with no unresolved model. The
+checker replays 144 blocked identities, four active and nine inactive exact
+seed certificates, 16 probe orders, eight learned certificates, 200 new affine
+clauses, and 300 exact affine certificate images.
+
+The decision is `COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS`.
+
+This is a finite, history-blocked, fixed-pattern diagnostic. It is not an
+all-order C25 obstruction, geometric realizability result, proof of Erdos
+Problem #97, counterexample, or official/global status update.
+
+Replay:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py \
+  --check data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/summary.json
+```
+
+SHA-256 of `summary.json`:
+
+`623d1a9408226243c24e47cb18635e16e6f7a044eaccb07877956230fd70c569`

--- a/data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/summary.json
+++ b/data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/summary.json
@@ -1,0 +1,18921 @@
+{
+  "active_exact_affine_seed_image_count": 100,
+  "active_seed_orbit_count": 4,
+  "blocked_history": {
+    "dihedral_order_count": 144,
+    "identities": [
+      {
+        "dihedral_order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "history_id": "prior:probe:0",
+        "order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "e47ce1873ef7df7855de6ac947539b6b8cb08f69fe551b55db4dacd8594de6fa",
+        "history_id": "prior:probe:1",
+        "order_sha256": "efc4a292c226cfc11e313d0c4404977f0e4d67f8b6f44f92009cfc421b5fd29c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8a17cf46dc234917d8cfe36ff788438c4f49bf137c67a6edf37c6f305c1063df",
+        "history_id": "prior:probe:2",
+        "order_sha256": "c95c42099fef5ebc90a4037cad6d101892b494c64604c119a628293f7bf2331d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "82db3aad7af4566f9bf5624f50133b7cbe34e22b3cc2a81981c4777199a73adf",
+        "history_id": "prior:probe:3",
+        "order_sha256": "666ea584ade30a2e1f2c73701e959a53a5f62313940e4908b36c432228be554f",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "02ed07cd34ac32b87a770c4ef50acbaa24091fe89c0fed35a5d52989e08d6367",
+        "history_id": "prior:probe:4",
+        "order_sha256": "0e6cd6f07b0e787550f167b7b2618c093798a7daf6532ed7034883102e630f6a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "history_id": "prior:probe:5",
+        "order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "79babcff39c14382587e9985c2a7f29e9f235ec820f9be660d4a5b389a80c157",
+        "history_id": "prior:probe:6",
+        "order_sha256": "fff3141a6a0cb083c0c47caa9d503962f2e8df7d09b0cb7bd7feb48749db91cc",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "58ca3889b456993b7269bc29f804db9ae48ab1f1cba6e3b32fffc551643f18f2",
+        "history_id": "prior:probe:7",
+        "order_sha256": "4f1bd2dba49c94c3347c1f8d305a64c63909a7c554fb8dcae8d30043d81ff5f2",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ef45651dea4eb7f0dd109be674abd64408952f633702ede41bc2fde02d1cae72",
+        "history_id": "prior:probe:8",
+        "order_sha256": "e20270d7c562e00367c52995549417843bcef3d8603184d207639c904148c571",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "12332dd76c249041d5a28b9c81dbe613f45a41c5a2685910daa3517ad4b34027",
+        "history_id": "prior:probe:9",
+        "order_sha256": "dc61176ac8c0097851f2854c265eb7583663b5a6a2f66126bf5a03846d56e63e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "0f6cc8e662af54f44907d245f9adbd6cca93dbdbb8c14ef9a99adfcb9ac1ed0d",
+        "history_id": "prior:probe:10",
+        "order_sha256": "754426e7bc885a0f2e8fb1c853807baed5351586254e29bb8c92b0d0f7cd25ef",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "15e5a1a1fea1a5c4c47229faa4ebc023063d8e2802139a23bd754d30c5c851ea",
+        "history_id": "prior:probe:11",
+        "order_sha256": "060fe21eab6ec94f7825cfb799fd2d022cee8a3f0db90f73fd69e6154d7da5fd",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "141cf222b3b0697645027b016fa45231adbca52849dc3f7d9523cb32061d7665",
+        "history_id": "prior:probe:12",
+        "order_sha256": "d09f13e9829115f310886304f784cb62e2385fd9dcf291bd1b0db6670624e40d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "086627559e7a75648d34ad8dc52bd10baba93dabd028de442ad497dcc3c34818",
+        "history_id": "prior:probe:13",
+        "order_sha256": "2bc81b26171354d28295d62241623aadd68a98cff34fee7b7e0ec47465187abb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "bb962a4708e2b29db9d7ed570225b789a34ccca8a14ce7121ba8f514dcecb481",
+        "history_id": "prior:probe:14",
+        "order_sha256": "581f88dbcd0fe62dd4b80be4521d5ba21399a400fd50945694dc2c01287cc430",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "74e24135b5924adfadf007c806b6aa922dd473ca0b82512b9699e83ee4395b8b",
+        "history_id": "prior:probe:15",
+        "order_sha256": "6ca9c08de031a639defe03c7f5aee697b8142cc1884460d9aa314df76e2d13ec",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "cf586c61dd9f421f025969fd3dc6342bd632daf4221e035c00af56f422f07b6a",
+        "history_id": "prior:seeded:0",
+        "order_sha256": "3d9f6fafb2bdc898aaefab174932d060919b4992440954d03266ac0c4c3a8c54",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2a2374e7b829f31f5a3afc50a6115620f53894bd7b47689f9ce838591a7d3145",
+        "history_id": "prior:seeded:1",
+        "order_sha256": "b143a0412b3d7179d2dfa5ab7056fc86f0f61678f29463343201cd3755310912",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2664a62fd1f2df2ceb8c350104fbc18f01fb918c919f345a51234f0fc080a765",
+        "history_id": "prior:seeded:2",
+        "order_sha256": "7ddc43a26c71be6f9226d86a4094064ea2a56f1f87af69c787c9b50e7285fc18",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "87025881b3c0d75c80505a291d7206657e7cf8267543f6b1f4c9bfd897d402ac",
+        "history_id": "prior:seeded:3",
+        "order_sha256": "62af9cce7d384bb07a18bee0a5666e752f08ab91ff6cb8f28d94bdaec6de126a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f9be89d8cca62869c2d7500e4d75ae8a28d5cd90e8315cc711ecdc6a76899523",
+        "history_id": "prior:seeded:4",
+        "order_sha256": "e7ff334e2ba96bd7861442773e354845c776db61d2723a7fe9229928c2af8a95",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "6198d5cd8e6689d0af6250c76d076db6606ff85eaaf14a9ca1125944ecbb0f8f",
+        "history_id": "prior:seeded:5",
+        "order_sha256": "9ca9bcb9f7ac3012eddcd1faa95a2e41c5c2062ac1b662d828938d902ba81902",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "history_id": "prior:seeded:6",
+        "order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "history_id": "prior:seeded:7",
+        "order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f65bb867cbc8532d2c2c89682895ae8999d75de687ef6d03e8122039b88a60c1",
+        "history_id": "first_fresh:fresh:0",
+        "order_sha256": "b3fb01c68d5763b9f7e1145de43d85fa10593e255de1664502289aba9f2c18d5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1495f18db025b31993978b203d9884065a466f27754cbb6930c0349d027d6837",
+        "history_id": "first_fresh:fresh:1",
+        "order_sha256": "e5bbf6b4fe5c23b4d8660b0ee114ae5197a9d92f8b8a7817c809d66c67b6bc7f",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "14e2003e2113af6086da7654e7dad616e2b5b87fb06dfa1826f5e27d276da60a",
+        "history_id": "first_fresh:fresh:2",
+        "order_sha256": "fffc543b5fe7bd806e59be736acb34787451c354d733cb00cbc0d3e1d4a17ceb",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0b7138c621548805e187aa1d5f0b70c169765362a98c21535a3b7797b62c9fe",
+        "history_id": "first_fresh:fresh:3",
+        "order_sha256": "f1f588b6a76fe0727293f263ff3d40bbfe537e40293f68a9e14b7745d23a419c",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "120335beb6c2273c2f30312e297cd69ae2316e1a273044a0959d79f824424a5c",
+        "history_id": "first_fresh:fresh:4",
+        "order_sha256": "6bb23677f914747186d71bf861bd525e7f3788e608396f106b27bf70524c4637",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "history_id": "first_fresh:fresh:5",
+        "order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "history_id": "first_fresh:fresh:6",
+        "order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "history_id": "first_fresh:fresh:7",
+        "order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "history_id": "first_fresh:fresh:8",
+        "order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "history_id": "first_fresh:fresh:9",
+        "order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "history_id": "first_fresh:fresh:10",
+        "order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "history_id": "first_fresh:fresh:11",
+        "order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "169cb63c511b5342437e41bab670aca22fa1a8dd49197596a5b400c0df9aad93",
+        "history_id": "first_fresh:fresh:12",
+        "order_sha256": "7d26dac32a4f49b310623dc118741fd3eae62a98fddc3fc02343cda28982e0d2",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "history_id": "first_fresh:fresh:13",
+        "order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "history_id": "first_fresh:fresh:14",
+        "order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "history_id": "first_fresh:fresh:15",
+        "order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "history_id": "first_fresh:fresh:16",
+        "order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "history_id": "first_fresh:fresh:17",
+        "order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b2ea5b6ee6ac796d5383ae7260006a43c9ef172de728ce355103ad818c011870",
+        "history_id": "first_fresh:fresh:18",
+        "order_sha256": "ad2c330339c8d008ca9dddebd31e6e72a92f3a882529ef6afe1eb15687ac3a92",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "39344073585252f9a0c4b427237efa9eaff37765c4aebfeba914b69695fc05b3",
+        "history_id": "first_fresh:fresh:19",
+        "order_sha256": "f3ff2b091996877bb676eb68b61bd8740b052aa0b0cc11bf737b7921f33ce237",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "history_id": "first_fresh:fresh:20",
+        "order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ec5946bf2f40dc5430e51e9490586f5672dce0247712e3725efa519a53aca7de",
+        "history_id": "first_fresh:fresh:21",
+        "order_sha256": "9bca3aac19a02dae679142542a99e8f2691b6b621620d71a97ab7ae9cc651128",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "history_id": "first_fresh:fresh:22",
+        "order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "history_id": "first_fresh:fresh:23",
+        "order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "history_id": "first_fresh:fresh:24",
+        "order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "history_id": "first_fresh:fresh:25",
+        "order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "history_id": "first_fresh:fresh:26",
+        "order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "history_id": "first_fresh:fresh:27",
+        "order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "history_id": "first_fresh:fresh:28",
+        "order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "history_id": "first_fresh:fresh:29",
+        "order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "history_id": "first_fresh:fresh:30",
+        "order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "history_id": "first_fresh:fresh:31",
+        "order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "history_id": "second_fresh:fresh:0",
+        "order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "79992c5f6bd66f15584ce60b9059f4f9adf6d6c3bbfe13a6c7e985e4cc98e934",
+        "history_id": "second_fresh:fresh:1",
+        "order_sha256": "813b0573bbb49d2ec6fdd5850c98a09faf809b8d202f75b9b5039304d45fc12a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "history_id": "second_fresh:fresh:2",
+        "order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "history_id": "second_fresh:fresh:3",
+        "order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "history_id": "second_fresh:fresh:4",
+        "order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "history_id": "second_fresh:fresh:5",
+        "order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "history_id": "second_fresh:fresh:6",
+        "order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "history_id": "second_fresh:fresh:7",
+        "order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "history_id": "second_fresh:fresh:8",
+        "order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "history_id": "second_fresh:fresh:9",
+        "order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "history_id": "second_fresh:fresh:10",
+        "order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "history_id": "second_fresh:fresh:11",
+        "order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "history_id": "second_fresh:fresh:12",
+        "order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "history_id": "second_fresh:fresh:13",
+        "order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "history_id": "second_fresh:fresh:14",
+        "order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "history_id": "second_fresh:fresh:15",
+        "order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "history_id": "second_fresh:fresh:16",
+        "order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "history_id": "second_fresh:fresh:17",
+        "order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2210ce735dc632ef83e03e7b2d4a3634375c2de67696f6a365b902a9b4bc3f86",
+        "history_id": "second_fresh:fresh:18",
+        "order_sha256": "fe45925710e246345dc057ea7c935ae9c3070ad9544efd0b19be6b546fa64220",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "194f3fd7909ff96ed4d2f5e2dfd692d275d2133f0855cd649b6d759e5aab8643",
+        "history_id": "second_fresh:fresh:19",
+        "order_sha256": "ec5c74f9b07ef5d4a791ebd149abe20ec81a42ebfc23d8121afcacd22fe5fe66",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "41c5ce250a21087b96de0cd9afe6e772afe256bfba0efb86dc4b9cd866ba1775",
+        "history_id": "second_fresh:fresh:20",
+        "order_sha256": "e5bfda8732de5ace04841e34b1683f96d951c7b3c720e01ae8fbca8252cee2e2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1f94d235621cb6118fbcec853d4ce051fbc0da58aac1f6536f86c1a07a7c8ce3",
+        "history_id": "second_fresh:fresh:21",
+        "order_sha256": "f10f76dcdd591f5c4d36be49cea8e7b063f8aad6880f227da5b1541bd2fc65e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "91c0adb00ca0fc2c9c95e0a6231d9ee98bb106fd4e4be71d22321a23dd713102",
+        "history_id": "second_fresh:fresh:22",
+        "order_sha256": "c7c0cf5c2af1ee6ab12519d404279ed36f2b3c63a3f047b2f34208670ffa6a33",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "history_id": "second_fresh:fresh:23",
+        "order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "history_id": "second_fresh:fresh:24",
+        "order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "history_id": "second_fresh:fresh:25",
+        "order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "history_id": "second_fresh:fresh:26",
+        "order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "history_id": "second_fresh:fresh:27",
+        "order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "history_id": "second_fresh:fresh:28",
+        "order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "history_id": "second_fresh:fresh:29",
+        "order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "history_id": "second_fresh:fresh:30",
+        "order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "history_id": "second_fresh:fresh:31",
+        "order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "21af0fdceaa2c7b6d6fd444590571ed04a48bd7e0dce5aeafecf86e80e6b2081",
+        "history_id": "transfer_cegar_probe:0",
+        "order_sha256": "01e5595550dc1a887be1e0a5745e1ea9ab38070460f5afa569ad45df8ae3a32c",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "2ec108f7f3fbc4f5b9dbc523095b381676452797aa2384d5d4e65eb375b22f3c",
+        "history_id": "transfer_cegar_probe:1",
+        "order_sha256": "793e8e7d2770941c399debc6a5e57e4c903561f826f10991922fb616d14081c4",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "892d53605b57f7e885514c3bc240208a75c949cd05d38d6b869f9a52a222fbda",
+        "history_id": "transfer_cegar_probe:2",
+        "order_sha256": "8477beb967b9eb08f3528689ba26bed083a58f98b3aa384414b5b625d0ed28f5",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "history_id": "transfer_cegar_probe:3",
+        "order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "history_id": "transfer_cegar_probe:4",
+        "order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "history_id": "transfer_cegar_probe:5",
+        "order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "11bec0ac6af6f23f784eb87a4829063a3fcafa5afe5f0312d6f596981dd16623",
+        "history_id": "transfer_cegar_probe:6",
+        "order_sha256": "c2be4b0fce6eeeab8dff1f8c2569d23305b998bdf248f09edb0c16adcbd739a1",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "history_id": "transfer_cegar_probe:7",
+        "order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "3f394554dde1776db09fd7018a91729b93c154520d599454bb8c00b9aaf6e7f4",
+        "history_id": "transfer_cegar_probe:8",
+        "order_sha256": "c60c083264a78b314734ec064a7dfc0d27f62cf6954b1652613439d313b74f00",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "history_id": "transfer_cegar_probe:9",
+        "order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "b62b485b3882d8da27d08d57d4f9623cec3e06fb0cbab1100ef51f7d58af5760",
+        "history_id": "transfer_cegar_probe:10",
+        "order_sha256": "443391e50babb2e418cf3acce0b958bf584bbfbdd5d30cf538e5c5ed299f388e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "history_id": "transfer_cegar_probe:11",
+        "order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5198401fb43886093718c4425e1cba2cd6ba7bc36a1e43ca52f68acb1467822",
+        "history_id": "transfer_cegar_probe:12",
+        "order_sha256": "918febc87d6907cc754ee5cfd79b8a5c258ab2c0d3045606b310f3a5e076e3cc",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "history_id": "transfer_cegar_probe:13",
+        "order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "history_id": "transfer_cegar_probe:14",
+        "order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "history_id": "transfer_cegar_probe:15",
+        "order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "518976209920025e367b9beb159b8cdc524e485ef40fff87460cdc2959476cab",
+        "history_id": "transfer_cegar_residual:0",
+        "order_sha256": "e24c65ad7cd685c73d1cb969841fd4c72ecd0d56957a03239f4033de180555c6",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "5846cfb91ddf84cfda808e3f4c44d58a8cbb429d53db50f4e303fbada897be4f",
+        "history_id": "transfer_cegar_residual:1",
+        "order_sha256": "4ab9d66bab68c96f6804a8acbbb80d5e865a4e4cccbe628661f47c89878ae8cd",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "history_id": "transfer_cegar_residual:2",
+        "order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "history_id": "transfer_cegar_residual:3",
+        "order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "history_id": "transfer_cegar_residual:4",
+        "order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "history_id": "transfer_cegar_residual:5",
+        "order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "history_id": "transfer_cegar_residual:6",
+        "order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "history_id": "transfer_cegar_residual:7",
+        "order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "history_id": "augmentation_probe:0",
+        "order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "history_id": "augmentation_probe:1",
+        "order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "1c386c157cf50020135c32b97b2bd1252a10e0a76acc05739ebd1f79813cab0b",
+        "history_id": "augmentation_probe:2",
+        "order_sha256": "2968b0a163e6b15c9a4fd3ae309091089b864290224eff954088809fea1786aa",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "6dc35b1d65c62e2042ff2f2274085bb0d5e54b8f93048bdcb02beff769356f7e",
+        "history_id": "augmentation_probe:3",
+        "order_sha256": "c98f9fda4a774c274f83baf63ad5fe0be5e64d5110323e63decf1b243e42b4a6",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f8f07b4dfa0c7b5b1cdb5e52ec58e09f720179fe9c2bd6e15132f3adf1e94023",
+        "history_id": "augmentation_probe:4",
+        "order_sha256": "9cfffb312b0cbe7074847072c804ef7890f0de69cd2a3475901941885ef11098",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "history_id": "augmentation_probe:5",
+        "order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "ba04e21c82460534a05f784da7af74b5db4579daf575969d2f3664c64527d8c2",
+        "history_id": "augmentation_probe:6",
+        "order_sha256": "58ef1145544aba90699ee3949e67dac9f93ee20e108de7a7ed81c3a50ce1f882",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "eaff5f7030f3780b3ac105f0031dab52a5aa483dc42d156895a227713fd3d357",
+        "history_id": "augmentation_probe:7",
+        "order_sha256": "aa82c870cdec719876a50964d030d7c13da82a632c3a0f16ce05efaa8a41a6aa",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "history_id": "augmentation_probe:8",
+        "order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "history_id": "augmentation_probe:9",
+        "order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "history_id": "augmentation_probe:10",
+        "order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "history_id": "augmentation_probe:11",
+        "order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "30f362230bc2ecc4c569923228b5a4ce003220f93c3869bcd57bad5a6f8240fe",
+        "history_id": "augmentation_probe:12",
+        "order_sha256": "fd1d0c8af17efe869c2a5eaa37f44d2ff196df14e2f4e2b5d645d1fa3f7ebf2e",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "history_id": "augmentation_probe:13",
+        "order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "4a99c5a82c42e9253460d4e3612a3b4d30d567e71749a417bb9378be8a3ebc52",
+        "history_id": "augmentation_probe:14",
+        "order_sha256": "a343ff07c8321bf23451fe9b7cefad97adaa8f48e9557f25187f4cab5d732760",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "history_id": "augmentation_probe:15",
+        "order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "history_id": "augmentation_probe:16",
+        "order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "history_id": "augmentation_probe:17",
+        "order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "history_id": "augmentation_probe:18",
+        "order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "history_id": "augmentation_probe:19",
+        "order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "history_id": "augmentation_probe:20",
+        "order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "e71b60f92693ae63a66e0e0805134f1436381cd85e61e4cfcf0fb9c7843d4fd3",
+        "history_id": "augmentation_probe:21",
+        "order_sha256": "383b5131a68b22240a74ec5281be3ba01a372dc02241d9b706d11a80e66bae0c",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "7ae8308d62d26f3fbefa7a9862f88a26c3a1aa2cc4a51f07c5e2cfd0fd7b67e2",
+        "history_id": "augmentation_probe:22",
+        "order_sha256": "47cbe888ff88b45b833d8fd1f8dc89bca00656bf9795ef484a3a481345b027f3",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "8ccd5b799ffa1e43f5b47f14a140bb0a6484ff859f9621f0a41bfb294c9a6869",
+        "history_id": "augmentation_probe:23",
+        "order_sha256": "4c6f5a3aea2e6afe78c2ae409b429cd35c9c06ea7cc1ac23a355ac50f97ca0bd",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "715ff051ef4e9563096c2798eaa5894890379a3089e5875874e624b9799cabb7",
+        "history_id": "augmentation_probe:24",
+        "order_sha256": "e4706b5d6ecbd1b1f03ae78cf2f130f9b962e32236ada16185baf6b25f4d40f7",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "history_id": "augmentation_probe:25",
+        "order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "history_id": "augmentation_probe:26",
+        "order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "history_id": "augmentation_probe:27",
+        "order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "history_id": "augmentation_probe:28",
+        "order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "history_id": "augmentation_probe:29",
+        "order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "history_id": "augmentation_probe:30",
+        "order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "history_id": "augmentation_probe:31",
+        "order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "packet": "augmentation_probe"
+      }
+    ],
+    "order_count": 144,
+    "packet_histogram": {
+      "augmentation_probe": 32,
+      "first_fresh": 32,
+      "prior": 24,
+      "second_fresh": 32,
+      "transfer_cegar_probe": 16,
+      "transfer_cegar_residual": 8
+    }
+  },
+  "circulant_offsets": [
+    2,
+    5,
+    9,
+    14
+  ],
+  "claim_scope": "Three transferred exact C25 certificate orbits plus one selected exact width-four persistent orbit seed a bounded order CEGAR after 144 known C25 orders are blocked under rotation and reversal. Probe coverage, newly learned certificates, and affine images are exact, but finite limits and history blocking preclude any all-order obstruction, geometric realizability result, counterexample, proof of Erdos Problem #97, or official/global status update.",
+  "configuration": {
+    "active_seed_policy": "three transferred orbits plus exact minimum new-marginal persistent width-four orbit only",
+    "conflict_cap": 1024,
+    "full_certificate_limit": 8,
+    "history_equivalence": "cyclic rotation and reversal",
+    "inactive_seed_policy": "dominated persistent width-five orbit and eight zero-marginal compressed residual orbits",
+    "max_iterations": 12000,
+    "pattern": "C25_sidon_2_5_9_14",
+    "probe_max_iterations": 12000,
+    "probe_order_limit": 16,
+    "random_seed": 20260730,
+    "tolerance": 1e-09
+  },
+  "counterfactual_probe": {
+    "blocked_history_dihedral_order_count": 144,
+    "inverse_pair_clause_count": 14122,
+    "inverse_pair_escape_order_count": 16,
+    "iterations": 454,
+    "models": [
+      {
+        "dihedral_order_sha256": "5ef345f1349ff914bcf3bcf459fa62203386351a2c723979b5ff8699028e0402",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          15,
+          7,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "5ef345f1349ff914bcf3bcf459fa62203386351a2c723979b5ff8699028e0402",
+        "probe_model_index": 0,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 439
+      },
+      {
+        "dihedral_order_sha256": "5ddbaeff0aeeede2790d73f42e3b2f4d0f5c6d117c5e26984674ecf8abdd7726",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          7,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "5ddbaeff0aeeede2790d73f42e3b2f4d0f5c6d117c5e26984674ecf8abdd7726",
+        "probe_model_index": 1,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 440
+      },
+      {
+        "dihedral_order_sha256": "37f73c3cf6ff91b10b5246de93ea8e08ebb1b574edde9a364becddac7d2c7ca8",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          7,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          14,
+          3
+        ],
+        "order_sha256": "a97a21ca890dbb3cede13d40a49b3cd3c80de3739ee22fc1539c27f7a2c9ff55",
+        "probe_model_index": 2,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 441
+      },
+      {
+        "dihedral_order_sha256": "e545f59d547cb4eb16eb05f6f005cb5eb81a686f2b8316cb82739be659c5a8f3",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          15,
+          7,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          14,
+          3
+        ],
+        "order_sha256": "c4ba39e59e4c4bfc0384ad21fa13f5409990000ac475de2e49c5ee7d449bc1fc",
+        "probe_model_index": 3,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 442
+      },
+      {
+        "dihedral_order_sha256": "d01d8a2d708f94901e3c82ce71c4cbb576ffd85bf3527edca38d5557e4e2bed9",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          7,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          3
+        ],
+        "order_sha256": "2040570e16bad06ccb17f53583fee3437e24528ad579074b1cc1f90d62b1226d",
+        "probe_model_index": 4,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 443
+      },
+      {
+        "dihedral_order_sha256": "0aadb2e30d2093eb0d54ef2ba26477212a4838c3eb7c11795e5a4783dfeb52fb",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          7,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          17,
+          9,
+          6,
+          3
+        ],
+        "order_sha256": "8a0e23f99c788d5ddfcbce03e64fdd5a670757c2d9f285084dde56c019d112c9",
+        "probe_model_index": 5,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 444
+      },
+      {
+        "dihedral_order_sha256": "e3b7e4b11cc8876bb0c2b2a8a845fad3919ec4f548167266c9a7c1159acaa7cf",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          7,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          17,
+          6,
+          3
+        ],
+        "order_sha256": "c19090f55d494cdf88cc62828d3f4ac1725e571b9ad9d1ffb898104085504e0c",
+        "probe_model_index": 6,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 445
+      },
+      {
+        "dihedral_order_sha256": "fa936ef8774e4ac5ee1e28b74b40472027e67a63373150d54384715f1eebb25a",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          15,
+          7,
+          4,
+          1,
+          12,
+          23,
+          20,
+          17,
+          9,
+          6,
+          3
+        ],
+        "order_sha256": "cfc8b5c7172ce19b98f64af0ddca23b74caecaf10c77f520786967af46237551",
+        "probe_model_index": 7,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 446
+      },
+      {
+        "dihedral_order_sha256": "2832320261578a148556886137ceac035b359ac0144c8f3a2b38bcd6ff28cb29",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          15,
+          7,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          3
+        ],
+        "order_sha256": "2b21e2d8946e6ac3eab28de470203b7087e85eccdfbbea71f516e60950816ba0",
+        "probe_model_index": 8,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 447
+      },
+      {
+        "dihedral_order_sha256": "994dcfacd99ef5e89dce19f8c4b55340744813f26d4382fd5ef1e11ffb0798d7",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          18,
+          15,
+          7,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          17,
+          6,
+          3
+        ],
+        "order_sha256": "d2558f98e57e8713c96f183a33d6f267400acb9507249cc6cfca3af7d5bd31fa",
+        "probe_model_index": 9,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 448
+      },
+      {
+        "dihedral_order_sha256": "c15c6171b383b87320dec07cf0a520c0ff82afc545deeced2b4a70d1cccdc2f5",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          6,
+          17,
+          14,
+          3
+        ],
+        "order_sha256": "11f5903dbcc4c0363747842df6060739e22027b66c17029f4115ef7b286f6e10",
+        "probe_model_index": 10,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 449
+      },
+      {
+        "dihedral_order_sha256": "1e6edfeee8c2a8c9aa09b1c1464126ceaa8f4047b4b01d746204536bd0e5a4b1",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          17,
+          6,
+          14,
+          3
+        ],
+        "order_sha256": "0325aff35bca425d6cdf128772fa9184aa63903356fe4a35c82d369bdd961da3",
+        "probe_model_index": 11,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 450
+      },
+      {
+        "dihedral_order_sha256": "6e4b8d2b6f199af5da0d25043f232d352b667439e5b8adb1e2784f24a61b45d9",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          9,
+          17,
+          14,
+          6,
+          3
+        ],
+        "order_sha256": "f7e9ad983fb5473c0ca2f1a9229c71e65a24473ce415437a15a1cf04baa11f7d",
+        "probe_model_index": 12,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 451
+      },
+      {
+        "dihedral_order_sha256": "92981ebf7bafb1138f1db7b0f7c035b8055e31dbe73b38fc8a1c6492ba51eae2",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          17,
+          9,
+          6,
+          14,
+          3
+        ],
+        "order_sha256": "af99cf38492e495b31ce644fe86d4d564fdea23e6bde20ef65321f69274ce099",
+        "probe_model_index": 13,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 452
+      },
+      {
+        "dihedral_order_sha256": "d250a8468ba4f6dcf76c13ceb832ff74cf6ce83a7b5aae837fcee8b663f8757d",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          17,
+          9,
+          14,
+          6,
+          3
+        ],
+        "order_sha256": "9d1d5c00d4b3bbe90ba30b80a0d1c119bba06a1b47f3554b0e8696e0cf1a1f33",
+        "probe_model_index": 14,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 453
+      },
+      {
+        "dihedral_order_sha256": "ec12a86d316165551a7e0da91fefdf023021a7bd3fa1aa7362d787d7fad699dc",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          10,
+          24,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          20,
+          17,
+          9,
+          6,
+          3
+        ],
+        "order_sha256": "eae5019a4c4ff562c07cfdd815ae7b390c8482d0911418583d09f04b8befc64e",
+        "probe_model_index": 15,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 454
+      }
+    ],
+    "solver_result": "bounded_after_inverse_pair_escape_models",
+    "status": "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+  },
+  "counterfactual_seed_packet_coverage": {
+    "active_uncovered_probe_model_indices": [],
+    "selected_width4_marginal_over_transferred_probe_model_indices": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "selected_width4_only": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 16,
+          "matched_strong_probe_orders": 16,
+          "matching_orbit_clause_occurrences": 55,
+          "source_model_index": 0
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "1": 16
+      },
+      "strong_probe_order_count": 16
+    },
+    "transferred_only": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 15
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 19
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 28
+        }
+      ],
+      "covered_probe_order_count": 0,
+      "covered_probe_order_fraction": 0.0,
+      "covered_strong_probe_order_count": 0,
+      "covered_strong_probe_order_fraction": 0.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "0": 16
+      },
+      "strong_probe_order_count": 16
+    },
+    "transferred_plus_selected_width4": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 16,
+          "matched_strong_probe_orders": 16,
+          "matching_orbit_clause_occurrences": 55,
+          "source_model_index": 0
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 15
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 19
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 28
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "1": 16
+      },
+      "strong_probe_order_count": 16
+    },
+    "transferred_uncovered_probe_model_indices": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ]
+  },
+  "decision": "COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS",
+  "distinct_active_seed_orbit_class_count": 4,
+  "inactive_seed_templates": [
+    {
+      "compressed_certificate_sha256": "927e35f69e86103e506d9551848bd6a409dccd8b8567708397064941bf8d5877",
+      "inactive_reason": "ZERO_MARGINAL_TARGETS_BEYOND_SELECTED_WIDTH4_ON_144_ORDER_PACKET",
+      "ordered_quad_count": 5,
+      "seed_id": "persistent_compressed:1",
+      "source_model_index": 1,
+      "source_screen_target_id": "probe:1",
+      "source_target_id": "transfer_cegar_probe:1"
+    },
+    {
+      "canonical_clause_sha256": "2a1134337269121a8b4079afa9888294b5c6529a6ddd902656d6ac01f6058a01",
+      "compressed_certificate_sha256": "f8362079fc6ea9df386ca8b3cc210f3758db59850e2f108ad6c63017cc5b774a",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 7,
+      "seed_id": "residual:0",
+      "source_model_index": 0,
+      "source_target_id": "seeded:0"
+    },
+    {
+      "canonical_clause_sha256": "688754a4f2259235dee0ce04f4b92bf61a6318b4eb02aa8e6bc4d8af6171d985",
+      "compressed_certificate_sha256": "e9efcb62532b22e33a1488b4087ed4fc29d3c763b47293de7331b909113dd98d",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 9,
+      "seed_id": "residual:1",
+      "source_model_index": 1,
+      "source_target_id": "seeded:1"
+    },
+    {
+      "canonical_clause_sha256": "30e4470c4e78617f43f5a3dad6cb61d5ef815069dc51cfb6ed0851cac4ac8867",
+      "compressed_certificate_sha256": "3a3abbda9514b96acaf4ad09c589c2b1a087e08924456ca6fcf33eb9d8d35ef8",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 5,
+      "seed_id": "residual:2",
+      "source_model_index": 2,
+      "source_target_id": "seeded:2"
+    },
+    {
+      "canonical_clause_sha256": "08c7e636bc3eefd93c58b8f58a864916e9f84975e4ad67dab4ecae3402e8fc32",
+      "compressed_certificate_sha256": "721ded29b8624d830c7ed6ff2c15ec544b8c8662701e03f7aadcb1863b96ccae",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 3,
+      "seed_id": "residual:3",
+      "source_model_index": 3,
+      "source_target_id": "seeded:3"
+    },
+    {
+      "canonical_clause_sha256": "844f79396e7613092e180c74a09acabf7ea09e34faeea3525a7846b5dedf37c2",
+      "compressed_certificate_sha256": "58873106a85fd064758c92dab5ed86e479b6de082e9964e0d939e3f7617c36c3",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 7,
+      "seed_id": "residual:4",
+      "source_model_index": 4,
+      "source_target_id": "seeded:4"
+    },
+    {
+      "canonical_clause_sha256": "9443f651b1c48564f709c3a3f6b31982163e24554d34cb161368838e8f0a82bc",
+      "compressed_certificate_sha256": "fc724cd90b08c77c9e596e081bf5de1b03fb9f34fe32486a7daddf39eebb9cb9",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 4,
+      "seed_id": "residual:5",
+      "source_model_index": 5,
+      "source_target_id": "seeded:5"
+    },
+    {
+      "canonical_clause_sha256": "b0a00925436f41f730b62d9d038110d3d2f378b6bc7a315cd89e28915b934e68",
+      "compressed_certificate_sha256": "1b589e8f5a2740c1ffb0244713b246e8cb9d48bc72d3caf358a280528f1b9805",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 6,
+      "seed_id": "residual:6",
+      "source_model_index": 6,
+      "source_target_id": "seeded:6"
+    },
+    {
+      "canonical_clause_sha256": "46e63bc7b5da9b7781532a95387b53cee9065d4becae5aa8409b1a102cc9b4aa",
+      "compressed_certificate_sha256": "75509de4030d9b89c00358503d3ed00f9d1733e07666eb1c2035f7cfbbae9814",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 4,
+      "seed_id": "residual:7",
+      "source_model_index": 7,
+      "source_target_id": "seeded:7"
+    }
+  ],
+  "n": 25,
+  "next_target": "Compress the eight newly learned exact C25 residual certificates, construct their quotient-preserving affine orbits, and measure marginal reuse before increasing the order-search budget.",
+  "pattern": "C25_sidon_2_5_9_14",
+  "seeded_cegar": {
+    "active_unique_seed_orbit_clause_count": 100,
+    "blocked_history_dihedral_order_count": 144,
+    "final_inverse_pair_clause_count": 15006,
+    "initial_probe_inverse_clause_count": 14122,
+    "iterations": 102,
+    "models": [
+      {
+        "dihedral_order_sha256": "55db65a812422826d3953cc6ad5a34d108f4bd1b1a1d1b6bbf1cee8185bf36f2",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "fe12a7a87f991f0181579a6f4c256ba373cb42db174f4173d9a959842ea892a6",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 0,
+            "source_order": [
+              0,
+              11,
+              3,
+              6,
+              14,
+              17,
+              20,
+              9,
+              23,
+              12,
+              1,
+              4,
+              7,
+              15,
+              10,
+              18,
+              21,
+              24,
+              2,
+              13,
+              16,
+              5,
+              8,
+              19,
+              22
+            ],
+            "source_unique_ordered_quad_count": 197,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              3,
+              6,
+              14,
+              17,
+              20,
+              9,
+              23,
+              12,
+              1,
+              4,
+              7,
+              15,
+              10,
+              18,
+              21,
+              24,
+              2,
+              13,
+              16,
+              5,
+              8,
+              19,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  3,
+                  16
+                ],
+                "weight": 210989159766734949
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  6,
+                  4
+                ],
+                "weight": 527976306899347211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  12,
+                  7
+                ],
+                "weight": 269228950707044583
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  18,
+                  13
+                ],
+                "weight": 505809100872518098
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  7,
+                  24
+                ],
+                "weight": 158969701145832641
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  18
+                ],
+                "weight": 411691382654653316
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  16,
+                  22
+                ],
+                "weight": 52019458620902308
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  17,
+                  24
+                ],
+                "weight": 58065147101511836
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  18,
+                  19
+                ],
+                "weight": 469911159797835375
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  21,
+                  16
+                ],
+                "weight": 98981109206343060
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  17,
+                  2
+                ],
+                "weight": 1483382528344532716
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  20,
+                  5
+                ],
+                "weight": 1263570734501402664
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  12,
+                  22
+                ],
+                "weight": 281713164110207661
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  23,
+                  21
+                ],
+                "weight": 590715556015228267
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  4,
+                  5
+                ],
+                "weight": 741491760663261283
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  7,
+                  8
+                ],
+                "weight": 209240358767555002
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  9,
+                  13
+                ],
+                "weight": 2496879251205219793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  23,
+                  12
+                ],
+                "weight": 327893070878425621
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  12,
+                  7
+                ],
+                "weight": 108568695765994835
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  5,
+                  8
+                ],
+                "weight": 197962218412686120
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  13,
+                  5
+                ],
+                "weight": 622999618785151718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  1,
+                  4
+                ],
+                "weight": 213515453763914072
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  1,
+                  8
+                ],
+                "weight": 331617739704821458
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 545133193468735530
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  10,
+                  24
+                ],
+                "weight": 564028878015700157
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  18,
+                  24
+                ],
+                "weight": 766846413653901693
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  21,
+                  22
+                ],
+                "weight": 98981109206343060
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  2,
+                  19
+                ],
+                "weight": 411691382654653316
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  16,
+                  19
+                ],
+                "weight": 564028878015700157
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  24,
+                  8
+                ],
+                "weight": 1330875291669601850
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  8,
+                  19
+                ],
+                "weight": 197962218412686120
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  16,
+                  5
+                ],
+                "weight": 117190517912633620
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  3,
+                  14,
+                  20
+                ],
+                "weight": 2173805699872071945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  3,
+                  17,
+                  4
+                ],
+                "weight": 1599931876906495839
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  3,
+                  20,
+                  8
+                ],
+                "weight": 6185628315642245064
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  3,
+                  9,
+                  13
+                ],
+                "weight": 3758454968476966097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  6,
+                  17,
+                  23
+                ],
+                "weight": 354991766630726874
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  6,
+                  9,
+                  15
+                ],
+                "weight": 965168071882787268
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  6,
+                  12,
+                  19
+                ],
+                "weight": 559506045195732362
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  14,
+                  17,
+                  13
+                ],
+                "weight": 2173805699872071945
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  17,
+                  20,
+                  9
+                ],
+                "weight": 4128729343409294658
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  17,
+                  1,
+                  7
+                ],
+                "weight": 504539097601553673
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  17,
+                  19,
+                  22
+                ],
+                "weight": 640530103732940072
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  20,
+                  23,
+                  12
+                ],
+                "weight": 2140415233801451512
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  20,
+                  10,
+                  19
+                ],
+                "weight": 198003230395996994
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  20,
+                  21,
+                  13
+                ],
+                "weight": 430101446841410014
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  20,
+                  13,
+                  22
+                ],
+                "weight": 3410559508201840977
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  20,
+                  8,
+                  19
+                ],
+                "weight": 640530103732940072
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  20,
+                  8,
+                  22
+                ],
+                "weight": 6346226320443949702
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  9,
+                  24,
+                  2
+                ],
+                "weight": 995633858050569477
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  23,
+                  12,
+                  16
+                ],
+                "weight": 781678475518460849
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  23,
+                  7,
+                  10
+                ],
+                "weight": 235310146894509090
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  23,
+                  15,
+                  8
+                ],
+                "weight": 966438075153751693
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  23,
+                  10,
+                  2
+                ],
+                "weight": 37306916498512096
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  12,
+                  4,
+                  21
+                ],
+                "weight": 1071955570007148628
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  12,
+                  24,
+                  8
+                ],
+                "weight": 801128108534644710
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  1,
+                  15,
+                  16
+                ],
+                "weight": 504539097601553673
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 505809100872518098
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  2,
+                  8
+                ],
+                "weight": 430101446841410014
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  2,
+                  13
+                ],
+                "weight": 1796761966585214187
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  16,
+                  8
+                ],
+                "weight": 816280631705947467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  7
+                ],
+                "weight": 944468802102422527
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  12,
+                  13
+                ],
+                "weight": 1570806191136240966
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  14,
+                  9,
+                  16
+                ],
+                "weight": 1773732904355115574
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  14,
+                  1,
+                  10
+                ],
+                "weight": 1775019783027945273
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  14,
+                  21,
+                  13
+                ],
+                "weight": 392794530342897918
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  20,
+                  4
+                ],
+                "weight": 3067353813667750592
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  9,
+                  8
+                ],
+                "weight": 1984722064121850523
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  12,
+                  1
+                ],
+                "weight": 880295312039461447
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  10,
+                  19
+                ],
+                "weight": 205779446819513156
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  23,
+                  21
+                ],
+                "weight": 430101446841410014
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  23,
+                  24
+                ],
+                "weight": 1054759228861691261
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  15,
+                  18
+                ],
+                "weight": 198228193314822834
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  10,
+                  13
+                ],
+                "weight": 1794854246997827213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  18,
+                  2
+                ],
+                "weight": 240326452911785308
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  16,
+                  8
+                ],
+                "weight": 1984722064121850523
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  7,
+                  8
+                ],
+                "weight": 944468802102422527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  15,
+                  18
+                ],
+                "weight": 213463189339830482
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  24,
+                  8
+                ],
+                "weight": 441999885464242830
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  10,
+                  21,
+                  2
+                ],
+                "weight": 37306916498512096
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  2,
+                  8
+                ],
+                "weight": 225613910789395096
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  24,
+                  22
+                ],
+                "weight": 453789642251615790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  2,
+                  22
+                ],
+                "weight": 52019458620902308
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  14,
+                  15,
+                  8
+                ],
+                "weight": 331617739704821458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  14,
+                  10,
+                  5
+                ],
+                "weight": 117190517912633620
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  14,
+                  2,
+                  19
+                ],
+                "weight": 912226687080934117
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  17,
+                  20,
+                  2
+                ],
+                "weight": 780770045284334769
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  9,
+                  23
+                ],
+                "weight": 354991766630726874
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  9,
+                  12
+                ],
+                "weight": 610176305252060394
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  1,
+                  13
+                ],
+                "weight": 433826989380229241
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  4,
+                  7
+                ],
+                "weight": 972212724003217088
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  12,
+                  2
+                ],
+                "weight": 2148186998043288902
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  12,
+                  13
+                ],
+                "weight": 32795498345012458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  2,
+                  13
+                ],
+                "weight": 1235960310962354785
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  7,
+                  15
+                ],
+                "weight": 27743921900794561
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  10,
+                  24
+                ],
+                "weight": 58065147101511836
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  8,
+                  22
+                ],
+                "weight": 270277901468384686
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  15,
+                  21
+                ],
+                "weight": 76274555807802396
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  13,
+                  16
+                ],
+                "weight": 98981109206343060
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  10,
+                  18,
+                  8
+                ],
+                "weight": 175255665014145456
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  21,
+                  19
+                ],
+                "weight": 175255665014145456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  24,
+                  5,
+                  19
+                ],
+                "weight": 117190517912633620
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  9,
+                  19
+                ],
+                "weight": 3921555789246343025
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  23,
+                  10
+                ],
+                "weight": 1652608159104481906
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  12,
+                  16
+                ],
+                "weight": 233171616856994775
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  4,
+                  13
+                ],
+                "weight": 2095141089664533504
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  9,
+                  13
+                ],
+                "weight": 1042614981814034958
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  12,
+                  4
+                ],
+                "weight": 320121306636588231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  15,
+                  10
+                ],
+                "weight": 5221106010829747
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  9,
+                  23,
+                  16
+                ],
+                "weight": 1989965355434878148
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  23,
+                  2,
+                  13
+                ],
+                "weight": 26587641252812165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  1,
+                  4
+                ],
+                "weight": 1775019783027945273
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  15,
+                  21
+                ],
+                "weight": 326396633693991711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  21,
+                  24
+                ],
+                "weight": 281713164110207661
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  12,
+                  21,
+                  22
+                ],
+                "weight": 105860260221860510
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  1,
+                  21,
+                  8
+                ],
+                "weight": 331617739704821458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  15,
+                  18,
+                  2
+                ],
+                "weight": 597743482516410764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  15,
+                  24,
+                  22
+                ],
+                "weight": 281713164110207661
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  13,
+                  19
+                ],
+                "weight": 597743482516410764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  23
+                ],
+                "weight": 757994517719835635
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  24,
+                  16
+                ],
+                "weight": 40186714855199566
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  23,
+                  7
+                ],
+                "weight": 2055610910193590667
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  21,
+                  16
+                ],
+                "weight": 192984902001795209
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  7,
+                  21
+                ],
+                "weight": 578859088588819906
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  15,
+                  10
+                ],
+                "weight": 1446828712284968750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  15,
+                  24
+                ],
+                "weight": 581004593957645436
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 497771113631994377
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  4,
+                  8,
+                  22
+                ],
+                "weight": 1386468687566665357
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  18,
+                  13
+                ],
+                "weight": 598883026203957706
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  18,
+                  24,
+                  13
+                ],
+                "weight": 598883026203957706
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  21,
+                  2,
+                  22
+                ],
+                "weight": 204841369428203570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  21,
+                  13,
+                  5
+                ],
+                "weight": 243720647031266906
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  2,
+                  8,
+                  22
+                ],
+                "weight": 1547033961641807714
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  7,
+                  10
+                ],
+                "weight": 45407820866029313
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  5,
+                  22
+                ],
+                "weight": 622999618785151718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  4,
+                  2
+                ],
+                "weight": 884662352583500615
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  10,
+                  16
+                ],
+                "weight": 40186714855199566
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  24,
+                  2
+                ],
+                "weight": 482754600175453518
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  18,
+                  13
+                ],
+                "weight": 591831670003836246
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  5,
+                  19
+                ],
+                "weight": 838533334128937066
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  15,
+                  19
+                ],
+                "weight": 153976516632024148
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 442567885320253952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  12,
+                  4
+                ],
+                "weight": 1091233856630080080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  4,
+                  18
+                ],
+                "weight": 420086957810493537
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  10,
+                  16
+                ],
+                "weight": 1260306338537319607
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  10,
+                  19
+                ],
+                "weight": 177244999792997254
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  21,
+                  24
+                ],
+                "weight": 59125370811121784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  1,
+                  22
+                ],
+                "weight": 133859531190673425
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  12,
+                  4,
+                  24
+                ],
+                "weight": 1002169544599890567
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  12,
+                  13,
+                  8
+                ],
+                "weight": 89064312030189513
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  15,
+                  16
+                ],
+                "weight": 198228193314822834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  21,
+                  16
+                ],
+                "weight": 133859531190673425
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  10,
+                  19
+                ],
+                "weight": 311895087801481039
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  2,
+                  19,
+                  22
+                ],
+                "weight": 489140087594478293
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  1,
+                  15
+                ],
+                "weight": 213515453763914072
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  12,
+                  7,
+                  19
+                ],
+                "weight": 153976516632024148
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  13,
+                  22
+                ],
+                "weight": 41993372697673726
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  8,
+                  19
+                ],
+                "weight": 405529528563708214
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  15,
+                  13
+                ],
+                "weight": 185771531863119511
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  19,
+                  22
+                ],
+                "weight": 228284528770710960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  18,
+                  2
+                ],
+                "weight": 895381627829200546
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  8
+                ],
+                "weight": 1153709160869977529
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  24,
+                  13,
+                  5
+                ],
+                "weight": 117190517912633620
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  16,
+                  8,
+                  22
+                ],
+                "weight": 52019458620902308
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  15,
+                  19
+                ],
+                "weight": 683785926397865193
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  16,
+                  5
+                ],
+                "weight": 741491760663261283
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  7,
+                  15,
+                  10
+                ],
+                "weight": 875923965817181196
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  18,
+                  2
+                ],
+                "weight": 482754600175453518
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  21,
+                  8
+                ],
+                "weight": 482754600175453518
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  2,
+                  13,
+                  5
+                ],
+                "weight": 74788871042686184
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  16,
+                  5,
+                  8
+                ],
+                "weight": 816280631705947467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  13,
+                  16
+                ],
+                "weight": 836626822107049932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 228284528770710960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  15,
+                  21,
+                  19
+                ],
+                "weight": 610248805358226106
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  15,
+                  24,
+                  13
+                ],
+                "weight": 1818600996945798530
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  10,
+                  18,
+                  13
+                ],
+                "weight": 363547141233125286
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  13,
+                  5
+                ],
+                "weight": 204370972971792841
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  2,
+                  13
+                ],
+                "weight": 497771113631994377
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  10,
+                  18
+                ],
+                "weight": 875923965817181196
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  21,
+                  19
+                ],
+                "weight": 995681014199346232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  2,
+                  16
+                ],
+                "weight": 1481603749010454006
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  16,
+                  22
+                ],
+                "weight": 1386468687566665357
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  13,
+                  22
+                ],
+                "weight": 98981109206343060
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  24,
+                  16,
+                  19
+                ],
+                "weight": 607876712508069052
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  10,
+                  18,
+                  8
+                ],
+                "weight": 1638374226830909912
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  10,
+                  21,
+                  16
+                ],
+                "weight": 610248805358226106
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  16,
+                  5
+                ],
+                "weight": 1114787902959779779
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  8,
+                  19
+                ],
+                "weight": 184177744982990081
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  2,
+                  5,
+                  22
+                ],
+                "weight": 1114787902959779779
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  2,
+                  8,
+                  19
+                ],
+                "weight": 597743482516410764
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  13,
+                  8,
+                  19
+                ],
+                "weight": 184516847654350848
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  13,
+                  19
+                ],
+                "weight": 254050466600727471
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 236830898317033585
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 413226634862059916
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  2,
+                  16,
+                  19
+                ],
+                "weight": 303087987732720845
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  2,
+                  16,
+                  8
+                ],
+                "weight": 1386468687566665357
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  16,
+                  5,
+                  19
+                ],
+                "weight": 1585132225385829125
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 197,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 153998997927804297937
+          },
+          "certificate_sha256": "199e062515fb01bc2b4f802e0930b28ba88ceccd5b678a325ae622ae82f6a0e2",
+          "max_weight": 6346226320443949702,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 197,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 197,
+          "weight_sum": 153998997927804297937,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14537,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 0,
+        "order": [
+          0,
+          11,
+          3,
+          6,
+          14,
+          17,
+          20,
+          9,
+          23,
+          12,
+          1,
+          4,
+          7,
+          15,
+          10,
+          18,
+          21,
+          24,
+          2,
+          13,
+          16,
+          5,
+          8,
+          19,
+          22
+        ],
+        "order_sha256": "55db65a812422826d3953cc6ad5a34d108f4bd1b1a1d1b6bbf1cee8185bf36f2",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 40
+      },
+      {
+        "dihedral_order_sha256": "5130eb5b4f4b45105f5365b91ffe649d866eb8b2039eaafbb9108386201f7316",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "62869a2ec9d8d5a2b7e2a19a2a8d1bfb209515826a26f8f9e05c45d2d7814416",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 1,
+            "source_order": [
+              0,
+              3,
+              11,
+              6,
+              14,
+              17,
+              20,
+              9,
+              23,
+              12,
+              1,
+              4,
+              7,
+              15,
+              10,
+              18,
+              21,
+              24,
+              2,
+              13,
+              16,
+              5,
+              8,
+              19,
+              22
+            ],
+            "source_unique_ordered_quad_count": 197,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              3,
+              11,
+              6,
+              14,
+              17,
+              20,
+              9,
+              23,
+              12,
+              1,
+              4,
+              7,
+              15,
+              10,
+              18,
+              21,
+              24,
+              2,
+              13,
+              16,
+              5,
+              8,
+              19,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  17,
+                  12
+                ],
+                "weight": 221783687753508087
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  1,
+                  18
+                ],
+                "weight": 21638454904880276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  24
+                ],
+                "weight": 538955277820959917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  6,
+                  14
+                ],
+                "weight": 235048655544210269
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  14,
+                  21
+                ],
+                "weight": 241429246790434715
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  17,
+                  20
+                ],
+                "weight": 523814596626012451
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  18,
+                  5
+                ],
+                "weight": 21638454904880276
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  2,
+                  8
+                ],
+                "weight": 151792873001450090
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  13,
+                  19
+                ],
+                "weight": 151131349264910010
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  20,
+                  15
+                ],
+                "weight": 317171590067451830
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  1,
+                  19
+                ],
+                "weight": 235048655544210269
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  16,
+                  5
+                ],
+                "weight": 116600321858714922
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  9,
+                  21
+                ],
+                "weight": 56319793557066133
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  21,
+                  22
+                ],
+                "weight": 200452637782585408
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  16,
+                  19
+                ],
+                "weight": 106581007967106840
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  23,
+                  5
+                ],
+                "weight": 560241830437360817
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  4,
+                  2
+                ],
+                "weight": 185356453942159721
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  2,
+                  13
+                ],
+                "weight": 298132471928022512
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  9,
+                  10
+                ],
+                "weight": 120474217528924910
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  23,
+                  1
+                ],
+                "weight": 159690548135408017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  12,
+                  15
+                ],
+                "weight": 221783687753508087
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  2
+                ],
+                "weight": 50004560349429974
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  13
+                ],
+                "weight": 81690783969133070
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  7,
+                  16
+                ],
+                "weight": 96996562313682528
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  24,
+                  8
+                ],
+                "weight": 185356453942159721
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  24,
+                  2
+                ],
+                "weight": 209465979653280921
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  13,
+                  5
+                ],
+                "weight": 228691906632245572
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  24,
+                  13
+                ],
+                "weight": 144132844225519275
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  11,
+                  6,
+                  17
+                ],
+                "weight": 270423931527379202
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  11,
+                  12,
+                  24
+                ],
+                "weight": 432500177144471793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  11,
+                  4,
+                  24
+                ],
+                "weight": 169978726302331606
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  11,
+                  10,
+                  19
+                ],
+                "weight": 72940374216039908
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  23,
+                  18
+                ],
+                "weight": 100484383699449069
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  1,
+                  22
+                ],
+                "weight": 270059232752773599
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  4,
+                  5
+                ],
+                "weight": 364698774605603
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  14,
+                  9,
+                  21
+                ],
+                "weight": 19860382296553682
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  14,
+                  18,
+                  2
+                ],
+                "weight": 177597713198896611
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  14,
+                  8,
+                  19
+                ],
+                "weight": 103696485561530256
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  20,
+                  19
+                ],
+                "weight": 610578651593763249
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  2,
+                  16
+                ],
+                "weight": 10689396777645166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  1,
+                  8
+                ],
+                "weight": 170375158177131150
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  15,
+                  22
+                ],
+                "weight": 440203493416632099
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  4,
+                  19
+                ],
+                "weight": 8874160556974039
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  10,
+                  13
+                ],
+                "weight": 661523736540080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  10,
+                  16
+                ],
+                "weight": 10986221739579643
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  15,
+                  18
+                ],
+                "weight": 98751784404327818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  5,
+                  19
+                ],
+                "weight": 322783077650349696
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  13
+                ],
+                "weight": 11647745476119723
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  21,
+                  16
+                ],
+                "weight": 661523736540080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  2,
+                  22
+                ],
+                "weight": 167569840157791525
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  10,
+                  24,
+                  5
+                ],
+                "weight": 63523625625843482
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  8,
+                  22
+                ],
+                "weight": 96235865168279354
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  21,
+                  13,
+                  8
+                ],
+                "weight": 661523736540080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  16,
+                  8
+                ],
+                "weight": 661523736540080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  6,
+                  17,
+                  13
+                ],
+                "weight": 253390665098633249
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  6,
+                  9,
+                  2
+                ],
+                "weight": 103036573310076278
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  6,
+                  23,
+                  12
+                ],
+                "weight": 203586681203923135
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  6,
+                  12,
+                  16
+                ],
+                "weight": 347406577622339389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  6,
+                  10,
+                  8
+                ],
+                "weight": 259816516472953279
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  6,
+                  18,
+                  22
+                ],
+                "weight": 30353617981039059
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  6,
+                  5,
+                  19
+                ],
+                "weight": 224071723480949918
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  14,
+                  20,
+                  2
+                ],
+                "weight": 235048655544210269
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  14,
+                  9,
+                  7
+                ],
+                "weight": 18597899232419759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  17,
+                  1,
+                  21
+                ],
+                "weight": 288680280726055539
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  17,
+                  4,
+                  10
+                ],
+                "weight": 186876142256913371
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  20,
+                  9,
+                  1
+                ],
+                "weight": 437399964588862286
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  9,
+                  12,
+                  1
+                ],
+                "weight": 288680280726055539
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  23,
+                  7,
+                  2
+                ],
+                "weight": 31404188747790033
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  23,
+                  15,
+                  5
+                ],
+                "weight": 172182492456133102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  23,
+                  13,
+                  22
+                ],
+                "weight": 53295745476547958
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  1,
+                  2,
+                  8
+                ],
+                "weight": 170375158177131150
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  1,
+                  16,
+                  5
+                ],
+                "weight": 297449200096267936
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  1,
+                  5,
+                  22
+                ],
+                "weight": 38932732195067468
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  4,
+                  18,
+                  19
+                ],
+                "weight": 16897415954581765
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  5,
+                  22
+                ],
+                "weight": 12806289515370274
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  8,
+                  22
+                ],
+                "weight": 172182492456133102
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  21,
+                  5
+                ],
+                "weight": 47251033935620824
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  2,
+                  16
+                ],
+                "weight": 602478903446803399
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  8,
+                  19
+                ],
+                "weight": 106216309192501237
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  14,
+                  12,
+                  21
+                ],
+                "weight": 165249070936814900
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  14,
+                  24,
+                  13
+                ],
+                "weight": 243651220422846736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  7,
+                  2
+                ],
+                "weight": 112776017985862791
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  17,
+                  15,
+                  19
+                ],
+                "weight": 565371577371504932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  17,
+                  21,
+                  24
+                ],
+                "weight": 446094785184369883
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  5
+                ],
+                "weight": 407107638213448482
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  4,
+                  21
+                ],
+                "weight": 46314389035558301
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  7,
+                  19
+                ],
+                "weight": 105868319616271182
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  10,
+                  18
+                ],
+                "weight": 84618006518788485
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  9,
+                  23,
+                  7
+                ],
+                "weight": 304071064903372204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  15,
+                  10
+                ],
+                "weight": 121135741265464990
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  1,
+                  7
+                ],
+                "weight": 218644337602133973
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  15,
+                  21
+                ],
+                "weight": 280845714247554983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  15,
+                  8
+                ],
+                "weight": 75151861712246079
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  24,
+                  5
+                ],
+                "weight": 186577187580862563
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  5,
+                  19
+                ],
+                "weight": 293683890428491956
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  2,
+                  13
+                ],
+                "weight": 9739444675786513
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  10,
+                  19
+                ],
+                "weight": 296334251219629784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  10,
+                  8,
+                  19
+                ],
+                "weight": 162786127805530403
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  24,
+                  19
+                ],
+                "weight": 15866377180660584
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  16,
+                  8,
+                  22
+                ],
+                "weight": 230806255763624467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  7,
+                  15
+                ],
+                "weight": 530187046160690701
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  9,
+                  1,
+                  19
+                ],
+                "weight": 87734422106139427
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  9,
+                  4,
+                  19
+                ],
+                "weight": 345435181412848021
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  23,
+                  12,
+                  4
+                ],
+                "weight": 660562536273592475
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  23,
+                  4,
+                  24
+                ],
+                "weight": 136035750370204478
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  23,
+                  4,
+                  2
+                ],
+                "weight": 179091604490539976
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  5,
+                  19
+                ],
+                "weight": 313426885475163567
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  8,
+                  22
+                ],
+                "weight": 7460620393250902
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  1,
+                  15,
+                  24
+                ],
+                "weight": 538688489222830628
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  15,
+                  2
+                ],
+                "weight": 87734422106139427
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  1,
+                  18,
+                  22
+                ],
+                "weight": 192992017389334506
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  7,
+                  18,
+                  13
+                ],
+                "weight": 14959313790601164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  24,
+                  16
+                ],
+                "weight": 548784945393110460
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  15,
+                  10,
+                  22
+                ],
+                "weight": 96235865168279354
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  15,
+                  24,
+                  2
+                ],
+                "weight": 259167343283307452
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  8,
+                  19
+                ],
+                "weight": 96235865168279354
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  16,
+                  22
+                ],
+                "weight": 30353617981039059
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  2,
+                  5
+                ],
+                "weight": 25612579030740548
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  13,
+                  16,
+                  5
+                ],
+                "weight": 228691906632245572
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  12
+                ],
+                "weight": 221783687753508087
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  5
+                ],
+                "weight": 34247445244327191
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  1,
+                  19
+                ],
+                "weight": 504710331977492067
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  7,
+                  16
+                ],
+                "weight": 10689396777645166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  23,
+                  8
+                ],
+                "weight": 23290442844273670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  12,
+                  18
+                ],
+                "weight": 436625138619712131
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  4,
+                  15
+                ],
+                "weight": 163585699412639701
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  7,
+                  19
+                ],
+                "weight": 232740690153561608
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  24,
+                  22
+                ],
+                "weight": 65068567895895704
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  4,
+                  10
+                ],
+                "weight": 23290442844273670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  1,
+                  10
+                ],
+                "weight": 712870527449946997
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  10,
+                  5
+                ],
+                "weight": 525994385193033626
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  18,
+                  21
+                ],
+                "weight": 436625138619712131
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  24,
+                  13
+                ],
+                "weight": 82876289997760888
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  1,
+                  7,
+                  24
+                ],
+                "weight": 399532977215346718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  13,
+                  22
+                ],
+                "weight": 38134483168371625
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  7,
+                  21,
+                  24
+                ],
+                "weight": 594039643078026475
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  24,
+                  8,
+                  19
+                ],
+                "weight": 532032870038040660
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  23,
+                  2
+                ],
+                "weight": 159690548135408017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  21,
+                  8
+                ],
+                "weight": 45208185599342022
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  4,
+                  5
+                ],
+                "weight": 441355083457775673
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  15,
+                  8
+                ],
+                "weight": 125166972577789128
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  7,
+                  2
+                ],
+                "weight": 92380180746778236
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  18,
+                  13
+                ],
+                "weight": 81690783969133070
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  15,
+                  19
+                ],
+                "weight": 41739198532150591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  10,
+                  21
+                ],
+                "weight": 46975912772098381
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  21,
+                  16
+                ],
+                "weight": 10689396777645166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  21,
+                  5
+                ],
+                "weight": 82832123782234806
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  2,
+                  19
+                ],
+                "weight": 185044095194780295
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  12,
+                  18
+                ],
+                "weight": 389129974886077365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  12,
+                  19
+                ],
+                "weight": 336175444459690305
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  4,
+                  8
+                ],
+                "weight": 98442304556519749
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  1,
+                  2
+                ],
+                "weight": 159690548135408017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  13,
+                  16
+                ],
+                "weight": 10986221739579643
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  15,
+                  5
+                ],
+                "weight": 10970864272601270
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  7,
+                  8,
+                  19
+                ],
+                "weight": 338609009769832790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  21,
+                  22
+                ],
+                "weight": 65068567895895704
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  24,
+                  22
+                ],
+                "weight": 53420822419775981
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  24,
+                  13
+                ],
+                "weight": 11647745476119723
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  5,
+                  8
+                ],
+                "weight": 407107638213448482
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  1,
+                  18
+                ],
+                "weight": 218644337602133973
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  7,
+                  24
+                ],
+                "weight": 261992857185372549
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  21,
+                  16
+                ],
+                "weight": 336420355882759746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  13,
+                  5
+                ],
+                "weight": 53295745476547958
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  10,
+                  2
+                ],
+                "weight": 40115848325276826
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  16,
+                  8
+                ],
+                "weight": 244911423069441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 53295745476547958
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  24,
+                  8
+                ],
+                "weight": 75151861712246079
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  10,
+                  18,
+                  8
+                ],
+                "weight": 63406291169550496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  10,
+                  24,
+                  2
+                ],
+                "weight": 50805245102921992
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  2,
+                  16,
+                  19
+                ],
+                "weight": 336175444459690305
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  15,
+                  13
+                ],
+                "weight": 406012686825344111
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  10,
+                  2
+                ],
+                "weight": 341812866090221208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  24,
+                  22
+                ],
+                "weight": 7460620393250902
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  10,
+                  8
+                ],
+                "weight": 75757964673540870
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  18,
+                  19
+                ],
+                "weight": 607110775903655523
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  2,
+                  5
+                ],
+                "weight": 182122317954813191
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  13,
+                  8
+                ],
+                "weight": 117100249223243435
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  13,
+                  5
+                ],
+                "weight": 217022369343919431
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  18,
+                  21
+                ],
+                "weight": 175931016954139758
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  16,
+                  22
+                ],
+                "weight": 200452637782585408
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  18,
+                  8
+                ],
+                "weight": 262606133673222479
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  15,
+                  10,
+                  18
+                ],
+                "weight": 661437560154124662
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  24,
+                  16
+                ],
+                "weight": 296824961934477
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  8,
+                  19
+                ],
+                "weight": 661523736540080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  8,
+                  22
+                ],
+                "weight": 175030460551042427
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  16,
+                  5,
+                  19
+                ],
+                "weight": 364698774605603
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  10,
+                  21
+                ],
+                "weight": 75757964673540870
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  24,
+                  13
+                ],
+                "weight": 14959313790601164
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  24,
+                  5,
+                  22
+                ],
+                "weight": 12806289515370274
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  10,
+                  2,
+                  16
+                ],
+                "weight": 10689396777645166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  5,
+                  19
+                ],
+                "weight": 1031038773921181
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  16,
+                  5,
+                  8
+                ],
+                "weight": 906435159609521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  24,
+                  16,
+                  8
+                ],
+                "weight": 53693958053692939
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  2,
+                  16,
+                  5
+                ],
+                "weight": 25612579030740548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  2,
+                  13,
+                  16
+                ],
+                "weight": 72889525118400156
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 12806289515370274
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  8,
+                  19
+                ],
+                "weight": 151131349264910010
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 197,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 36249870628917141311
+          },
+          "certificate_sha256": "32a24c69137418e6c70ed7ced7584f6556bed38b64af413896d110fe3da806c7",
+          "max_weight": 712870527449946997,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 197,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 197,
+          "weight_sum": 36249870628917141311,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14537,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 1,
+        "order": [
+          0,
+          3,
+          11,
+          6,
+          14,
+          17,
+          20,
+          9,
+          23,
+          12,
+          1,
+          4,
+          7,
+          15,
+          10,
+          18,
+          21,
+          24,
+          2,
+          13,
+          16,
+          5,
+          8,
+          19,
+          22
+        ],
+        "order_sha256": "5130eb5b4f4b45105f5365b91ffe649d866eb8b2039eaafbb9108386201f7316",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 41
+      },
+      {
+        "dihedral_order_sha256": "7d73aa04a3840408e2a9250b347d54a0a96720e6d2c9c485d3912890d47f536e",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "6668a16d43420d502d9fdb287d36b52ac09789f7d102725653928391f947c096",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 2,
+            "source_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              21,
+              10,
+              13,
+              24,
+              2,
+              5,
+              8,
+              16,
+              19,
+              11,
+              22
+            ],
+            "source_unique_ordered_quad_count": 193,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              21,
+              10,
+              13,
+              24,
+              2,
+              5,
+              8,
+              16,
+              19,
+              11,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  12
+                ],
+                "weight": 48355115303889962
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  19
+                ],
+                "weight": 83238293806445826
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  17,
+                  18
+                ],
+                "weight": 11678462995174590
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  9,
+                  15
+                ],
+                "weight": 10457502204641213
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  8,
+                  22
+                ],
+                "weight": 36897423905614665
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  7
+                ],
+                "weight": 87804374231268140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  4
+                ],
+                "weight": 52820068422653231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  16
+                ],
+                "weight": 194262748181196
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  23,
+                  16
+                ],
+                "weight": 43789034879067648
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  1,
+                  21
+                ],
+                "weight": 516305898475468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  7,
+                  5
+                ],
+                "weight": 57528415080046736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  18,
+                  24
+                ],
+                "weight": 38351339203799319
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  13,
+                  19
+                ],
+                "weight": 28481978141702441
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  20,
+                  13
+                ],
+                "weight": 3134213392962481
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  15,
+                  22
+                ],
+                "weight": 8544249602212109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  10,
+                  8
+                ],
+                "weight": 9168471409736945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  24,
+                  16
+                ],
+                "weight": 10622386707921599
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  21
+                ],
+                "weight": 64127043974483000
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  15,
+                  1
+                ],
+                "weight": 1913252602429104
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  5
+                ],
+                "weight": 23677330256785140
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  23,
+                  11
+                ],
+                "weight": 36985951498865037
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  4,
+                  22
+                ],
+                "weight": 20518903790886468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  5,
+                  11
+                ],
+                "weight": 32442211834426802
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  10,
+                  22
+                ],
+                "weight": 4659215866944465
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  4,
+                  10
+                ],
+                "weight": 13311381378205942
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  4,
+                  11
+                ],
+                "weight": 25541749147009629
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  24,
+                  8
+                ],
+                "weight": 27728952495877720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  1,
+                  2
+                ],
+                "weight": 1396946703953636
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  21,
+                  10
+                ],
+                "weight": 516305898475468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  2,
+                  19
+                ],
+                "weight": 19157170039291388
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  5,
+                  19
+                ],
+                "weight": 6551965893448808
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  13,
+                  16
+                ],
+                "weight": 25010503567511198
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  13,
+                  19
+                ],
+                "weight": 81205745336831876
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  2,
+                  16
+                ],
+                "weight": 26672876208624729
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  5,
+                  11
+                ],
+                "weight": 134698227046045515
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  16,
+                  22
+                ],
+                "weight": 58938009119102723
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  19,
+                  22
+                ],
+                "weight": 47639148180993829
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  17,
+                  23
+                ],
+                "weight": 61007916886552567
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  6,
+                  5
+                ],
+                "weight": 22937803885289800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  9,
+                  8
+                ],
+                "weight": 44601154335701737
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  12,
+                  22
+                ],
+                "weight": 36897423905614665
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  23,
+                  13
+                ],
+                "weight": 74808514245546859
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  24,
+                  11
+                ],
+                "weight": 1754333991986041
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  12,
+                  5
+                ],
+                "weight": 739526371495340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  20,
+                  7
+                ],
+                "weight": 48589927519882637
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  20,
+                  8
+                ],
+                "weight": 11782827810929607
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  21,
+                  10
+                ],
+                "weight": 9168471409736945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  6,
+                  20,
+                  10
+                ],
+                "weight": 22684799057283724
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  6,
+                  1,
+                  22
+                ],
+                "weight": 22937803885289800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  9,
+                  7,
+                  13
+                ],
+                "weight": 21473579611141140
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  15,
+                  8
+                ],
+                "weight": 16040285744672699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  4,
+                  19
+                ],
+                "weight": 6987271472497216
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  10,
+                  11
+                ],
+                "weight": 67017268643423269
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  15,
+                  2,
+                  19
+                ],
+                "weight": 26497787949313912
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  15,
+                  8,
+                  19
+                ],
+                "weight": 27496265117739300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  23,
+                  18,
+                  2
+                ],
+                "weight": 17760223335337752
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  4,
+                  8
+                ],
+                "weight": 18554477674512413
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  10,
+                  16
+                ],
+                "weight": 4383326210777387
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  13,
+                  11
+                ],
+                "weight": 25541749147009629
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  21,
+                  8
+                ],
+                "weight": 21473579611141140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  7,
+                  13,
+                  24
+                ],
+                "weight": 70740344709678370
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  24,
+                  22
+                ],
+                "weight": 29438686330512342
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  21,
+                  8,
+                  11
+                ],
+                "weight": 28887717028892044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 1754333991986041
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 39547324387179987
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  2,
+                  16,
+                  22
+                ],
+                "weight": 8737564613976160
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  9,
+                  7
+                ],
+                "weight": 44601154335701737
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  18,
+                  22
+                ],
+                "weight": 36897423905614665
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  23,
+                  16
+                ],
+                "weight": 106257521359189290
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  1,
+                  4
+                ],
+                "weight": 52820068422653231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  1,
+                  5
+                ],
+                "weight": 10744706549849892
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  21,
+                  2
+                ],
+                "weight": 3563346753928801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  2,
+                  19
+                ],
+                "weight": 3563346753928801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  23,
+                  1
+                ],
+                "weight": 25167350732459200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  10,
+                  13
+                ],
+                "weight": 50406188756248687
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  7,
+                  11
+                ],
+                "weight": 14325195184480333
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  1,
+                  18,
+                  8
+                ],
+                "weight": 13321950273876413
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  10,
+                  19
+                ],
+                "weight": 11868034975691759
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  21,
+                  13,
+                  19
+                ],
+                "weight": 4079652652404269
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  16,
+                  11
+                ],
+                "weight": 62274223731940446
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  5,
+                  19
+                ],
+                "weight": 36597005211813278
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  8,
+                  19,
+                  11
+                ],
+                "weight": 1754333991986041
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  9,
+                  19
+                ],
+                "weight": 44601154335701737
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  20,
+                  7
+                ],
+                "weight": 11782827810929607
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  19
+                ],
+                "weight": 29526122320569848
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  7,
+                  16
+                ],
+                "weight": 10622386707921599
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  18,
+                  13
+                ],
+                "weight": 3134213392962481
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  24,
+                  11
+                ],
+                "weight": 6865470050397874
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  7,
+                  21
+                ],
+                "weight": 84641337384425345
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  23,
+                  11
+                ],
+                "weight": 61605837088861847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  1,
+                  7
+                ],
+                "weight": 295405520152649418
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  7,
+                  2
+                ],
+                "weight": 3563346753928801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  18,
+                  22
+                ],
+                "weight": 3247034026860894
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  23,
+                  4
+                ],
+                "weight": 41781530361927452
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  21,
+                  5
+                ],
+                "weight": 3592959482696942
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  7,
+                  22
+                ],
+                "weight": 103387367450789299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  24,
+                  8
+                ],
+                "weight": 3756916657523725
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  1,
+                  4,
+                  18
+                ],
+                "weight": 53251041698872770
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  11,
+                  22
+                ],
+                "weight": 158688156450725069
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  4,
+                  2,
+                  16
+                ],
+                "weight": 11469511336945318
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  7,
+                  21,
+                  11
+                ],
+                "weight": 90216849311465348
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  18,
+                  2,
+                  11
+                ],
+                "weight": 6381247419823375
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  13,
+                  5,
+                  19
+                ],
+                "weight": 2853433111201602
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  2,
+                  8,
+                  19
+                ],
+                "weight": 17850758756768693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  2,
+                  19
+                ],
+                "weight": 3563346753928801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  16
+                ],
+                "weight": 10622386707921599
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  7,
+                  21
+                ],
+                "weight": 93509403178658006
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  18,
+                  5
+                ],
+                "weight": 739526371495340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  23,
+                  21
+                ],
+                "weight": 39956910337854453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  18,
+                  2
+                ],
+                "weight": 12874437955173377
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  21,
+                  2
+                ],
+                "weight": 29382359204175006
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  4,
+                  19
+                ],
+                "weight": 13539237365946024
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  18,
+                  11
+                ],
+                "weight": 26417672971908429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  10,
+                  13
+                ],
+                "weight": 3134213392962481
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  7,
+                  24,
+                  22
+                ],
+                "weight": 6865470050397874
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  10,
+                  2,
+                  19
+                ],
+                "weight": 25819012450246205
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  8,
+                  19
+                ],
+                "weight": 70563929902342784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  15,
+                  7
+                ],
+                "weight": 70995142038733843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  5,
+                  16
+                ],
+                "weight": 109165255470292414
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  1,
+                  22
+                ],
+                "weight": 70995142038733843
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  4,
+                  16
+                ],
+                "weight": 127729203513160857
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  10,
+                  19
+                ],
+                "weight": 7430367066230720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  21,
+                  24
+                ],
+                "weight": 7430367066230720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  4,
+                  19,
+                  22
+                ],
+                "weight": 20518903790886468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  7,
+                  18,
+                  5
+                ],
+                "weight": 130414909407997784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  13,
+                  8
+                ],
+                "weight": 21473579611141140
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  16,
+                  11
+                ],
+                "weight": 24381313722244264
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  19,
+                  22
+                ],
+                "weight": 20518903790886468
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  24,
+                  16
+                ],
+                "weight": 7430367066230720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  13,
+                  5,
+                  16
+                ],
+                "weight": 42947159222282280
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  13,
+                  8,
+                  16
+                ],
+                "weight": 21473579611141140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  7,
+                  16
+                ],
+                "weight": 10622386707921599
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  8,
+                  22
+                ],
+                "weight": 7906249893805359
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  1,
+                  22
+                ],
+                "weight": 64755210526701426
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  4,
+                  10
+                ],
+                "weight": 3047040855453333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  10,
+                  19
+                ],
+                "weight": 3563346753928801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  21,
+                  11
+                ],
+                "weight": 61605837088861847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  21,
+                  13
+                ],
+                "weight": 3728737239278572
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  10,
+                  16
+                ],
+                "weight": 3047040855453333
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  7,
+                  18,
+                  8
+                ],
+                "weight": 3986560398356234
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  10,
+                  13
+                ],
+                "weight": 4177512654526787
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  13,
+                  24
+                ],
+                "weight": 7906249893805359
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 7906249893805359
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  23,
+                  5
+                ],
+                "weight": 66948881094386652
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  21,
+                  22
+                ],
+                "weight": 6981591650982505
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  5,
+                  11
+                ],
+                "weight": 85229723769130899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  13
+                ],
+                "weight": 146317936518119715
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  10,
+                  2
+                ],
+                "weight": 1396946703953636
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  10,
+                  5
+                ],
+                "weight": 35697860674089109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  13,
+                  24
+                ],
+                "weight": 99045961154833509
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  5,
+                  11
+                ],
+                "weight": 25167350732459200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  18,
+                  21
+                ],
+                "weight": 6981591650982505
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  2,
+                  8
+                ],
+                "weight": 35862988346745060
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  16,
+                  19
+                ],
+                "weight": 6987271472497216
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  7,
+                  24,
+                  16
+                ],
+                "weight": 126774913650711229
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  2,
+                  5,
+                  19
+                ],
+                "weight": 34466041642791424
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  24,
+                  19
+                ],
+                "weight": 24467930746483364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  13,
+                  5
+                ],
+                "weight": 54744600895456934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  24,
+                  2
+                ],
+                "weight": 129024087072193932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  8,
+                  11
+                ],
+                "weight": 85229723769130899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  5,
+                  22
+                ],
+                "weight": 69432484087504239
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  13,
+                  2,
+                  8
+                ],
+                "weight": 41693172906718900
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  24,
+                  2,
+                  16
+                ],
+                "weight": 45074117006126649
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  18,
+                  5
+                ],
+                "weight": 53251041698872770
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  24,
+                  11
+                ],
+                "weight": 3756916657523725
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  16,
+                  19
+                ],
+                "weight": 36259754159166213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  5,
+                  16
+                ],
+                "weight": 120199922793259422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  18,
+                  22
+                ],
+                "weight": 168142577977490725
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  13
+                ],
+                "weight": 150074853175643440
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  11
+                ],
+                "weight": 53269030751136308
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  13,
+                  8
+                ],
+                "weight": 3756916657523725
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  13,
+                  5
+                ],
+                "weight": 88948902372961879
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  13,
+                  5
+                ],
+                "weight": 10097058781871630
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  8,
+                  16,
+                  11
+                ],
+                "weight": 31876427948388826
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  19,
+                  11,
+                  22
+                ],
+                "weight": 68158051971880297
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  21,
+                  10
+                ],
+                "weight": 4177512654526787
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  24,
+                  8
+                ],
+                "weight": 17308510672232647
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  10,
+                  2
+                ],
+                "weight": 10358766902942601
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  13,
+                  5,
+                  22
+                ],
+                "weight": 120199922793259422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  2,
+                  22
+                ],
+                "weight": 10358766902942601
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  10,
+                  24,
+                  19
+                ],
+                "weight": 185058656013226791
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  5,
+                  11
+                ],
+                "weight": 54524830868747507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  24,
+                  8,
+                  19
+                ],
+                "weight": 56012667102109800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  5,
+                  16,
+                  22
+                ],
+                "weight": 61261913674156699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  5,
+                  19,
+                  11
+                ],
+                "weight": 159865577778504715
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  10,
+                  24,
+                  22
+                ],
+                "weight": 9402260778427288
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  2,
+                  5
+                ],
+                "weight": 100816937348653638
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  5,
+                  19
+                ],
+                "weight": 11868034975691759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 20036425552085054
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  10,
+                  13,
+                  5
+                ],
+                "weight": 21473579611141140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  16,
+                  22
+                ],
+                "weight": 102064488773319349
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  8,
+                  11,
+                  22
+                ],
+                "weight": 4743044911482823
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  16,
+                  22
+                ],
+                "weight": 37643749939895929
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 193,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 7605620403880266591
+          },
+          "certificate_sha256": "6ba89b8f4192e6815c71669baae002d5e3790f81fd8959ff702119f5f1264c57",
+          "max_weight": 295405520152649418,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 193,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 193,
+          "weight_sum": 7605620403880266591,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14873,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 2,
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          6,
+          9,
+          12,
+          20,
+          15,
+          23,
+          1,
+          4,
+          7,
+          18,
+          21,
+          10,
+          13,
+          24,
+          2,
+          5,
+          8,
+          16,
+          19,
+          11,
+          22
+        ],
+        "order_sha256": "7d73aa04a3840408e2a9250b347d54a0a96720e6d2c9c485d3912890d47f536e",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 81
+      },
+      {
+        "dihedral_order_sha256": "7ca60b4094c81d67ce63bc047e16ecc90dbbb9ba3fa4e9787198e259995c7542",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "2fe2b6252600c33aebc9ca648e4ed35180b24f163a85c5d78b35f9399b2ac4f5",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 3,
+            "source_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              10,
+              21,
+              13,
+              24,
+              2,
+              5,
+              8,
+              16,
+              11,
+              19,
+              22
+            ],
+            "source_unique_ordered_quad_count": 194,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              10,
+              21,
+              13,
+              24,
+              2,
+              5,
+              8,
+              16,
+              11,
+              19,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  17
+                ],
+                "weight": 16616712214091711
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  20
+                ],
+                "weight": 10750947270139422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  21
+                ],
+                "weight": 45173359466653465
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  23,
+                  16
+                ],
+                "weight": 101303293300654245
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  10,
+                  11
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  21,
+                  8
+                ],
+                "weight": 17516026672963053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  17,
+                  1
+                ],
+                "weight": 23514451696127344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  24
+                ],
+                "weight": 43403833976901193
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  8
+                ],
+                "weight": 29137184973983405
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  4,
+                  8
+                ],
+                "weight": 3361505828190720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  24,
+                  11
+                ],
+                "weight": 26890356498760403
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  6,
+                  2
+                ],
+                "weight": 2536631926993904
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  9,
+                  5
+                ],
+                "weight": 4361107555041729
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  12,
+                  8
+                ],
+                "weight": 23420953467895011
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  13
+                ],
+                "weight": 2536631926993904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  11
+                ],
+                "weight": 57470025936193002
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  13,
+                  11
+                ],
+                "weight": 2246828475223002
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  20,
+                  1
+                ],
+                "weight": 10654333260117172
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  21,
+                  16
+                ],
+                "weight": 140444477598654993
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  15,
+                  21
+                ],
+                "weight": 169858111034285277
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  23,
+                  16
+                ],
+                "weight": 14786336178884623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  4,
+                  24
+                ],
+                "weight": 29137184973983405
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  10,
+                  16
+                ],
+                "weight": 52038451265911581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  1,
+                  4
+                ],
+                "weight": 32498690802174125
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  7,
+                  10
+                ],
+                "weight": 6218673000679210
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  10,
+                  24
+                ],
+                "weight": 192776623007589472
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  18,
+                  2
+                ],
+                "weight": 8984239106046781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  18,
+                  10
+                ],
+                "weight": 48086727123273915
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  2,
+                  11
+                ],
+                "weight": 66225330863866116
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  21,
+                  19
+                ],
+                "weight": 57070966229320696
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  16,
+                  22
+                ],
+                "weight": 201611019069829605
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  11
+                ],
+                "weight": 2246828475223002
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  8,
+                  19
+                ],
+                "weight": 26782459296085731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  9,
+                  13
+                ],
+                "weight": 18224957048926887
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  1,
+                  18
+                ],
+                "weight": 1727503956188238
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  7,
+                  21
+                ],
+                "weight": 20745438736763904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  2,
+                  8
+                ],
+                "weight": 17516026672963053
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  9,
+                  13
+                ],
+                "weight": 16616712214091711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  4,
+                  13
+                ],
+                "weight": 4475459724774436
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  6,
+                  23,
+                  4
+                ],
+                "weight": 4475459724774436
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  9,
+                  20,
+                  10
+                ],
+                "weight": 2482517827100995
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  12,
+                  15,
+                  19
+                ],
+                "weight": 8320478828240421
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  24,
+                  2
+                ],
+                "weight": 43144137329329424
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  23,
+                  24
+                ],
+                "weight": 43144137329329424
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  23,
+                  22
+                ],
+                "weight": 13233465097240417
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  2,
+                  11
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  15,
+                  23,
+                  7
+                ],
+                "weight": 8320478828240421
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  5,
+                  22
+                ],
+                "weight": 1727503956188238
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  7,
+                  18,
+                  21
+                ],
+                "weight": 24427920729889561
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  2,
+                  19
+                ],
+                "weight": 20745438736763904
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  10,
+                  16
+                ],
+                "weight": 22700416773701323
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  13,
+                  2
+                ],
+                "weight": 22700416773701323
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  13,
+                  5,
+                  19
+                ],
+                "weight": 7383469298839522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  6,
+                  21
+                ],
+                "weight": 59675573339116006
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  9,
+                  10
+                ],
+                "weight": 63660849152674329
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  20,
+                  8
+                ],
+                "weight": 10750947270139422
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  10,
+                  22
+                ],
+                "weight": 201611019069829605
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  13,
+                  11
+                ],
+                "weight": 26890356498760403
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  12,
+                  10
+                ],
+                "weight": 59675573339116006
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  23,
+                  13
+                ],
+                "weight": 50406085561080043
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  23,
+                  10
+                ],
+                "weight": 140799871284788705
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  18,
+                  8
+                ],
+                "weight": 45435892103747442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  21,
+                  24
+                ],
+                "weight": 16513477478140790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  16,
+                  19
+                ],
+                "weight": 127095888340108054
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  7,
+                  22
+                ],
+                "weight": 20745438736763904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  13,
+                  5
+                ],
+                "weight": 5290772013392753
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  1,
+                  4,
+                  19
+                ],
+                "weight": 3361505828190720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  21
+                ],
+                "weight": 24746738935724368
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 47163396059935680
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  2,
+                  19
+                ],
+                "weight": 85557886720765268
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  13,
+                  8,
+                  16
+                ],
+                "weight": 127095888340108054
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  5,
+                  22
+                ],
+                "weight": 68041860047802215
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  12,
+                  19
+                ],
+                "weight": 160562288672686263
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  1
+                ],
+                "weight": 46477195104170967
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  23,
+                  8
+                ],
+                "weight": 21423127577980641
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  15,
+                  7
+                ],
+                "weight": 65144055184500287
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  24,
+                  11
+                ],
+                "weight": 17632434879678592
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  2,
+                  19
+                ],
+                "weight": 8320478828240421
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  20,
+                  5
+                ],
+                "weight": 32768827715271544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  1,
+                  10
+                ],
+                "weight": 153689897025625275
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  1,
+                  13
+                ],
+                "weight": 16616712214091711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  18,
+                  16
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  10,
+                  8
+                ],
+                "weight": 54115347340254623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  21,
+                  19
+                ],
+                "weight": 49787880121313456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  23,
+                  1
+                ],
+                "weight": 25671084666038837
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  7,
+                  11
+                ],
+                "weight": 17642630745652778
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  5,
+                  11
+                ],
+                "weight": 15126196969618766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  8,
+                  16
+                ],
+                "weight": 4375249699479344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  7,
+                  18
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  4,
+                  10
+                ],
+                "weight": 4475459724774436
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  7,
+                  21
+                ],
+                "weight": 42618752519245042
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  16,
+                  11
+                ],
+                "weight": 9257921619081811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  4,
+                  10,
+                  13
+                ],
+                "weight": 35913700532696323
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 17632434879678592
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  2,
+                  5
+                ],
+                "weight": 104871307772177970
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  21,
+                  13,
+                  16
+                ],
+                "weight": 127095888340108054
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  13,
+                  5,
+                  19
+                ],
+                "weight": 85384003247517475
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  2,
+                  8,
+                  22
+                ],
+                "weight": 115728418527412295
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  24,
+                  22
+                ],
+                "weight": 42771287877340200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  10
+                ],
+                "weight": 101543627461710711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  7,
+                  16
+                ],
+                "weight": 29632764554743568
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  23,
+                  18
+                ],
+                "weight": 19322682099946649
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  23,
+                  11
+                ],
+                "weight": 35558863185907830
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  4,
+                  13
+                ],
+                "weight": 50695889012850945
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  4,
+                  22
+                ],
+                "weight": 26358174083227861
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  21,
+                  19
+                ],
+                "weight": 61807219611437977
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  24,
+                  2
+                ],
+                "weight": 22364611315854927
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  5,
+                  8
+                ],
+                "weight": 15126196969618766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  4,
+                  18
+                ],
+                "weight": 45813217093248478
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  4,
+                  21
+                ],
+                "weight": 36905976368589146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  16,
+                  19
+                ],
+                "weight": 56374621707719507
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  1,
+                  7,
+                  22
+                ],
+                "weight": 27837261381449434
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  18,
+                  24
+                ],
+                "weight": 65135899193195127
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  10,
+                  16
+                ],
+                "weight": 41868054122594705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  11,
+                  19
+                ],
+                "weight": 42380447353528779
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  21,
+                  2,
+                  11
+                ],
+                "weight": 24901243242848831
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  5,
+                  16,
+                  11
+                ],
+                "weight": 15126196969618766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  15,
+                  16
+                ],
+                "weight": 82713753162251800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  13,
+                  16
+                ],
+                "weight": 16616712214091711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  2,
+                  22
+                ],
+                "weight": 11758285736878375
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  23,
+                  16
+                ],
+                "weight": 49434491050551903
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  4,
+                  5
+                ],
+                "weight": 14754237247579224
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  1,
+                  22
+                ],
+                "weight": 31013002140461825
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  7,
+                  2
+                ],
+                "weight": 3437806908637954
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  24,
+                  22
+                ],
+                "weight": 17569697977751513
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  16,
+                  19
+                ],
+                "weight": 8320478828240421
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  21,
+                  2
+                ],
+                "weight": 41667335400578997
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  4,
+                  18,
+                  8
+                ],
+                "weight": 77042873635642022
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  5,
+                  8
+                ],
+                "weight": 19115344802620953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  18,
+                  21,
+                  22
+                ],
+                "weight": 35669079717001415
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  21,
+                  16
+                ],
+                "weight": 79621539959215371
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  24,
+                  8
+                ],
+                "weight": 26320547301126489
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  15,
+                  23
+                ],
+                "weight": 252571864196537077
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  10,
+                  11
+                ],
+                "weight": 1992941897673441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  4,
+                  8
+                ],
+                "weight": 29137184973983405
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  24,
+                  5
+                ],
+                "weight": 57410786332247212
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  11,
+                  22
+                ],
+                "weight": 6875613817275908
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  10,
+                  8
+                ],
+                "weight": 24978162366271218
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  5,
+                  19
+                ],
+                "weight": 24641958616975668
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  18,
+                  11
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  16,
+                  22
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  21,
+                  2
+                ],
+                "weight": 31385851592451049
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  21,
+                  16
+                ],
+                "weight": 78457472874980163
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  1,
+                  2
+                ],
+                "weight": 17481939396252460
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  18,
+                  13
+                ],
+                "weight": 50695889012850945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  7,
+                  21
+                ],
+                "weight": 25657804563866214
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  24
+                ],
+                "weight": 43838511164066134
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  10,
+                  24
+                ],
+                "weight": 4475459724774436
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  21,
+                  16
+                ],
+                "weight": 71160957886604130
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  5,
+                  19
+                ],
+                "weight": 7482982873444872
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  18,
+                  13
+                ],
+                "weight": 17294536982329406
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  7,
+                  21,
+                  24
+                ],
+                "weight": 16304066288700061
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  5,
+                  16
+                ],
+                "weight": 25657804563866214
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  16,
+                  19
+                ],
+                "weight": 54324236737993105
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 108133977488024352
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  5,
+                  16
+                ],
+                "weight": 40262221289972917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  24,
+                  2
+                ],
+                "weight": 23124392967508234
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  13,
+                  5
+                ],
+                "weight": 38057574627355097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  11,
+                  22
+                ],
+                "weight": 48582700118213338
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  10,
+                  2,
+                  5
+                ],
+                "weight": 2204646662617820
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  21,
+                  24,
+                  16
+                ],
+                "weight": 36905976368589146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  16,
+                  11
+                ],
+                "weight": 48582700118213338
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  13,
+                  22
+                ],
+                "weight": 14387587456799395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  18,
+                  2
+                ],
+                "weight": 55218575472195093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  8,
+                  11
+                ],
+                "weight": 21423127577980641
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  24,
+                  22
+                ],
+                "weight": 9096815443406642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  2,
+                  5
+                ],
+                "weight": 55218575472195093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  11,
+                  19
+                ],
+                "weight": 63857604581164379
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  18,
+                  10
+                ],
+                "weight": 65135899193195127
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  21,
+                  8
+                ],
+                "weight": 54677909760385478
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  2,
+                  22
+                ],
+                "weight": 43952352794437067
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  13,
+                  16
+                ],
+                "weight": 31004299670891106
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  24,
+                  19
+                ],
+                "weight": 16304066288700061
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  24,
+                  11
+                ],
+                "weight": 20957319775548138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  2,
+                  5,
+                  19
+                ],
+                "weight": 94603927301062845
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  2,
+                  11,
+                  19
+                ],
+                "weight": 11699398156466327
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 29699747394114260
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  21,
+                  13
+                ],
+                "weight": 71598506225240107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  19,
+                  22
+                ],
+                "weight": 3361505828190720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 150836128198648453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  16,
+                  11
+                ],
+                "weight": 4882671919602467
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  21,
+                  13,
+                  2
+                ],
+                "weight": 41667335400578997
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  5,
+                  22
+                ],
+                "weight": 19115344802620953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  10,
+                  2,
+                  19
+                ],
+                "weight": 37049505025463965
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  10,
+                  21,
+                  19
+                ],
+                "weight": 96089907754658755
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  5,
+                  22
+                ],
+                "weight": 39030585545192135
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 143901893317370105
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  21,
+                  2,
+                  22
+                ],
+                "weight": 16553734914380462
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  24,
+                  5,
+                  22
+                ],
+                "weight": 103832276707493912
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  24,
+                  11
+                ],
+                "weight": 73483943361062169
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  5,
+                  8
+                ],
+                "weight": 8804520628163436
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  8,
+                  19
+                ],
+                "weight": 156625077127521376
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  2,
+                  16,
+                  11
+                ],
+                "weight": 91230213106582251
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 93477041581805253
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 194,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 8420955620579689635
+          },
+          "certificate_sha256": "4ef9e784f616d2566cdd3e08cea17fbb2b15b866f2ec45890b26a58508255ecd",
+          "max_weight": 252571864196537077,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 194,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 194,
+          "weight_sum": 8420955620579689635,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14873,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 3,
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          6,
+          9,
+          12,
+          20,
+          15,
+          23,
+          1,
+          4,
+          7,
+          18,
+          10,
+          21,
+          13,
+          24,
+          2,
+          5,
+          8,
+          16,
+          11,
+          19,
+          22
+        ],
+        "order_sha256": "7ca60b4094c81d67ce63bc047e16ecc90dbbb9ba3fa4e9787198e259995c7542",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 82
+      },
+      {
+        "dihedral_order_sha256": "a62219f86227c146e1169b27697de6488957a23f0df7182b347bed2fe13830be",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "0af718b94ed18c59561864a2f01ee623d35ba6b4c818f24c612d8d1366075f73",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 4,
+            "source_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              10,
+              13,
+              21,
+              24,
+              2,
+              5,
+              8,
+              16,
+              11,
+              19,
+              22
+            ],
+            "source_unique_ordered_quad_count": 192,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              10,
+              13,
+              21,
+              24,
+              2,
+              5,
+              8,
+              16,
+              11,
+              19,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  12
+                ],
+                "weight": 152867945082331319
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  23
+                ],
+                "weight": 21282392707449692
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  17,
+                  4
+                ],
+                "weight": 47791293481013258
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  17,
+                  11
+                ],
+                "weight": 57167000290043956
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  6,
+                  7
+                ],
+                "weight": 46023241939243564
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  20,
+                  13
+                ],
+                "weight": 83538318471918223
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  23,
+                  19
+                ],
+                "weight": 35890525467344865
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  7,
+                  22
+                ],
+                "weight": 40512442653661264
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  8,
+                  16
+                ],
+                "weight": 136043262143301344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  17,
+                  13
+                ],
+                "weight": 68250777444222674
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  18
+                ],
+                "weight": 105899560345558337
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  15
+                ],
+                "weight": 51039025497507150
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  18
+                ],
+                "weight": 101828919584824169
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  13,
+                  8
+                ],
+                "weight": 92576155293884837
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  20,
+                  24
+                ],
+                "weight": 80011000475806270
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  4,
+                  13
+                ],
+                "weight": 152177400267122104
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  7,
+                  8
+                ],
+                "weight": 815544678923814
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  18,
+                  22
+                ],
+                "weight": 173209071215279888
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  13
+                ],
+                "weight": 96188522180636265
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  15,
+                  1
+                ],
+                "weight": 55734280104165636
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  1,
+                  22
+                ],
+                "weight": 55734280104165636
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  10,
+                  24
+                ],
+                "weight": 3093716102926542
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  5,
+                  11
+                ],
+                "weight": 6274877190163653
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  13,
+                  2
+                ],
+                "weight": 59601244973237267
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  5,
+                  8
+                ],
+                "weight": 42651562170492693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  5,
+                  16
+                ],
+                "weight": 78603423407166164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  21,
+                  5
+                ],
+                "weight": 2893387984740773
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  7,
+                  8
+                ],
+                "weight": 4695254606658486
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  10,
+                  22
+                ],
+                "weight": 104386106786108846
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  18,
+                  21
+                ],
+                "weight": 2893387984740773
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  2,
+                  16
+                ],
+                "weight": 74273539615196492
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 107479822889035388
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  16,
+                  22
+                ],
+                "weight": 24375106310302576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  17,
+                  12
+                ],
+                "weight": 203801570235176297
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  6,
+                  1
+                ],
+                "weight": 21706287507208444
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  9,
+                  4
+                ],
+                "weight": 55677745150549553
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  20,
+                  10
+                ],
+                "weight": 24006514446455707
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  23,
+                  7
+                ],
+                "weight": 66426665690458572
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  16,
+                  22
+                ],
+                "weight": 28089742636063885
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  6,
+                  2
+                ],
+                "weight": 55602937180794691
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  20,
+                  13
+                ],
+                "weight": 100407339573368348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  4,
+                  13
+                ],
+                "weight": 109446281501869361
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  6,
+                  15,
+                  10
+                ],
+                "weight": 24067321458436920
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  6,
+                  23,
+                  16
+                ],
+                "weight": 7218661290322651
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  6,
+                  1,
+                  7
+                ],
+                "weight": 77740471002386099
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  9,
+                  18,
+                  8
+                ],
+                "weight": 6127931748553535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  18,
+                  24
+                ],
+                "weight": 4442433370289059
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  12,
+                  21,
+                  22
+                ],
+                "weight": 1920487156216653
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  7,
+                  19
+                ],
+                "weight": 113481492664709651
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  24,
+                  16
+                ],
+                "weight": 10932361355114404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  24,
+                  19
+                ],
+                "weight": 10932361355114404
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  15,
+                  23,
+                  11
+                ],
+                "weight": 15483626447637055
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  15,
+                  10,
+                  16
+                ],
+                "weight": 8583695010799865
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  15,
+                  16,
+                  11
+                ],
+                "weight": 57167000290043956
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  10,
+                  8
+                ],
+                "weight": 56034183495177655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  8,
+                  11
+                ],
+                "weight": 101559829832333066
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  18,
+                  21
+                ],
+                "weight": 15337597911108544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  18,
+                  13,
+                  2
+                ],
+                "weight": 25907963029951138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  18,
+                  2,
+                  11
+                ],
+                "weight": 25907963029951138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  8,
+                  11
+                ],
+                "weight": 40611364059521813
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  13,
+                  24,
+                  22
+                ],
+                "weight": 12422700017597379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  21,
+                  24,
+                  8
+                ],
+                "weight": 1920487156216653
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  5,
+                  16
+                ],
+                "weight": 31765476513753781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  6,
+                  9
+                ],
+                "weight": 144843849798277859
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  9,
+                  7
+                ],
+                "weight": 66426665690458572
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  9,
+                  13
+                ],
+                "weight": 37364729161327724
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  20,
+                  19
+                ],
+                "weight": 75879562922658440
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  1,
+                  10
+                ],
+                "weight": 341286045224414835
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  9,
+                  18
+                ],
+                "weight": 123137562291069415
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  23,
+                  4
+                ],
+                "weight": 41923282955383321
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  4,
+                  16
+                ],
+                "weight": 5028447720441503
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  21,
+                  22
+                ],
+                "weight": 28089742636063885
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  18,
+                  19
+                ],
+                "weight": 26407362194028299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  13,
+                  5
+                ],
+                "weight": 49048398278351386
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  1,
+                  5
+                ],
+                "weight": 4983027709154824
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  21,
+                  11
+                ],
+                "weight": 46890020767047909
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  23,
+                  24
+                ],
+                "weight": 51039025497507150
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  13,
+                  21
+                ],
+                "weight": 74979763403111794
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  13
+                ],
+                "weight": 99702783831801017
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  8,
+                  22
+                ],
+                "weight": 18782909915607735
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  10,
+                  2
+                ],
+                "weight": 217576746946158111
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  2,
+                  19
+                ],
+                "weight": 16559095178252694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  2,
+                  16,
+                  19
+                ],
+                "weight": 16559095178252694
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  16,
+                  22
+                ],
+                "weight": 16559095178252694
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  4,
+                  19
+                ],
+                "weight": 23890820912534781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  10,
+                  22
+                ],
+                "weight": 20973605355510378
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  13,
+                  21
+                ],
+                "weight": 12246846546787858
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  12,
+                  11
+                ],
+                "weight": 78417184107819287
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  20,
+                  2
+                ],
+                "weight": 97373619198413785
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  15,
+                  10
+                ],
+                "weight": 185221654823375267
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  5,
+                  19
+                ],
+                "weight": 9723718827065408
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  16,
+                  22
+                ],
+                "weight": 32535293942581834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  20,
+                  8
+                ],
+                "weight": 7876415693895597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  15,
+                  24
+                ],
+                "weight": 67764153929018412
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  2,
+                  19
+                ],
+                "weight": 15813704805589480
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  16,
+                  11
+                ],
+                "weight": 44392829542289110
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  23,
+                  11
+                ],
+                "weight": 25239034416503112
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  1,
+                  7
+                ],
+                "weight": 65611121011534758
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  1,
+                  18
+                ],
+                "weight": 32535293942581834
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  1,
+                  13
+                ],
+                "weight": 343391819606252721
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  4,
+                  10
+                ],
+                "weight": 237732860856456684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 7296259526078722
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  2,
+                  16
+                ],
+                "weight": 25956977212029614
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  18,
+                  8
+                ],
+                "weight": 25239034416503112
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  10,
+                  5
+                ],
+                "weight": 60694865099906738
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  4,
+                  11,
+                  22
+                ],
+                "weight": 101559829832333066
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 12246846546787858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  5,
+                  16
+                ],
+                "weight": 50971146272841330
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  20,
+                  18
+                ],
+                "weight": 17238001945511078
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  23,
+                  7
+                ],
+                "weight": 41923282955383321
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  21,
+                  8
+                ],
+                "weight": 3595787078511873
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  13
+                ],
+                "weight": 49048398278351386
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  13,
+                  19
+                ],
+                "weight": 23890820912534781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  21,
+                  16
+                ],
+                "weight": 12247109010764154
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  7,
+                  8,
+                  22
+                ],
+                "weight": 35817188047002778
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  2,
+                  11
+                ],
+                "weight": 58784098268031802
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  5,
+                  19
+                ],
+                "weight": 3093716102926542
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  2,
+                  5,
+                  22
+                ],
+                "weight": 3181161087237111
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  15,
+                  2
+                ],
+                "weight": 156974864171651052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  4,
+                  10
+                ],
+                "weight": 105356983822283186
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  16,
+                  19
+                ],
+                "weight": 36131081021093707
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  15,
+                  23
+                ],
+                "weight": 28246790651724215
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  20,
+                  1,
+                  11
+                ],
+                "weight": 14706746536220232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 32535293942581834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  13,
+                  5
+                ],
+                "weight": 14706746536220232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  21,
+                  24
+                ],
+                "weight": 8583695010799865
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  5,
+                  8
+                ],
+                "weight": 9723718827065408
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  4,
+                  18,
+                  8
+                ],
+                "weight": 15567342500268734
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  7,
+                  13,
+                  19
+                ],
+                "weight": 98583078777888943
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  13,
+                  2
+                ],
+                "weight": 79864671001092081
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  24,
+                  16
+                ],
+                "weight": 8583695010799865
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  16,
+                  22
+                ],
+                "weight": 4987907932287992
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  15,
+                  7
+                ],
+                "weight": 224739018100669464
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  23,
+                  11
+                ],
+                "weight": 15999944104936357
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  11,
+                  19
+                ],
+                "weight": 50024298670466534
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  7,
+                  8
+                ],
+                "weight": 52448465020604943
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  16,
+                  22
+                ],
+                "weight": 1920487156216653
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  4,
+                  22
+                ],
+                "weight": 131860107266666863
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  18,
+                  2
+                ],
+                "weight": 80656316209063771
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  18,
+                  5
+                ],
+                "weight": 26503123444383677
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  21,
+                  19
+                ],
+                "weight": 102717006283158389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  21,
+                  2
+                ],
+                "weight": 60504843156997801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  8,
+                  19
+                ],
+                "weight": 1920487156216653
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  24,
+                  5,
+                  19
+                ],
+                "weight": 72206587299307471
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  1,
+                  4
+                ],
+                "weight": 19090454272074471
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  1,
+                  19
+                ],
+                "weight": 46520666739460287
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  10,
+                  2
+                ],
+                "weight": 146137064547858379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  24
+                ],
+                "weight": 12246846546787858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  24,
+                  16
+                ],
+                "weight": 10932361355114404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  10,
+                  21
+                ],
+                "weight": 12247109010764154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  7,
+                  18,
+                  10
+                ],
+                "weight": 118651590077681805
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  10,
+                  2
+                ],
+                "weight": 144213074564345843
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  2,
+                  16
+                ],
+                "weight": 146137064547858379
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  21,
+                  22
+                ],
+                "weight": 12247109010764154
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  13,
+                  22
+                ],
+                "weight": 183945658045286571
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  11,
+                  19
+                ],
+                "weight": 48534291097165615
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 7876415693895597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  7,
+                  8
+                ],
+                "weight": 4695254606658486
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  10,
+                  13
+                ],
+                "weight": 98870584315646575
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  21,
+                  22
+                ],
+                "weight": 39831553468660556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  5,
+                  19
+                ],
+                "weight": 96544965409926821
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  7,
+                  5,
+                  22
+                ],
+                "weight": 4695254606658486
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  13,
+                  21
+                ],
+                "weight": 39831553468660556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  10,
+                  24,
+                  2
+                ],
+                "weight": 221420307352414072
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  13,
+                  2,
+                  5
+                ],
+                "weight": 101240220016585307
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  24,
+                  16,
+                  11
+                ],
+                "weight": 22626328067214477
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  24,
+                  5
+                ],
+                "weight": 7972499680956487
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  10,
+                  8
+                ],
+                "weight": 84175966952341641
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  10,
+                  22
+                ],
+                "weight": 75389482463211672
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  10,
+                  24,
+                  22
+                ],
+                "weight": 41752040624877209
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  5,
+                  11
+                ],
+                "weight": 43822599990976570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  24,
+                  8,
+                  16
+                ],
+                "weight": 1793212908575100
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  11,
+                  19
+                ],
+                "weight": 84545260855116737
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  18,
+                  8
+                ],
+                "weight": 80656316209063771
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  13,
+                  19
+                ],
+                "weight": 14898413886820708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  21,
+                  2
+                ],
+                "weight": 80656316209063771
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  13,
+                  8,
+                  19
+                ],
+                "weight": 14898413886820708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  13,
+                  11,
+                  19
+                ],
+                "weight": 14706746536220232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  8,
+                  19,
+                  22
+                ],
+                "weight": 76125827162501227
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  10,
+                  5
+                ],
+                "weight": 34475623125340164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  18,
+                  10,
+                  5
+                ],
+                "weight": 77474269717225007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  2,
+                  16
+                ],
+                "weight": 96792369865880891
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  19,
+                  22
+                ],
+                "weight": 92868739267382784
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  13,
+                  24,
+                  22
+                ],
+                "weight": 148912990671532280
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  8,
+                  19
+                ],
+                "weight": 68977918354848003
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  16,
+                  19
+                ],
+                "weight": 84545260855116737
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  18,
+                  13,
+                  8
+                ],
+                "weight": 14898413886820708
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  8,
+                  16,
+                  11
+                ],
+                "weight": 145238614667926218
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  24,
+                  8,
+                  11
+                ],
+                "weight": 25907963029951138
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  13,
+                  5,
+                  11
+                ],
+                "weight": 86533473480365075
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 45922109420843262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  8,
+                  11,
+                  22
+                ],
+                "weight": 3067420776071339
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 192,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 11338721885072919842
+          },
+          "certificate_sha256": "2ba491dd57e787e361ec88157f42dc0e2f1345c103c4cdc10155991f4bb9ab3b",
+          "max_weight": 343391819606252721,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 192,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 192,
+          "weight_sum": 11338721885072919842,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14873,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 4,
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          6,
+          9,
+          12,
+          20,
+          15,
+          23,
+          1,
+          4,
+          7,
+          18,
+          10,
+          13,
+          21,
+          24,
+          2,
+          5,
+          8,
+          16,
+          11,
+          19,
+          22
+        ],
+        "order_sha256": "a62219f86227c146e1169b27697de6488957a23f0df7182b347bed2fe13830be",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 83
+      },
+      {
+        "dihedral_order_sha256": "b794577f9b684ad39dfc20bf8c49ceb4007a340c1a949f1d1ae9553367265642",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "ba8e5e9fe7d3991f91c0ffcfb0bf43c0e3e58b760ff1c4c25d7db7c16215e7cb",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 5,
+            "source_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              10,
+              13,
+              21,
+              24,
+              2,
+              5,
+              8,
+              16,
+              19,
+              11,
+              22
+            ],
+            "source_unique_ordered_quad_count": 200,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              15,
+              23,
+              1,
+              4,
+              7,
+              18,
+              10,
+              13,
+              21,
+              24,
+              2,
+              5,
+              8,
+              16,
+              19,
+              11,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  23
+                ],
+                "weight": 1380297332132126385
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  21
+                ],
+                "weight": 644214431375430007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  17,
+                  9
+                ],
+                "weight": 677214020851961788
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  6,
+                  18
+                ],
+                "weight": 345932489010548048
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  6,
+                  13
+                ],
+                "weight": 301146967442944639
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  4,
+                  8
+                ],
+                "weight": 173310501595480146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  2,
+                  16
+                ],
+                "weight": 1821627228494262609
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  16,
+                  22
+                ],
+                "weight": 128507564570302984
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  19
+                ],
+                "weight": 1093603100293795507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  10
+                ],
+                "weight": 784520468786632754
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  16
+                ],
+                "weight": 567914421813268491
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  13,
+                  8
+                ],
+                "weight": 362994241400492394
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  6,
+                  20
+                ],
+                "weight": 322324600392922348
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  4,
+                  16
+                ],
+                "weight": 354889420459039440
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  10,
+                  13
+                ],
+                "weight": 2653472472620040596
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  4,
+                  11
+                ],
+                "weight": 969404056846415035
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  18,
+                  21
+                ],
+                "weight": 495372370945104073
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  23,
+                  4
+                ],
+                "weight": 1965423096437330738
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  13,
+                  19
+                ],
+                "weight": 239658162270175948
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  20,
+                  24
+                ],
+                "weight": 809365076057323567
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  15,
+                  7
+                ],
+                "weight": 284238024236471940
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  23,
+                  18
+                ],
+                "weight": 149439881934556025
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  4,
+                  7
+                ],
+                "weight": 467819117536396117
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  21
+                ],
+                "weight": 673618136656248552
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  1,
+                  16
+                ],
+                "weight": 497086112515839105
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  21,
+                  11
+                ],
+                "weight": 1139586802320534080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  5,
+                  19
+                ],
+                "weight": 144521589983346059
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  8,
+                  16
+                ],
+                "weight": 173310501595480146
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  7,
+                  10
+                ],
+                "weight": 315218047399874693
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  13,
+                  11
+                ],
+                "weight": 181868065115964412
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  24,
+                  19
+                ],
+                "weight": 521017066519727128
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  19,
+                  11
+                ],
+                "weight": 384179752253522007
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  13,
+                  2
+                ],
+                "weight": 1868952003833407842
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 521017066519727128
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  17,
+                  8
+                ],
+                "weight": 1237394692825015050
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  6,
+                  2
+                ],
+                "weight": 345932489010548048
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  9,
+                  5
+                ],
+                "weight": 328492856825292512
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  20,
+                  1
+                ],
+                "weight": 112469199148708368
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  15,
+                  19
+                ],
+                "weight": 637223186050711176
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  7,
+                  22
+                ],
+                "weight": 214032042346894645
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  18,
+                  11
+                ],
+                "weight": 257015129140605968
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  12,
+                  22
+                ],
+                "weight": 560180671973053262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  1,
+                  10
+                ],
+                "weight": 788542994237679949
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  18,
+                  21
+                ],
+                "weight": 644214431375430007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  6,
+                  7,
+                  24
+                ],
+                "weight": 29773810478481065
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  9,
+                  7,
+                  18
+                ],
+                "weight": 1127701605162289283
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  4,
+                  19
+                ],
+                "weight": 975616354484210159
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  15,
+                  22
+                ],
+                "weight": 108557307947570846
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  1,
+                  18
+                ],
+                "weight": 343074517932349379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  13,
+                  5
+                ],
+                "weight": 3911891201137522
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  15,
+                  10,
+                  24
+                ],
+                "weight": 745780493998282022
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  13,
+                  22
+                ],
+                "weight": 1019148313021320960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  1,
+                  11,
+                  22
+                ],
+                "weight": 128507564570302984
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  7,
+                  11
+                ],
+                "weight": 535929279081277447
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  18,
+                  13
+                ],
+                "weight": 223614073568054639
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  10,
+                  16
+                ],
+                "weight": 42762500239397927
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  13,
+                  8
+                ],
+                "weight": 356120014895085344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  7,
+                  2,
+                  16
+                ],
+                "weight": 1551316722173857096
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  18,
+                  24,
+                  19
+                ],
+                "weight": 273838124973547511
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  18,
+                  2,
+                  8
+                ],
+                "weight": 616242995330953561
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  13,
+                  8,
+                  22
+                ],
+                "weight": 1680327186560488465
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  5,
+                  16
+                ],
+                "weight": 244064314495066446
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 128507564570302984
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  6,
+                  8
+                ],
+                "weight": 1074414432958420750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  12,
+                  13
+                ],
+                "weight": 499596492151701475
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  20,
+                  24
+                ],
+                "weight": 112469199148708368
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  15,
+                  13
+                ],
+                "weight": 224482743093402451
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  10,
+                  21
+                ],
+                "weight": 193432612138519581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  13,
+                  16
+                ],
+                "weight": 567914421813268491
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  24,
+                  11
+                ],
+                "weight": 345932489010548048
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  9,
+                  19
+                ],
+                "weight": 520729257530087704
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  23,
+                  18
+                ],
+                "weight": 1600531865297425211
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  23,
+                  24
+                ],
+                "weight": 207752686417784998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  18,
+                  10
+                ],
+                "weight": 1970264531653290947
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  12,
+                  1
+                ],
+                "weight": 230470310707582484
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  15,
+                  19
+                ],
+                "weight": 447320188477970535
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  10,
+                  22
+                ],
+                "weight": 290258946822505220
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  15,
+                  18
+                ],
+                "weight": 112717537215259768
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  7,
+                  8
+                ],
+                "weight": 356120014895085344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  4,
+                  24
+                ],
+                "weight": 433474777765137588
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  13,
+                  11
+                ],
+                "weight": 125114682476952565
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  11
+                ],
+                "weight": 433474777765137588
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  10,
+                  2
+                ],
+                "weight": 268577726140495804
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  24,
+                  11
+                ],
+                "weight": 87542288754589540
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  13,
+                  21,
+                  16
+                ],
+                "weight": 193432612138519581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 214032042346894645
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  5,
+                  11
+                ],
+                "weight": 345932489010548048
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  9,
+                  22
+                ],
+                "weight": 70828309297429386
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  8
+                ],
+                "weight": 707592375206495267
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  16
+                ],
+                "weight": 1937281843785671863
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  4,
+                  5
+                ],
+                "weight": 141170335635638532
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  23,
+                  4
+                ],
+                "weight": 141170335635638532
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  18,
+                  11
+                ],
+                "weight": 70828309297429386
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  19,
+                  22
+                ],
+                "weight": 560180671973053262
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  23,
+                  5
+                ],
+                "weight": 118985897969281338
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  1,
+                  21
+                ],
+                "weight": 398051663324705829
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  7,
+                  18
+                ],
+                "weight": 438045307057915052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  10,
+                  13
+                ],
+                "weight": 2809637286051876031
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  2,
+                  16
+                ],
+                "weight": 203338702423641010
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  15,
+                  7,
+                  19
+                ],
+                "weight": 136837314266205121
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  24,
+                  2
+                ],
+                "weight": 233463289861839680
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  5,
+                  22
+                ],
+                "weight": 156211481904117267
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  18,
+                  19
+                ],
+                "weight": 260156233604919870
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  18,
+                  10
+                ],
+                "weight": 751275195530995803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  7,
+                  21,
+                  5
+                ],
+                "weight": 574882621324120173
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  13,
+                  2,
+                  5
+                ],
+                "weight": 30124587438198670
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  21,
+                  16,
+                  11
+                ],
+                "weight": 1014478001513363932
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 126086894465918597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  5,
+                  19,
+                  11
+                ],
+                "weight": 345932489010548048
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  1,
+                  16
+                ],
+                "weight": 1072176806484702054
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  15,
+                  10
+                ],
+                "weight": 2281939955897319711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  23,
+                  4
+                ],
+                "weight": 975616354484210159
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  19
+                ],
+                "weight": 520729257530087704
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  18,
+                  16
+                ],
+                "weight": 865105037300969809
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  23,
+                  16
+                ],
+                "weight": 624915510813215052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  7,
+                  2
+                ],
+                "weight": 29773810478481065
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  4,
+                  5
+                ],
+                "weight": 378696832531904595
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  10,
+                  13
+                ],
+                "weight": 311675424244028764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  21,
+                  22
+                ],
+                "weight": 147223831220350395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  13,
+                  21
+                ],
+                "weight": 642596202165454468
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  2,
+                  19
+                ],
+                "weight": 29773810478481065
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  5,
+                  19
+                ],
+                "weight": 237526496896266063
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  21,
+                  11
+                ],
+                "weight": 97643360064003699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  2,
+                  5
+                ],
+                "weight": 15311533880785387
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  20,
+                  15,
+                  11
+                ],
+                "weight": 1289026684255090105
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  10,
+                  19
+                ],
+                "weight": 166249093218058779
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  1,
+                  18
+                ],
+                "weight": 841706495777119570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  7,
+                  2
+                ],
+                "weight": 15311533880785387
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  7,
+                  22
+                ],
+                "weight": 81699050276980763
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  10,
+                  24
+                ],
+                "weight": 917521812959066558
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  13,
+                  21
+                ],
+                "weight": 667028951002641455
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  7,
+                  10
+                ],
+                "weight": 1083770906177125337
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  21,
+                  22
+                ],
+                "weight": 137731587248095071
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  4,
+                  13,
+                  16
+                ],
+                "weight": 193432612138519581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  13,
+                  16
+                ],
+                "weight": 728372415778624155
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 431654003690542685
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  5,
+                  8
+                ],
+                "weight": 343804390706077899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  8,
+                  16
+                ],
+                "weight": 343804390706077899
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  13,
+                  24,
+                  19
+                ],
+                "weight": 1349175816649609243
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  15,
+                  10
+                ],
+                "weight": 2394657493112579479
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  2,
+                  8
+                ],
+                "weight": 399696926728400656
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  18,
+                  24
+                ],
+                "weight": 1053429390552390013
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  13,
+                  19
+                ],
+                "weight": 500385871784506055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  10,
+                  16
+                ],
+                "weight": 451605009217734906
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  13,
+                  11
+                ],
+                "weight": 88532437530769360
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  5,
+                  8
+                ],
+                "weight": 369923116249919591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  2,
+                  5
+                ],
+                "weight": 141170335635638532
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  7,
+                  13,
+                  5
+                ],
+                "weight": 233965382654846146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  21,
+                  2
+                ],
+                "weight": 525555728483253801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  24,
+                  5
+                ],
+                "weight": 244064314495066446
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  10,
+                  16
+                ],
+                "weight": 301041890466679972
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  8,
+                  16
+                ],
+                "weight": 413500028083234903
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  13,
+                  21,
+                  8
+                ],
+                "weight": 822883691970121561
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  13,
+                  19,
+                  11
+                ],
+                "weight": 97643360064003699
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  23,
+                  11
+                ],
+                "weight": 149439881934556025
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  1,
+                  24
+                ],
+                "weight": 741126181257055208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  4,
+                  13
+                ],
+                "weight": 2809637286051876031
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  18,
+                  8
+                ],
+                "weight": 421812032598091902
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  10,
+                  16
+                ],
+                "weight": 581228886157355331
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 369923116249919591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  18,
+                  21
+                ],
+                "weight": 210942198474911783
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  21,
+                  8
+                ],
+                "weight": 157815878716995174
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  5,
+                  16
+                ],
+                "weight": 247025327079500731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  19,
+                  22
+                ],
+                "weight": 13681891368627641
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  24,
+                  8
+                ],
+                "weight": 1229485678697949555
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  21,
+                  8,
+                  19
+                ],
+                "weight": 179930984586686420
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  2,
+                  11,
+                  22
+                ],
+                "weight": 638996864000358658
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  7,
+                  21
+                ],
+                "weight": 381248608394238090
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  10,
+                  2
+                ],
+                "weight": 471260174370412395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  13,
+                  22
+                ],
+                "weight": 129353224233527184
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  18,
+                  8
+                ],
+                "weight": 704363236670791731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  2,
+                  5
+                ],
+                "weight": 222485350627787328
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  16,
+                  11
+                ],
+                "weight": 70828309297429386
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  21,
+                  8,
+                  11
+                ],
+                "weight": 285780342608403365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  13,
+                  19
+                ],
+                "weight": 307594226468396358
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  10,
+                  13
+                ],
+                "weight": 53126319757916609
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  21,
+                  22
+                ],
+                "weight": 53126319757916609
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  18,
+                  22
+                ],
+                "weight": 13681891368627641
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  11
+                ],
+                "weight": 64207238073165900
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  10,
+                  21,
+                  22
+                ],
+                "weight": 214032042346894645
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  10,
+                  19,
+                  22
+                ],
+                "weight": 76226904475610575
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  24,
+                  5
+                ],
+                "weight": 207752686417784998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  8,
+                  19
+                ],
+                "weight": 173310501595480146
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  2,
+                  5,
+                  19
+                ],
+                "weight": 471260174370412395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  18,
+                  19
+                ],
+                "weight": 1592981691308115373
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  2,
+                  16
+                ],
+                "weight": 369923116249919591
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 845947708633601791
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  10,
+                  24,
+                  11
+                ],
+                "weight": 433474777765137588
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  13,
+                  8,
+                  19
+                ],
+                "weight": 4081197775632406
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  13,
+                  19,
+                  22
+                ],
+                "weight": 1285387464839719015
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  8,
+                  11
+                ],
+                "weight": 53360500545661428
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  8,
+                  16,
+                  11
+                ],
+                "weight": 285780342608403365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  10,
+                  22
+                ],
+                "weight": 53126319757916609
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  24,
+                  8
+                ],
+                "weight": 157815878716995174
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  2,
+                  19
+                ],
+                "weight": 1474287383226993441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  2,
+                  16,
+                  19
+                ],
+                "weight": 118694308081121932
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  18,
+                  10,
+                  5
+                ],
+                "weight": 368344367157791302
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  21,
+                  24,
+                  16
+                ],
+                "weight": 244064314495066446
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  2,
+                  5,
+                  22
+                ],
+                "weight": 126086894465918597
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  19,
+                  11,
+                  22
+                ],
+                "weight": 560180671973053262
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 200,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 105239174433716993061
+          },
+          "certificate_sha256": "e5b7f516b928d44d1f5cd3af358226a8b28a98ad44b6ba7b8a469b176eeff15c",
+          "max_weight": 2809637286051876031,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 200,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 200,
+          "weight_sum": 105239174433716993061,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14873,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 5,
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          6,
+          9,
+          12,
+          20,
+          15,
+          23,
+          1,
+          4,
+          7,
+          18,
+          10,
+          13,
+          21,
+          24,
+          2,
+          5,
+          8,
+          16,
+          19,
+          11,
+          22
+        ],
+        "order_sha256": "b794577f9b684ad39dfc20bf8c49ceb4007a340c1a949f1d1ae9553367265642",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 84
+      },
+      {
+        "dihedral_order_sha256": "21e13c0d8d493dec39d581382440e682b367c863bd076be5db0f6481365cd6df",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "3cc1dd5dd27efa379ce5c713c644874e689018cae56fb03c623a553e327f6034",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 6,
+            "source_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              23,
+              15,
+              1,
+              4,
+              7,
+              18,
+              10,
+              13,
+              21,
+              24,
+              2,
+              5,
+              8,
+              16,
+              11,
+              19,
+              22
+            ],
+            "source_unique_ordered_quad_count": 191,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              14,
+              3,
+              17,
+              6,
+              9,
+              12,
+              20,
+              23,
+              15,
+              1,
+              4,
+              7,
+              18,
+              10,
+              13,
+              21,
+              24,
+              2,
+              5,
+              8,
+              16,
+              11,
+              19,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  3,
+                  20
+                ],
+                "weight": 984906882666852073
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  14,
+                  15,
+                  2
+                ],
+                "weight": 502753960755024767
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  15,
+                  11
+                ],
+                "weight": 311082224232818618
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  1,
+                  2
+                ],
+                "weight": 90335579762901783
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  14,
+                  21,
+                  5
+                ],
+                "weight": 439367659436009443
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  17,
+                  22
+                ],
+                "weight": 445727571813354326
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  2
+                ],
+                "weight": 539179310853497747
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  4
+                ],
+                "weight": 208622548480990270
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  16,
+                  11
+                ],
+                "weight": 666840383356384628
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  9,
+                  15
+                ],
+                "weight": 199129718534046129
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  12,
+                  21
+                ],
+                "weight": 199729669091606900
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  20,
+                  15
+                ],
+                "weight": 850472918149825953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  23,
+                  10
+                ],
+                "weight": 78079812705113321
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  18,
+                  19
+                ],
+                "weight": 246597853279308197
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  22
+                ],
+                "weight": 58860733509783283
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  15,
+                  4
+                ],
+                "weight": 36636733161982568
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  1,
+                  18
+                ],
+                "weight": 168518040574194876
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  5
+                ],
+                "weight": 194617220784304833
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  8,
+                  11
+                ],
+                "weight": 285701356559409631
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  2,
+                  11
+                ],
+                "weight": 958046232942879468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  7,
+                  24
+                ],
+                "weight": 168295368940264544
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  11,
+                  22
+                ],
+                "weight": 408352217572597170
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  24,
+                  8
+                ],
+                "weight": 285701356559409631
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  1,
+                  21
+                ],
+                "weight": 239637990344402543
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  5,
+                  16
+                ],
+                "weight": 438414807909509809
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  4,
+                  13
+                ],
+                "weight": 125476630043030184
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  4,
+                  13
+                ],
+                "weight": 119782651599942654
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  1,
+                  13,
+                  24
+                ],
+                "weight": 125476630043030184
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  24,
+                  22
+                ],
+                "weight": 378708959081556548
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  5,
+                  19
+                ],
+                "weight": 362912589724569377
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  10,
+                  11
+                ],
+                "weight": 78079812705113321
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  16,
+                  19
+                ],
+                "weight": 370638316657671451
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  17,
+                  4
+                ],
+                "weight": 613634400205212360
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  6,
+                  23
+                ],
+                "weight": 63693875422849568
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  9,
+                  18
+                ],
+                "weight": 139173139591949901
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  3,
+                  9,
+                  16
+                ],
+                "weight": 642180657331410083
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  3,
+                  15,
+                  7
+                ],
+                "weight": 311082224232818618
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  6,
+                  20
+                ],
+                "weight": 850472918149825953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  12,
+                  5
+                ],
+                "weight": 582290152322642475
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  17,
+                  18,
+                  10
+                ],
+                "weight": 84767388450381155
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  17,
+                  10,
+                  22
+                ],
+                "weight": 31344247882569885
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  6,
+                  12,
+                  4
+                ],
+                "weight": 682276410230521075
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  6,
+                  20,
+                  2
+                ],
+                "weight": 231890383342154446
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  6,
+                  18,
+                  2
+                ],
+                "weight": 511053413339922116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  6,
+                  10,
+                  11
+                ],
+                "weight": 108949826152800652
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  9,
+                  23,
+                  2
+                ],
+                "weight": 958046232942879468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  9,
+                  4,
+                  18
+                ],
+                "weight": 4438794298937396
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  1,
+                  7
+                ],
+                "weight": 237503766459335990
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  12,
+                  7,
+                  16
+                ],
+                "weight": 96377122792738634
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  13,
+                  11
+                ],
+                "weight": 14304431122784180
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  12,
+                  21,
+                  2
+                ],
+                "weight": 30430874995024746
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  23,
+                  16
+                ],
+                "weight": 68763866769794161
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  20,
+                  21,
+                  19
+                ],
+                "weight": 297560481089386405
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  20,
+                  16,
+                  11
+                ],
+                "weight": 187827966957233786
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  23,
+                  5,
+                  19
+                ],
+                "weight": 56796180244961965
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  15,
+                  7,
+                  18
+                ],
+                "weight": 452208867899415974
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  1,
+                  4,
+                  19
+                ],
+                "weight": 147168186696434207
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  10,
+                  22
+                ],
+                "weight": 4244365583629222
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  4,
+                  13,
+                  8
+                ],
+                "weight": 147362615411742381
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  4,
+                  21,
+                  2
+                ],
+                "weight": 51605252182979688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  14,
+                  4,
+                  24,
+                  8
+                ],
+                "weight": 161667046534526561
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  10,
+                  21,
+                  5
+                ],
+                "weight": 59771051168618604
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  13,
+                  8,
+                  22
+                ],
+                "weight": 161667046534526561
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  14,
+                  24,
+                  16,
+                  22
+                ],
+                "weight": 161667046534526561
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  6,
+                  15
+                ],
+                "weight": 648341654715696395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  15,
+                  11
+                ],
+                "weight": 513696307135160687
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  1,
+                  19
+                ],
+                "weight": 727750578768256400
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  18,
+                  13
+                ],
+                "weight": 262495688343225723
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  10,
+                  24
+                ],
+                "weight": 38472839462747628
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  10,
+                  16
+                ],
+                "weight": 638070668827907535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  21,
+                  19
+                ],
+                "weight": 251653523750371457
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  9,
+                  5
+                ],
+                "weight": 183908445709758827
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  12,
+                  16
+                ],
+                "weight": 82072691669954454
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  4
+                ],
+                "weight": 763407921315572177
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  8
+                ],
+                "weight": 382360517335983114
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  4,
+                  21
+                ],
+                "weight": 35106588091717117
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  12,
+                  8
+                ],
+                "weight": 44735306117808926
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  15,
+                  22
+                ],
+                "weight": 445727571813354326
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  10,
+                  13
+                ],
+                "weight": 136607915131254909
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  1,
+                  18
+                ],
+                "weight": 537385883323501379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  2,
+                  19
+                ],
+                "weight": 29595468537036763
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  23,
+                  22
+                ],
+                "weight": 160861555984703218
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  1,
+                  21
+                ],
+                "weight": 178074096195906712
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  13,
+                  11
+                ],
+                "weight": 249747609206597750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  18,
+                  5
+                ],
+                "weight": 135717055388325755
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  2,
+                  11
+                ],
+                "weight": 93955615462347570
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  10,
+                  11
+                ],
+                "weight": 311082224232818618
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  11,
+                  19
+                ],
+                "weight": 96603532985373809
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  13,
+                  2
+                ],
+                "weight": 149355994267882882
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  5,
+                  16
+                ],
+                "weight": 974877653386845808
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  21,
+                  24,
+                  19
+                ],
+                "weight": 38472839462747628
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  16,
+                  11
+                ],
+                "weight": 662730394852882080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  23,
+                  24
+                ],
+                "weight": 97167680561853650
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  23,
+                  24
+                ],
+                "weight": 1128121202333934185
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  4,
+                  16
+                ],
+                "weight": 447613644306167554
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  7,
+                  24
+                ],
+                "weight": 37312309125992614
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  15,
+                  1
+                ],
+                "weight": 1147209070190674514
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  1,
+                  13
+                ],
+                "weight": 262495688343225723
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  4,
+                  2
+                ],
+                "weight": 313188942595479013
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  18,
+                  5
+                ],
+                "weight": 347263076793606878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  10,
+                  11
+                ],
+                "weight": 513696307135160687
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  15,
+                  1,
+                  22
+                ],
+                "weight": 424700252655145012
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  15,
+                  7,
+                  18
+                ],
+                "weight": 14611545532771943
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  15,
+                  2,
+                  19
+                ],
+                "weight": 174169017291542052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 139019925303936961
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  4,
+                  8,
+                  19
+                ],
+                "weight": 147168186696434207
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  7,
+                  21,
+                  8
+                ],
+                "weight": 51923854658764557
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  7,
+                  24,
+                  5
+                ],
+                "weight": 96007150225098636
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  24,
+                  8,
+                  16
+                ],
+                "weight": 190457024521739981
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  23,
+                  19
+                ],
+                "weight": 160861555984703218
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  10,
+                  24
+                ],
+                "weight": 431068785451079108
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  10
+                ],
+                "weight": 322118959298278456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  24,
+                  5
+                ],
+                "weight": 582290152322642475
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  15,
+                  7
+                ],
+                "weight": 23032954429361348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  13,
+                  24
+                ],
+                "weight": 248389047433417017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  7,
+                  16
+                ],
+                "weight": 82072691669954454
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  19,
+                  22
+                ],
+                "weight": 160861555984703218
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  18,
+                  21
+                ],
+                "weight": 283495635525134134
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  7,
+                  18,
+                  13
+                ],
+                "weight": 59039737240593106
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  21,
+                  11
+                ],
+                "weight": 248389047433417017
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  2,
+                  5,
+                  19
+                ],
+                "weight": 203764485828578815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  23,
+                  4
+                ],
+                "weight": 53502925851327268
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  18,
+                  24
+                ],
+                "weight": 537385883323501379
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  19,
+                  22
+                ],
+                "weight": 29595468537036763
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  20,
+                  1,
+                  10
+                ],
+                "weight": 200048731893564748
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  1,
+                  13
+                ],
+                "weight": 248389047433417017
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  20,
+                  4,
+                  11
+                ],
+                "weight": 525337404145841448
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  15,
+                  2
+                ],
+                "weight": 644857290347400455
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  1,
+                  11
+                ],
+                "weight": 59619460627676126
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  16,
+                  11
+                ],
+                "weight": 451723632809670102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  5,
+                  22
+                ],
+                "weight": 357271369766534280
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  10,
+                  16
+                ],
+                "weight": 508057239954657891
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  10,
+                  11
+                ],
+                "weight": 59619460627676126
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  7,
+                  13,
+                  8
+                ],
+                "weight": 44735306117808926
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  13,
+                  24
+                ],
+                "weight": 67045826184353182
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  24,
+                  5
+                ],
+                "weight": 173362924056775453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  24,
+                  16,
+                  19
+                ],
+                "weight": 190457024521739981
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  15,
+                  22
+                ],
+                "weight": 402359072643434826
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  4,
+                  10
+                ],
+                "weight": 226414411735758981
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  15,
+                  4,
+                  11
+                ],
+                "weight": 402359072643434826
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  13,
+                  16
+                ],
+                "weight": 14304431122784180
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  21,
+                  24
+                ],
+                "weight": 1251512302275057633
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  21,
+                  22
+                ],
+                "weight": 35588613466199107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  24,
+                  8,
+                  11
+                ],
+                "weight": 44735306117808926
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  2,
+                  11,
+                  22
+                ],
+                "weight": 30430874995024746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  1,
+                  10
+                ],
+                "weight": 426463143629323729
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  11,
+                  19
+                ],
+                "weight": 191298539245578211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  21,
+                  19
+                ],
+                "weight": 106261941843808194
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  2,
+                  5
+                ],
+                "weight": 231890383342154446
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  18,
+                  21
+                ],
+                "weight": 284336038039714906
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  7,
+                  22
+                ],
+                "weight": 14279354696631266
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  5,
+                  16
+                ],
+                "weight": 231890383342154446
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  7,
+                  8,
+                  16
+                ],
+                "weight": 96659160776573483
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  4,
+                  7
+                ],
+                "weight": 313188942595479013
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  1,
+                  7,
+                  19
+                ],
+                "weight": 218612247873722519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  10,
+                  19
+                ],
+                "weight": 87233163505836958
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  24,
+                  11
+                ],
+                "weight": 833740861326928704
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  18,
+                  16
+                ],
+                "weight": 72482931869627891
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  21,
+                  8
+                ],
+                "weight": 114547776982360827
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  5,
+                  11
+                ],
+                "weight": 147947911360864896
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  21,
+                  24,
+                  11
+                ],
+                "weight": 294380341007005481
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  7,
+                  2
+                ],
+                "weight": 139019925303936961
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  21,
+                  22
+                ],
+                "weight": 45991293573588464
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  5,
+                  19
+                ],
+                "weight": 274736980692262716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  13,
+                  24
+                ],
+                "weight": 1003274633532200808
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  2,
+                  16
+                ],
+                "weight": 5693978443087530
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  21,
+                  22
+                ],
+                "weight": 60270648270219730
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  2,
+                  11
+                ],
+                "weight": 1373807656001492138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  10,
+                  16
+                ],
+                "weight": 466820413432187917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  24,
+                  5
+                ],
+                "weight": 149355994267882882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 5693978443087530
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  24,
+                  11,
+                  22
+                ],
+                "weight": 721700974151459562
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  18,
+                  16
+                ],
+                "weight": 508057239954657891
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  18,
+                  10,
+                  21
+                ],
+                "weight": 82310168083529700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  18,
+                  13,
+                  19
+                ],
+                "weight": 5693978443087530
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  24,
+                  16
+                ],
+                "weight": 1073194983966429297
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  18,
+                  16,
+                  22
+                ],
+                "weight": 18523720280260488
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  21,
+                  5,
+                  19
+                ],
+                "weight": 231890383342154446
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  8,
+                  16,
+                  11
+                ],
+                "weight": 309029661946268942
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 82310168083529700
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  18,
+                  2,
+                  19
+                ],
+                "weight": 144300341850846858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  2,
+                  11
+                ],
+                "weight": 1730881173807899220
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 45991293573588464
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  10,
+                  2,
+                  5
+                ],
+                "weight": 149355994267882882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  5,
+                  11,
+                  22
+                ],
+                "weight": 18523720280260488
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  16,
+                  11,
+                  19
+                ],
+                "weight": 389162036937931939
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 971346009040656117
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  16,
+                  22
+                ],
+                "weight": 5693978443087530
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  5,
+                  8,
+                  11
+                ],
+                "weight": 166471631641125384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  19,
+                  22
+                ],
+                "weight": 18523720280260488
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 143143326254266073
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 191,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 56393977812280430202
+          },
+          "certificate_sha256": "0390256e4033e366bd7f4838594948695d35f21cf5856ec24453aba7bb58273e",
+          "max_weight": 1730881173807899220,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 191,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 191,
+          "weight_sum": 56393977812280430202,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14873,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 6,
+        "order": [
+          0,
+          14,
+          3,
+          17,
+          6,
+          9,
+          12,
+          20,
+          23,
+          15,
+          1,
+          4,
+          7,
+          18,
+          10,
+          13,
+          21,
+          24,
+          2,
+          5,
+          8,
+          16,
+          11,
+          19,
+          22
+        ],
+        "order_sha256": "21e13c0d8d493dec39d581382440e682b367c863bd076be5db0f6481365cd6df",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 85
+      },
+      {
+        "dihedral_order_sha256": "7878fbe6f726d920f08ac5c0d6e0ab5ee52a85cf5d9e9f99dd65dc385a1fb241",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "d60372dbce9b2101548b7ee6d07e6a8c070d97c212f9c2216a9818c56eb12b37",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 7,
+            "source_order": [
+              0,
+              20,
+              3,
+              6,
+              9,
+              23,
+              12,
+              1,
+              15,
+              18,
+              4,
+              21,
+              24,
+              7,
+              10,
+              13,
+              16,
+              2,
+              5,
+              19,
+              22,
+              8,
+              11,
+              14,
+              17
+            ],
+            "source_unique_ordered_quad_count": 195,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              20,
+              3,
+              6,
+              9,
+              23,
+              12,
+              1,
+              15,
+              18,
+              4,
+              21,
+              24,
+              7,
+              10,
+              13,
+              16,
+              2,
+              5,
+              19,
+              22,
+              8,
+              11,
+              14,
+              17
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  3,
+                  24
+                ],
+                "weight": 482359507196763989
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 5713756235126544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  4,
+                  21
+                ],
+                "weight": 87440506199109187
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  14
+                ],
+                "weight": 22776216664058344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  14
+                ],
+                "weight": 77884239732454427
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  21,
+                  11
+                ],
+                "weight": 67555840175569139
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  10,
+                  22
+                ],
+                "weight": 103085097546470208
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  22,
+                  8
+                ],
+                "weight": 233834329742270215
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  2
+                ],
+                "weight": 74001203120196948
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  23,
+                  12
+                ],
+                "weight": 160937858870877587
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  16,
+                  22
+                ],
+                "weight": 9596792847384023
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  23,
+                  24
+                ],
+                "weight": 98451091550387378
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  12,
+                  1
+                ],
+                "weight": 271651545616310200
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  15,
+                  11
+                ],
+                "weight": 122304988802722715
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  21,
+                  17
+                ],
+                "weight": 19884666023540048
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  15,
+                  13
+                ],
+                "weight": 5995438522992640
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  22,
+                  11
+                ],
+                "weight": 127483819776067429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  1,
+                  15
+                ],
+                "weight": 326454620270257155
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  18,
+                  17
+                ],
+                "weight": 110713686745432613
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  8,
+                  14
+                ],
+                "weight": 112818567196338134
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  1,
+                  15,
+                  4
+                ],
+                "weight": 198154192944541800
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  22
+                ],
+                "weight": 54803074653946955
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  10
+                ],
+                "weight": 110713686745432613
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  24,
+                  10
+                ],
+                "weight": 119865875687535912
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  11,
+                  14
+                ],
+                "weight": 346571339939308974
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  21,
+                  10,
+                  19
+                ],
+                "weight": 16780778141065704
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  2,
+                  22
+                ],
+                "weight": 495551500851824312
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  8,
+                  17
+                ],
+                "weight": 21414784137148534
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  13,
+                  11
+                ],
+                "weight": 22776216664058344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  2,
+                  14
+                ],
+                "weight": 32852958499362594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  22,
+                  8
+                ],
+                "weight": 134233351333486668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  19,
+                  17
+                ],
+                "weight": 16780778141065704
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  23,
+                  14
+                ],
+                "weight": 14385827593525492
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  13,
+                  8
+                ],
+                "weight": 112738683068265569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  2,
+                  17
+                ],
+                "weight": 5713756235126544
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  9,
+                  22
+                ],
+                "weight": 4383804456189764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  12,
+                  21
+                ],
+                "weight": 48119291674539453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  1,
+                  10
+                ],
+                "weight": 168499762447733087
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  15,
+                  2
+                ],
+                "weight": 173596224916165289
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  24,
+                  7
+                ],
+                "weight": 16544997860511390
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  16,
+                  11
+                ],
+                "weight": 106896227854871806
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  10,
+                  13
+                ],
+                "weight": 112738683068265569
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  12,
+                  1
+                ],
+                "weight": 224912666656428320
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  12,
+                  15
+                ],
+                "weight": 14385827593525492
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  15,
+                  14
+                ],
+                "weight": 8390389070532852
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  16,
+                  19
+                ],
+                "weight": 54299924372394188
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  1,
+                  18
+                ],
+                "weight": 56412904208695233
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  15,
+                  2
+                ],
+                "weight": 215063626828691469
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  4,
+                  24
+                ],
+                "weight": 100210925836514730
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  4,
+                  22
+                ],
+                "weight": 287417785924493265
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  7,
+                  8
+                ],
+                "weight": 39321214524569734
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  24,
+                  10,
+                  11
+                ],
+                "weight": 55761079379467518
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  5,
+                  22
+                ],
+                "weight": 22305101186535967
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  19,
+                  8
+                ],
+                "weight": 376388478034224682
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  2,
+                  8
+                ],
+                "weight": 209349870593564925
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  16,
+                  22,
+                  14
+                ],
+                "weight": 161196152227265994
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  5,
+                  22,
+                  8
+                ],
+                "weight": 22305101186535967
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  8,
+                  17
+                ],
+                "weight": 322088553661830494
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  18,
+                  4
+                ],
+                "weight": 63804647249876051
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  24,
+                  2
+                ],
+                "weight": 400529193838453403
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  10,
+                  11
+                ],
+                "weight": 1173433530772978914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  11,
+                  17
+                ],
+                "weight": 382315849079189864
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  18,
+                  13
+                ],
+                "weight": 68190258605190622
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  18,
+                  17
+                ],
+                "weight": 123138126629437998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  4,
+                  10
+                ],
+                "weight": 295593167876833170
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  7,
+                  14
+                ],
+                "weight": 128063445599081018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  1,
+                  7
+                ],
+                "weight": 896879174014284500
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  15,
+                  21
+                ],
+                "weight": 237288697964330652
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  21,
+                  17
+                ],
+                "weight": 304844538139899791
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  13,
+                  16
+                ],
+                "weight": 143571979264900178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  15,
+                  24
+                ],
+                "weight": 357018004588140846
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  7,
+                  10
+                ],
+                "weight": 877840362896145744
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  11,
+                  14
+                ],
+                "weight": 928131324253408936
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  18,
+                  14
+                ],
+                "weight": 450734723287571320
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  16,
+                  19
+                ],
+                "weight": 143571979264900178
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  24,
+                  10
+                ],
+                "weight": 438848317946451432
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  2,
+                  11
+                ],
+                "weight": 267019437825624559
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  19,
+                  11
+                ],
+                "weight": 204569482735189025
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  5,
+                  8
+                ],
+                "weight": 231788520626957119
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  21,
+                  7,
+                  11
+                ],
+                "weight": 67555840175569139
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  13,
+                  8
+                ],
+                "weight": 37356962408556013
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  2,
+                  17
+                ],
+                "weight": 139223512247955388
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  22,
+                  8,
+                  17
+                ],
+                "weight": 103085097546470208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  23,
+                  2
+                ],
+                "weight": 284810165065729014
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  1,
+                  18
+                ],
+                "weight": 8217843469182859
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  1,
+                  14
+                ],
+                "weight": 123872306194851427
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  7,
+                  5
+                ],
+                "weight": 47747247908339708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  11,
+                  17
+                ],
+                "weight": 53298122647884167
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  4,
+                  7
+                ],
+                "weight": 177110812965189232
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  7,
+                  8
+                ],
+                "weight": 112818567196338134
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  1,
+                  15,
+                  22
+                ],
+                "weight": 13079195954467995
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  18,
+                  21
+                ],
+                "weight": 48119291674539453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  8,
+                  17
+                ],
+                "weight": 265763157700216200
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  24,
+                  17
+                ],
+                "weight": 39901448205356594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  14,
+                  17
+                ],
+                "weight": 77884239732454427
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  16,
+                  5
+                ],
+                "weight": 106896227854871806
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  10,
+                  22
+                ],
+                "weight": 23356450344845204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  5,
+                  19
+                ],
+                "weight": 154643475763211514
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  22,
+                  11
+                ],
+                "weight": 261056674785085115
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  10,
+                  2,
+                  17
+                ],
+                "weight": 37212737029366777
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  10,
+                  19,
+                  8
+                ],
+                "weight": 154643475763211514
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  12,
+                  16
+                ],
+                "weight": 525203012201143978
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  1,
+                  8
+                ],
+                "weight": 243024335469763189
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  21,
+                  5
+                ],
+                "weight": 227028418776484571
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  12,
+                  24,
+                  17
+                ],
+                "weight": 253551466584833778
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  13,
+                  11
+                ],
+                "weight": 408169578329681666
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  16,
+                  14
+                ],
+                "weight": 603624286075946081
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  15,
+                  2
+                ],
+                "weight": 78569501584373026
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  18,
+                  11
+                ],
+                "weight": 460682365915640908
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  13,
+                  17
+                ],
+                "weight": 53993515170432481
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  5,
+                  8
+                ],
+                "weight": 126018634155157925
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  18,
+                  5
+                ],
+                "weight": 74185697128183262
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  22,
+                  17
+                ],
+                "weight": 4383804456189764
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  10,
+                  13
+                ],
+                "weight": 574901776568379716
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  24,
+                  2
+                ],
+                "weight": 118592331231961618
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  10,
+                  2
+                ],
+                "weight": 641204741744135396
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  2,
+                  19
+                ],
+                "weight": 108436087544522953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  14,
+                  17
+                ],
+                "weight": 402200515102729912
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  24,
+                  10,
+                  14
+                ],
+                "weight": 70065695528729371
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  10,
+                  5,
+                  19
+                ],
+                "weight": 22588510746524543
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  16,
+                  5,
+                  19
+                ],
+                "weight": 78421273874802103
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  16,
+                  19,
+                  11
+                ],
+                "weight": 22588510746524543
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  5,
+                  8,
+                  14
+                ],
+                "weight": 126018634155157925
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  12,
+                  24,
+                  5
+                ],
+                "weight": 216277051273574320
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  12,
+                  5,
+                  11
+                ],
+                "weight": 19029769982001643
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  1,
+                  7,
+                  17
+                ],
+                "weight": 216694823187245461
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  4,
+                  16
+                ],
+                "weight": 545088784956933052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  5,
+                  11
+                ],
+                "weight": 74185697128183262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  19,
+                  8
+                ],
+                "weight": 21014411882655519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  22,
+                  8
+                ],
+                "weight": 127483819776067429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  10,
+                  8
+                ],
+                "weight": 94526103811040241
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  21,
+                  7
+                ],
+                "weight": 249495617080099882
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  7,
+                  10
+                ],
+                "weight": 390119271687873411
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  24,
+                  7,
+                  11
+                ],
+                "weight": 216277051273574320
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  16,
+                  5
+                ],
+                "weight": 74185697128183262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  5,
+                  19
+                ],
+                "weight": 75314336255049707
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  2,
+                  14,
+                  17
+                ],
+                "weight": 176436249277322165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  15,
+                  22
+                ],
+                "weight": 277820993077109242
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  4,
+                  2
+                ],
+                "weight": 198154192944541800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  13,
+                  5
+                ],
+                "weight": 551741557594581844
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  16,
+                  11
+                ],
+                "weight": 427199348311683309
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  15,
+                  18,
+                  19
+                ],
+                "weight": 137537460960818784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  2,
+                  19
+                ],
+                "weight": 81929860812989261
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  4,
+                  17
+                ],
+                "weight": 193950365169514017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  24,
+                  17
+                ],
+                "weight": 116066125437059590
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  19,
+                  11
+                ],
+                "weight": 114782819312351855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  24,
+                  16,
+                  19
+                ],
+                "weight": 32852958499362594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  16,
+                  2,
+                  22
+                ],
+                "weight": 9596792847384023
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  2,
+                  5,
+                  19
+                ],
+                "weight": 108436087544522953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  15,
+                  18,
+                  11
+                ],
+                "weight": 48119291674539453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  15,
+                  24,
+                  10
+                ],
+                "weight": 765548744303559081
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  24,
+                  2
+                ],
+                "weight": 282658990386095364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  7,
+                  22
+                ],
+                "weight": 74185697128183262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  7,
+                  14
+                ],
+                "weight": 735528300201905665
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  8,
+                  11
+                ],
+                "weight": 231788520626957119
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  7,
+                  2
+                ],
+                "weight": 68126365566056817
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 104122174597677143
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  2,
+                  5
+                ],
+                "weight": 425722923439423919
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  2,
+                  14
+                ],
+                "weight": 68730717856651844
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  24,
+                  13,
+                  2
+                ],
+                "weight": 874818731308588010
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  24,
+                  11,
+                  17
+                ],
+                "weight": 272038130653041838
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  2,
+                  22
+                ],
+                "weight": 386300385869692785
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  19,
+                  8
+                ],
+                "weight": 114782819312351855
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 323077173714006166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  19,
+                  22,
+                  11
+                ],
+                "weight": 114782819312351855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  4,
+                  7
+                ],
+                "weight": 643440326288696559
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  16,
+                  22
+                ],
+                "weight": 279405584942440798
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  7,
+                  16
+                ],
+                "weight": 824494369899373850
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  2,
+                  14
+                ],
+                "weight": 333469797246078068
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  7,
+                  10,
+                  19
+                ],
+                "weight": 181054043610677291
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  2,
+                  22,
+                  8
+                ],
+                "weight": 77943711516923518
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  2,
+                  8,
+                  14
+                ],
+                "weight": 117264926041493252
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  19,
+                  22,
+                  14
+                ],
+                "weight": 342024889156052704
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  24,
+                  13
+                ],
+                "weight": 402524866073631276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  24,
+                  8,
+                  14
+                ],
+                "weight": 247580839884967568
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  10,
+                  11,
+                  14
+                ],
+                "weight": 37212737029366777
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  13,
+                  16,
+                  17
+                ],
+                "weight": 37212737029366777
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  5,
+                  22
+                ],
+                "weight": 74185697128183262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  19,
+                  8
+                ],
+                "weight": 342106943696007809
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  24,
+                  7,
+                  14
+                ],
+                "weight": 140623654607773529
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  2,
+                  19
+                ],
+                "weight": 260674899224802080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  22,
+                  14
+                ],
+                "weight": 268687100206854547
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  10,
+                  16,
+                  5
+                ],
+                "weight": 279405584942440798
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  19,
+                  22
+                ],
+                "weight": 260674899224802080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  19,
+                  22
+                ],
+                "weight": 220914700061536950
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  22,
+                  17
+                ],
+                "weight": 77471310939290073
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  2,
+                  22,
+                  8
+                ],
+                "weight": 143443389122246877
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  16,
+                  2
+                ],
+                "weight": 32852958499362594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  2,
+                  22,
+                  14
+                ],
+                "weight": 458270190021470468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  16,
+                  11,
+                  17
+                ],
+                "weight": 37212737029366777
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  5,
+                  19,
+                  11
+                ],
+                "weight": 19029769982001643
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  8,
+                  14
+                ],
+                "weight": 104122174597677143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  5,
+                  19,
+                  8
+                ],
+                "weight": 335502053595579077
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  22,
+                  11,
+                  14
+                ],
+                "weight": 503221041383318698
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  22,
+                  8
+                ],
+                "weight": 22305101186535967
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 195,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 39444011546548531679
+          },
+          "certificate_sha256": "55b0e4d8639a7d38da1dc015425124e1acf0cb754656b24aaeddb04662192d70",
+          "max_weight": 1173433530772978914,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 195,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 195,
+          "weight_sum": 39444011546548531679,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15006,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 7,
+        "order": [
+          0,
+          20,
+          3,
+          6,
+          9,
+          23,
+          12,
+          1,
+          15,
+          18,
+          4,
+          21,
+          24,
+          7,
+          10,
+          13,
+          16,
+          2,
+          5,
+          19,
+          22,
+          8,
+          11,
+          14,
+          17
+        ],
+        "order_sha256": "090fbe04e428d5c9f63a576cd1f89ba16b37ac3b8d9618f71d1bf54e01999a7e",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 102
+      }
+    ],
+    "new_full_certificate_count": 8,
+    "new_unique_affine_orbit_clause_count": 200,
+    "solver_result": "bounded_after_new_exact_certificates",
+    "status": "BOUNDED_C25_PERSISTENT_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+  },
+  "selected_persistent_seed_template": {
+    "affine_clause_orbit": {
+      "affine_map_count": 25,
+      "affine_stabilizer_size": 1,
+      "canonical_clause_sha256": "e6d0b98cba90d29f3aa607bf13cfd6beb0b3bf9b7bd4a2acec69c7d04feec52a",
+      "quotient_automorphism_multipliers": [
+        1
+      ],
+      "source_model_index": 0,
+      "source_order": [
+        0,
+        22,
+        14,
+        11,
+        8,
+        19,
+        5,
+        2,
+        24,
+        16,
+        13,
+        10,
+        21,
+        7,
+        4,
+        1,
+        18,
+        15,
+        12,
+        23,
+        9,
+        20,
+        6,
+        17,
+        3
+      ],
+      "source_unique_ordered_quad_count": 4,
+      "unique_orbit_clause_count": 25
+    },
+    "compressed_certificate_sha256": "d1c462bafbb1dc530029d3478fb4cde3c3dcbf4191586250b641453eba85638c",
+    "max_weight": 1,
+    "ordered_quad_count": 4,
+    "positive_inequalities": 4,
+    "seed_id": "persistent_compressed:0",
+    "seed_role": "PRIMARY_MINIMUM_NEW_MARGINAL_COVER",
+    "source_model_index": 0,
+    "source_screen_target_id": "probe:0",
+    "source_target_id": "transfer_cegar_probe:0",
+    "weight_sum": 4
+  },
+  "source_compression_artifact": "data/runs/sparse_full_cone_c25_persistent_escape_compression_2026-07-30/summary.json",
+  "source_compression_sha256": "7bf2872171f0c9a5f6fd088d664a91eb24cf3cf96d3c7d739ac1bcc7e19e4f5a",
+  "status": "BOUNDED_C25_PERSISTENT_WIDTH4_AUGMENTED_CEGAR",
+  "transferred_seed_templates": [
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 28,
+        "source_order": [
+          0,
+          14,
+          17,
+          3,
+          6,
+          9,
+          20,
+          23,
+          12,
+          15,
+          1,
+          4,
+          7,
+          18,
+          10,
+          21,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 3,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "208e5267b8492857aee1419ecfe360c84ef365b86496726caed2e6f832aee6db",
+      "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+      "max_weight": 1,
+      "ordered_quad_count": 3,
+      "positive_inequalities": 3,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 28,
+      "source_target_id": "fresh:28",
+      "template_id": "C25_sidon_2_5_9_14:fresh-28:w3:6459e9d4dd618172",
+      "weight_sum": 3
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 19,
+        "source_order": [
+          0,
+          3,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          1,
+          12,
+          4,
+          15,
+          18,
+          7,
+          21,
+          10,
+          24,
+          2,
+          13,
+          5,
+          16,
+          19,
+          22,
+          8,
+          11
+        ],
+        "source_unique_ordered_quad_count": 5,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f68d46d4978292392c65fda379bf7ab80d51230f1aaa0b03f856506902b3399e",
+      "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+      "max_weight": 1,
+      "ordered_quad_count": 5,
+      "positive_inequalities": 5,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 19,
+      "source_target_id": "fresh:19",
+      "template_id": "C25_sidon_2_5_9_14:fresh-19:w5:e0b19b1c4bee1919",
+      "weight_sum": 5
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 15,
+        "source_order": [
+          0,
+          14,
+          3,
+          6,
+          17,
+          20,
+          23,
+          1,
+          9,
+          12,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          19,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 14,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f22b31f1c564b1456c9f0882bcedee26fe51161cdd64141ff4f96f06f79e71f1",
+      "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+      "max_weight": 1,
+      "ordered_quad_count": 14,
+      "positive_inequalities": 14,
+      "seed_role": "SECONDARY_PRIOR_PACKET_TRANSFER",
+      "source_model_index": 15,
+      "source_target_id": "fresh:15",
+      "template_id": "C25_sidon_2_5_9_14:fresh-15:w14:0b360a662009eea4",
+      "weight_sum": 14
+    }
+  ],
+  "trust": "EXACT_CLAUSES_IN_BOUNDED_144_HISTORY_C25_CEGAR",
+  "type": "sparse_full_cone_c25_persistent_augmented_cegar_v1",
+  "unique_active_seed_orbit_clause_count": 100
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -750,8 +750,15 @@ and must not assume that the finite `n=9` pivot census generalizes.
    seeds and width `4` cover 142/144 stored orders. Next run a bounded
    144-history-blocked C25 order CEGAR with the three transferred seeds and
    only the new width-`4` orbit, keeping all eight zero-marginal residual
-   orbits and width `5` inactive. Stop the current C29 template-mining route.
-   This is still not an all-order obstruction.
+   orbits and width `5` inactive. The completed follow-up in
+   `docs/sparse-full-cone-c25-persistent-augmented-cegar.md` finds that the
+   transferred seeds cover 0/16 fresh probe orders while the selected width-4
+   orbit covers 16/16. With that orbit active, CEGAR learns eight further exact
+   full-cone certificates of widths `191`--`200` before its configured limit,
+   with no unresolved model. Next compress those eight certificates and audit
+   their exact affine reuse before increasing order-search budget. Stop the
+   current C29 template-mining route. This is still not an all-order
+   obstruction.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external

--- a/docs/index.md
+++ b/docs/index.md
@@ -1003,6 +1003,10 @@ put detailed reconciliation in the canonical synthesis.
   exact compression to widths 4 and 5 over the current 144-order C25 packet;
   the width-4 orbit is the one-source minimum cover of all 23 targets marginal
   over the existing seeds and is the only new orbit selected for the next CEGAR.
+- [`sparse-full-cone-c25-persistent-augmented-cegar.md`](sparse-full-cone-c25-persistent-augmented-cegar.md):
+  144-history-blocked C25 CEGAR with the selected width-4 orbit; it marginally
+  covers all 16 fresh probe orders and the augmented search learns eight new
+  exact width-191--200 certificates before its configured limit.
 - [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
   cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
   numerical evidence only, not an exact coordinate certificate.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -737,8 +737,13 @@ benchmarks for the larger frontier:
   exact compression and seed-selection decision: the circuits compress to
   widths `4` and `5`; the width-`4` orbit alone covers all 23 targets marginal
   over the existing seeds in the current 144-order packet, while width `5`
-  adds no marginal target. Run the next bounded C25 CEGAR with 144 history
-  blocks, the three transferred seeds, and only that width-`4` orbit; keep the
+  adds no marginal target;
+- use `docs/sparse-full-cone-c25-persistent-augmented-cegar.md` as the
+  outside-packet transfer and continuation decision: with 144 history blocks,
+  the transferred seeds cover 0/16 fresh probe orders while width `4` covers
+  16/16; the augmented CEGAR learns eight exact width-`191`--`200`
+  certificates before its configured limit. Compress those eight residuals
+  and audit exact affine reuse before more order-search budget; keep the
   current C29 template family stopped;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.

--- a/docs/sparse-full-cone-c25-persistent-augmented-cegar.md
+++ b/docs/sparse-full-cone-c25-persistent-augmented-cegar.md
@@ -1,0 +1,99 @@
+# C25 persistent width-4 augmented CEGAR
+
+Status: bounded fixed-pattern, history-blocked exact-clause diagnostic. No
+general proof, all-order C25 obstruction, geometric counterexample, or
+official-status change is claimed.
+
+## Target
+
+The compression packet in
+`docs/sparse-full-cone-c25-persistent-escape-compression.md` found that the
+exact width-4 orbit from `transfer_cegar_probe:0` is the one-source minimum
+cover of all 23 targets marginal over the 11 older seed orbits in the current
+144-order C25 packet. The width-5 persistent orbit adds no marginal target.
+
+This follow-up tests that seed-selection decision outside the source packet. It
+blocks all 144 known C25 cyclic-order identities under rotation and reversal,
+keeps the three transferred seed orbits plus only the selected width-4 orbit
+active, and leaves these nine exact seed orbits inactive:
+
+- the dominated width-5 persistent orbit;
+- all eight compressed residual orbits, whose augmentation probe had zero
+  marginal coverage.
+
+The four active certificates have widths `3, 5, 14, 4` and produce 100 exact
+quotient-preserving affine images.
+
+## Deterministic bounded protocol
+
+`scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py`
+uses random seed `20260730`, conflict cap `1024`, and two limits:
+
+1. collect 16 history-disjoint inverse-pair-escape orders within at most 12,000
+   Z3 iterations without activating the full-cone seed clauses, then compare
+   exact seed coverage;
+2. activate the four seed orbits and learn at most eight new exact full-cone
+   certificate orbits within at most 12,000 iterations.
+
+The numerical LP is only a certificate finder. Every stored positive
+certificate is exactified and replayed with integer arithmetic. All history
+identities, seed certificates, affine images, clause matches, and learned
+certificates are checked without rerunning the search.
+
+## Fresh 16-order transfer result
+
+The fresh probe reaches its 16-order limit after 454 iterations and 14,122
+inverse-pair clauses. All 16 orders survive the stored vertex-circle and both
+Altman lightweight filters.
+
+| Seed packet | Covered probe orders | Covered strong orders |
+| --- | ---: | ---: |
+| Three transferred orbits | 0/16 | 0/16 |
+| Selected width-4 orbit only | 16/16 | 16/16 |
+| Transferred plus selected width 4 | 16/16 | 16/16 |
+
+Thus every fresh probe order is marginally covered by the selected width-4
+orbit. The transfer is exact for this bounded probe, not a claim about all C25
+orders.
+
+## Augmented CEGAR result
+
+With all four active seed orbits, the CEGAR search excludes the 16 probe orders
+and finds eight further history-disjoint orders. All eight are strong
+lightweight survivors and escape every active seed and previously learned
+clause at discovery. Each has an exact positive full-Kalmanson-cone
+certificate.
+
+| Learned model | Z3 iteration | Exact certificate width |
+| ---: | ---: | ---: |
+| 0 | 40 | 197 |
+| 1 | 41 | 197 |
+| 2 | 81 | 193 |
+| 3 | 82 | 194 |
+| 4 | 83 | 192 |
+| 5 | 84 | 200 |
+| 6 | 85 | 191 |
+| 7 | 102 | 195 |
+
+The run stops at the configured eight-certificate limit with no unresolved
+model. The eight learned orbits contribute 200 unique affine clauses. Together
+with the 100 active seed images, the checker replays 300 exact affine
+certificate images.
+
+## Decision and next target
+
+The route decision is
+`COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS`.
+
+Before increasing the cyclic-order search budget, compress the eight new
+width-191--200 certificates, construct their exact quotient-preserving affine
+orbits, and measure reuse and marginal coverage against both the 16-order probe
+and eight new residual orders. This remains bounded clause engineering for one
+fixed selected-witness quotient.
+
+Replay:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py \
+  --check data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/summary.json
+```

--- a/docs/sparse-full-cone-c25-persistent-escape-compression.md
+++ b/docs/sparse-full-cone-c25-persistent-escape-compression.md
@@ -76,11 +76,18 @@ The same orbit is also the one-source, width-4 minimum cover of the two
 persistent targets. Therefore the route decision is
 `ADD_MINIMUM_COMPRESSED_MARGINAL_COVER_BEFORE_C25_ORDER_SEARCH`.
 
-The next bounded experiment should block the complete 144-order history and
-run C25 order CEGAR with the three transferred seed orbits plus only this new
-width-4 orbit. Keep the width-5 orbit and all eight zero-marginal compressed
-residual orbits inactive. This remains clause engineering for one fixed
-selected-witness quotient, not evidence of an all-order obstruction.
+The completed follow-up in
+`docs/sparse-full-cone-c25-persistent-augmented-cegar.md` blocks the complete
+144-order history and keeps the three transferred seeds plus only this
+width-4 orbit active. On 16 new history-disjoint probe orders, the transferred
+seeds cover none while width 4 covers all 16.
+
+The augmented CEGAR then learns eight further exact full-cone certificates of
+widths `191`--`200` before its configured limit, with no unresolved model. The
+next bounded target is to compress those eight certificates and measure their
+exact affine reuse before increasing the order-search budget. This remains
+clause engineering for one fixed selected-witness quotient, not evidence of
+an all-order obstruction.
 
 Replay:
 

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -3163,6 +3163,16 @@
         "data/runs/sparse_full_cone_c25_persistent_escape_compression_2026-07-30/summary.json"
       ],
       "claim_scope": "Replay two exact compressed C25 positive circuits of widths 4 and 5, 50 exact quotient-preserving affine images, exact coverage over the current 144-order C25 packet, and exhaustive minimum-source covers inside that finite packet. The deterministic-budget objective search is non-exhaustive; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
+    },
+    {
+      "id": "sparse_full_cone_c25_persistent_augmented_cegar",
+      "command": [
+        "python",
+        "scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py",
+        "--check",
+        "data/runs/sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30/summary.json"
+      ],
+      "claim_scope": "Replay four active exact C25 seed certificates, nine explicitly inactive exact seed summaries, 144 blocked order identities, 16 history-disjoint probe orders, eight newly learned exact full-cone certificates, 200 new affine clauses, and 300 exact affine certificate images. The run stops at configured finite limits; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
     }
   ],
   "make_targets": {

--- a/scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py
@@ -669,6 +669,8 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     if payload["type"] != "sparse_full_cone_c25_persistent_augmented_cegar_v1":
         raise AssertionError("persistent augmented artifact type drifted")
     source_path = ROOT / str(payload["source_compression_artifact"])
+    if source_path.resolve() != DEFAULT_SOURCE.resolve():
+        raise AssertionError("persistent augmented source artifact drifted")
     if file_sha256(source_path) != str(payload["source_compression_sha256"]):
         raise AssertionError("persistent augmented source hash drifted")
     (

--- a/scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_persistent_augmented_cegar.py
@@ -1,0 +1,881 @@
+#!/usr/bin/env python3
+"""Run C25 CEGAR with the selected persistent width-four seed orbit.
+
+The source compression packet selects one exact width-four positive-circuit
+orbit as the minimum cover of every target marginal over the eleven older C25
+seed orbits.  This bounded follow-up blocks the complete current 144-order
+history, keeps only the three transferred seeds plus that width-four orbit
+active, compares their coverage on a fresh inverse-pair-escape probe, and
+learns new exact full-cone certificate orbits from seed-escaping orders.
+
+The dominated width-five persistent orbit and all eight zero-marginal
+compressed residual orbits are explicitly inactive.  History blocking and
+finite limits make this a fixed-pattern search diagnostic only.  No solver
+status here is an all-order obstruction, geometric realizability result,
+counterexample, or proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+EXPLORATION = Path(__file__).resolve().parent
+for path in (SCRIPTS, EXPLORATION):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_kalmanson_certificate import check_certificate_dict  # noqa: E402
+from compress_sparse_full_cone_c25_persistent_escapes import (  # noqa: E402
+    check_payload as check_compression_payload,
+    current_c25_targets,
+    load_source_chain,
+    stable_json_sha256,
+)
+from compress_sparse_full_cone_certificates import (  # noqa: E402
+    order_satisfies_quads,
+)
+from pilot_sparse_full_cone_order_cegar import (  # noqa: E402
+    PATTERNS,
+    certificate_order_quads,
+)
+from probe_sparse_full_cone_c25_residual_seed_augmentation import (  # noqa: E402
+    seed_packets,
+)
+from probe_sparse_full_cone_small_templates import (  # noqa: E402
+    dihedral_order_key,
+)
+from run_sparse_full_cone_c25_transfer_cegar import (  # noqa: E402
+    PATTERN,
+    c25_seed_packet,
+    check_order_record,
+    collect_history_disjoint_probe,
+    history_identity,
+    run_history_disjoint_seeded_cegar,
+)
+from run_sparse_full_cone_seeded_cegar import (  # noqa: E402
+    ClauseOrbit,
+    FullClause,
+    build_clause_orbit,
+    clause_matches,
+    file_sha256,
+    probe_coverage_summary,
+    unique_clauses,
+)
+
+
+DEFAULT_SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_persistent_escape_compression_2026-07-30"
+    / "summary.json"
+)
+DEFAULT_PROBE_ORDER_LIMIT = 16
+DEFAULT_PROBE_MAX_ITERATIONS = 12_000
+DEFAULT_FULL_CERTIFICATE_LIMIT = 8
+DEFAULT_MAX_ITERATIONS = 12_000
+DEFAULT_CONFLICT_CAP = 1_024
+DEFAULT_RANDOM_SEED = 20_260_730
+SELECTED_SOURCE_TARGET_ID = "transfer_cegar_probe:0"
+INACTIVE_PERSISTENT_SOURCE_TARGET_ID = "transfer_cegar_probe:1"
+CERTIFICATE_LIMIT_STATUS = (
+    "BOUNDED_C25_PERSISTENT_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+)
+CONTINUE_DECISION = "COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS"
+REVIEW_DECISION = "REVIEW_C25_PERSISTENT_AUGMENTED_CEGAR_BEFORE_CONTINUING"
+
+
+def load_sources(
+    source_path: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    """Replay the compression source and return its C25 provenance payloads."""
+
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    check_compression_payload(source)
+    screen_path = ROOT / str(source["source_screen_artifact"])
+    (
+        _screen,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = load_source_chain(screen_path)
+    return (
+        source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    )
+
+
+def blocked_history(
+    augmentation: Mapping[str, Any],
+    prior_cegar: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+    first: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    """Return the complete current 144-order C25 history."""
+
+    targets = current_c25_targets(augmentation, prior_cegar, transfer, first)
+    history = [
+        {
+            "history_id": str(target["target_id"]),
+            "packet": str(target["stream"]),
+            "order": [int(label) for label in target["order"]],
+            "order_sha256": str(target["order_sha256"]),
+            "dihedral_order_sha256": str(target["dihedral_order_sha256"]),
+        }
+        for target in targets
+    ]
+    keys = {dihedral_order_key(record["order"]) for record in history}
+    if len(history) != 144 or len(keys) != len(history):
+        raise AssertionError("persistent augmented history must have 144 classes")
+    return history
+
+
+def selected_seed_record(
+    row: Mapping[str, Any],
+    orbit: ClauseOrbit,
+) -> dict[str, object]:
+    certificate = row["compressed_certificate"]
+    checked = check_certificate_dict(certificate)
+    if not checked.zero_sum_verified:
+        raise AssertionError("selected persistent seed failed exact replay")
+    return {
+        "seed_id": "persistent_compressed:0",
+        "seed_role": "PRIMARY_MINIMUM_NEW_MARGINAL_COVER",
+        "source_target_id": str(row["source_target_id"]),
+        "source_screen_target_id": str(row["source_screen_target_id"]),
+        "source_model_index": int(row["source_model_index"]),
+        "ordered_quad_count": int(row["compressed_unique_ordered_quad_count"]),
+        "compressed_certificate_sha256": str(
+            row["compressed_certificate_sha256"]
+        ),
+        "positive_inequalities": checked.positive_inequalities,
+        "weight_sum": checked.weight_sum,
+        "max_weight": checked.max_weight,
+        "affine_clause_orbit": orbit.summary(),
+    }
+
+
+def inactive_persistent_record(row: Mapping[str, Any]) -> dict[str, object]:
+    return {
+        "seed_id": "persistent_compressed:1",
+        "source_target_id": str(row["source_target_id"]),
+        "source_screen_target_id": str(row["source_screen_target_id"]),
+        "source_model_index": int(row["source_model_index"]),
+        "ordered_quad_count": int(row["compressed_unique_ordered_quad_count"]),
+        "compressed_certificate_sha256": str(
+            row["compressed_certificate_sha256"]
+        ),
+        "inactive_reason": (
+            "ZERO_MARGINAL_TARGETS_BEYOND_SELECTED_WIDTH4_ON_144_ORDER_PACKET"
+        ),
+    }
+
+
+def inactive_residual_records(
+    residual_records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "seed_id": str(record["seed_id"]),
+            "source_target_id": str(record["source_target_id"]),
+            "source_model_index": int(record["source_model_index"]),
+            "ordered_quad_count": int(record["ordered_quad_count"]),
+            "compressed_certificate_sha256": str(
+                record["compressed_certificate_sha256"]
+            ),
+            "canonical_clause_sha256": str(
+                record["affine_clause_orbit"]["canonical_clause_sha256"]
+            ),
+            "inactive_reason": (
+                "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE"
+            ),
+        }
+        for record in residual_records
+    ]
+
+
+def seed_selection(
+    source: Mapping[str, Any],
+    residual_compression: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+) -> tuple[
+    list[dict[str, object]],
+    list[ClauseOrbit],
+    dict[str, object],
+    list[dict[str, object]],
+]:
+    """Return the four active orbits and the explicitly inactive packet."""
+
+    transferred_records, transferred_orbits = c25_seed_packet(transfer)
+    selected_ids = source["stopping_assessment"][
+        "minimum_new_marginal_cover_source_target_ids"
+    ]
+    if selected_ids != [SELECTED_SOURCE_TARGET_ID]:
+        raise AssertionError("persistent minimum marginal cover selection drifted")
+    rows = {
+        str(row["source_target_id"]): row for row in source["compressed_models"]
+    }
+    if set(rows) != {
+        SELECTED_SOURCE_TARGET_ID,
+        INACTIVE_PERSISTENT_SOURCE_TARGET_ID,
+    }:
+        raise AssertionError("persistent compressed source packet drifted")
+
+    selected_row = rows[SELECTED_SOURCE_TARGET_ID]
+    selected_orbit = build_clause_orbit(
+        PATTERN,
+        int(selected_row["source_model_index"]),
+        selected_row["compressed_certificate"],
+    )
+    if selected_orbit.summary() != selected_row["affine_clause_orbit"]:
+        raise AssertionError("selected persistent affine orbit drifted")
+    active_orbits = [*transferred_orbits, selected_orbit]
+    hashes = [orbit.canonical_clause_sha256 for orbit in active_orbits]
+    if len(hashes) != len(set(hashes)):
+        raise AssertionError("persistent augmented active seed orbit duplicated")
+
+    (
+        residual_transferred_records,
+        residual_transferred_orbits,
+        residual_records,
+        _residual_orbits,
+    ) = seed_packets(residual_compression, transfer)
+    if residual_transferred_records != transferred_records:
+        raise AssertionError("persistent transferred seed summaries drifted")
+    if [
+        orbit.canonical_clause_sha256 for orbit in residual_transferred_orbits
+    ] != [
+        orbit.canonical_clause_sha256 for orbit in transferred_orbits
+    ]:
+        raise AssertionError("persistent transferred seed orbits drifted")
+
+    selected_record = selected_seed_record(selected_row, selected_orbit)
+    inactive_persistent = inactive_persistent_record(
+        rows[INACTIVE_PERSISTENT_SOURCE_TARGET_ID]
+    )
+    inactive_residuals = inactive_residual_records(residual_records)
+    if len(inactive_residuals) != 8:
+        raise AssertionError("persistent augmented residual packet drifted")
+    return (
+        transferred_records,
+        active_orbits,
+        selected_record,
+        [inactive_persistent, *inactive_residuals],
+    )
+
+
+def coverage_for(
+    models: Sequence[Mapping[str, Any]],
+    orbits: Sequence[ClauseOrbit],
+) -> dict[str, object]:
+    rows = [
+        {
+            **model,
+            "seed_orbit_matches": clause_matches(model["order"], orbits),
+        }
+        for model in models
+    ]
+    return probe_coverage_summary(rows, orbits)
+
+
+def probe_packet_comparison(
+    models: Sequence[Mapping[str, Any]],
+    transferred_orbits: Sequence[ClauseOrbit],
+    selected_orbit: ClauseOrbit,
+) -> dict[str, object]:
+    active_orbits = [*transferred_orbits, selected_orbit]
+    transferred = coverage_for(models, transferred_orbits)
+    selected = coverage_for(models, [selected_orbit])
+    active = coverage_for(models, active_orbits)
+    transferred_covered = {
+        int(model["probe_model_index"])
+        for model in models
+        if clause_matches(model["order"], transferred_orbits)
+    }
+    selected_covered = {
+        int(model["probe_model_index"])
+        for model in models
+        if clause_matches(model["order"], [selected_orbit])
+    }
+    return {
+        "transferred_only": transferred,
+        "selected_width4_only": selected,
+        "transferred_plus_selected_width4": active,
+        "selected_width4_marginal_over_transferred_probe_model_indices": sorted(
+            selected_covered - transferred_covered
+        ),
+        "transferred_uncovered_probe_model_indices": sorted(
+            set(range(len(models))) - transferred_covered
+        ),
+        "active_uncovered_probe_model_indices": sorted(
+            set(range(len(models))) - (transferred_covered | selected_covered)
+        ),
+    }
+
+
+def route_decision(
+    probe: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+    seeded: Mapping[str, Any],
+    *,
+    full_certificate_limit: int,
+) -> str:
+    probe_count = int(probe["inverse_pair_escape_order_count"])
+    transferred_covered = int(
+        comparison["transferred_only"]["covered_probe_order_count"]
+    )
+    selected_covered = int(
+        comparison["selected_width4_only"]["covered_probe_order_count"]
+    )
+    active_covered = int(
+        comparison["transferred_plus_selected_width4"][
+            "covered_probe_order_count"
+        ]
+    )
+    certificates = int(seeded["new_full_certificate_count"])
+    unresolved = sum(
+        "certificate" not in model["full_kalmanson"]
+        for model in seeded["models"]
+    )
+    if (
+        probe_count > 0
+        and transferred_covered == 0
+        and selected_covered == probe_count
+        and active_covered == probe_count
+        and certificates == full_certificate_limit
+        and unresolved == 0
+        and seeded["status"] == CERTIFICATE_LIMIT_STATUS
+    ):
+        return CONTINUE_DECISION
+    return REVIEW_DECISION
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    (
+        source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = load_sources(source_path)
+    history = blocked_history(augmentation, prior_cegar, transfer, first)
+    (
+        transferred_records,
+        active_orbits,
+        selected_record,
+        inactive_records,
+    ) = seed_selection(source, residual_compression, transfer)
+    transferred_orbits = active_orbits[:-1]
+    selected_orbit = active_orbits[-1]
+
+    probe, inverse_clauses = collect_history_disjoint_probe(
+        active_orbits,
+        history,
+        order_limit=args.probe_order_limit,
+        max_iterations=args.probe_max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+    )
+    comparison = probe_packet_comparison(
+        probe["models"],
+        transferred_orbits,
+        selected_orbit,
+    )
+    seeded = run_history_disjoint_seeded_cegar(
+        active_orbits,
+        history,
+        inverse_clauses,
+        full_certificate_limit=args.full_certificate_limit,
+        max_iterations=args.max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+        certificate_limit_status=CERTIFICATE_LIMIT_STATUS,
+    )
+    decision = route_decision(
+        probe,
+        comparison,
+        seeded,
+        full_certificate_limit=args.full_certificate_limit,
+    )
+    n, offsets = PATTERNS[PATTERN]
+    return {
+        "type": "sparse_full_cone_c25_persistent_augmented_cegar_v1",
+        "trust": "EXACT_CLAUSES_IN_BOUNDED_144_HISTORY_C25_CEGAR",
+        "status": "BOUNDED_C25_PERSISTENT_WIDTH4_AUGMENTED_CEGAR",
+        "claim_scope": (
+            "Three transferred exact C25 certificate orbits plus one selected "
+            "exact width-four persistent orbit seed a bounded order CEGAR "
+            "after 144 known C25 orders are blocked under rotation and "
+            "reversal. Probe coverage, newly learned certificates, and affine "
+            "images are exact, but finite limits and history blocking preclude "
+            "any all-order obstruction, geometric realizability result, "
+            "counterexample, proof of Erdos Problem #97, or official/global "
+            "status update."
+        ),
+        "source_compression_artifact": source_path.relative_to(ROOT).as_posix(),
+        "source_compression_sha256": file_sha256(source_path),
+        "configuration": {
+            "pattern": PATTERN,
+            "probe_order_limit": args.probe_order_limit,
+            "probe_max_iterations": args.probe_max_iterations,
+            "full_certificate_limit": args.full_certificate_limit,
+            "max_iterations": args.max_iterations,
+            "conflict_cap": args.conflict_cap,
+            "random_seed": args.random_seed,
+            "tolerance": 1.0e-9,
+            "history_equivalence": "cyclic rotation and reversal",
+            "active_seed_policy": (
+                "three transferred orbits plus exact minimum new-marginal "
+                "persistent width-four orbit only"
+            ),
+            "inactive_seed_policy": (
+                "dominated persistent width-five orbit and eight zero-marginal "
+                "compressed residual orbits"
+            ),
+        },
+        "pattern": PATTERN,
+        "n": n,
+        "circulant_offsets": list(offsets),
+        "transferred_seed_templates": transferred_records,
+        "selected_persistent_seed_template": selected_record,
+        "inactive_seed_templates": inactive_records,
+        "active_seed_orbit_count": len(active_orbits),
+        "active_exact_affine_seed_image_count": sum(
+            orbit.affine_map_count for orbit in active_orbits
+        ),
+        "distinct_active_seed_orbit_class_count": len(
+            {orbit.canonical_clause_sha256 for orbit in active_orbits}
+        ),
+        "unique_active_seed_orbit_clause_count": len(unique_clauses(active_orbits)),
+        "blocked_history": {
+            "order_count": len(history),
+            "dihedral_order_count": len(
+                {dihedral_order_key(record["order"]) for record in history}
+            ),
+            "packet_histogram": dict(
+                sorted(Counter(str(record["packet"]) for record in history).items())
+            ),
+            "identities": history_identity(history),
+        },
+        "counterfactual_probe": probe,
+        "counterfactual_seed_packet_coverage": comparison,
+        "seeded_cegar": seeded,
+        "decision": decision,
+        "next_target": (
+            "Compress the eight newly learned exact C25 residual certificates, "
+            "construct their quotient-preserving affine orbits, and measure "
+            "marginal reuse before increasing the order-search budget."
+        ),
+    }
+
+
+def check_probe(
+    probe: Mapping[str, Any],
+    history: Sequence[Mapping[str, Any]],
+    active_orbits: Sequence[ClauseOrbit],
+    *,
+    order_limit: int,
+    max_iterations: int,
+    conflict_cap: int,
+) -> int:
+    n, offsets = PATTERNS[PATTERN]
+    history_keys = {dihedral_order_key(record["order"]) for record in history}
+    if int(probe["blocked_history_dihedral_order_count"]) != len(history_keys):
+        raise AssertionError("persistent augmented probe history count drifted")
+    iterations = int(probe["iterations"])
+    if not 1 <= iterations <= max_iterations:
+        raise AssertionError("persistent augmented probe iterations drifted")
+    inverse_count = int(probe["inverse_pair_clause_count"])
+    if not 0 <= inverse_count <= iterations * conflict_cap:
+        raise AssertionError("persistent augmented probe inverse clauses drifted")
+
+    models = probe["models"]
+    seen = set(history_keys)
+    previous_iteration = 0
+    for expected_index, model in enumerate(models):
+        if int(model["probe_model_index"]) != expected_index:
+            raise AssertionError("persistent augmented probe index drifted")
+        iteration = int(model["z3_iteration"])
+        if not previous_iteration < iteration <= iterations:
+            raise AssertionError("persistent augmented probe provenance drifted")
+        previous_iteration = iteration
+        order = check_order_record(model, n=n, offsets=offsets)
+        key = dihedral_order_key(order)
+        if key in seen:
+            raise AssertionError("persistent augmented probe is not disjoint")
+        seen.add(key)
+        expected_matches = clause_matches(order, active_orbits)
+        if model["seed_orbit_matches"] != expected_matches:
+            raise AssertionError("persistent augmented probe matches drifted")
+
+    if int(probe["inverse_pair_escape_order_count"]) != len(models):
+        raise AssertionError("persistent augmented probe count drifted")
+    if len(models) != order_limit:
+        raise AssertionError("persistent augmented probe did not reach limit")
+    if probe["status"] != "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED":
+        raise AssertionError("persistent augmented probe status drifted")
+    if probe["solver_result"] != "bounded_after_inverse_pair_escape_models":
+        raise AssertionError("persistent augmented probe result drifted")
+    if iterations != previous_iteration:
+        raise AssertionError("persistent augmented probe terminal iteration drifted")
+    return inverse_count
+
+
+def check_seeded_cegar(
+    seeded: Mapping[str, Any],
+    history: Sequence[Mapping[str, Any]],
+    active_orbits: Sequence[ClauseOrbit],
+    *,
+    initial_inverse_count: int,
+    full_certificate_limit: int,
+    max_iterations: int,
+    conflict_cap: int,
+) -> dict[str, int]:
+    n, offsets = PATTERNS[PATTERN]
+    history_keys = {dihedral_order_key(record["order"]) for record in history}
+    if int(seeded["blocked_history_dihedral_order_count"]) != len(history_keys):
+        raise AssertionError("persistent augmented seeded history drifted")
+    if int(seeded["active_unique_seed_orbit_clause_count"]) != len(
+        unique_clauses(active_orbits)
+    ):
+        raise AssertionError("persistent augmented active clauses drifted")
+    iterations = int(seeded["iterations"])
+    if not 1 <= iterations <= max_iterations:
+        raise AssertionError("persistent augmented seeded iterations drifted")
+    if int(seeded["initial_probe_inverse_clause_count"]) != initial_inverse_count:
+        raise AssertionError("persistent augmented initial clauses drifted")
+    final_inverse_count = int(seeded["final_inverse_pair_clause_count"])
+    if not initial_inverse_count <= final_inverse_count <= (
+        initial_inverse_count + iterations * conflict_cap
+    ):
+        raise AssertionError("persistent augmented final clauses drifted")
+
+    learned_clauses: set[FullClause] = set()
+    seen = set(history_keys)
+    verified_certificates = 0
+    verified_images = sum(orbit.affine_map_count for orbit in active_orbits)
+    previous_iteration = 0
+    previous_clause_count = initial_inverse_count
+    models = seeded["models"]
+    for expected_index, model in enumerate(models):
+        if int(model["model_index"]) != expected_index:
+            raise AssertionError("persistent augmented model index drifted")
+        iteration = int(model["z3_iteration"])
+        if not previous_iteration < iteration <= iterations:
+            raise AssertionError("persistent augmented model provenance drifted")
+        previous_iteration = iteration
+        discovery_count = int(model["inverse_clause_count_at_discovery"])
+        if not previous_clause_count <= discovery_count <= final_inverse_count:
+            raise AssertionError("persistent augmented clause provenance drifted")
+        previous_clause_count = discovery_count
+        order = check_order_record(model, n=n, offsets=offsets)
+        key = dihedral_order_key(order)
+        if key in seen:
+            raise AssertionError("persistent augmented model is not disjoint")
+        seen.add(key)
+        expected_matches = clause_matches(order, active_orbits)
+        if model["seed_orbit_matches"] != expected_matches or expected_matches:
+            raise AssertionError("persistent augmented active seed match drifted")
+        prior_matches = sum(
+            order_satisfies_quads(order, clause) for clause in learned_clauses
+        )
+        if int(model["prior_learned_orbit_clause_matches"]) != prior_matches:
+            raise AssertionError("persistent augmented learned match drifted")
+        if prior_matches:
+            raise AssertionError("persistent augmented prior clause admitted model")
+
+        full = model["full_kalmanson"]
+        certificate = full.get("certificate")
+        if certificate is None:
+            raise AssertionError("persistent augmented stored unresolved model")
+        checked = check_certificate_dict(certificate)
+        if not checked.zero_sum_verified:
+            raise AssertionError("persistent augmented certificate failed")
+        for field, value in {
+            "status": checked.status,
+            "positive_inequalities": checked.positive_inequalities,
+            "weight_sum": checked.weight_sum,
+            "max_weight": checked.max_weight,
+            "zero_sum_verified": checked.zero_sum_verified,
+        }.items():
+            if full[field] != value:
+                raise AssertionError(
+                    f"persistent augmented certificate {field} drifted"
+                )
+        if stable_json_sha256(certificate) != full["certificate_sha256"]:
+            raise AssertionError("persistent augmented certificate hash drifted")
+        quads = certificate_order_quads(certificate, order)
+        if len(quads) != int(full["unique_ordered_quad_count"]):
+            raise AssertionError("persistent augmented certificate width drifted")
+        orbit = build_clause_orbit(PATTERN, expected_index, certificate)
+        if orbit.summary() != full["affine_clause_orbit"]:
+            raise AssertionError("persistent augmented learned orbit drifted")
+        new_clauses = [
+            clause for clause in orbit.clauses if clause not in learned_clauses
+        ]
+        if len(new_clauses) != int(
+            full["new_unique_affine_orbit_clauses_added"]
+        ):
+            raise AssertionError("persistent augmented learned clauses drifted")
+        learned_clauses.update(new_clauses)
+        verified_certificates += 1
+        verified_images += orbit.affine_map_count
+
+    if verified_certificates != full_certificate_limit:
+        raise AssertionError("persistent augmented certificate limit drifted")
+    if int(seeded["new_full_certificate_count"]) != verified_certificates:
+        raise AssertionError("persistent augmented certificate count drifted")
+    if int(seeded["new_unique_affine_orbit_clause_count"]) != len(
+        learned_clauses
+    ):
+        raise AssertionError("persistent augmented learned clause total drifted")
+    if seeded["status"] != CERTIFICATE_LIMIT_STATUS:
+        raise AssertionError("persistent augmented terminal status drifted")
+    if seeded["solver_result"] != "bounded_after_new_exact_certificates":
+        raise AssertionError("persistent augmented terminal result drifted")
+    if iterations != previous_iteration:
+        raise AssertionError("persistent augmented terminal iteration drifted")
+    return {
+        "verified_certificates": verified_certificates,
+        "verified_images": verified_images,
+        "verified_learned_clauses": len(learned_clauses),
+    }
+
+
+def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    if payload["type"] != "sparse_full_cone_c25_persistent_augmented_cegar_v1":
+        raise AssertionError("persistent augmented artifact type drifted")
+    source_path = ROOT / str(payload["source_compression_artifact"])
+    if file_sha256(source_path) != str(payload["source_compression_sha256"]):
+        raise AssertionError("persistent augmented source hash drifted")
+    (
+        source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = load_sources(source_path)
+    configuration = payload["configuration"]
+    expected_configuration = {
+        "pattern": PATTERN,
+        "probe_order_limit": DEFAULT_PROBE_ORDER_LIMIT,
+        "probe_max_iterations": DEFAULT_PROBE_MAX_ITERATIONS,
+        "full_certificate_limit": DEFAULT_FULL_CERTIFICATE_LIMIT,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
+        "conflict_cap": DEFAULT_CONFLICT_CAP,
+        "random_seed": DEFAULT_RANDOM_SEED,
+        "tolerance": 1.0e-9,
+        "history_equivalence": "cyclic rotation and reversal",
+        "active_seed_policy": (
+            "three transferred orbits plus exact minimum new-marginal "
+            "persistent width-four orbit only"
+        ),
+        "inactive_seed_policy": (
+            "dominated persistent width-five orbit and eight zero-marginal "
+            "compressed residual orbits"
+        ),
+    }
+    if configuration != expected_configuration:
+        raise AssertionError("persistent augmented configuration drifted")
+    n, offsets = PATTERNS[PATTERN]
+    if payload["pattern"] != PATTERN or int(payload["n"]) != n:
+        raise AssertionError("persistent augmented pattern drifted")
+    if payload["circulant_offsets"] != list(offsets):
+        raise AssertionError("persistent augmented offsets drifted")
+
+    history = blocked_history(augmentation, prior_cegar, transfer, first)
+    expected_history = {
+        "order_count": len(history),
+        "dihedral_order_count": len(
+            {dihedral_order_key(record["order"]) for record in history}
+        ),
+        "packet_histogram": dict(
+            sorted(Counter(str(record["packet"]) for record in history).items())
+        ),
+        "identities": history_identity(history),
+    }
+    if payload["blocked_history"] != expected_history:
+        raise AssertionError("persistent augmented history drifted")
+
+    (
+        transferred_records,
+        active_orbits,
+        selected_record,
+        inactive_records,
+    ) = seed_selection(source, residual_compression, transfer)
+    if payload["transferred_seed_templates"] != transferred_records:
+        raise AssertionError("persistent augmented transferred seeds drifted")
+    if payload["selected_persistent_seed_template"] != selected_record:
+        raise AssertionError("persistent augmented selected seed drifted")
+    if payload["inactive_seed_templates"] != inactive_records:
+        raise AssertionError("persistent augmented inactive seeds drifted")
+    if int(payload["active_seed_orbit_count"]) != len(active_orbits):
+        raise AssertionError("persistent augmented seed count drifted")
+    if int(payload["active_exact_affine_seed_image_count"]) != sum(
+        orbit.affine_map_count for orbit in active_orbits
+    ):
+        raise AssertionError("persistent augmented seed images drifted")
+    if int(payload["distinct_active_seed_orbit_class_count"]) != len(
+        {orbit.canonical_clause_sha256 for orbit in active_orbits}
+    ):
+        raise AssertionError("persistent augmented seed classes drifted")
+    if int(payload["unique_active_seed_orbit_clause_count"]) != len(
+        unique_clauses(active_orbits)
+    ):
+        raise AssertionError("persistent augmented seed clauses drifted")
+
+    probe = payload["counterfactual_probe"]
+    initial_inverse_count = check_probe(
+        probe,
+        history,
+        active_orbits,
+        order_limit=DEFAULT_PROBE_ORDER_LIMIT,
+        max_iterations=DEFAULT_PROBE_MAX_ITERATIONS,
+        conflict_cap=DEFAULT_CONFLICT_CAP,
+    )
+    expected_comparison = probe_packet_comparison(
+        probe["models"],
+        active_orbits[:-1],
+        active_orbits[-1],
+    )
+    if payload["counterfactual_seed_packet_coverage"] != expected_comparison:
+        raise AssertionError("persistent augmented coverage drifted")
+
+    seeded = payload["seeded_cegar"]
+    seeded_audit = check_seeded_cegar(
+        seeded,
+        history,
+        active_orbits,
+        initial_inverse_count=initial_inverse_count,
+        full_certificate_limit=DEFAULT_FULL_CERTIFICATE_LIMIT,
+        max_iterations=DEFAULT_MAX_ITERATIONS,
+        conflict_cap=DEFAULT_CONFLICT_CAP,
+    )
+    decision = route_decision(
+        probe,
+        expected_comparison,
+        seeded,
+        full_certificate_limit=DEFAULT_FULL_CERTIFICATE_LIMIT,
+    )
+    if payload["decision"] != decision:
+        raise AssertionError("persistent augmented decision drifted")
+    return {
+        "status": "OK",
+        "verified_blocked_history_orders": len(history),
+        "verified_active_seed_certificates": len(active_orbits),
+        "verified_inactive_seed_certificates": len(inactive_records),
+        "verified_counterfactual_probe_orders": len(probe["models"]),
+        "verified_new_exact_full_cone_certificates": seeded_audit[
+            "verified_certificates"
+        ],
+        "verified_exact_affine_certificate_images": seeded_audit[
+            "verified_images"
+        ],
+        "verified_new_unique_affine_orbit_clauses": seeded_audit[
+            "verified_learned_clauses"
+        ],
+        "decision": decision,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument(
+        "--probe-order-limit",
+        type=int,
+        default=DEFAULT_PROBE_ORDER_LIMIT,
+    )
+    parser.add_argument(
+        "--probe-max-iterations",
+        type=int,
+        default=DEFAULT_PROBE_MAX_ITERATIONS,
+    )
+    parser.add_argument(
+        "--full-certificate-limit",
+        type=int,
+        default=DEFAULT_FULL_CERTIFICATE_LIMIT,
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=DEFAULT_MAX_ITERATIONS,
+    )
+    parser.add_argument("--conflict-cap", type=int, default=DEFAULT_CONFLICT_CAP)
+    parser.add_argument("--random-seed", type=int, default=DEFAULT_RANDOM_SEED)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    limits = (
+        args.probe_order_limit,
+        args.probe_max_iterations,
+        args.full_certificate_limit,
+        args.max_iterations,
+        args.conflict_cap,
+    )
+    if any(value <= 0 for value in limits):
+        raise SystemExit("all persistent augmented CEGAR limits must be positive")
+    if args.check is not None:
+        path = args.check if args.check.is_absolute() else ROOT / args.check
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        print(json.dumps(check_payload(payload), indent=2, sort_keys=True))
+        return 0
+
+    payload = build_payload(args)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        path = args.out if args.out.is_absolute() else ROOT / args.out
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+    if args.json or args.out is None:
+        print(text, end="")
+    else:
+        comparison = payload["counterfactual_seed_packet_coverage"]
+        seeded = payload["seeded_cegar"]
+        print(
+            f"{PATTERN}: "
+            f"history={payload['blocked_history']['order_count']} "
+            f"probe_transferred="
+            f"{comparison['transferred_only']['covered_probe_order_count']}/"
+            f"{payload['counterfactual_probe']['inverse_pair_escape_order_count']} "
+            f"probe_width4="
+            f"{comparison['selected_width4_only']['covered_probe_order_count']}/"
+            f"{payload['counterfactual_probe']['inverse_pair_escape_order_count']} "
+            f"new_certificates={seeded['new_full_certificate_count']} "
+            f"status={seeded['status']} "
+            f"decision={payload['decision']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/exploration/run_sparse_full_cone_c25_transfer_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_transfer_cegar.py
@@ -338,6 +338,9 @@ def run_history_disjoint_seeded_cegar(
     max_iterations: int,
     conflict_cap: int,
     random_seed: int,
+    certificate_limit_status: str = (
+        "BOUNDED_C25_TRANSFER_SEEDED_CERTIFICATE_LIMIT_REACHED"
+    ),
 ) -> dict[str, object]:
     require_z3()
     n, offsets = PATTERNS[PATTERN]
@@ -453,7 +456,7 @@ def run_history_disjoint_seeded_cegar(
         seen.add(key)
         block_dihedral_order(solver, positions, order)
         if len(learned_orbits) >= full_certificate_limit:
-            status = "BOUNDED_C25_TRANSFER_SEEDED_CERTIFICATE_LIMIT_REACHED"
+            status = certificate_limit_status
             solver_result = "bounded_after_new_exact_certificates"
             break
 

--- a/tests/test_sparse_full_cone_c25_persistent_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_persistent_augmented_cegar.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "exploration"
+    / "run_sparse_full_cone_c25_persistent_augmented_cegar.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_full_cone_c25_persistent_augmented_cegar",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+CEGAR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CEGAR
+SPEC.loader.exec_module(CEGAR)
+
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_persistent_augmented_cegar_2026-07-30"
+    / "summary.json"
+)
+
+
+def artifact_payload() -> dict[str, object]:
+    return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def test_stored_packet_blocks_the_complete_144_order_history() -> None:
+    history = artifact_payload()["blocked_history"]
+
+    assert history["order_count"] == 144
+    assert history["dihedral_order_count"] == 144
+    assert history["packet_histogram"] == {
+        "augmentation_probe": 32,
+        "first_fresh": 32,
+        "prior": 24,
+        "second_fresh": 32,
+        "transfer_cegar_probe": 16,
+        "transfer_cegar_residual": 8,
+    }
+    assert len(history["identities"]) == 144
+    assert len(
+        {record["dihedral_order_sha256"] for record in history["identities"]}
+    ) == 144
+
+
+def test_seed_policy_activates_only_transferred_plus_selected_width_four() -> None:
+    payload = artifact_payload()
+    transferred = payload["transferred_seed_templates"]
+    selected = payload["selected_persistent_seed_template"]
+    inactive = payload["inactive_seed_templates"]
+
+    assert [record["ordered_quad_count"] for record in transferred] == [3, 5, 14]
+    assert selected["source_target_id"] == "transfer_cegar_probe:0"
+    assert selected["ordered_quad_count"] == 4
+    assert selected["seed_role"] == "PRIMARY_MINIMUM_NEW_MARGINAL_COVER"
+    assert payload["active_seed_orbit_count"] == 4
+    assert payload["active_exact_affine_seed_image_count"] == 100
+    assert payload["unique_active_seed_orbit_clause_count"] == 100
+    assert [record["seed_id"] for record in inactive] == [
+        "persistent_compressed:1",
+        "residual:0",
+        "residual:1",
+        "residual:2",
+        "residual:3",
+        "residual:4",
+        "residual:5",
+        "residual:6",
+        "residual:7",
+    ]
+    assert [record["ordered_quad_count"] for record in inactive] == [
+        5,
+        7,
+        9,
+        5,
+        3,
+        7,
+        4,
+        6,
+        4,
+    ]
+
+
+def test_width_four_orbit_covers_all_sixteen_fresh_probe_orders_marginally() -> None:
+    payload = artifact_payload()
+    probe = payload["counterfactual_probe"]
+    comparison = payload["counterfactual_seed_packet_coverage"]
+
+    assert probe["status"] == "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+    assert probe["iterations"] == 454
+    assert probe["inverse_pair_clause_count"] == 14122
+    assert probe["inverse_pair_escape_order_count"] == 16
+    assert all(model["lightweight_filters"]["survives"] for model in probe["models"])
+    assert comparison["transferred_only"]["covered_probe_order_count"] == 0
+    assert comparison["selected_width4_only"]["covered_probe_order_count"] == 16
+    assert (
+        comparison["transferred_plus_selected_width4"][
+            "covered_probe_order_count"
+        ]
+        == 16
+    )
+    assert comparison[
+        "selected_width4_marginal_over_transferred_probe_model_indices"
+    ] == list(range(16))
+    assert comparison["active_uncovered_probe_model_indices"] == []
+
+
+def test_augmented_cegar_learns_eight_new_exact_wide_certificates() -> None:
+    payload = artifact_payload()
+    seeded = payload["seeded_cegar"]
+    models = seeded["models"]
+
+    assert seeded["status"] == (
+        "BOUNDED_C25_PERSISTENT_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+    )
+    assert seeded["solver_result"] == "bounded_after_new_exact_certificates"
+    assert seeded["iterations"] == 102
+    assert seeded["initial_probe_inverse_clause_count"] == 14122
+    assert seeded["final_inverse_pair_clause_count"] == 15006
+    assert seeded["new_full_certificate_count"] == 8
+    assert seeded["new_unique_affine_orbit_clause_count"] == 200
+    assert [
+        model["full_kalmanson"]["unique_ordered_quad_count"] for model in models
+    ] == [197, 197, 193, 194, 192, 200, 191, 195]
+    assert all(
+        model["full_kalmanson"]["zero_sum_verified"] for model in models
+    )
+    assert all(model["lightweight_filters"]["survives"] for model in models)
+    assert all(model["seed_orbit_matches"] == [] for model in models)
+    assert payload["decision"] == (
+        "COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS"
+    )
+
+
+def test_stored_persistent_augmented_cegar_replays_exactly() -> None:
+    assert CEGAR.check_payload(artifact_payload()) == {
+        "status": "OK",
+        "verified_blocked_history_orders": 144,
+        "verified_active_seed_certificates": 4,
+        "verified_inactive_seed_certificates": 9,
+        "verified_counterfactual_probe_orders": 16,
+        "verified_new_exact_full_cone_certificates": 8,
+        "verified_exact_affine_certificate_images": 300,
+        "verified_new_unique_affine_orbit_clauses": 200,
+        "decision": "COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS",
+    }

--- a/tests/test_sparse_full_cone_c25_persistent_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_persistent_augmented_cegar.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
@@ -154,3 +156,13 @@ def test_stored_persistent_augmented_cegar_replays_exactly() -> None:
         "verified_new_unique_affine_orbit_clauses": 200,
         "decision": "COMPRESS_NEW_C25_PERSISTENT_AUGMENTED_RESIDUALS",
     }
+
+def test_checker_rejects_substituted_source_artifact(tmp_path: Path) -> None:
+    substitute = tmp_path / "summary.json"
+    substitute.write_bytes(CEGAR.DEFAULT_SOURCE.read_bytes())
+    payload = artifact_payload()
+    payload["source_compression_artifact"] = str(substitute)
+    payload["source_compression_sha256"] = CEGAR.file_sha256(substitute)
+
+    with pytest.raises(AssertionError, match="source artifact drifted"):
+        CEGAR.check_payload(payload)


### PR DESCRIPTION
## What changed

- add a bounded C25 CEGAR generator and exact replay checker with all 144 current order identities blocked
- activate only the three transferred seed orbits plus the selected persistent width-4 orbit
- keep the dominated persistent width-5 orbit and all eight zero-marginal residual orbits explicitly inactive
- store the fresh probe comparison, eight newly learned exact certificates, tests, audit registration, and bounded research documentation
- make the shared C25 CEGAR certificate-limit status configurable while preserving the existing default

## Exact bounded result

- active seed widths are `3, 5, 14, 4`, producing 100 exact affine seed images
- on 16 fresh strong inverse-pair-escape orders, transferred seeds cover `0/16` and width 4 covers `16/16`
- after activating width 4, CEGAR learns eight further exact full-cone certificates
- learned widths are `197, 197, 193, 194, 192, 200, 191, 195`
- the run stops at its configured eight-certificate limit with no unresolved model
- the learned orbits contribute 200 unique affine clauses; the checker replays 300 exact affine images overall

The next bounded route is to compress these eight new certificates and audit exact affine reuse before increasing the order-search budget.

## Claim scope

This is an exact certificate and coverage result for a finite, history-blocked packet of fixed C25 cyclic orders. It is not an all-order C25 obstruction, a geometric realizability result, a proof of Erdos Problem #97, a counterexample, or an official/global status update.

## Review hardening

- pins the exact persistent-compression source artifact
- adds a regression rejecting byte-identical substituted source paths
- leaves the full CEGAR configuration, certificates, and summary SHA-256 unchanged

## Validation

- fast text/status/provenance/generator/diff checks and Ruff: passed
- focused packet tests: `6 passed`
- cumulative corrected stack: `1,828 passed` across four non-overlapping tracked-test shards
- complete required artifact tier and all seven C25 packet replays: passed
- exact-head GitHub tests and artifact audit: passed