### PR TITLE
Run 168-history C25 selected residual CEGAR

### DIFF
--- a/data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/README.md
+++ b/data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/README.md
@@ -1,0 +1,44 @@
+# C25 selected-residual width-3 augmented CEGAR
+
+Status: bounded fixed-pattern, history-blocked exact-clause diagnostic. No
+all-order obstruction, geometric counterexample, general proof, or
+official-status update is claimed.
+
+This packet blocks the complete current 168-order C25 history and activates
+only the three transferred exact seed orbits, persistent width-4 orbit, and
+the width-3 orbit selected by the preceding residual-compression packet.
+
+## Result
+
+- Blocked dihedral order classes: `168`.
+- Active exact seed orbits: `5`, with widths `3, 5, 14, 4, 3`.
+- Inactive exact seed summaries: `16`.
+- Active exact affine seed images: `125`.
+- Fresh history-disjoint probe orders: `16`.
+- Four parent seeds cover `16/16` probe orders.
+- Selected width-3 only covers `4/16`, all already covered by the parent
+  seeds, so its fresh-probe marginal coverage is `0/16`.
+- Five-seed CEGAR learns eight new exact full-cone certificates of widths
+  `219, 220, 214, 216, 211, 217, 219, 210`.
+- The run reaches its eight-certificate limit with no unresolved model and
+  adds `200` unique affine clauses.
+- The checker replays `325` exact affine certificate images in total.
+- Decision: `COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES`.
+
+Generate:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py \
+  --out data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/summary.json
+```
+
+Replay:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py \
+  --check data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/summary.json
+```
+
+SHA-256 of `summary.json`:
+
+`f6abf754d8fb31913ddb986e993ccf4917a985c41890ca1e2c22d5ae081a2388`

--- a/data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/summary.json
+++ b/data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/summary.json
@@ -1,0 +1,20903 @@
+{
+  "active_exact_affine_seed_image_count": 125,
+  "active_seed_orbit_count": 5,
+  "blocked_history": {
+    "dihedral_order_count": 168,
+    "identities": [
+      {
+        "dihedral_order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "history_id": "prior:probe:0",
+        "order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "e47ce1873ef7df7855de6ac947539b6b8cb08f69fe551b55db4dacd8594de6fa",
+        "history_id": "prior:probe:1",
+        "order_sha256": "efc4a292c226cfc11e313d0c4404977f0e4d67f8b6f44f92009cfc421b5fd29c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8a17cf46dc234917d8cfe36ff788438c4f49bf137c67a6edf37c6f305c1063df",
+        "history_id": "prior:probe:2",
+        "order_sha256": "c95c42099fef5ebc90a4037cad6d101892b494c64604c119a628293f7bf2331d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "82db3aad7af4566f9bf5624f50133b7cbe34e22b3cc2a81981c4777199a73adf",
+        "history_id": "prior:probe:3",
+        "order_sha256": "666ea584ade30a2e1f2c73701e959a53a5f62313940e4908b36c432228be554f",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "02ed07cd34ac32b87a770c4ef50acbaa24091fe89c0fed35a5d52989e08d6367",
+        "history_id": "prior:probe:4",
+        "order_sha256": "0e6cd6f07b0e787550f167b7b2618c093798a7daf6532ed7034883102e630f6a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "history_id": "prior:probe:5",
+        "order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "79babcff39c14382587e9985c2a7f29e9f235ec820f9be660d4a5b389a80c157",
+        "history_id": "prior:probe:6",
+        "order_sha256": "fff3141a6a0cb083c0c47caa9d503962f2e8df7d09b0cb7bd7feb48749db91cc",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "58ca3889b456993b7269bc29f804db9ae48ab1f1cba6e3b32fffc551643f18f2",
+        "history_id": "prior:probe:7",
+        "order_sha256": "4f1bd2dba49c94c3347c1f8d305a64c63909a7c554fb8dcae8d30043d81ff5f2",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ef45651dea4eb7f0dd109be674abd64408952f633702ede41bc2fde02d1cae72",
+        "history_id": "prior:probe:8",
+        "order_sha256": "e20270d7c562e00367c52995549417843bcef3d8603184d207639c904148c571",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "12332dd76c249041d5a28b9c81dbe613f45a41c5a2685910daa3517ad4b34027",
+        "history_id": "prior:probe:9",
+        "order_sha256": "dc61176ac8c0097851f2854c265eb7583663b5a6a2f66126bf5a03846d56e63e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "0f6cc8e662af54f44907d245f9adbd6cca93dbdbb8c14ef9a99adfcb9ac1ed0d",
+        "history_id": "prior:probe:10",
+        "order_sha256": "754426e7bc885a0f2e8fb1c853807baed5351586254e29bb8c92b0d0f7cd25ef",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "15e5a1a1fea1a5c4c47229faa4ebc023063d8e2802139a23bd754d30c5c851ea",
+        "history_id": "prior:probe:11",
+        "order_sha256": "060fe21eab6ec94f7825cfb799fd2d022cee8a3f0db90f73fd69e6154d7da5fd",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "141cf222b3b0697645027b016fa45231adbca52849dc3f7d9523cb32061d7665",
+        "history_id": "prior:probe:12",
+        "order_sha256": "d09f13e9829115f310886304f784cb62e2385fd9dcf291bd1b0db6670624e40d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "086627559e7a75648d34ad8dc52bd10baba93dabd028de442ad497dcc3c34818",
+        "history_id": "prior:probe:13",
+        "order_sha256": "2bc81b26171354d28295d62241623aadd68a98cff34fee7b7e0ec47465187abb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "bb962a4708e2b29db9d7ed570225b789a34ccca8a14ce7121ba8f514dcecb481",
+        "history_id": "prior:probe:14",
+        "order_sha256": "581f88dbcd0fe62dd4b80be4521d5ba21399a400fd50945694dc2c01287cc430",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "74e24135b5924adfadf007c806b6aa922dd473ca0b82512b9699e83ee4395b8b",
+        "history_id": "prior:probe:15",
+        "order_sha256": "6ca9c08de031a639defe03c7f5aee697b8142cc1884460d9aa314df76e2d13ec",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "cf586c61dd9f421f025969fd3dc6342bd632daf4221e035c00af56f422f07b6a",
+        "history_id": "prior:seeded:0",
+        "order_sha256": "3d9f6fafb2bdc898aaefab174932d060919b4992440954d03266ac0c4c3a8c54",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2a2374e7b829f31f5a3afc50a6115620f53894bd7b47689f9ce838591a7d3145",
+        "history_id": "prior:seeded:1",
+        "order_sha256": "b143a0412b3d7179d2dfa5ab7056fc86f0f61678f29463343201cd3755310912",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2664a62fd1f2df2ceb8c350104fbc18f01fb918c919f345a51234f0fc080a765",
+        "history_id": "prior:seeded:2",
+        "order_sha256": "7ddc43a26c71be6f9226d86a4094064ea2a56f1f87af69c787c9b50e7285fc18",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "87025881b3c0d75c80505a291d7206657e7cf8267543f6b1f4c9bfd897d402ac",
+        "history_id": "prior:seeded:3",
+        "order_sha256": "62af9cce7d384bb07a18bee0a5666e752f08ab91ff6cb8f28d94bdaec6de126a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f9be89d8cca62869c2d7500e4d75ae8a28d5cd90e8315cc711ecdc6a76899523",
+        "history_id": "prior:seeded:4",
+        "order_sha256": "e7ff334e2ba96bd7861442773e354845c776db61d2723a7fe9229928c2af8a95",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "6198d5cd8e6689d0af6250c76d076db6606ff85eaaf14a9ca1125944ecbb0f8f",
+        "history_id": "prior:seeded:5",
+        "order_sha256": "9ca9bcb9f7ac3012eddcd1faa95a2e41c5c2062ac1b662d828938d902ba81902",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "history_id": "prior:seeded:6",
+        "order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "history_id": "prior:seeded:7",
+        "order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f65bb867cbc8532d2c2c89682895ae8999d75de687ef6d03e8122039b88a60c1",
+        "history_id": "first_fresh:fresh:0",
+        "order_sha256": "b3fb01c68d5763b9f7e1145de43d85fa10593e255de1664502289aba9f2c18d5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1495f18db025b31993978b203d9884065a466f27754cbb6930c0349d027d6837",
+        "history_id": "first_fresh:fresh:1",
+        "order_sha256": "e5bbf6b4fe5c23b4d8660b0ee114ae5197a9d92f8b8a7817c809d66c67b6bc7f",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "14e2003e2113af6086da7654e7dad616e2b5b87fb06dfa1826f5e27d276da60a",
+        "history_id": "first_fresh:fresh:2",
+        "order_sha256": "fffc543b5fe7bd806e59be736acb34787451c354d733cb00cbc0d3e1d4a17ceb",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0b7138c621548805e187aa1d5f0b70c169765362a98c21535a3b7797b62c9fe",
+        "history_id": "first_fresh:fresh:3",
+        "order_sha256": "f1f588b6a76fe0727293f263ff3d40bbfe537e40293f68a9e14b7745d23a419c",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "120335beb6c2273c2f30312e297cd69ae2316e1a273044a0959d79f824424a5c",
+        "history_id": "first_fresh:fresh:4",
+        "order_sha256": "6bb23677f914747186d71bf861bd525e7f3788e608396f106b27bf70524c4637",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "history_id": "first_fresh:fresh:5",
+        "order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "history_id": "first_fresh:fresh:6",
+        "order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "history_id": "first_fresh:fresh:7",
+        "order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "history_id": "first_fresh:fresh:8",
+        "order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "history_id": "first_fresh:fresh:9",
+        "order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "history_id": "first_fresh:fresh:10",
+        "order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "history_id": "first_fresh:fresh:11",
+        "order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "169cb63c511b5342437e41bab670aca22fa1a8dd49197596a5b400c0df9aad93",
+        "history_id": "first_fresh:fresh:12",
+        "order_sha256": "7d26dac32a4f49b310623dc118741fd3eae62a98fddc3fc02343cda28982e0d2",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "history_id": "first_fresh:fresh:13",
+        "order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "history_id": "first_fresh:fresh:14",
+        "order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "history_id": "first_fresh:fresh:15",
+        "order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "history_id": "first_fresh:fresh:16",
+        "order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "history_id": "first_fresh:fresh:17",
+        "order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b2ea5b6ee6ac796d5383ae7260006a43c9ef172de728ce355103ad818c011870",
+        "history_id": "first_fresh:fresh:18",
+        "order_sha256": "ad2c330339c8d008ca9dddebd31e6e72a92f3a882529ef6afe1eb15687ac3a92",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "39344073585252f9a0c4b427237efa9eaff37765c4aebfeba914b69695fc05b3",
+        "history_id": "first_fresh:fresh:19",
+        "order_sha256": "f3ff2b091996877bb676eb68b61bd8740b052aa0b0cc11bf737b7921f33ce237",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "history_id": "first_fresh:fresh:20",
+        "order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ec5946bf2f40dc5430e51e9490586f5672dce0247712e3725efa519a53aca7de",
+        "history_id": "first_fresh:fresh:21",
+        "order_sha256": "9bca3aac19a02dae679142542a99e8f2691b6b621620d71a97ab7ae9cc651128",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "history_id": "first_fresh:fresh:22",
+        "order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "history_id": "first_fresh:fresh:23",
+        "order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "history_id": "first_fresh:fresh:24",
+        "order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "history_id": "first_fresh:fresh:25",
+        "order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "history_id": "first_fresh:fresh:26",
+        "order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "history_id": "first_fresh:fresh:27",
+        "order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "history_id": "first_fresh:fresh:28",
+        "order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "history_id": "first_fresh:fresh:29",
+        "order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "history_id": "first_fresh:fresh:30",
+        "order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "history_id": "first_fresh:fresh:31",
+        "order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "history_id": "second_fresh:fresh:0",
+        "order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "79992c5f6bd66f15584ce60b9059f4f9adf6d6c3bbfe13a6c7e985e4cc98e934",
+        "history_id": "second_fresh:fresh:1",
+        "order_sha256": "813b0573bbb49d2ec6fdd5850c98a09faf809b8d202f75b9b5039304d45fc12a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "history_id": "second_fresh:fresh:2",
+        "order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "history_id": "second_fresh:fresh:3",
+        "order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "history_id": "second_fresh:fresh:4",
+        "order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "history_id": "second_fresh:fresh:5",
+        "order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "history_id": "second_fresh:fresh:6",
+        "order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "history_id": "second_fresh:fresh:7",
+        "order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "history_id": "second_fresh:fresh:8",
+        "order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "history_id": "second_fresh:fresh:9",
+        "order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "history_id": "second_fresh:fresh:10",
+        "order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "history_id": "second_fresh:fresh:11",
+        "order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "history_id": "second_fresh:fresh:12",
+        "order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "history_id": "second_fresh:fresh:13",
+        "order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "history_id": "second_fresh:fresh:14",
+        "order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "history_id": "second_fresh:fresh:15",
+        "order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "history_id": "second_fresh:fresh:16",
+        "order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "history_id": "second_fresh:fresh:17",
+        "order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2210ce735dc632ef83e03e7b2d4a3634375c2de67696f6a365b902a9b4bc3f86",
+        "history_id": "second_fresh:fresh:18",
+        "order_sha256": "fe45925710e246345dc057ea7c935ae9c3070ad9544efd0b19be6b546fa64220",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "194f3fd7909ff96ed4d2f5e2dfd692d275d2133f0855cd649b6d759e5aab8643",
+        "history_id": "second_fresh:fresh:19",
+        "order_sha256": "ec5c74f9b07ef5d4a791ebd149abe20ec81a42ebfc23d8121afcacd22fe5fe66",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "41c5ce250a21087b96de0cd9afe6e772afe256bfba0efb86dc4b9cd866ba1775",
+        "history_id": "second_fresh:fresh:20",
+        "order_sha256": "e5bfda8732de5ace04841e34b1683f96d951c7b3c720e01ae8fbca8252cee2e2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1f94d235621cb6118fbcec853d4ce051fbc0da58aac1f6536f86c1a07a7c8ce3",
+        "history_id": "second_fresh:fresh:21",
+        "order_sha256": "f10f76dcdd591f5c4d36be49cea8e7b063f8aad6880f227da5b1541bd2fc65e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "91c0adb00ca0fc2c9c95e0a6231d9ee98bb106fd4e4be71d22321a23dd713102",
+        "history_id": "second_fresh:fresh:22",
+        "order_sha256": "c7c0cf5c2af1ee6ab12519d404279ed36f2b3c63a3f047b2f34208670ffa6a33",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "history_id": "second_fresh:fresh:23",
+        "order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "history_id": "second_fresh:fresh:24",
+        "order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "history_id": "second_fresh:fresh:25",
+        "order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "history_id": "second_fresh:fresh:26",
+        "order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "history_id": "second_fresh:fresh:27",
+        "order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "history_id": "second_fresh:fresh:28",
+        "order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "history_id": "second_fresh:fresh:29",
+        "order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "history_id": "second_fresh:fresh:30",
+        "order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "history_id": "second_fresh:fresh:31",
+        "order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "21af0fdceaa2c7b6d6fd444590571ed04a48bd7e0dce5aeafecf86e80e6b2081",
+        "history_id": "transfer_cegar_probe:0",
+        "order_sha256": "01e5595550dc1a887be1e0a5745e1ea9ab38070460f5afa569ad45df8ae3a32c",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "2ec108f7f3fbc4f5b9dbc523095b381676452797aa2384d5d4e65eb375b22f3c",
+        "history_id": "transfer_cegar_probe:1",
+        "order_sha256": "793e8e7d2770941c399debc6a5e57e4c903561f826f10991922fb616d14081c4",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "892d53605b57f7e885514c3bc240208a75c949cd05d38d6b869f9a52a222fbda",
+        "history_id": "transfer_cegar_probe:2",
+        "order_sha256": "8477beb967b9eb08f3528689ba26bed083a58f98b3aa384414b5b625d0ed28f5",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "history_id": "transfer_cegar_probe:3",
+        "order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "history_id": "transfer_cegar_probe:4",
+        "order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "history_id": "transfer_cegar_probe:5",
+        "order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "11bec0ac6af6f23f784eb87a4829063a3fcafa5afe5f0312d6f596981dd16623",
+        "history_id": "transfer_cegar_probe:6",
+        "order_sha256": "c2be4b0fce6eeeab8dff1f8c2569d23305b998bdf248f09edb0c16adcbd739a1",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "history_id": "transfer_cegar_probe:7",
+        "order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "3f394554dde1776db09fd7018a91729b93c154520d599454bb8c00b9aaf6e7f4",
+        "history_id": "transfer_cegar_probe:8",
+        "order_sha256": "c60c083264a78b314734ec064a7dfc0d27f62cf6954b1652613439d313b74f00",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "history_id": "transfer_cegar_probe:9",
+        "order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "b62b485b3882d8da27d08d57d4f9623cec3e06fb0cbab1100ef51f7d58af5760",
+        "history_id": "transfer_cegar_probe:10",
+        "order_sha256": "443391e50babb2e418cf3acce0b958bf584bbfbdd5d30cf538e5c5ed299f388e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "history_id": "transfer_cegar_probe:11",
+        "order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5198401fb43886093718c4425e1cba2cd6ba7bc36a1e43ca52f68acb1467822",
+        "history_id": "transfer_cegar_probe:12",
+        "order_sha256": "918febc87d6907cc754ee5cfd79b8a5c258ab2c0d3045606b310f3a5e076e3cc",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "history_id": "transfer_cegar_probe:13",
+        "order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "history_id": "transfer_cegar_probe:14",
+        "order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "history_id": "transfer_cegar_probe:15",
+        "order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "518976209920025e367b9beb159b8cdc524e485ef40fff87460cdc2959476cab",
+        "history_id": "transfer_cegar_residual:0",
+        "order_sha256": "e24c65ad7cd685c73d1cb969841fd4c72ecd0d56957a03239f4033de180555c6",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "5846cfb91ddf84cfda808e3f4c44d58a8cbb429d53db50f4e303fbada897be4f",
+        "history_id": "transfer_cegar_residual:1",
+        "order_sha256": "4ab9d66bab68c96f6804a8acbbb80d5e865a4e4cccbe628661f47c89878ae8cd",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "history_id": "transfer_cegar_residual:2",
+        "order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "history_id": "transfer_cegar_residual:3",
+        "order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "history_id": "transfer_cegar_residual:4",
+        "order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "history_id": "transfer_cegar_residual:5",
+        "order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "history_id": "transfer_cegar_residual:6",
+        "order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "history_id": "transfer_cegar_residual:7",
+        "order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "history_id": "augmentation_probe:0",
+        "order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "history_id": "augmentation_probe:1",
+        "order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "1c386c157cf50020135c32b97b2bd1252a10e0a76acc05739ebd1f79813cab0b",
+        "history_id": "augmentation_probe:2",
+        "order_sha256": "2968b0a163e6b15c9a4fd3ae309091089b864290224eff954088809fea1786aa",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "6dc35b1d65c62e2042ff2f2274085bb0d5e54b8f93048bdcb02beff769356f7e",
+        "history_id": "augmentation_probe:3",
+        "order_sha256": "c98f9fda4a774c274f83baf63ad5fe0be5e64d5110323e63decf1b243e42b4a6",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f8f07b4dfa0c7b5b1cdb5e52ec58e09f720179fe9c2bd6e15132f3adf1e94023",
+        "history_id": "augmentation_probe:4",
+        "order_sha256": "9cfffb312b0cbe7074847072c804ef7890f0de69cd2a3475901941885ef11098",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "history_id": "augmentation_probe:5",
+        "order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "ba04e21c82460534a05f784da7af74b5db4579daf575969d2f3664c64527d8c2",
+        "history_id": "augmentation_probe:6",
+        "order_sha256": "58ef1145544aba90699ee3949e67dac9f93ee20e108de7a7ed81c3a50ce1f882",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "eaff5f7030f3780b3ac105f0031dab52a5aa483dc42d156895a227713fd3d357",
+        "history_id": "augmentation_probe:7",
+        "order_sha256": "aa82c870cdec719876a50964d030d7c13da82a632c3a0f16ce05efaa8a41a6aa",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "history_id": "augmentation_probe:8",
+        "order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "history_id": "augmentation_probe:9",
+        "order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "history_id": "augmentation_probe:10",
+        "order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "history_id": "augmentation_probe:11",
+        "order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "30f362230bc2ecc4c569923228b5a4ce003220f93c3869bcd57bad5a6f8240fe",
+        "history_id": "augmentation_probe:12",
+        "order_sha256": "fd1d0c8af17efe869c2a5eaa37f44d2ff196df14e2f4e2b5d645d1fa3f7ebf2e",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "history_id": "augmentation_probe:13",
+        "order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "4a99c5a82c42e9253460d4e3612a3b4d30d567e71749a417bb9378be8a3ebc52",
+        "history_id": "augmentation_probe:14",
+        "order_sha256": "a343ff07c8321bf23451fe9b7cefad97adaa8f48e9557f25187f4cab5d732760",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "history_id": "augmentation_probe:15",
+        "order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "history_id": "augmentation_probe:16",
+        "order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "history_id": "augmentation_probe:17",
+        "order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "history_id": "augmentation_probe:18",
+        "order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "history_id": "augmentation_probe:19",
+        "order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "history_id": "augmentation_probe:20",
+        "order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "e71b60f92693ae63a66e0e0805134f1436381cd85e61e4cfcf0fb9c7843d4fd3",
+        "history_id": "augmentation_probe:21",
+        "order_sha256": "383b5131a68b22240a74ec5281be3ba01a372dc02241d9b706d11a80e66bae0c",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "7ae8308d62d26f3fbefa7a9862f88a26c3a1aa2cc4a51f07c5e2cfd0fd7b67e2",
+        "history_id": "augmentation_probe:22",
+        "order_sha256": "47cbe888ff88b45b833d8fd1f8dc89bca00656bf9795ef484a3a481345b027f3",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "8ccd5b799ffa1e43f5b47f14a140bb0a6484ff859f9621f0a41bfb294c9a6869",
+        "history_id": "augmentation_probe:23",
+        "order_sha256": "4c6f5a3aea2e6afe78c2ae409b429cd35c9c06ea7cc1ac23a355ac50f97ca0bd",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "715ff051ef4e9563096c2798eaa5894890379a3089e5875874e624b9799cabb7",
+        "history_id": "augmentation_probe:24",
+        "order_sha256": "e4706b5d6ecbd1b1f03ae78cf2f130f9b962e32236ada16185baf6b25f4d40f7",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "history_id": "augmentation_probe:25",
+        "order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "history_id": "augmentation_probe:26",
+        "order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "history_id": "augmentation_probe:27",
+        "order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "history_id": "augmentation_probe:28",
+        "order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "history_id": "augmentation_probe:29",
+        "order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "history_id": "augmentation_probe:30",
+        "order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "history_id": "augmentation_probe:31",
+        "order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "5ef345f1349ff914bcf3bcf459fa62203386351a2c723979b5ff8699028e0402",
+        "history_id": "persistent_augmented_probe:0",
+        "order_sha256": "5ef345f1349ff914bcf3bcf459fa62203386351a2c723979b5ff8699028e0402",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "5ddbaeff0aeeede2790d73f42e3b2f4d0f5c6d117c5e26984674ecf8abdd7726",
+        "history_id": "persistent_augmented_probe:1",
+        "order_sha256": "5ddbaeff0aeeede2790d73f42e3b2f4d0f5c6d117c5e26984674ecf8abdd7726",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "37f73c3cf6ff91b10b5246de93ea8e08ebb1b574edde9a364becddac7d2c7ca8",
+        "history_id": "persistent_augmented_probe:2",
+        "order_sha256": "a97a21ca890dbb3cede13d40a49b3cd3c80de3739ee22fc1539c27f7a2c9ff55",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "e545f59d547cb4eb16eb05f6f005cb5eb81a686f2b8316cb82739be659c5a8f3",
+        "history_id": "persistent_augmented_probe:3",
+        "order_sha256": "c4ba39e59e4c4bfc0384ad21fa13f5409990000ac475de2e49c5ee7d449bc1fc",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "d01d8a2d708f94901e3c82ce71c4cbb576ffd85bf3527edca38d5557e4e2bed9",
+        "history_id": "persistent_augmented_probe:4",
+        "order_sha256": "2040570e16bad06ccb17f53583fee3437e24528ad579074b1cc1f90d62b1226d",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "0aadb2e30d2093eb0d54ef2ba26477212a4838c3eb7c11795e5a4783dfeb52fb",
+        "history_id": "persistent_augmented_probe:5",
+        "order_sha256": "8a0e23f99c788d5ddfcbce03e64fdd5a670757c2d9f285084dde56c019d112c9",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "e3b7e4b11cc8876bb0c2b2a8a845fad3919ec4f548167266c9a7c1159acaa7cf",
+        "history_id": "persistent_augmented_probe:6",
+        "order_sha256": "c19090f55d494cdf88cc62828d3f4ac1725e571b9ad9d1ffb898104085504e0c",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "fa936ef8774e4ac5ee1e28b74b40472027e67a63373150d54384715f1eebb25a",
+        "history_id": "persistent_augmented_probe:7",
+        "order_sha256": "cfc8b5c7172ce19b98f64af0ddca23b74caecaf10c77f520786967af46237551",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "2832320261578a148556886137ceac035b359ac0144c8f3a2b38bcd6ff28cb29",
+        "history_id": "persistent_augmented_probe:8",
+        "order_sha256": "2b21e2d8946e6ac3eab28de470203b7087e85eccdfbbea71f516e60950816ba0",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "994dcfacd99ef5e89dce19f8c4b55340744813f26d4382fd5ef1e11ffb0798d7",
+        "history_id": "persistent_augmented_probe:9",
+        "order_sha256": "d2558f98e57e8713c96f183a33d6f267400acb9507249cc6cfca3af7d5bd31fa",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "c15c6171b383b87320dec07cf0a520c0ff82afc545deeced2b4a70d1cccdc2f5",
+        "history_id": "persistent_augmented_probe:10",
+        "order_sha256": "11f5903dbcc4c0363747842df6060739e22027b66c17029f4115ef7b286f6e10",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "1e6edfeee8c2a8c9aa09b1c1464126ceaa8f4047b4b01d746204536bd0e5a4b1",
+        "history_id": "persistent_augmented_probe:11",
+        "order_sha256": "0325aff35bca425d6cdf128772fa9184aa63903356fe4a35c82d369bdd961da3",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "6e4b8d2b6f199af5da0d25043f232d352b667439e5b8adb1e2784f24a61b45d9",
+        "history_id": "persistent_augmented_probe:12",
+        "order_sha256": "f7e9ad983fb5473c0ca2f1a9229c71e65a24473ce415437a15a1cf04baa11f7d",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "92981ebf7bafb1138f1db7b0f7c035b8055e31dbe73b38fc8a1c6492ba51eae2",
+        "history_id": "persistent_augmented_probe:13",
+        "order_sha256": "af99cf38492e495b31ce644fe86d4d564fdea23e6bde20ef65321f69274ce099",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "d250a8468ba4f6dcf76c13ceb832ff74cf6ce83a7b5aae837fcee8b663f8757d",
+        "history_id": "persistent_augmented_probe:14",
+        "order_sha256": "9d1d5c00d4b3bbe90ba30b80a0d1c119bba06a1b47f3554b0e8696e0cf1a1f33",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "ec12a86d316165551a7e0da91fefdf023021a7bd3fa1aa7362d787d7fad699dc",
+        "history_id": "persistent_augmented_probe:15",
+        "order_sha256": "eae5019a4c4ff562c07cfdd815ae7b390c8482d0911418583d09f04b8befc64e",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "55db65a812422826d3953cc6ad5a34d108f4bd1b1a1d1b6bbf1cee8185bf36f2",
+        "history_id": "persistent_augmented_residual:0",
+        "order_sha256": "55db65a812422826d3953cc6ad5a34d108f4bd1b1a1d1b6bbf1cee8185bf36f2",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "5130eb5b4f4b45105f5365b91ffe649d866eb8b2039eaafbb9108386201f7316",
+        "history_id": "persistent_augmented_residual:1",
+        "order_sha256": "5130eb5b4f4b45105f5365b91ffe649d866eb8b2039eaafbb9108386201f7316",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "7d73aa04a3840408e2a9250b347d54a0a96720e6d2c9c485d3912890d47f536e",
+        "history_id": "persistent_augmented_residual:2",
+        "order_sha256": "7d73aa04a3840408e2a9250b347d54a0a96720e6d2c9c485d3912890d47f536e",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "7ca60b4094c81d67ce63bc047e16ecc90dbbb9ba3fa4e9787198e259995c7542",
+        "history_id": "persistent_augmented_residual:3",
+        "order_sha256": "7ca60b4094c81d67ce63bc047e16ecc90dbbb9ba3fa4e9787198e259995c7542",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "a62219f86227c146e1169b27697de6488957a23f0df7182b347bed2fe13830be",
+        "history_id": "persistent_augmented_residual:4",
+        "order_sha256": "a62219f86227c146e1169b27697de6488957a23f0df7182b347bed2fe13830be",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "b794577f9b684ad39dfc20bf8c49ceb4007a340c1a949f1d1ae9553367265642",
+        "history_id": "persistent_augmented_residual:5",
+        "order_sha256": "b794577f9b684ad39dfc20bf8c49ceb4007a340c1a949f1d1ae9553367265642",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "21e13c0d8d493dec39d581382440e682b367c863bd076be5db0f6481365cd6df",
+        "history_id": "persistent_augmented_residual:6",
+        "order_sha256": "21e13c0d8d493dec39d581382440e682b367c863bd076be5db0f6481365cd6df",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "7878fbe6f726d920f08ac5c0d6e0ab5ee52a85cf5d9e9f99dd65dc385a1fb241",
+        "history_id": "persistent_augmented_residual:7",
+        "order_sha256": "090fbe04e428d5c9f63a576cd1f89ba16b37ac3b8d9618f71d1bf54e01999a7e",
+        "packet": "persistent_augmented_residual"
+      }
+    ],
+    "order_count": 168,
+    "packet_histogram": {
+      "augmentation_probe": 32,
+      "first_fresh": 32,
+      "persistent_augmented_probe": 16,
+      "persistent_augmented_residual": 8,
+      "prior": 24,
+      "second_fresh": 32,
+      "transfer_cegar_probe": 16,
+      "transfer_cegar_residual": 8
+    }
+  },
+  "circulant_offsets": [
+    2,
+    5,
+    9,
+    14
+  ],
+  "claim_scope": "Three transferred exact C25 certificate orbits, one persistent width-four seed, and the selected exact residual width-three orbit seed a bounded order CEGAR after 168 known C25 orders are blocked under rotation and reversal. Probe coverage, newly learned certificates, and affine images are exact, but finite limits and history blocking preclude any all-order obstruction, geometric realizability result, counterexample, proof of Erdos Problem #97, or official/global status update.",
+  "configuration": {
+    "active_seed_policy": "three transferred orbits plus persistent width-four orbit plus exact minimum residual-cover width-three orbit only",
+    "conflict_cap": 1024,
+    "full_certificate_limit": 8,
+    "history_equivalence": "cyclic rotation and reversal",
+    "inactive_seed_policy": "nine inherited inactive orbits plus seven nonselected persistent-augmented compressed residual orbits",
+    "max_iterations": 12000,
+    "pattern": "C25_sidon_2_5_9_14",
+    "probe_max_iterations": 12000,
+    "probe_order_limit": 16,
+    "random_seed": 20260731,
+    "tolerance": 1e-09
+  },
+  "counterfactual_probe": {
+    "blocked_history_dihedral_order_count": 168,
+    "inverse_pair_clause_count": 14485,
+    "inverse_pair_escape_order_count": 16,
+    "iterations": 497,
+    "models": [
+      {
+        "dihedral_order_sha256": "9e9942503d8326886c1fc092a25ae8f71dd463725708aa7884049b2148b8dbdd",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          4,
+          18,
+          21,
+          7,
+          24,
+          10,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "9e9942503d8326886c1fc092a25ae8f71dd463725708aa7884049b2148b8dbdd",
+        "probe_model_index": 0,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 11,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 470
+      },
+      {
+        "dihedral_order_sha256": "531643184f51441dbd88a25c684aed28cff41893d27f62f501c7e5b07913d05e",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          12,
+          1,
+          15,
+          4,
+          18,
+          21,
+          7,
+          24,
+          10,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "30584c2826d14a34fb1754a4b4eee389e0cfeb9decf1adfbc2631656586d679d",
+        "probe_model_index": 1,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 9,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 471
+      },
+      {
+        "dihedral_order_sha256": "1e3367b3ad0722e8dad98d1bc1ef4735c77d5d688d169017bbf3302ee4775bfd",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          1,
+          12,
+          15,
+          4,
+          18,
+          21,
+          7,
+          24,
+          10,
+          13,
+          2,
+          16,
+          5,
+          19,
+          22,
+          8
+        ],
+        "order_sha256": "d728eafd0dbd649d5451b5ddf669d8705a9942323b252338792ef2227525d526",
+        "probe_model_index": 2,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 7,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 472
+      },
+      {
+        "dihedral_order_sha256": "bb3773624a3787d41f9ae8d9c166829c9de1763e0b993607fa10a867c1d0fb5c",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          14,
+          3,
+          17,
+          6,
+          20,
+          9,
+          23,
+          1,
+          12,
+          15,
+          4,
+          18,
+          21,
+          7,
+          24,
+          10,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22
+        ],
+        "order_sha256": "bb3773624a3787d41f9ae8d9c166829c9de1763e0b993607fa10a867c1d0fb5c",
+        "probe_model_index": 3,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 9,
+            "source_model_index": 28
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 19
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 473
+      },
+      {
+        "dihedral_order_sha256": "d07d0c3bbc5257b5147290b15a9c21ada2558deb9e35669a4f76c77fc50e9c37",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          19,
+          16,
+          5,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "b9a91b3f8bebf9b67f30563b17af166cc111f25f6be5210c64b903fdb2d2cbda",
+        "probe_model_index": 4,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 486
+      },
+      {
+        "dihedral_order_sha256": "17342cdd2bf3dce538024cb84374950cea4fea3eb71cd40200329d792f536722",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          5,
+          22,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "17342cdd2bf3dce538024cb84374950cea4fea3eb71cd40200329d792f536722",
+        "probe_model_index": 5,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 487
+      },
+      {
+        "dihedral_order_sha256": "415bb579d8af0acefb7defb5815feedadee692dfda99e142e9ad3584395625c0",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          5,
+          22,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          9,
+          23,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "415bb579d8af0acefb7defb5815feedadee692dfda99e142e9ad3584395625c0",
+        "probe_model_index": 6,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 488
+      },
+      {
+        "dihedral_order_sha256": "b30808379af6404c5d6ce4ce993e58417983b43adb018ea880ebbe735ef8784a",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          19,
+          16,
+          5,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          9,
+          23,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "ad7162b38bc6a4b81720129ed8cd661106030e1a0f77779ea46f8ab42dba70c8",
+        "probe_model_index": 7,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 489
+      },
+      {
+        "dihedral_order_sha256": "f366a8313a78ffbd74198bec3557fbe7fd032ef918f546a2b9278fd95d77a376",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          5,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          9,
+          23,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "9a8fe41c57528ff4636f314d34b3959bc1fc493dc8aae2007640cc9920589b5f",
+        "probe_model_index": 8,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 490
+      },
+      {
+        "dihedral_order_sha256": "576fceed3d90c2fb794664163d2415b2fc3533855a71397399fd52eb10a1dffd",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          19,
+          5,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          9,
+          23,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "4836d1d7c3baefd980d2f86ac6bcf9d17ebe6570152763ac17d33980c4c76332",
+        "probe_model_index": 9,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 491
+      },
+      {
+        "dihedral_order_sha256": "eefc193614d35cc47d5b2594106f909c06f3669dea5a26a021d96b04e5221c9a",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          5,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "17211b47a0f84b7998518989a70fbb94ebd3b042a605e2bd602a5d49f198c744",
+        "probe_model_index": 10,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 492
+      },
+      {
+        "dihedral_order_sha256": "fb1b5258eac6b7f84f213c7f36680368aa0644a8bec2a0e80ec82f145e55ec57",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          19,
+          5,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          4,
+          1,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "498d4906b5edd357fcdf3c776b1446eaee9ac80276cd50b77c380c6b35a74de6",
+        "probe_model_index": 11,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 493
+      },
+      {
+        "dihedral_order_sha256": "380cee06e9a5961300f1f48361c4d51085b505e611d7bb9a305b6170b94e78b0",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          19,
+          5,
+          16,
+          2,
+          13,
+          24,
+          10,
+          7,
+          21,
+          18,
+          4,
+          1,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "1ff9bd64e103bb6c0d2a2496ab96e328cab46b1ffdf84e43822f50ddfe42b178",
+        "probe_model_index": 12,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 494
+      },
+      {
+        "dihedral_order_sha256": "57c5b4cac6f3afd5dc5e92a496082434afe8371cc2960705bb72ac8176529c7b",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          5,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          7,
+          21,
+          18,
+          4,
+          1,
+          15,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "1577f685ba3d1b667090592bc43493c40e4864adac22c2564a443ac1f45246df",
+        "probe_model_index": 13,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 495
+      },
+      {
+        "dihedral_order_sha256": "6fa4c4f4a93452bf8339f25281142379a18c191b65eae5c44c50e66df6f631ea",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          5,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          7,
+          21,
+          18,
+          4,
+          1,
+          15,
+          12,
+          9,
+          23,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "c80b4cf93f08d2847adb385f5414589217aedd666653f91c06a8dd95cb395378",
+        "probe_model_index": 14,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 496
+      },
+      {
+        "dihedral_order_sha256": "7a418f66b1c2b15c2adc093b9bb224916b8d37211aa342787cfc194c4f4eeada",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          19,
+          5,
+          16,
+          2,
+          13,
+          24,
+          10,
+          7,
+          21,
+          18,
+          4,
+          1,
+          15,
+          12,
+          9,
+          23,
+          20,
+          6,
+          17,
+          3,
+          14,
+          11,
+          8
+        ],
+        "order_sha256": "1ac3d22cdc916dfe78f7edd78bc1a10c994d1d65b84e5f757668b1fd883f2e28",
+        "probe_model_index": 15,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          }
+        ],
+        "z3_iteration": 497
+      }
+    ],
+    "solver_result": "bounded_after_inverse_pair_escape_models",
+    "status": "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+  },
+  "counterfactual_seed_packet_coverage": {
+    "active_uncovered_probe_model_indices": [],
+    "parent_covered_probe_model_indices": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "parent_four_seeds": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 12,
+          "matched_strong_probe_orders": 12,
+          "matching_orbit_clause_occurrences": 28,
+          "source_model_index": 0
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 15
+        },
+        {
+          "matched_probe_orders": 4,
+          "matched_strong_probe_orders": 4,
+          "matching_orbit_clause_occurrences": 14,
+          "source_model_index": 19
+        },
+        {
+          "matched_probe_orders": 4,
+          "matched_strong_probe_orders": 4,
+          "matching_orbit_clause_occurrences": 36,
+          "source_model_index": 28
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "1": 12,
+        "2": 4
+      },
+      "strong_probe_order_count": 16
+    },
+    "parent_plus_selected_width3": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 12,
+          "matched_strong_probe_orders": 12,
+          "matching_orbit_clause_occurrences": 28,
+          "source_model_index": 0
+        },
+        {
+          "matched_probe_orders": 4,
+          "matched_strong_probe_orders": 4,
+          "matching_orbit_clause_occurrences": 10,
+          "source_model_index": 2
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 15
+        },
+        {
+          "matched_probe_orders": 4,
+          "matched_strong_probe_orders": 4,
+          "matching_orbit_clause_occurrences": 14,
+          "source_model_index": 19
+        },
+        {
+          "matched_probe_orders": 4,
+          "matched_strong_probe_orders": 4,
+          "matching_orbit_clause_occurrences": 36,
+          "source_model_index": 28
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "1": 12,
+        "3": 4
+      },
+      "strong_probe_order_count": 16
+    },
+    "parent_uncovered_probe_model_indices": [],
+    "selected_width3_covered_probe_model_indices": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "selected_width3_marginal_over_parent_probe_model_indices": [],
+    "selected_width3_only": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 4,
+          "matched_strong_probe_orders": 4,
+          "matching_orbit_clause_occurrences": 10,
+          "source_model_index": 2
+        }
+      ],
+      "covered_probe_order_count": 4,
+      "covered_probe_order_fraction": 0.25,
+      "covered_strong_probe_order_count": 4,
+      "covered_strong_probe_order_fraction": 0.25,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "0": 12,
+        "1": 4
+      },
+      "strong_probe_order_count": 16
+    },
+    "selected_width3_overlap_with_parent_probe_model_indices": [
+      0,
+      1,
+      2,
+      3
+    ]
+  },
+  "decision": "COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES",
+  "distinct_active_seed_orbit_class_count": 5,
+  "inactive_seed_templates": [
+    {
+      "compressed_certificate_sha256": "927e35f69e86103e506d9551848bd6a409dccd8b8567708397064941bf8d5877",
+      "inactive_reason": "ZERO_MARGINAL_TARGETS_BEYOND_SELECTED_WIDTH4_ON_144_ORDER_PACKET",
+      "ordered_quad_count": 5,
+      "seed_id": "persistent_compressed:1",
+      "source_model_index": 1,
+      "source_screen_target_id": "probe:1",
+      "source_target_id": "transfer_cegar_probe:1"
+    },
+    {
+      "canonical_clause_sha256": "2a1134337269121a8b4079afa9888294b5c6529a6ddd902656d6ac01f6058a01",
+      "compressed_certificate_sha256": "f8362079fc6ea9df386ca8b3cc210f3758db59850e2f108ad6c63017cc5b774a",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 7,
+      "seed_id": "residual:0",
+      "source_model_index": 0,
+      "source_target_id": "seeded:0"
+    },
+    {
+      "canonical_clause_sha256": "688754a4f2259235dee0ce04f4b92bf61a6318b4eb02aa8e6bc4d8af6171d985",
+      "compressed_certificate_sha256": "e9efcb62532b22e33a1488b4087ed4fc29d3c763b47293de7331b909113dd98d",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 9,
+      "seed_id": "residual:1",
+      "source_model_index": 1,
+      "source_target_id": "seeded:1"
+    },
+    {
+      "canonical_clause_sha256": "30e4470c4e78617f43f5a3dad6cb61d5ef815069dc51cfb6ed0851cac4ac8867",
+      "compressed_certificate_sha256": "3a3abbda9514b96acaf4ad09c589c2b1a087e08924456ca6fcf33eb9d8d35ef8",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 5,
+      "seed_id": "residual:2",
+      "source_model_index": 2,
+      "source_target_id": "seeded:2"
+    },
+    {
+      "canonical_clause_sha256": "08c7e636bc3eefd93c58b8f58a864916e9f84975e4ad67dab4ecae3402e8fc32",
+      "compressed_certificate_sha256": "721ded29b8624d830c7ed6ff2c15ec544b8c8662701e03f7aadcb1863b96ccae",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 3,
+      "seed_id": "residual:3",
+      "source_model_index": 3,
+      "source_target_id": "seeded:3"
+    },
+    {
+      "canonical_clause_sha256": "844f79396e7613092e180c74a09acabf7ea09e34faeea3525a7846b5dedf37c2",
+      "compressed_certificate_sha256": "58873106a85fd064758c92dab5ed86e479b6de082e9964e0d939e3f7617c36c3",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 7,
+      "seed_id": "residual:4",
+      "source_model_index": 4,
+      "source_target_id": "seeded:4"
+    },
+    {
+      "canonical_clause_sha256": "9443f651b1c48564f709c3a3f6b31982163e24554d34cb161368838e8f0a82bc",
+      "compressed_certificate_sha256": "fc724cd90b08c77c9e596e081bf5de1b03fb9f34fe32486a7daddf39eebb9cb9",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 4,
+      "seed_id": "residual:5",
+      "source_model_index": 5,
+      "source_target_id": "seeded:5"
+    },
+    {
+      "canonical_clause_sha256": "b0a00925436f41f730b62d9d038110d3d2f378b6bc7a315cd89e28915b934e68",
+      "compressed_certificate_sha256": "1b589e8f5a2740c1ffb0244713b246e8cb9d48bc72d3caf358a280528f1b9805",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 6,
+      "seed_id": "residual:6",
+      "source_model_index": 6,
+      "source_target_id": "seeded:6"
+    },
+    {
+      "canonical_clause_sha256": "46e63bc7b5da9b7781532a95387b53cee9065d4becae5aa8409b1a102cc9b4aa",
+      "compressed_certificate_sha256": "75509de4030d9b89c00358503d3ed00f9d1733e07666eb1c2035f7cfbbae9814",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 4,
+      "seed_id": "residual:7",
+      "source_model_index": 7,
+      "source_target_id": "seeded:7"
+    },
+    {
+      "canonical_clause_sha256": "031f49008a7141bfeca38e246b980d5ff9c9ceafbd1906a06dd5dd04d00d3d99",
+      "compressed_certificate_sha256": "624bf38bbc9768b5cbea7dbb2fe4b2d902037856e331b1e5dfb5e039b7327e72",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 6,
+      "seed_id": "persistent_augmented_residual_compressed:0",
+      "source_model_index": 0,
+      "source_target_id": "residual:0"
+    },
+    {
+      "canonical_clause_sha256": "3454cf41222ca2a2f424f1a3f2f7e1dc011bd0c70ee7de0fd2816caccd4e66a5",
+      "compressed_certificate_sha256": "641e516995a9334447704b904acbd304ed08f3542df6bf6a0df7e13f1160490f",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 6,
+      "seed_id": "persistent_augmented_residual_compressed:1",
+      "source_model_index": 1,
+      "source_target_id": "residual:1"
+    },
+    {
+      "canonical_clause_sha256": "f2220c1fe3b90b137b2cb4b9679c4ca1ea814fa341a635a6fd84c1c19921b550",
+      "compressed_certificate_sha256": "e36ccbea23b58810856633af7c9fd5341a346661a22e358c8136efc8ed63cbb7",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 8,
+      "seed_id": "persistent_augmented_residual_compressed:3",
+      "source_model_index": 3,
+      "source_target_id": "residual:3"
+    },
+    {
+      "canonical_clause_sha256": "6349022671fa2f0217254acb0534b027422893a203abb0af6e0565a46216ce2e",
+      "compressed_certificate_sha256": "fbe2c4404bca7188fa903eea6704171144e454df454cbb558467d01416509c3a",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 4,
+      "seed_id": "persistent_augmented_residual_compressed:4",
+      "source_model_index": 4,
+      "source_target_id": "residual:4"
+    },
+    {
+      "canonical_clause_sha256": "716297fef78455ed9ff7468de591e121b2fcb79bf2f4a8faaee291c7c85b0d5f",
+      "compressed_certificate_sha256": "b02ae34b4ba9cf837f30512e581498efc6e929957c8188a17bd29c2e029627bc",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 7,
+      "seed_id": "persistent_augmented_residual_compressed:5",
+      "source_model_index": 5,
+      "source_target_id": "residual:5"
+    },
+    {
+      "canonical_clause_sha256": "0e9df79690878d0f014b022dbd13d22de8c7c53e5683020918d6ed1341789cae",
+      "compressed_certificate_sha256": "55e031c4337784b357928248a8e9ad6fcfc2181fc220cb6e6389be62c7ed7f43",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 3,
+      "seed_id": "persistent_augmented_residual_compressed:6",
+      "source_model_index": 6,
+      "source_target_id": "residual:6"
+    },
+    {
+      "canonical_clause_sha256": "c130f5e2411d4dc4e5b3ec1f834ba5fc0f52f24429e572d41828190e554cc791",
+      "compressed_certificate_sha256": "b23307341ba52bef07383b32b1f0265580666c1735a3e50da423c578af6d4981",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 4,
+      "seed_id": "persistent_augmented_residual_compressed:7",
+      "source_model_index": 7,
+      "source_target_id": "residual:7"
+    }
+  ],
+  "n": 25,
+  "next_target": "Compress the eight newly learned exact C25 certificates, build their quotient-preserving affine orbits, and compare marginal coverage against the four parent seeds and the selected width-three orbit before choosing a 192-history CEGAR seed packet.",
+  "pattern": "C25_sidon_2_5_9_14",
+  "seeded_cegar": {
+    "active_unique_seed_orbit_clause_count": 125,
+    "blocked_history_dihedral_order_count": 168,
+    "final_inverse_pair_clause_count": 15094,
+    "initial_probe_inverse_clause_count": 14485,
+    "iterations": 81,
+    "models": [
+      {
+        "dihedral_order_sha256": "0c51120774bdecd9e7cb71cff2477aaf06c4e6c923aaeb821fd92124ade0f0f0",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "55a245aef6bfcab9934eb0d384be9991cc4197a7f881441b2897a4bfd7935bbc",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 0,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 219,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              5,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  16
+                ],
+                "weight": 20925823996697650066
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  2
+                ],
+                "weight": 3445601851336887806
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  7
+                ],
+                "weight": 2338946756845094473
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  5,
+                  6
+                ],
+                "weight": 5532011715574686238
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  15,
+                  9
+                ],
+                "weight": 782072033351750395
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  12,
+                  14
+                ],
+                "weight": 4233942880432933518
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  23,
+                  6
+                ],
+                "weight": 98156566949104597
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  5
+                ],
+                "weight": 8097343504867399191
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  23
+                ],
+                "weight": 2512618944635154053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  3
+                ],
+                "weight": 11273082418293075021
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  5,
+                  24
+                ],
+                "weight": 6221526570294906913
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  5,
+                  21
+                ],
+                "weight": 1875816934572492278
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  24,
+                  6
+                ],
+                "weight": 6221526570294906913
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  10,
+                  4
+                ],
+                "weight": 804021969532562695
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  21,
+                  3
+                ],
+                "weight": 1191901468169846480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  17,
+                  14
+                ],
+                "weight": 2902433508730343429
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  16,
+                  14
+                ],
+                "weight": 5784548608181982279
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  18,
+                  15
+                ],
+                "weight": 782072033351750395
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  5,
+                  14
+                ],
+                "weight": 17275823075707627432
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  16,
+                  13
+                ],
+                "weight": 2210168215161344231
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  10,
+                  6
+                ],
+                "weight": 4607221792088000833
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  12
+                ],
+                "weight": 13275234200721409295
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  1,
+                  9
+                ],
+                "weight": 9004132666279189131
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  23,
+                  17
+                ],
+                "weight": 2911630281436179169
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  13,
+                  4
+                ],
+                "weight": 5065580107437813852
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  10,
+                  3
+                ],
+                "weight": 6170674331916169633
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  3,
+                  14
+                ],
+                "weight": 8287645772132636392
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  17,
+                  14
+                ],
+                "weight": 9196772705835740
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  10,
+                  7
+                ],
+                "weight": 2855411892276469621
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  21,
+                  18
+                ],
+                "weight": 683915466402645798
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  7,
+                  4
+                ],
+                "weight": 7585530391818447003
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  7,
+                  3
+                ],
+                "weight": 8100305828267250668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  12,
+                  3
+                ],
+                "weight": 6851799593994755779
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  4,
+                  1
+                ],
+                "weight": 5869602076970376547
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  23,
+                  3
+                ],
+                "weight": 15685836220085697671
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  6,
+                  14
+                ],
+                "weight": 98156566949104597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 5142586319910479879
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  23,
+                  14
+                ],
+                "weight": 3134530589308812584
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  3,
+                  14
+                ],
+                "weight": 11085742474427689297
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  7
+                ],
+                "weight": 3398362216213857770
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  4
+                ],
+                "weight": 1769561963944900249
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  21,
+                  20
+                ],
+                "weight": 1106036783856516533
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  4,
+                  1
+                ],
+                "weight": 2573583933477462944
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  19,
+                  4
+                ],
+                "weight": 3979730179106244480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  19,
+                  20
+                ],
+                "weight": 1722322328821870213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  2,
+                  3
+                ],
+                "weight": 2116971440216466759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  5,
+                  16
+                ],
+                "weight": 5532011715574686238
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  10,
+                  14
+                ],
+                "weight": 5237041440647781353
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  1,
+                  12
+                ],
+                "weight": 465011067280333340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  2,
+                  6
+                ],
+                "weight": 5532011715574686238
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  12,
+                  23
+                ],
+                "weight": 3988246321246219688
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  24,
+                  6
+                ],
+                "weight": 7522853808703183117
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  10,
+                  7
+                ],
+                "weight": 528777990423851731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  7,
+                  3
+                ],
+                "weight": 2116971440216466759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  17,
+                  3
+                ],
+                "weight": 1472767570078648743
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  24,
+                  10,
+                  7
+                ],
+                "weight": 528777990423851731
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  18,
+                  9
+                ],
+                "weight": 7522853808703183117
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  21,
+                  18
+                ],
+                "weight": 3436450920507858832
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  9,
+                  20
+                ],
+                "weight": 6294597421495484815
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  15,
+                  3
+                ],
+                "weight": 1027768592538464225
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  4,
+                  9
+                ],
+                "weight": 3514719111825911140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  7,
+                  17,
+                  14
+                ],
+                "weight": 4233942880432933518
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  23,
+                  6
+                ],
+                "weight": 4086402888195324285
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  12,
+                  6
+                ],
+                "weight": 245696559186713830
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  4,
+                  1,
+                  14
+                ],
+                "weight": 2108572866197129604
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 5706710450511582261
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  19,
+                  21
+                ],
+                "weight": 11273082418293075021
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  16,
+                  14
+                ],
+                "weight": 2902433508730343429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  13,
+                  18
+                ],
+                "weight": 17766931921351958794
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  18,
+                  23
+                ],
+                "weight": 12005473763922857513
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  15,
+                  23
+                ],
+                "weight": 2451653419477716236
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  1,
+                  20
+                ],
+                "weight": 128007837646537708
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  18,
+                  14
+                ],
+                "weight": 98156566949104597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  12,
+                  23
+                ],
+                "weight": 60965525157437817
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  17,
+                  14
+                ],
+                "weight": 2804276941781238832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 3499649962034824380
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  7,
+                  15
+                ],
+                "weight": 15723687561987491205
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  15,
+                  1
+                ],
+                "weight": 2701591771124000652
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  9,
+                  17
+                ],
+                "weight": 9645051791241285548
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  10,
+                  1
+                ],
+                "weight": 4303671931567387075
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 13458748187721352291
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  15,
+                  9
+                ],
+                "weight": 10570442371385774317
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  6,
+                  3
+                ],
+                "weight": 11600558831475870549
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  21,
+                  6,
+                  14
+                ],
+                "weight": 4061482704000769548
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  18,
+                  6
+                ],
+                "weight": 5663301590479996684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  12,
+                  9,
+                  6
+                ],
+                "weight": 60965525157437817
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  23,
+                  9,
+                  3
+                ],
+                "weight": 864425054987050952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  20
+                ],
+                "weight": 1652916406635250612
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  23
+                ],
+                "weight": 855120340527229297
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  17
+                ],
+                "weight": 2511368201784330279
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  13,
+                  4
+                ],
+                "weight": 2210168215161344231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  21,
+                  15
+                ],
+                "weight": 180748780342442080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  7,
+                  6
+                ],
+                "weight": 3384189882700321352
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  1
+                ],
+                "weight": 1652916406635250612
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  24,
+                  12
+                ],
+                "weight": 13602006842873344452
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  2,
+                  3
+                ],
+                "weight": 2116971440216466759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  13,
+                  1
+                ],
+                "weight": 2001739140963184525
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  24,
+                  21
+                ],
+                "weight": 11453831198635517101
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  24,
+                  18
+                ],
+                "weight": 16984859888000208399
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  15,
+                  20
+                ],
+                "weight": 1850330166468407921
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  10,
+                  17
+                ],
+                "weight": 21171651247177038954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  1,
+                  9
+                ],
+                "weight": 956496015107957646
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  17,
+                  14
+                ],
+                "weight": 8686982116912325708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  21,
+                  9,
+                  17
+                ],
+                "weight": 771764981078681633
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  7,
+                  1,
+                  17
+                ],
+                "weight": 1045243125855226879
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  1,
+                  12,
+                  23
+                ],
+                "weight": 13602006842873344452
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  12,
+                  9,
+                  6
+                ],
+                "weight": 184731034029276013
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  2,
+                  20
+                ],
+                "weight": 2144503006875167505
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  9,
+                  3
+                ],
+                "weight": 3198056664876371423
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  10,
+                  23
+                ],
+                "weight": 2385521230038190749
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  21,
+                  15
+                ],
+                "weight": 81201929847921961
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  4,
+                  9
+                ],
+                "weight": 4261414993079769991
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  9,
+                  20
+                ],
+                "weight": 111342858155822479
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  9,
+                  17
+                ],
+                "weight": 2144503006875167505
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  24,
+                  10
+                ],
+                "weight": 11635895720860676879
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  7,
+                  4
+                ],
+                "weight": 3384189882700321352
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  21,
+                  4
+                ],
+                "weight": 3251526201172175125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  4,
+                  3
+                ],
+                "weight": 164132875631382255
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  15,
+                  20,
+                  14
+                ],
+                "weight": 180748780342442080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  1,
+                  12,
+                  9
+                ],
+                "weight": 1192487536827591416
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 1657498604107924756
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 7991411674788322185
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  13
+                ],
+                "weight": 10599052040849097280
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  13,
+                  20
+                ],
+                "weight": 3002954802024247172
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  10,
+                  9
+                ],
+                "weight": 17951751744191033550
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  7,
+                  20
+                ],
+                "weight": 5590370712105605815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  15,
+                  12
+                ],
+                "weight": 5779948567967927680
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  20,
+                  17
+                ],
+                "weight": 2511368201784330279
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  24,
+                  12
+                ],
+                "weight": 10599052040849097280
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  13,
+                  24,
+                  10
+                ],
+                "weight": 3002954802024247172
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  18,
+                  4
+                ],
+                "weight": 7744536331283208104
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 16769988932257689175
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  4,
+                  17
+                ],
+                "weight": 400262079651848890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  7,
+                  23
+                ],
+                "weight": 27153825585251335133
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  21,
+                  18,
+                  6
+                ],
+                "weight": 3456815195416627519
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  7,
+                  15,
+                  1
+                ],
+                "weight": 876277806265404957
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  18,
+                  15,
+                  1
+                ],
+                "weight": 11201351526699835623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  18,
+                  4,
+                  1
+                ],
+                "weight": 10506361641289229741
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  18,
+                  23,
+                  9
+                ],
+                "weight": 8968163391060688235
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  1,
+                  6
+                ],
+                "weight": 17857577900933168260
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  4,
+                  9,
+                  3
+                ],
+                "weight": 3162087389657870527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  12,
+                  23,
+                  17
+                ],
+                "weight": 17109046154380606379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  18
+                ],
+                "weight": 13858264774655586864
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  23
+                ],
+                "weight": 22408803682470736521
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  14
+                ],
+                "weight": 2868995167173178132
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  15,
+                  6
+                ],
+                "weight": 5698746638120005719
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  4,
+                  17
+                ],
+                "weight": 2817205733684046192
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  24,
+                  7
+                ],
+                "weight": 528777990423851731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  1,
+                  23
+                ],
+                "weight": 10156914292924395692
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  23,
+                  20
+                ],
+                "weight": 7906064482928700106
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  23
+                ],
+                "weight": 528777990423851731
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  21,
+                  7,
+                  1
+                ],
+                "weight": 5739198539988181204
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  7,
+                  18,
+                  12
+                ],
+                "weight": 19846090918104909521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  7,
+                  23,
+                  9
+                ],
+                "weight": 22213166737270803541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  4,
+                  1,
+                  23
+                ],
+                "weight": 3621370848042090053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  4,
+                  20,
+                  6
+                ],
+                "weight": 1824107170583177398
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  1,
+                  12,
+                  17
+                ],
+                "weight": 14127107875294419658
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 13059237378772442987
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  21,
+                  6
+                ],
+                "weight": 3456815195416627519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  21,
+                  6
+                ],
+                "weight": 3998507326383767521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  9,
+                  14
+                ],
+                "weight": 111342858155822479
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  24,
+                  4,
+                  14
+                ],
+                "weight": 1605406180136925886
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  20,
+                  14
+                ],
+                "weight": 2766849081723191393
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  18
+                ],
+                "weight": 3499649962034824380
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  7,
+                  18,
+                  15
+                ],
+                "weight": 6926857453032883813
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  4,
+                  23
+                ],
+                "weight": 24685133490451802463
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  12,
+                  17
+                ],
+                "weight": 4952511967853377957
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  15,
+                  1,
+                  20
+                ],
+                "weight": 3098083470834601673
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  1,
+                  20,
+                  3
+                ],
+                "weight": 3098083470834601673
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  12,
+                  23,
+                  20
+                ],
+                "weight": 2276329807981065942
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  20,
+                  6,
+                  14
+                ],
+                "weight": 3831772403838448040
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  3
+                ],
+                "weight": 1472767570078648743
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  21,
+                  17
+                ],
+                "weight": 1259711248733376784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  4,
+                  12
+                ],
+                "weight": 32306765208838162644
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  23
+                ],
+                "weight": 2738796077650390737
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  18,
+                  17
+                ],
+                "weight": 4659771074561617270
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  1,
+                  6
+                ],
+                "weight": 7455322521800395040
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  12,
+                  17
+                ],
+                "weight": 16111618092963572794
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  12,
+                  14
+                ],
+                "weight": 13170580236928265466
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  23,
+                  17
+                ],
+                "weight": 487946267654695151
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  7,
+                  12,
+                  17
+                ],
+                "weight": 3024566878946324384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  15,
+                  9,
+                  20
+                ],
+                "weight": 9756394649397108027
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  9
+                ],
+                "weight": 3935441667574820923
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  4,
+                  20
+                ],
+                "weight": 7185268312166598113
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  18,
+                  4,
+                  12
+                ],
+                "weight": 683915466402645798
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  1,
+                  12
+                ],
+                "weight": 21707713167989065364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  1,
+                  23
+                ],
+                "weight": 5142586319910479879
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 4613808329486628148
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  12,
+                  9,
+                  3
+                ],
+                "weight": 1472767570078648743
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 2276329807981065942
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 13744380378998090030
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 12228447201870855448
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  1,
+                  20
+                ],
+                "weight": 1106036783856516533
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  7,
+                  15,
+                  3
+                ],
+                "weight": 19273019399435321177
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  7,
+                  1,
+                  14
+                ],
+                "weight": 7933538796280484113
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  18,
+                  12,
+                  20
+                ],
+                "weight": 2276329807981065942
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  15,
+                  12,
+                  3
+                ],
+                "weight": 20381989921821707363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  4,
+                  23,
+                  20
+                ],
+                "weight": 3621370848042090053
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  23,
+                  9,
+                  17
+                ],
+                "weight": 3445867705230438310
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 8752458101763476342
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  18,
+                  12
+                ],
+                "weight": 17439116666538333205
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  4,
+                  17
+                ],
+                "weight": 164132875631382255
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  18,
+                  15,
+                  3
+                ],
+                "weight": 81201929847921961
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  1,
+                  12,
+                  23
+                ],
+                "weight": 24978219624689764449
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  1,
+                  9,
+                  14
+                ],
+                "weight": 1192487536827591416
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  4,
+                  12
+                ],
+                "weight": 13455132468788823550
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  15,
+                  1,
+                  12
+                ],
+                "weight": 6926857453032883813
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  23,
+                  3
+                ],
+                "weight": 34958855619521018848
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  23,
+                  9,
+                  6
+                ],
+                "weight": 17830783267193414315
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  9,
+                  20,
+                  17
+                ],
+                "weight": 5590370712105605815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  9,
+                  6,
+                  14
+                ],
+                "weight": 12167481676713417631
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  6,
+                  17
+                ],
+                "weight": 5033713897701299918
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  23,
+                  17,
+                  3
+                ],
+                "weight": 81201929847921961
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  17,
+                  14
+                ],
+                "weight": 180748780342442080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  1,
+                  12,
+                  14
+                ],
+                "weight": 683915466402645798
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  9,
+                  20,
+                  14
+                ],
+                "weight": 6553384349837926154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  17,
+                  3
+                ],
+                "weight": 3162087389657870527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  12,
+                  20,
+                  3
+                ],
+                "weight": 64003918823268854
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  9,
+                  20,
+                  3
+                ],
+                "weight": 3162087389657870527
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  20,
+                  6,
+                  14
+                ],
+                "weight": 2902360726341920194
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 220,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 1375595537629549278028
+          },
+          "certificate_sha256": "13bd5e616c63e0ea2980b54d3b09b588aea2d96e38dc8a9febd9ea6884022f4b",
+          "max_weight": 34958855619521018848,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 220,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 219,
+          "weight_sum": 1375595537629549278028,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 0,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "0c51120774bdecd9e7cb71cff2477aaf06c4e6c923aaeb821fd92124ade0f0f0",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 74
+      },
+      {
+        "dihedral_order_sha256": "2c01223fc713b5e71f5b20bd5ea76e7e9ea829f5eeaf40dc90578681783e387b",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "2d2162ae68dee09b1f7be8a4524167121fb8d5a01342617d60770c83d4818ce6",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 1,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              16,
+              5,
+              2,
+              13,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 220,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              16,
+              5,
+              2,
+              13,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  19
+                ],
+                "weight": 268166159318277193859
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  23
+                ],
+                "weight": 16182506457582229890
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  19,
+                  24
+                ],
+                "weight": 58142070693474663594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  16,
+                  18
+                ],
+                "weight": 10817760469914665680
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  10,
+                  15
+                ],
+                "weight": 96637939791538050698
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  21,
+                  6
+                ],
+                "weight": 16587960433992246105
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  1,
+                  14
+                ],
+                "weight": 8326976944350230971
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  20,
+                  3
+                ],
+                "weight": 3297732347599893850
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  24
+                ],
+                "weight": 215775797985079449510
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  2,
+                  3
+                ],
+                "weight": 96704095600249509915
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  24,
+                  17
+                ],
+                "weight": 171462063718027683944
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  10,
+                  1
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  15,
+                  14
+                ],
+                "weight": 200203925741180843028
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  4,
+                  3
+                ],
+                "weight": 22208427788077867260
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  13,
+                  9
+                ],
+                "weight": 16182506457582229890
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  16,
+                  13
+                ],
+                "weight": 5751709360276919245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  13,
+                  12
+                ],
+                "weight": 5751709360276919245
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  5,
+                  23
+                ],
+                "weight": 29085149341647433250
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  2,
+                  15
+                ],
+                "weight": 103565985949642792330
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  13,
+                  10
+                ],
+                "weight": 18435778311156084535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  24,
+                  1
+                ],
+                "weight": 3943740138036531896
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  9,
+                  20
+                ],
+                "weight": 33130370908564062899
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  9,
+                  6
+                ],
+                "weight": 27514384199266760519
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 40369994129015233670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  12,
+                  17
+                ],
+                "weight": 11685485880227726585
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  7,
+                  6
+                ],
+                "weight": 16167036882270266726
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  20,
+                  6
+                ],
+                "weight": 82477783900838872044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  6,
+                  14
+                ],
+                "weight": 43136938644658058715
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  4,
+                  9
+                ],
+                "weight": 16587960433992246105
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  21,
+                  20,
+                  6
+                ],
+                "weight": 26969901762387791989
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  18,
+                  14
+                ],
+                "weight": 17299818008043223957
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  12,
+                  9
+                ],
+                "weight": 16167036882270266726
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  9,
+                  17
+                ],
+                "weight": 6482057538128558277
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  23,
+                  9
+                ],
+                "weight": 38796388222070113365
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  12,
+                  20
+                ],
+                "weight": 107614385856793194
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  3,
+                  14
+                ],
+                "weight": 22208427788077867260
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  17,
+                  14
+                ],
+                "weight": 11685485880227726585
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  19
+                ],
+                "weight": 63732633336629218693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  2,
+                  15
+                ],
+                "weight": 207449286349819320814
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  21,
+                  7
+                ],
+                "weight": 31737349887311568523
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  12,
+                  3
+                ],
+                "weight": 3297732347599893850
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  9,
+                  17
+                ],
+                "weight": 22317783846089313516
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  13,
+                  20
+                ],
+                "weight": 1599962330823664394
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  10,
+                  17
+                ],
+                "weight": 62132671005805554299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  7,
+                  12
+                ],
+                "weight": 4114519764048288919
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  16,
+                  6
+                ],
+                "weight": 24625130811160582604
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  16,
+                  17
+                ],
+                "weight": 109820339026234562042
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  5,
+                  21
+                ],
+                "weight": 32186487744648042029
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  5,
+                  20
+                ],
+                "weight": 1186245380991861304
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  2,
+                  23
+                ],
+                "weight": 65637302094396042424
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  10,
+                  3
+                ],
+                "weight": 66897142005494145485
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  21,
+                  9
+                ],
+                "weight": 449137857336473506
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  12,
+                  14
+                ],
+                "weight": 8326976944350230971
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  23,
+                  9
+                ],
+                "weight": 16943466975462008157
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  4,
+                  17
+                ],
+                "weight": 33372733125639903333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  24,
+                  7
+                ],
+                "weight": 5161165696082848092
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  15,
+                  4
+                ],
+                "weight": 119138323502631501087
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  10,
+                  9
+                ],
+                "weight": 29755203718749665456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  7,
+                  23
+                ],
+                "weight": 32783995819346127696
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  4,
+                  14
+                ],
+                "weight": 813060189568970959
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  4,
+                  9
+                ],
+                "weight": 63303236389557511686
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  6,
+                  17
+                ],
+                "weight": 36849926906071497850
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  17,
+                  14
+                ],
+                "weight": 25297150032439816692
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  21,
+                  18,
+                  23
+                ],
+                "weight": 10831533327950449429
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  4,
+                  12
+                ],
+                "weight": 21649293797865115109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  18,
+                  12,
+                  17
+                ],
+                "weight": 2979366186350503176
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  1,
+                  3
+                ],
+                "weight": 8326976944350230971
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  12,
+                  23,
+                  20
+                ],
+                "weight": 10489555714252339078
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  19,
+                  14
+                ],
+                "weight": 153009020671709326937
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  16,
+                  23
+                ],
+                "weight": 25258183141395162151
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  24,
+                  1
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  21,
+                  18
+                ],
+                "weight": 849493410011965293
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  20,
+                  17
+                ],
+                "weight": 47420984645674670390
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  21
+                ],
+                "weight": 965856023259096120
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  23,
+                  14
+                ],
+                "weight": 19943985174527959841
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  2,
+                  14
+                ],
+                "weight": 180259940566652883187
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  13,
+                  9
+                ],
+                "weight": 25258183141395162151
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  20,
+                  3
+                ],
+                "weight": 13585144644124762078
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  21,
+                  20
+                ],
+                "weight": 965856023259096120
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 2982269174341480145
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  10,
+                  4
+                ],
+                "weight": 34197622874497412991
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  6,
+                  17
+                ],
+                "weight": 142018987206877974933
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 29922000454040507110
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  7,
+                  17
+                ],
+                "weight": 12141193344383971418
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  4,
+                  20
+                ],
+                "weight": 37061354392809637493
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  18,
+                  17
+                ],
+                "weight": 9461423724479061453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  4,
+                  23
+                ],
+                "weight": 34417119507216478488
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  12,
+                  14
+                ],
+                "weight": 3297732347599893850
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  23,
+                  6
+                ],
+                "weight": 5314197966867202310
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  15,
+                  4,
+                  14
+                ],
+                "weight": 7245360608638477786
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  4,
+                  9,
+                  6
+                ],
+                "weight": 22317783846089313516
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 108625111091802508947
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  15
+                ],
+                "weight": 129114340216389897978
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  18
+                ],
+                "weight": 27060195440704246140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  2,
+                  9
+                ],
+                "weight": 25207037234195491431
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  7,
+                  15
+                ],
+                "weight": 4114519764048288919
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  2,
+                  17
+                ],
+                "weight": 64515311818813922498
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  10,
+                  6
+                ],
+                "weight": 39340845256180813329
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  21,
+                  14
+                ],
+                "weight": 27060195440704246140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 120458712851984821749
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  24,
+                  15
+                ],
+                "weight": 68553435481113266359
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  18,
+                  14
+                ],
+                "weight": 21168913571896147570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  10,
+                  12
+                ],
+                "weight": 4114519764048288919
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  21,
+                  4
+                ],
+                "weight": 11673156750347293795
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  18,
+                  14
+                ],
+                "weight": 15942369499305399687
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  10,
+                  15,
+                  9
+                ],
+                "weight": 19417009303988156762
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  21,
+                  4,
+                  3
+                ],
+                "weight": 7397534329890387914
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  20,
+                  3
+                ],
+                "weight": 37883858781039574642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  7,
+                  4,
+                  1
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  18,
+                  15,
+                  1
+                ],
+                "weight": 37960776481213512550
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 45326102487341949039
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  15,
+                  9,
+                  14
+                ],
+                "weight": 28441540080601418303
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  15,
+                  20,
+                  14
+                ],
+                "weight": 7937163533811431354
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  23,
+                  6,
+                  14
+                ],
+                "weight": 54401779171154881300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 108625111091802508947
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  24,
+                  20
+                ],
+                "weight": 58890171851545401622
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  2,
+                  20
+                ],
+                "weight": 28854748488107157018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  21,
+                  12
+                ],
+                "weight": 40458625511893879519
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  15,
+                  4
+                ],
+                "weight": 12295611610955865119
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  12,
+                  23
+                ],
+                "weight": 40458625511893879519
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  21
+                ],
+                "weight": 3647711253911665587
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  15
+                ],
+                "weight": 145524471591394052016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  9,
+                  6
+                ],
+                "weight": 24625130811160582604
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  21,
+                  12
+                ],
+                "weight": 54223331920647627647
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  3,
+                  14
+                ],
+                "weight": 24427624629709833983
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  7,
+                  18
+                ],
+                "weight": 19188437015506779857
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  7,
+                  4,
+                  20
+                ],
+                "weight": 15073917251458490938
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  18,
+                  4,
+                  12
+                ],
+                "weight": 18870988157362489290
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  18,
+                  20,
+                  14
+                ],
+                "weight": 7871758425197466283
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  15,
+                  1,
+                  23
+                ],
+                "weight": 5234691407974203064
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  4,
+                  1,
+                  12
+                ],
+                "weight": 21649293797865115109
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  1,
+                  12,
+                  23
+                ],
+                "weight": 26883985205839318173
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 49832168045356074035
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  5,
+                  7,
+                  17
+                ],
+                "weight": 14279283394229511335
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  5,
+                  18,
+                  6
+                ],
+                "weight": 1574163689670145694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  5,
+                  1,
+                  9
+                ],
+                "weight": 10338194414761508694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  13,
+                  1
+                ],
+                "weight": 10338194414761508694
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  13,
+                  23
+                ],
+                "weight": 31376365913495883531
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  24,
+                  9
+                ],
+                "weight": 56740218189141969103
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  3,
+                  14
+                ],
+                "weight": 10842479985585071905
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  24,
+                  4
+                ],
+                "weight": 12141682366185425093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  10,
+                  6
+                ],
+                "weight": 13141550755350085031
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  15,
+                  1
+                ],
+                "weight": 27635874023630242009
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  12,
+                  3
+                ],
+                "weight": 8326976944350230971
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  21,
+                  18
+                ],
+                "weight": 9991728703781992574
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  4,
+                  23
+                ],
+                "weight": 12141682366185425093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  9,
+                  3
+                ],
+                "weight": 24427624629709833983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  21,
+                  17
+                ],
+                "weight": 13141550755350085031
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  18,
+                  15
+                ],
+                "weight": 2087519756883136361
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  20,
+                  17,
+                  3
+                ],
+                "weight": 45305027207420639544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  13,
+                  21
+                ],
+                "weight": 18435778311156084535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  24,
+                  17
+                ],
+                "weight": 47652016519869414668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  7,
+                  20
+                ],
+                "weight": 43708276381832882772
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  21,
+                  9
+                ],
+                "weight": 10338194414761508694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  7,
+                  4
+                ],
+                "weight": 12295611610955865119
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  21,
+                  15,
+                  4
+                ],
+                "weight": 5742426027764249954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  15,
+                  1
+                ],
+                "weight": 6553185583191615165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  7,
+                  18,
+                  20
+                ],
+                "weight": 28634359130374391834
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  18,
+                  1,
+                  23
+                ],
+                "weight": 12947639859916591963
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  18,
+                  23,
+                  6
+                ],
+                "weight": 1574163689670145694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  24,
+                  15
+                ],
+                "weight": 109553400405094231863
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  7,
+                  3
+                ],
+                "weight": 1132781125772957231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  10,
+                  21
+                ],
+                "weight": 22083489565067750122
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  15,
+                  1
+                ],
+                "weight": 14613816835218414575
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  23,
+                  17
+                ],
+                "weight": 34260936180900158893
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  18,
+                  14
+                ],
+                "weight": 7781384310557748255
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  12,
+                  20
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  7,
+                  1,
+                  12
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  4,
+                  3,
+                  14
+                ],
+                "weight": 83316566338911110600
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  23,
+                  9,
+                  6
+                ],
+                "weight": 52139515010427343123
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  9,
+                  17,
+                  3
+                ],
+                "weight": 51124231479844666723
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 24230009246923471220
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  1
+                ],
+                "weight": 31911496444087147890
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  18,
+                  6
+                ],
+                "weight": 11163984076994253885
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  15
+                ],
+                "weight": 11673156750347293795
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  18,
+                  23
+                ],
+                "weight": 1407629905850244165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  7,
+                  14
+                ],
+                "weight": 37059618239803033577
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  4,
+                  20
+                ],
+                "weight": 17553816457251342225
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  1,
+                  6
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  4,
+                  9,
+                  17
+                ],
+                "weight": 11685485880227726585
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  1,
+                  12,
+                  6
+                ],
+                "weight": 26724744904254444285
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  12,
+                  20,
+                  17
+                ],
+                "weight": 19153778788075006619
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  23,
+                  6,
+                  3
+                ],
+                "weight": 13583194148904359254
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  20,
+                  3,
+                  14
+                ],
+                "weight": 4123436078781171052
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  3
+                ],
+                "weight": 32139842355579877525
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  7,
+                  14
+                ],
+                "weight": 17299818008043223957
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  7,
+                  18,
+                  17
+                ],
+                "weight": 4817859669750449882
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  7,
+                  18,
+                  3
+                ],
+                "weight": 1132781125772957231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  23,
+                  20
+                ],
+                "weight": 22119253814714733800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  1,
+                  9,
+                  20
+                ],
+                "weight": 21589022567118148972
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  12,
+                  6,
+                  14
+                ],
+                "weight": 54223331920647627647
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  9,
+                  6,
+                  17
+                ],
+                "weight": 60464634326965826675
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  7,
+                  23
+                ],
+                "weight": 1407629905850244165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  1,
+                  20
+                ],
+                "weight": 62554052390174021810
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  18,
+                  1,
+                  14
+                ],
+                "weight": 9999422799098787437
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  15,
+                  4,
+                  3
+                ],
+                "weight": 37061354392809637493
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  15,
+                  12,
+                  20
+                ],
+                "weight": 37540915768877101223
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  4,
+                  20,
+                  3
+                ],
+                "weight": 58757991345784579659
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  9,
+                  3,
+                  14
+                ],
+                "weight": 93515290995698847619
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  18,
+                  12
+                ],
+                "weight": 29824094937037193430
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  15,
+                  9
+                ],
+                "weight": 16138822576655772599
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  18,
+                  4,
+                  9
+                ],
+                "weight": 6913313148421615066
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  1,
+                  23,
+                  14
+                ],
+                "weight": 9999422799098787437
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  12,
+                  20,
+                  6
+                ],
+                "weight": 10381941328395545884
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  9,
+                  17,
+                  3
+                ],
+                "weight": 13141550755350085031
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  18,
+                  15,
+                  3
+                ],
+                "weight": 16138822576655772599
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  18,
+                  4,
+                  6
+                ],
+                "weight": 4275622420456905881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  1,
+                  12
+                ],
+                "weight": 37540915768877101223
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  12,
+                  23,
+                  3
+                ],
+                "weight": 15006041450882815368
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  23,
+                  9
+                ],
+                "weight": 16884562406740530736
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  6,
+                  14
+                ],
+                "weight": 43624064223051327443
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  9,
+                  20,
+                  3
+                ],
+                "weight": 29249508760504095865
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  1,
+                  20,
+                  3
+                ],
+                "weight": 21696636952974942166
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  12,
+                  23,
+                  14
+                ],
+                "weight": 34417119507216478488
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  9,
+                  17,
+                  14
+                ],
+                "weight": 40841026033487183367
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 19153778788075006619
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  9,
+                  17
+                ],
+                "weight": 4704460160377618236
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 10489555714252339078
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  9,
+                  6
+                ],
+                "weight": 10381941328395545884
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 12752626665744072057
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 220,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 7343287900958483646690
+          },
+          "certificate_sha256": "351fd833f95a984d6539c8a20458e9cee599c16b7975cd86ab5f783fc9629ce2",
+          "max_weight": 268166159318277193859,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 220,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 220,
+          "weight_sum": 7343287900958483646690,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 1,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          16,
+          5,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "2c01223fc713b5e71f5b20bd5ea76e7e9ea829f5eeaf40dc90578681783e387b",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 75
+      },
+      {
+        "dihedral_order_sha256": "7a844de5b47bc27fafa790fb4de59dd3c5fb08f89356333036fc98f0df98f7f8",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "42fa08e86d26b7beaac32ab83810502dd46db99eccf74e96e1f3573ca4c70cb5",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 2,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              5,
+              19,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 214,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              5,
+              19,
+              16,
+              2,
+              13,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  14
+                ],
+                "weight": 5977907594860886657
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  5
+                ],
+                "weight": 10073974474854798974
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  15,
+                  9
+                ],
+                "weight": 2274230199131721465
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  4,
+                  9
+                ],
+                "weight": 27367330816455900550
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  20,
+                  14
+                ],
+                "weight": 31970718100692604190
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  23
+                ],
+                "weight": 5977907594860886657
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  14
+                ],
+                "weight": 270526533575569719
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  9,
+                  3
+                ],
+                "weight": 13853681987003844280
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  6,
+                  17
+                ],
+                "weight": 16835793648637234637
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  16,
+                  4
+                ],
+                "weight": 4929050386524717577
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  18
+                ],
+                "weight": 18772087600831528740
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  13,
+                  23
+                ],
+                "weight": 5144924088330081397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  13
+                ],
+                "weight": 13105532695656342193
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  18,
+                  6
+                ],
+                "weight": 11144081356136013268
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  13,
+                  24
+                ],
+                "weight": 27003988248209940390
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  18,
+                  12
+                ],
+                "weight": 6248434128436456376
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  15,
+                  14
+                ],
+                "weight": 11949160192096564497
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  23,
+                  6
+                ],
+                "weight": 10283430080952165248
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  6,
+                  3
+                ],
+                "weight": 22375089508945906686
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  7
+                ],
+                "weight": 36850859985056109453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  1,
+                  20
+                ],
+                "weight": 4614667156422811623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  12,
+                  20
+                ],
+                "weight": 6248434128436456376
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  23,
+                  17
+                ],
+                "weight": 2207585992246444957
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  17,
+                  3
+                ],
+                "weight": 16835793648637234637
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  21,
+                  14
+                ],
+                "weight": 9846871736846169063
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  7,
+                  4
+                ],
+                "weight": 36850859985056109453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  15,
+                  17
+                ],
+                "weight": 9846871736846169063
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  21,
+                  9,
+                  6
+                ],
+                "weight": 17783371720494962807
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  18,
+                  1
+                ],
+                "weight": 4614667156422811623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  12
+                ],
+                "weight": 6248434128436456376
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  3
+                ],
+                "weight": 3235095040163752527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  3
+                ],
+                "weight": 24070262128074455025
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  3,
+                  14
+                ],
+                "weight": 13853681987003844280
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  16
+                ],
+                "weight": 10073974474854798974
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  13,
+                  20
+                ],
+                "weight": 294839958048351988549
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  24,
+                  3
+                ],
+                "weight": 14550621658005472005
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  1,
+                  14
+                ],
+                "weight": 40718097459894596696
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  23,
+                  9
+                ],
+                "weight": 3453967842421577991
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  19,
+                  13
+                ],
+                "weight": 9471230506629149336
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  24,
+                  1
+                ],
+                "weight": 28404303645009316285
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  24,
+                  3
+                ],
+                "weight": 3071591934064004453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  4,
+                  14
+                ],
+                "weight": 37948625695553490847
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  23,
+                  17
+                ],
+                "weight": 602743968225649638
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  16,
+                  4
+                ],
+                "weight": 9471230506629149336
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  4,
+                  23
+                ],
+                "weight": 4056711810647227629
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  2,
+                  24
+                ],
+                "weight": 6316533770768974904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  12,
+                  17
+                ],
+                "weight": 646318818567950034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  6,
+                  17
+                ],
+                "weight": 2743085748562579491
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  10,
+                  9
+                ],
+                "weight": 3389404567130529525
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  21,
+                  17
+                ],
+                "weight": 9673197588098173498
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  7,
+                  20
+                ],
+                "weight": 32963915081850089720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  17,
+                  3
+                ],
+                "weight": 3389404567130529525
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  21,
+                  18,
+                  15
+                ],
+                "weight": 3071591934064004453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  12,
+                  20
+                ],
+                "weight": 9673197588098173498
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  21,
+                  20,
+                  6
+                ],
+                "weight": 568008327115647836
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  15,
+                  17
+                ],
+                "weight": 6783280656806823208
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  12,
+                  23
+                ],
+                "weight": 26180634425043266512
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  3,
+                  14
+                ],
+                "weight": 3071591934064004453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  9,
+                  6
+                ],
+                "weight": 3711688722742818755
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  4,
+                  1,
+                  12
+                ],
+                "weight": 14638006689744817926
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  1,
+                  6,
+                  3
+                ],
+                "weight": 26951800504630098337
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  12,
+                  20,
+                  14
+                ],
+                "weight": 36500150831709390044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  5,
+                  23
+                ],
+                "weight": 29928409006527901198
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  19,
+                  17
+                ],
+                "weight": 33623692021270255327
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  19,
+                  3
+                ],
+                "weight": 37040383997211585002
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  18,
+                  14
+                ],
+                "weight": 25623818539860522693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  15,
+                  1
+                ],
+                "weight": 13716104394637056178
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  4,
+                  17
+                ],
+                "weight": 3158266885384487452
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  12,
+                  6
+                ],
+                "weight": 83039643454428873739
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  10
+                ],
+                "weight": 15895724870246698503
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  13,
+                  14
+                ],
+                "weight": 14032684136281202695
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  1,
+                  3
+                ],
+                "weight": 28404303645009316285
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  19,
+                  2,
+                  20
+                ],
+                "weight": 70393549484906270610
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  10,
+                  23
+                ],
+                "weight": 18138846492565194769
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  7,
+                  6
+                ],
+                "weight": 7830852852536302708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  9,
+                  14
+                ],
+                "weight": 9386897858748757065
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  2,
+                  13,
+                  1
+                ],
+                "weight": 76040541010860279099
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  24,
+                  1
+                ],
+                "weight": 137701731633297463309
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  21,
+                  18
+                ],
+                "weight": 25623818539860522693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  24,
+                  10
+                ],
+                "weight": 12006356176872085753
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  21,
+                  18
+                ],
+                "weight": 6851730939028993953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  7,
+                  4
+                ],
+                "weight": 6316533770768974904
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  9,
+                  3
+                ],
+                "weight": 4466784128255087215
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  7,
+                  15
+                ],
+                "weight": 13716104394637056178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  1,
+                  12
+                ],
+                "weight": 123013532382925203202
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  23,
+                  9
+                ],
+                "weight": 6132490315693109016
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  21,
+                  6,
+                  14
+                ],
+                "weight": 32475549478889516646
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  12,
+                  17
+                ],
+                "weight": 27863491017942333790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  18,
+                  4,
+                  17
+                ],
+                "weight": 3158266885384487452
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  1,
+                  12,
+                  23
+                ],
+                "weight": 12110397910553995673
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  13
+                ],
+                "weight": 10073974474854798974
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  24,
+                  6
+                ],
+                "weight": 81767582788972312215
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  23,
+                  20
+                ],
+                "weight": 23701137987356246317
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  2,
+                  6
+                ],
+                "weight": 6002809915490547153
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  13,
+                  17
+                ],
+                "weight": 46527555255093775453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  20,
+                  14
+                ],
+                "weight": 25623818539860522693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  2,
+                  23
+                ],
+                "weight": 55320503239792650921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  7,
+                  1
+                ],
+                "weight": 6923977194528340290
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  21,
+                  18
+                ],
+                "weight": 42551225554451669334
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  15,
+                  9
+                ],
+                "weight": 3453967842421577991
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  21,
+                  7
+                ],
+                "weight": 10032456992298085896
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  18,
+                  4
+                ],
+                "weight": 6851730939028993953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  1,
+                  6
+                ],
+                "weight": 33925970259785880808
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  10,
+                  7,
+                  15
+                ],
+                "weight": 3108479797769745606
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  15,
+                  12
+                ],
+                "weight": 52583682546749755230
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  18,
+                  4,
+                  20
+                ],
+                "weight": 1922680552504276376
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  15,
+                  12,
+                  3
+                ],
+                "weight": 42321545994534277043
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  1,
+                  12,
+                  14
+                ],
+                "weight": 40718097459894596696
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  16,
+                  2
+                ],
+                "weight": 42130690244833700792
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  19,
+                  2,
+                  20
+                ],
+                "weight": 23701137987356246317
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  13,
+                  6
+                ],
+                "weight": 11669231585707039993
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  24,
+                  14
+                ],
+                "weight": 68923509105198302457
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  19,
+                  18,
+                  23
+                ],
+                "weight": 11144081356136013268
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  19,
+                  4,
+                  17
+                ],
+                "weight": 602743968225649638
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  21
+                ],
+                "weight": 44071739015448666517
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  7,
+                  9
+                ],
+                "weight": 9386897858748757065
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  10,
+                  21
+                ],
+                "weight": 25623818539860522693
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  7,
+                  20
+                ],
+                "weight": 29043525767288047948
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  12,
+                  6
+                ],
+                "weight": 18429552257477454475
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  13,
+                  24,
+                  17
+                ],
+                "weight": 44319969262847330496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  15,
+                  6
+                ],
+                "weight": 47821171909103348157
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  9,
+                  6
+                ],
+                "weight": 26660939978527522851
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  10,
+                  15,
+                  14
+                ],
+                "weight": 6139718933151840481
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  23,
+                  9
+                ],
+                "weight": 26660939978527522851
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  7,
+                  12,
+                  14
+                ],
+                "weight": 3068126999087836028
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  15,
+                  4,
+                  12
+                ],
+                "weight": 75458570098820479141
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  12,
+                  6
+                ],
+                "weight": 53960890842255188638
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  4,
+                  23,
+                  20
+                ],
+                "weight": 38112688371492637932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  18,
+                  3
+                ],
+                "weight": 11144081356136013268
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  13,
+                  10
+                ],
+                "weight": 36475218754839089726
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  7,
+                  12
+                ],
+                "weight": 18429552257477454475
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  7,
+                  14
+                ],
+                "weight": 3807174218235529062
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  24,
+                  7,
+                  17
+                ],
+                "weight": 34646771674749156998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  23,
+                  9
+                ],
+                "weight": 1060544509029811008
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 56883498150462140535
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  10,
+                  21,
+                  6
+                ],
+                "weight": 18576434733810905102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  1,
+                  12
+                ],
+                "weight": 7137385464340292428
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  15,
+                  1
+                ],
+                "weight": 11949160192096564497
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  15,
+                  12,
+                  9
+                ],
+                "weight": 888951335903836052
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  4,
+                  1,
+                  9
+                ],
+                "weight": 4811774727756272069
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  4,
+                  9,
+                  3
+                ],
+                "weight": 1949495844933647060
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  20,
+                  3,
+                  14
+                ],
+                "weight": 68470868932401994234
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 27955471582149752394
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  13,
+                  20
+                ],
+                "weight": 31666367124193894831
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  7,
+                  18
+                ],
+                "weight": 135905315099994427023
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  18,
+                  15
+                ],
+                "weight": 4839246705649463404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  23,
+                  20
+                ],
+                "weight": 9683656593424327831
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  6,
+                  3
+                ],
+                "weight": 3147126013146899153
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  10,
+                  14
+                ],
+                "weight": 10225509918045673633
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  18,
+                  3
+                ],
+                "weight": 9771625620441181205
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  13,
+                  4,
+                  6
+                ],
+                "weight": 11669231585707039993
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  20,
+                  3
+                ],
+                "weight": 30372044851935020801
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  7
+                ],
+                "weight": 6316533770768974904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  15,
+                  1
+                ],
+                "weight": 4192927887081513370
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  20,
+                  6
+                ],
+                "weight": 10977978865683201861
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  10,
+                  15,
+                  17
+                ],
+                "weight": 646318818567950034
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  12,
+                  17
+                ],
+                "weight": 646318818567950034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  18,
+                  23
+                ],
+                "weight": 83143006325782173521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  15,
+                  4,
+                  1
+                ],
+                "weight": 2731049307446826920
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  24,
+                  18
+                ],
+                "weight": 144018265404066438213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  10,
+                  1
+                ],
+                "weight": 80655208167283090722
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  13,
+                  18,
+                  9
+                ],
+                "weight": 6197053590984157482
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  13,
+                  1,
+                  20
+                ],
+                "weight": 19508943567075752802
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  10,
+                  7,
+                  4
+                ],
+                "weight": 117130426922122180448
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  4,
+                  1
+                ],
+                "weight": 153981286907178289901
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  23,
+                  3
+                ],
+                "weight": 3147126013146899153
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  23,
+                  6
+                ],
+                "weight": 6536530580277428678
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  15,
+                  1,
+                  9
+                ],
+                "weight": 1385278863227885413
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  12,
+                  9,
+                  17
+                ],
+                "weight": 2743085748562579491
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  4
+                ],
+                "weight": 68648851990411004969
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  21,
+                  3
+                ],
+                "weight": 10083837529750384790
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  4,
+                  14
+                ],
+                "weight": 59076637368352133394
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  7,
+                  3
+                ],
+                "weight": 46895626591263051853
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  21,
+                  12,
+                  17
+                ],
+                "weight": 51380537452298894
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  18,
+                  14
+                ],
+                "weight": 84826845262051636743
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  7,
+                  15,
+                  4
+                ],
+                "weight": 69769205272185326640
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  23,
+                  9
+                ],
+                "weight": 5144924088330081397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  1,
+                  12,
+                  9
+                ],
+                "weight": 6197053590984157482
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  14
+                ],
+                "weight": 22628677742043347583
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  21,
+                  15,
+                  3
+                ],
+                "weight": 12544840212292962793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  4,
+                  1
+                ],
+                "weight": 162023157704551075109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  1,
+                  6
+                ],
+                "weight": 119386061013099953677
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  12,
+                  20
+                ],
+                "weight": 21985936216166887859
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  4,
+                  23,
+                  3
+                ],
+                "weight": 1285599195230105467
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  12,
+                  9,
+                  3
+                ],
+                "weight": 21985936216166887859
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  23,
+                  9,
+                  17
+                ],
+                "weight": 225054686200294459
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  1,
+                  20
+                ],
+                "weight": 26405602951224233848
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  6,
+                  3
+                ],
+                "weight": 6536530580277428678
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  4,
+                  23,
+                  14
+                ],
+                "weight": 18542886757149514431
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 2743085748562579491
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 1292637637135900068
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 26405602951224233848
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  18,
+                  1
+                ],
+                "weight": 135617554753326841261
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  15,
+                  9
+                ],
+                "weight": 8877568258032560044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  1,
+                  3
+                ],
+                "weight": 59440466803556014646
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  12,
+                  20
+                ],
+                "weight": 10397826898118425730
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  23,
+                  20,
+                  17
+                ],
+                "weight": 1292637637135900068
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  9,
+                  6,
+                  17
+                ],
+                "weight": 225054686200294459
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  18,
+                  15,
+                  14
+                ],
+                "weight": 81755253327987632290
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  4,
+                  14
+                ],
+                "weight": 87894972261139472771
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  4,
+                  23,
+                  14
+                ],
+                "weight": 40533750611202618963
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  1,
+                  9,
+                  20
+                ],
+                "weight": 80791755106193638238
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  20,
+                  3
+                ],
+                "weight": 51609613951019711938
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  9,
+                  6,
+                  3
+                ],
+                "weight": 7830852852536302708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  23,
+                  17
+                ],
+                "weight": 3158266885384487452
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  1,
+                  23
+                ],
+                "weight": 61106479651162539883
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  20,
+                  6
+                ],
+                "weight": 207457579169631552586
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 53846967910315769275
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  12,
+                  9,
+                  6
+                ],
+                "weight": 14638006689744817926
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 39405326008628538000
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  23,
+                  20
+                ],
+                "weight": 48996081740608544210
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  20,
+                  6
+                ],
+                "weight": 39322884152510370712
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 1292637637135900068
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 32475549478889516646
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 214,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 6121708727810067548951
+          },
+          "certificate_sha256": "ca9d0edb8b2a6b5f25214b7e96cfd8e55ee863b0f658a7ffb7b7b0842449ad4d",
+          "max_weight": 294839958048351988549,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 214,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 214,
+          "weight_sum": 6121708727810067548951,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 2,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          5,
+          19,
+          16,
+          2,
+          13,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "7a844de5b47bc27fafa790fb4de59dd3c5fb08f89356333036fc98f0df98f7f8",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 76
+      },
+      {
+        "dihedral_order_sha256": "3c278ac529881595d138bdfdf0dba52105b9856da609a4f92e0364c0595002b8",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "0bba948cfb6c8c6cfd5d2428f3ddf7e3fd4166de92f5676212fa468d4c400d42",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 3,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              5,
+              19,
+              16,
+              13,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 216,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              5,
+              19,
+              16,
+              13,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  18
+                ],
+                "weight": 329356025498044432736
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  14
+                ],
+                "weight": 381177266114754203990
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  24
+                ],
+                "weight": 102267338238220968901
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  24,
+                  17
+                ],
+                "weight": 182665612277688446473
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  4,
+                  14
+                ],
+                "weight": 266020185474652707519
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  12,
+                  3
+                ],
+                "weight": 103566823136640194328
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  1
+                ],
+                "weight": 183669447095762791411
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  5,
+                  18
+                ],
+                "weight": 498574594621389321071
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  18
+                ],
+                "weight": 308454582454616906
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  19,
+                  20
+                ],
+                "weight": 98197334857846488428
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  10,
+                  7
+                ],
+                "weight": 106934636543048341307
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  7,
+                  20
+                ],
+                "weight": 106934636543048341307
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  15,
+                  14
+                ],
+                "weight": 344214004033258298504
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  20,
+                  17
+                ],
+                "weight": 113761362133562827227
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  19,
+                  1
+                ],
+                "weight": 35985984179932206953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  16,
+                  3
+                ],
+                "weight": 285936785333983760312
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  13,
+                  24
+                ],
+                "weight": 80398274039467477572
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  15
+                ],
+                "weight": 326536038393059932852
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  13,
+                  2
+                ],
+                "weight": 65304076156725063415
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  2,
+                  6
+                ],
+                "weight": 69187697463508248872
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  1,
+                  20
+                ],
+                "weight": 219655431275694998364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  9,
+                  6
+                ],
+                "weight": 58872863219151419165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  2,
+                  21
+                ],
+                "weight": 23803707052185103116
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  15,
+                  6
+                ],
+                "weight": 133926604953985154259
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  9,
+                  17
+                ],
+                "weight": 11775745242207386728
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  18,
+                  1
+                ],
+                "weight": 178059909486315529731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  23,
+                  3
+                ],
+                "weight": 223609073622409110957
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  20,
+                  17
+                ],
+                "weight": 59978402865729003284
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  18,
+                  15
+                ],
+                "weight": 151604570594183519911
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  21,
+                  12
+                ],
+                "weight": 23803707052185103116
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  9,
+                  6
+                ],
+                "weight": 83130929490863238191
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  4,
+                  12
+                ],
+                "weight": 44693959917488775163
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  17,
+                  3
+                ],
+                "weight": 59978402865729003284
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  23,
+                  6
+                ],
+                "weight": 310714145392141482682
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  6,
+                  17
+                ],
+                "weight": 58872863219151419165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 283587476488138114241
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  14
+                ],
+                "weight": 102267338238220968901
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  19,
+                  15
+                ],
+                "weight": 74338899124216427544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  2,
+                  17
+                ],
+                "weight": 182665612277688446473
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  7,
+                  3
+                ],
+                "weight": 154610301009304881455
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  15,
+                  20
+                ],
+                "weight": 26950479193630722478
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  9,
+                  14
+                ],
+                "weight": 434006069541843532834
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  16,
+                  23
+                ],
+                "weight": 571586255952341446896
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  2,
+                  9
+                ],
+                "weight": 299186053607140026490
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  24,
+                  21
+                ],
+                "weight": 583955661175552915043
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  4,
+                  6
+                ],
+                "weight": 85569814564446197714
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  13,
+                  12
+                ],
+                "weight": 74338899124216427544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  1,
+                  14
+                ],
+                "weight": 213191382047563378675
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  10,
+                  17
+                ],
+                "weight": 51043477872664687127
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  21,
+                  6
+                ],
+                "weight": 602393309856663492526
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  23,
+                  9
+                ],
+                "weight": 83829689557110391418
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 209401142159681637388
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  7,
+                  18
+                ],
+                "weight": 54790841150376755933
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  3,
+                  14
+                ],
+                "weight": 51043477872664687127
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  15,
+                  20
+                ],
+                "weight": 47388419930585705066
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  4,
+                  23
+                ],
+                "weight": 180450370910206509805
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  18,
+                  1,
+                  12
+                ],
+                "weight": 274565184347667676803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  12,
+                  20
+                ],
+                "weight": 274565184347667676803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  1,
+                  23,
+                  6
+                ],
+                "weight": 487756566395231055478
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 99478503518820379956
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  24,
+                  18
+                ],
+                "weight": 198610650468625218570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  21,
+                  3
+                ],
+                "weight": 139885404780203485281
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  1,
+                  17
+                ],
+                "weight": 232008878449565838129
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  19,
+                  4
+                ],
+                "weight": 74647353706671044450
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  12
+                ],
+                "weight": 5381618679155415139
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  13,
+                  23
+                ],
+                "weight": 29989201432864501642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  15,
+                  17
+                ],
+                "weight": 115869821699681975537
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  4,
+                  9
+                ],
+                "weight": 65304076156725063415
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  7,
+                  6
+                ],
+                "weight": 5381618679155415139
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  7,
+                  18
+                ],
+                "weight": 300272398735218719407
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  12,
+                  3
+                ],
+                "weight": 14724896229101396174
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  9,
+                  14
+                ],
+                "weight": 65304076156725063415
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  10,
+                  7
+                ],
+                "weight": 121054514972204751449
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  21,
+                  17
+                ],
+                "weight": 14119878429156410142
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  4,
+                  12
+                ],
+                "weight": 9343277549945981035
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  21,
+                  15,
+                  14
+                ],
+                "weight": 154005283209359895423
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  23,
+                  17
+                ],
+                "weight": 29989201432864501642
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  1,
+                  6,
+                  3
+                ],
+                "weight": 415678325545328629540
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  10
+                ],
+                "weight": 174977441326467823282
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  21,
+                  12
+                ],
+                "weight": 223509080335586654131
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  4,
+                  14
+                ],
+                "weight": 228657479349398030951
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  10,
+                  23
+                ],
+                "weight": 32058842685664430854
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  7,
+                  20
+                ],
+                "weight": 76360555054715976286
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  9,
+                  17
+                ],
+                "weight": 98616886271751846996
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  20,
+                  3
+                ],
+                "weight": 76360555054715976286
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  2,
+                  7
+                ],
+                "weight": 326536038393059932852
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  4,
+                  6
+                ],
+                "weight": 125125376755838124595
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  4,
+                  14
+                ],
+                "weight": 112003070455862733688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  10,
+                  7,
+                  18
+                ],
+                "weight": 198610650468625218570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  10,
+                  6,
+                  14
+                ],
+                "weight": 160434481482004488592
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  7,
+                  6
+                ],
+                "weight": 51564832869718737996
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  23,
+                  17
+                ],
+                "weight": 32058842685664430854
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  18,
+                  3,
+                  14
+                ],
+                "weight": 59301179365755341653
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  15,
+                  1,
+                  23
+                ],
+                "weight": 299585559199429210374
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  4,
+                  1,
+                  3
+                ],
+                "weight": 465785926561098889234
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  1,
+                  12,
+                  17
+                ],
+                "weight": 569348591490894468432
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  12,
+                  9,
+                  20
+                ],
+                "weight": 335389183270091685838
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  12,
+                  20,
+                  3
+                ],
+                "weight": 10450327885216128463
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 113761362133562827227
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  13,
+                  23
+                ],
+                "weight": 29989201432864501642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  19,
+                  7,
+                  23
+                ],
+                "weight": 514328998701096017580
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  18,
+                  1
+                ],
+                "weight": 383633246038272792730
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  19,
+                  18,
+                  12
+                ],
+                "weight": 62328070228029568274
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  19,
+                  1,
+                  23
+                ],
+                "weight": 278252636828681755283
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  9
+                ],
+                "weight": 351799331962226986557
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  16,
+                  24,
+                  3
+                ],
+                "weight": 204194611600112368887
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  10,
+                  9
+                ],
+                "weight": 313547462560063211154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  4,
+                  14
+                ],
+                "weight": 10922460857775153264
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  24,
+                  1
+                ],
+                "weight": 379761049575440546156
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  18,
+                  3
+                ],
+                "weight": 52613278355086960067
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  1,
+                  17
+                ],
+                "weight": 101508412746758790873
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  20,
+                  6
+                ],
+                "weight": 137716153799374324227
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 50431562396893981365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  15,
+                  6
+                ],
+                "weight": 115869821699681975537
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  9,
+                  17
+                ],
+                "weight": 14361408952923184664
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  7,
+                  12,
+                  6
+                ],
+                "weight": 56946451548874153135
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  12,
+                  23,
+                  20
+                ],
+                "weight": 137716153799374324227
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 224962612483484255185
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  7,
+                  6
+                ],
+                "weight": 26263639657841213445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  15
+                ],
+                "weight": 67509219701995037221
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  4,
+                  9
+                ],
+                "weight": 65304076156725063415
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  21,
+                  23
+                ],
+                "weight": 986548651725220068871
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  18,
+                  6
+                ],
+                "weight": 101796921024818454592
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  7,
+                  9
+                ],
+                "weight": 6431212937573644250
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  7,
+                  12
+                ],
+                "weight": 481634146105681159885
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  17,
+                  3
+                ],
+                "weight": 255909446831840316333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  7,
+                  15,
+                  3
+                ],
+                "weight": 67509219701995037221
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  18,
+                  17,
+                  14
+                ],
+                "weight": 39468850796788886318
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  1,
+                  12,
+                  20
+                ],
+                "weight": 121458096417848509936
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  1,
+                  23,
+                  9
+                ],
+                "weight": 163977814762577794366
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  24,
+                  4
+                ],
+                "weight": 450549734042264317124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  10,
+                  15
+                ],
+                "weight": 9070302485414811910
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  18
+                ],
+                "weight": 280545961107128606253
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  17
+                ],
+                "weight": 62122258009921316800
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  12,
+                  9
+                ],
+                "weight": 250063984169595323694
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  12,
+                  14
+                ],
+                "weight": 131030933019803296041
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  21
+                ],
+                "weight": 441479431556849505214
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  1
+                ],
+                "weight": 70034012529931148166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  15,
+                  14
+                ],
+                "weight": 9070302485414811910
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  10,
+                  9,
+                  17
+                ],
+                "weight": 68553470947494961050
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  1,
+                  12
+                ],
+                "weight": 381094917189398619735
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  21,
+                  1,
+                  14
+                ],
+                "weight": 229543451726982624647
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  7,
+                  18,
+                  9
+                ],
+                "weight": 733900265469785158761
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  7,
+                  4,
+                  3
+                ],
+                "weight": 3285798996714356171
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  7,
+                  1,
+                  14
+                ],
+                "weight": 130773421564438396676
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  15,
+                  4,
+                  1
+                ],
+                "weight": 1596558610934650450636
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  4,
+                  1,
+                  12
+                ],
+                "weight": 1138372215031325336419
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  23,
+                  17,
+                  3
+                ],
+                "weight": 32058842685664430854
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 5381618679155415139
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  2,
+                  24,
+                  20
+                ],
+                "weight": 22474090812452043477
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  1,
+                  9
+                ],
+                "weight": 82205955617870774483
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  14
+                ],
+                "weight": 9070302485414811910
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  9,
+                  20
+                ],
+                "weight": 160190244611826367704
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  9,
+                  17
+                ],
+                "weight": 52521936850996088965
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  21,
+                  18,
+                  3
+                ],
+                "weight": 18858963843596094956
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  15,
+                  9
+                ],
+                "weight": 79927045917328014945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  4,
+                  1
+                ],
+                "weight": 461967005193311320639
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  21,
+                  4,
+                  20
+                ],
+                "weight": 4944743208589008160
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  20,
+                  6
+                ],
+                "weight": 160190244611826367704
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  7,
+                  18,
+                  15
+                ],
+                "weight": 67509219701995037221
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  7,
+                  23,
+                  17
+                ],
+                "weight": 29989201432864501642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  12,
+                  17
+                ],
+                "weight": 89063795353317823718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  15,
+                  9,
+                  3
+                ],
+                "weight": 14724896229101396174
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  15,
+                  17,
+                  14
+                ],
+                "weight": 56233773671310251505
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  10,
+                  12
+                ],
+                "weight": 67509219701995037221
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  1,
+                  3
+                ],
+                "weight": 204194611600112368887
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  9
+                ],
+                "weight": 62122258009921316800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  15,
+                  3
+                ],
+                "weight": 55680166349426560372
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  6,
+                  14
+                ],
+                "weight": 52840123435551107107
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  21,
+                  23,
+                  17
+                ],
+                "weight": 223609073622409110957
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  7,
+                  18,
+                  14
+                ],
+                "weight": 98770030162544227971
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  4,
+                  20
+                ],
+                "weight": 147528309554439684955
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  15,
+                  9,
+                  3
+                ],
+                "weight": 16347574027957141765
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  15,
+                  20,
+                  14
+                ],
+                "weight": 106841812023464455828
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  1,
+                  12,
+                  20
+                ],
+                "weight": 198540152721798333262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  9,
+                  20,
+                  14
+                ],
+                "weight": 78190809584252188934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  9,
+                  6,
+                  3
+                ],
+                "weight": 16347574027957141765
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  23
+                ],
+                "weight": 545069220168370563657
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  18,
+                  23
+                ],
+                "weight": 253401491619001974503
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  15,
+                  1
+                ],
+                "weight": 417828088877618798759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  4,
+                  23
+                ],
+                "weight": 136857071129918676548
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  7,
+                  15,
+                  4
+                ],
+                "weight": 44693959917488775163
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  7,
+                  9,
+                  20
+                ],
+                "weight": 76360555054715976286
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  4,
+                  6
+                ],
+                "weight": 967031761436694395940
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  1,
+                  12
+                ],
+                "weight": 1161598319902166696499
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  4,
+                  12,
+                  23
+                ],
+                "weight": 596290088976299417820
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  4,
+                  12,
+                  6
+                ],
+                "weight": 497799011223872241458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  4,
+                  17,
+                  14
+                ],
+                "weight": 130143675426692357508
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  4,
+                  20
+                ],
+                "weight": 107857081472651654478
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  15,
+                  12,
+                  20
+                ],
+                "weight": 1010611879454367726880
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  4,
+                  6,
+                  17
+                ],
+                "weight": 130143675426692357508
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  4,
+                  17,
+                  14
+                ],
+                "weight": 98513803922705673443
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  1,
+                  20,
+                  3
+                ],
+                "weight": 319998249139646843198
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  23,
+                  20,
+                  6
+                ],
+                "weight": 798470711787372538160
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  20,
+                  3,
+                  14
+                ],
+                "weight": 264318082790220282826
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  18,
+                  12
+                ],
+                "weight": 476342828724138596735
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  4,
+                  23
+                ],
+                "weight": 415839718066092908015
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  18,
+                  15,
+                  9
+                ],
+                "weight": 195796867617009990482
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  18,
+                  4,
+                  12
+                ],
+                "weight": 290841439729788743650
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  1,
+                  23,
+                  9
+                ],
+                "weight": 65565636964404830281
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  12,
+                  23,
+                  14
+                ],
+                "weight": 383548734936342520070
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  20,
+                  6,
+                  3
+                ],
+                "weight": 274768410675436411289
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  18,
+                  1,
+                  3
+                ],
+                "weight": 130773421564438396676
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  9,
+                  14
+                ],
+                "weight": 229543451726982624647
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  1,
+                  6
+                ],
+                "weight": 967031761436694395940
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  9,
+                  17
+                ],
+                "weight": 89063795353317823718
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  12,
+                  6,
+                  14
+                ],
+                "weight": 150986440447798969619
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  23,
+                  9,
+                  17
+                ],
+                "weight": 299585559199429210374
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  20,
+                  3,
+                  14
+                ],
+                "weight": 384605855288270091601
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 415678325545328629540
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  12,
+                  20,
+                  14
+                ],
+                "weight": 542082126055025918599
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  20,
+                  3
+                ],
+                "weight": 462500127564384533063
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  23,
+                  6
+                ],
+                "weight": 643403832992515795938
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  9,
+                  14
+                ],
+                "weight": 250063984169595323694
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 145604821768643554480
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  9,
+                  20,
+                  17
+                ],
+                "weight": 462500127564384533063
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 216,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 45888194926137791576596
+          },
+          "certificate_sha256": "6ba8b953177f865b278650dc2a6ffbf462bab13e66ec41425fea4c78ba45ecfb",
+          "max_weight": 1596558610934650450636,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 216,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 216,
+          "weight_sum": 45888194926137791576596,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 3,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          5,
+          19,
+          16,
+          13,
+          2,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "3c278ac529881595d138bdfdf0dba52105b9856da609a4f92e0364c0595002b8",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 77
+      },
+      {
+        "dihedral_order_sha256": "e94b21cf5be2c3145b9746a7bc68723415fd28176c99103846304bb2385a1e1f",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "44ec645796ead98dde34b73847287f7442504129a7f7f08fcf16de892bc46668",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 4,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              16,
+              13,
+              5,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 211,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              16,
+              13,
+              5,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  6
+                ],
+                "weight": 9998889081902886888
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  19,
+                  10
+                ],
+                "weight": 84269608989529271
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  24,
+                  17
+                ],
+                "weight": 165186340150597845
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  6,
+                  14
+                ],
+                "weight": 16083491731427963676
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  7
+                ],
+                "weight": 8808358512957159656
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  12
+                ],
+                "weight": 928033457309624597
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  5,
+                  6
+                ],
+                "weight": 1190530568945727232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  2,
+                  21
+                ],
+                "weight": 9561256733188107957
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  7,
+                  17
+                ],
+                "weight": 11465309392812399506
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  19,
+                  18
+                ],
+                "weight": 6129723554227080901
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  13,
+                  9
+                ],
+                "weight": 2974518010564315951
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  4
+                ],
+                "weight": 6761873959702468302
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  23,
+                  14
+                ],
+                "weight": 9838504051912182417
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  16,
+                  6
+                ],
+                "weight": 6213993163216610172
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  21,
+                  17
+                ],
+                "weight": 338631533258848815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  1,
+                  17
+                ],
+                "weight": 2397564177531851761
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  4
+                ],
+                "weight": 8685236217913616612
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  4,
+                  23
+                ],
+                "weight": 2974518010564315951
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  1,
+                  20
+                ],
+                "weight": 4920348883375829535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  1,
+                  6
+                ],
+                "weight": 1190530568945727232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  18,
+                  12
+                ],
+                "weight": 3331998131722973034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  10,
+                  21
+                ],
+                "weight": 13159775140932173636
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  15,
+                  20
+                ],
+                "weight": 8850422558064214457
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  21,
+                  15
+                ],
+                "weight": 22382400340861432778
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  7,
+                  4
+                ],
+                "weight": 6326699979017416446
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  7,
+                  12
+                ],
+                "weight": 3177557178816858006
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  23,
+                  17
+                ],
+                "weight": 534812389708617747
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  9,
+                  3
+                ],
+                "weight": 6213993163216610172
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  18,
+                  4
+                ],
+                "weight": 2797725422504107867
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  15,
+                  12
+                ],
+                "weight": 13531977782797218321
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  12,
+                  6
+                ],
+                "weight": 7437588767849455637
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  17,
+                  14
+                ],
+                "weight": 8968801489764901711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  4,
+                  1
+                ],
+                "weight": 8508443629853408528
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 4894072080579349556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  16
+                ],
+                "weight": 1262656640680678053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  12
+                ],
+                "weight": 5150747399397261840
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  19,
+                  5
+                ],
+                "weight": 942264605144758928
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  19,
+                  6
+                ],
+                "weight": 5924300824018930426
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  13,
+                  14
+                ],
+                "weight": 3854109796570575432
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  10,
+                  21
+                ],
+                "weight": 1332645016204399771
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  10,
+                  3
+                ],
+                "weight": 5531935017164910517
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  15,
+                  6
+                ],
+                "weight": 2503194197634143729
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  4,
+                  9
+                ],
+                "weight": 476221820985189213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  23,
+                  9
+                ],
+                "weight": 1944715983100523068
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  13,
+                  6
+                ],
+                "weight": 6413404040077939893
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  12,
+                  17
+                ],
+                "weight": 3169353110259576669
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  23,
+                  3
+                ],
+                "weight": 36678306037162103
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  17,
+                  3
+                ],
+                "weight": 6782295820174160083
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  5,
+                  3
+                ],
+                "weight": 942264605144758928
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  2,
+                  23
+                ],
+                "weight": 6342892514064095185
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  1,
+                  3
+                ],
+                "weight": 259386702323388089
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  12,
+                  23
+                ],
+                "weight": 1981394289137685171
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  9,
+                  14
+                ],
+                "weight": 11933316926496838052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  2,
+                  10
+                ],
+                "weight": 6948849642358839559
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  4,
+                  17
+                ],
+                "weight": 3778129050065181259
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  20,
+                  6
+                ],
+                "weight": 12043638762284496624
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  24,
+                  7
+                ],
+                "weight": 2503194197634143729
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  21,
+                  7
+                ],
+                "weight": 1055403348781949691
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  21,
+                  14
+                ],
+                "weight": 2503194197634143729
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  24,
+                  7,
+                  15
+                ],
+                "weight": 1055403348781949691
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  1,
+                  17
+                ],
+                "weight": 2225952530211693649
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  4,
+                  3
+                ],
+                "weight": 1447790848852194038
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  4,
+                  9,
+                  6
+                ],
+                "weight": 5702141719902564510
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  1,
+                  20,
+                  3
+                ],
+                "weight": 2485339232535081738
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  20,
+                  3,
+                  14
+                ],
+                "weight": 296065008360550192
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  19,
+                  16
+                ],
+                "weight": 1262656640680678053
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  5,
+                  18
+                ],
+                "weight": 2788149849825363417
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  24,
+                  3
+                ],
+                "weight": 16898650504813881548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  2,
+                  12
+                ],
+                "weight": 4134064873606363369
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  19,
+                  2,
+                  14
+                ],
+                "weight": 320392035535919125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  10,
+                  4
+                ],
+                "weight": 1604557200309403876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  7,
+                  1
+                ],
+                "weight": 2656950879855239850
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  21,
+                  3
+                ],
+                "weight": 3810687469321080966
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  2,
+                  15
+                ],
+                "weight": 1610363022711997655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  10,
+                  20
+                ],
+                "weight": 2120051432258124690
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  2,
+                  24,
+                  17
+                ],
+                "weight": 2571009370640102731
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  1,
+                  9
+                ],
+                "weight": 2420937804085712281
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  18,
+                  14
+                ],
+                "weight": 3074021762414828450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  3,
+                  14
+                ],
+                "weight": 2391963616363128795
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  21,
+                  18,
+                  1
+                ],
+                "weight": 12201395021079444965
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  21,
+                  15,
+                  14
+                ],
+                "weight": 2503194197634143729
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  7,
+                  6,
+                  3
+                ],
+                "weight": 3433692509226215756
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  1,
+                  9
+                ],
+                "weight": 12487266933668909998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  18,
+                  17,
+                  3
+                ],
+                "weight": 4490206124301823556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  15,
+                  4,
+                  14
+                ],
+                "weight": 3854109796570575432
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  4,
+                  1,
+                  20
+                ],
+                "weight": 2249552596261171556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  1,
+                  20,
+                  14
+                ],
+                "weight": 14500806454160553985
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  12,
+                  23,
+                  17
+                ],
+                "weight": 1944715983100523068
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  23,
+                  20,
+                  6
+                ],
+                "weight": 1448563296818325389
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  24
+                ],
+                "weight": 2903966652181585023
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  2
+                ],
+                "weight": 3813672838070444244
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  17
+                ],
+                "weight": 4166210407016514071
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  13,
+                  3
+                ],
+                "weight": 3810687469321080966
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  2,
+                  4
+                ],
+                "weight": 16435519133092147674
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  12,
+                  20
+                ],
+                "weight": 355935823541182110
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  21,
+                  18
+                ],
+                "weight": 8917873404052444318
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  1,
+                  20
+                ],
+                "weight": 8265509712219315365
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  24,
+                  12
+                ],
+                "weight": 787469576566553876
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  7,
+                  20
+                ],
+                "weight": 4404263818695041022
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  10,
+                  6
+                ],
+                "weight": 4596072766138555196
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  7,
+                  15
+                ],
+                "weight": 4404094694262118634
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  15,
+                  23
+                ],
+                "weight": 2901776914917245224
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  15,
+                  3
+                ],
+                "weight": 3514323968235873855
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  1,
+                  23
+                ],
+                "weight": 4511449560647274379
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  4,
+                  9
+                ],
+                "weight": 9673645173389679372
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  10,
+                  21,
+                  18
+                ],
+                "weight": 345555288701085998
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  12,
+                  9
+                ],
+                "weight": 5376785279035145414
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  17,
+                  3
+                ],
+                "weight": 3886643413718384902
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  15,
+                  9,
+                  17
+                ],
+                "weight": 2012006188891000445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  15,
+                  9,
+                  14
+                ],
+                "weight": 715617520447248114
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  1,
+                  23,
+                  9
+                ],
+                "weight": 12776959272866589744
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  12,
+                  20,
+                  6
+                ],
+                "weight": 2563367992316750855
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 5702141719902564510
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 9122886531464934303
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  21,
+                  20
+                ],
+                "weight": 1625458465596503061
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  18,
+                  23
+                ],
+                "weight": 1560886556527126923
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  2,
+                  14
+                ],
+                "weight": 320392035535919125
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  10,
+                  9
+                ],
+                "weight": 15503192100210842979
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  21,
+                  7
+                ],
+                "weight": 19316864938281287223
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  7,
+                  23
+                ],
+                "weight": 6491609101125071717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  23,
+                  14
+                ],
+                "weight": 6491609101125071717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  10,
+                  21
+                ],
+                "weight": 10809482547854290918
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  3,
+                  14
+                ],
+                "weight": 682058146051699655
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  7,
+                  23
+                ],
+                "weight": 12889827746225591644
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  18,
+                  4
+                ],
+                "weight": 64571909069376138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  21,
+                  15,
+                  20
+                ],
+                "weight": 3535347988823603735
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  7,
+                  4,
+                  6
+                ],
+                "weight": 64571909069376138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  18,
+                  20,
+                  6
+                ],
+                "weight": 1625458465596503061
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 3535347988823603735
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  1,
+                  9,
+                  6
+                ],
+                "weight": 289692339197679746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 4423757212804043115
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  12,
+                  9,
+                  20
+                ],
+                "weight": 4134064873606363369
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  20,
+                  17,
+                  3
+                ],
+                "weight": 2503256231501482344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  24,
+                  9
+                ],
+                "weight": 14790278380206238588
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  5,
+                  2,
+                  17
+                ],
+                "weight": 4166210407016514071
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  10,
+                  18
+                ],
+                "weight": 345555288701085998
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  12,
+                  20
+                ],
+                "weight": 1981394289137685171
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  17
+                ],
+                "weight": 2736195710790700576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  7,
+                  3
+                ],
+                "weight": 11886311728024653565
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  23,
+                  3
+                ],
+                "weight": 5012338776789227983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  21,
+                  17
+                ],
+                "weight": 1477193799182382698
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  18,
+                  4,
+                  23
+                ],
+                "weight": 7334866976077271702
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  4,
+                  9,
+                  14
+                ],
+                "weight": 25374943309478823252
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 7562645160440863560
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  9,
+                  6,
+                  3
+                ],
+                "weight": 6213993163216610172
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  5,
+                  21,
+                  1
+                ],
+                "weight": 4468362194534041255
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  5,
+                  15,
+                  9
+                ],
+                "weight": 7686641195659438699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  21,
+                  14
+                ],
+                "weight": 320392035535919125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  1,
+                  23
+                ],
+                "weight": 9117077664624869474
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  12,
+                  6
+                ],
+                "weight": 3616794242128487146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  23,
+                  6
+                ],
+                "weight": 2013440480078069585
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 3177557178816858006
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  23
+                ],
+                "weight": 4129119173982483938
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  15,
+                  9
+                ],
+                "weight": 2819730468376355621
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  23,
+                  9
+                ],
+                "weight": 4129119173982483938
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  21,
+                  7,
+                  9
+                ],
+                "weight": 3177557178816858006
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  18,
+                  4,
+                  17
+                ],
+                "weight": 4490206124301823556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  1,
+                  12
+                ],
+                "weight": 3616794242128487146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  12,
+                  20,
+                  17
+                ],
+                "weight": 3778129050065181259
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  2,
+                  21,
+                  4
+                ],
+                "weight": 9433687163536422102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  4,
+                  1
+                ],
+                "weight": 9433687163536422102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  1,
+                  12
+                ],
+                "weight": 14175036218763240214
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  7,
+                  15,
+                  1
+                ],
+                "weight": 8019180680815132135
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  15,
+                  12,
+                  20
+                ],
+                "weight": 13387566642196686338
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  20,
+                  17
+                ],
+                "weight": 1942902507867691091
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  9,
+                  3,
+                  14
+                ],
+                "weight": 23189833295870281678
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  10,
+                  9
+                ],
+                "weight": 10809482547854290918
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  15,
+                  20
+                ],
+                "weight": 108045243367124245
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  12,
+                  23
+                ],
+                "weight": 10187411626125293892
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  15,
+                  1,
+                  12
+                ],
+                "weight": 11538015468710581755
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  12,
+                  9,
+                  6
+                ],
+                "weight": 8388544743768578637
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  12,
+                  6,
+                  3
+                ],
+                "weight": 3514323968235873855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  23,
+                  20,
+                  17
+                ],
+                "weight": 2479528372809140815
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  20,
+                  6,
+                  3
+                ],
+                "weight": 278148009394149586
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  20,
+                  17,
+                  14
+                ],
+                "weight": 4074729409185552155
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  1,
+                  6
+                ],
+                "weight": 10076393461575730166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  21,
+                  7,
+                  3
+                ],
+                "weight": 3558597546416093420
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  15,
+                  1
+                ],
+                "weight": 7799008582392799976
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  21,
+                  1,
+                  6
+                ],
+                "weight": 9601177594516080216
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  7,
+                  18,
+                  15
+                ],
+                "weight": 1448563296818325389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  7,
+                  12,
+                  20
+                ],
+                "weight": 4404263818695041022
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  4,
+                  9
+                ],
+                "weight": 20483127721243970290
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  18,
+                  23,
+                  6
+                ],
+                "weight": 1448563296818325389
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  4,
+                  1,
+                  12
+                ],
+                "weight": 8551733970613288130
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  4,
+                  23,
+                  14
+                ],
+                "weight": 5577215960048972179
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 4446158739369173435
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  4,
+                  12
+                ],
+                "weight": 3106987184519005656
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  9,
+                  6
+                ],
+                "weight": 8554342457852003420
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  18,
+                  6,
+                  14
+                ],
+                "weight": 3074021762414828450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  15,
+                  1,
+                  12
+                ],
+                "weight": 21952146340280129650
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  9,
+                  20,
+                  17
+                ],
+                "weight": 2012006188891000445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  18,
+                  17
+                ],
+                "weight": 410127197770462136
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  15,
+                  23
+                ],
+                "weight": 7799008582392799976
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  4,
+                  3
+                ],
+                "weight": 3042415275449629518
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  15,
+                  1,
+                  6
+                ],
+                "weight": 18155520052368083636
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  1,
+                  23,
+                  20
+                ],
+                "weight": 7169901479637001091
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  23,
+                  20,
+                  3
+                ],
+                "weight": 3634553490813397356
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  18,
+                  15,
+                  12
+                ],
+                "weight": 6570617383996806746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  18,
+                  4,
+                  1
+                ],
+                "weight": 8019180680815132135
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  4,
+                  12,
+                  23
+                ],
+                "weight": 8551733970613288130
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  4,
+                  6,
+                  17
+                ],
+                "weight": 4490206124301823556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 8558674291994439575
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 8968801489764901711
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  1,
+                  23
+                ],
+                "weight": 7799008582392799976
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  20,
+                  3
+                ],
+                "weight": 4490206124301823556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 2066533119383679817
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  23,
+                  9,
+                  14
+                ],
+                "weight": 20822147232913343793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  20,
+                  6,
+                  14
+                ],
+                "weight": 10130012036614451638
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 9341572809999680936
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  23,
+                  17
+                ],
+                "weight": 2339778230284594534
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  3,
+                  14
+                ],
+                "weight": 14500806454160553985
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 211,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 1207603842255128390571
+          },
+          "certificate_sha256": "13b45a8dcd3c5036f64322a112eb116946d71ff82315a26af78b9dfa326d17c9",
+          "max_weight": 25374943309478823252,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 211,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 211,
+          "weight_sum": 1207603842255128390571,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 4,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          16,
+          13,
+          5,
+          2,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "e94b21cf5be2c3145b9746a7bc68723415fd28176c99103846304bb2385a1e1f",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 78
+      },
+      {
+        "dihedral_order_sha256": "2bebdc8929cdb6568112fd5ded9f71b307f5e37eedce75f7ea00b36fce059f49",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "d5167fcbf338d1de5901bd3f0f500c3ced06926a3076417b43cad77a2183e9c3",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 5,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              5,
+              16,
+              13,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 217,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              5,
+              16,
+              13,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  13
+                ],
+                "weight": 1109687496270984191
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  7
+                ],
+                "weight": 230697238916245424
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  19,
+                  20
+                ],
+                "weight": 13856305788700764915
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  5,
+                  1
+                ],
+                "weight": 24256793089451710960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  24,
+                  14
+                ],
+                "weight": 13327068284571139209
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  10,
+                  7
+                ],
+                "weight": 10632080921816039489
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  4,
+                  20
+                ],
+                "weight": 5836044194670344500
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  1,
+                  6
+                ],
+                "weight": 3331384267140593044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  19
+                ],
+                "weight": 4605964752667771815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  5,
+                  10
+                ],
+                "weight": 10632080921816039489
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  24,
+                  20
+                ],
+                "weight": 1340384735187229615
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  13,
+                  4
+                ],
+                "weight": 5836044194670344500
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  7
+                ],
+                "weight": 14399574058343472708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  18,
+                  20
+                ],
+                "weight": 1661995624129166445
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  15,
+                  1
+                ],
+                "weight": 4605964752667771815
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  2,
+                  15
+                ],
+                "weight": 9250341036032993100
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  7,
+                  15
+                ],
+                "weight": 10364201960401143373
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  12,
+                  17
+                ],
+                "weight": 7710928661729427577
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  16,
+                  15
+                ],
+                "weight": 20031626918502610396
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  21,
+                  3
+                ],
+                "weight": 2156095961343715843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  20,
+                  3
+                ],
+                "weight": 27966304978709337691
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  1,
+                  6
+                ],
+                "weight": 4726356698399360309
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  1,
+                  12
+                ],
+                "weight": 582676224466438138
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  7,
+                  9
+                ],
+                "weight": 14667453019758368824
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  15,
+                  12
+                ],
+                "weight": 7128252437262989439
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  6,
+                  17
+                ],
+                "weight": 1961369037610975163
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  3,
+                  14
+                ],
+                "weight": 2156095961343715843
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  9,
+                  6
+                ],
+                "weight": 1661995624129166445
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  6,
+                  14
+                ],
+                "weight": 1370015229529617881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  17,
+                  3
+                ],
+                "weight": 8640417190006391491
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  3,
+                  14
+                ],
+                "weight": 26842089526699633097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  17,
+                  3
+                ],
+                "weight": 1031880509334011249
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  4
+                ],
+                "weight": 48718533150884355655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  4,
+                  3
+                ],
+                "weight": 2749726303050630082
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  17,
+                  14
+                ],
+                "weight": 1863607883035475708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  19,
+                  5
+                ],
+                "weight": 20562377429462635793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  16,
+                  21
+                ],
+                "weight": 2767850291688432657
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  16,
+                  9
+                ],
+                "weight": 32728401709905054705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  18,
+                  15
+                ],
+                "weight": 13087605927669918995
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  12,
+                  23
+                ],
+                "weight": 15990131440979300950
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  23,
+                  6
+                ],
+                "weight": 19051535559903356774
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  20,
+                  3
+                ],
+                "weight": 10694496966701078553
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  5,
+                  1
+                ],
+                "weight": 21754616042519043883
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  10,
+                  18
+                ],
+                "weight": 3926009281054168611
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  10,
+                  17
+                ],
+                "weight": 6706071640761870878
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  24,
+                  3
+                ],
+                "weight": 1192238613056408090
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  23,
+                  17
+                ],
+                "weight": 1221056237422930478
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  2,
+                  20
+                ],
+                "weight": 40093812778035688318
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  4,
+                  14
+                ],
+                "weight": 1738095668556326718
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  15,
+                  3
+                ],
+                "weight": 1582276121325088852
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  1,
+                  14
+                ],
+                "weight": 829207220207925967
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  9,
+                  14
+                ],
+                "weight": 894475649313733938
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  24,
+                  12
+                ],
+                "weight": 32779510784468306675
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  21,
+                  14
+                ],
+                "weight": 4116072514751820357
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  18,
+                  17
+                ],
+                "weight": 16528608598201755199
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  15,
+                  17
+                ],
+                "weight": 642551645612545230
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  3,
+                  14
+                ],
+                "weight": 10694496966701078553
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  4,
+                  6
+                ],
+                "weight": 1348222223063387700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  15,
+                  6
+                ],
+                "weight": 10862778160732284913
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  23,
+                  20
+                ],
+                "weight": 25690205244817505583
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  1,
+                  12,
+                  23
+                ],
+                "weight": 45962797042143792835
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  12,
+                  9,
+                  20
+                ],
+                "weight": 61952928483123093785
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  5,
+                  12
+                ],
+                "weight": 20228979920503824654
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  13,
+                  15
+                ],
+                "weight": 11433086496459094727
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  2,
+                  20
+                ],
+                "weight": 19871002876827232840
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  24,
+                  6
+                ],
+                "weight": 1579980203304223943
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  21,
+                  14
+                ],
+                "weight": 3061404118924055824
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  7,
+                  1
+                ],
+                "weight": 8113125390183482697
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  18,
+                  12
+                ],
+                "weight": 22653509035710186501
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  12
+                ],
+                "weight": 6773010876499215362
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  19,
+                  13,
+                  6
+                ],
+                "weight": 4605964752667771815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  24
+                ],
+                "weight": 1738095668556326718
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  24,
+                  23
+                ],
+                "weight": 16369909875187000527
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  6,
+                  17
+                ],
+                "weight": 22509036671899339928
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  7,
+                  4
+                ],
+                "weight": 1738095668556326718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  18,
+                  4
+                ],
+                "weight": 19292013238674953792
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  9,
+                  6
+                ],
+                "weight": 5320025225166431023
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  17,
+                  14
+                ],
+                "weight": 1863607883035475708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  18,
+                  23
+                ],
+                "weight": 8313177773353701928
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  10,
+                  23,
+                  9
+                ],
+                "weight": 8313177773353701928
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  9,
+                  6
+                ],
+                "weight": 2993152548187270905
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  20,
+                  14
+                ],
+                "weight": 7638928373628768584
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  21,
+                  7,
+                  15
+                ],
+                "weight": 3061404118924055824
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  17,
+                  3
+                ],
+                "weight": 12681927938747619815
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  15,
+                  12
+                ],
+                "weight": 11433086496459094727
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  1,
+                  23
+                ],
+                "weight": 8113125390183482697
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  20,
+                  3
+                ],
+                "weight": 30712488161096264797
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  4,
+                  12,
+                  17
+                ],
+                "weight": 29426519912209401863
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  9,
+                  6,
+                  3
+                ],
+                "weight": 2749726303050630082
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  16
+                ],
+                "weight": 4797344402083180505
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  24
+                ],
+                "weight": 25163210382099720796
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  3
+                ],
+                "weight": 7565194693771613162
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  13,
+                  21
+                ],
+                "weight": 2767850291688432657
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  10,
+                  9
+                ],
+                "weight": 28258885092801349272
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  2,
+                  9
+                ],
+                "weight": 19406270294296255164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  7,
+                  6
+                ],
+                "weight": 31116661919349281930
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  24,
+                  20
+                ],
+                "weight": 10838501534255320732
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  13,
+                  24,
+                  23
+                ],
+                "weight": 8236731827370508259
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  10,
+                  15
+                ],
+                "weight": 24520692424129013722
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  1,
+                  20
+                ],
+                "weight": 5006696235952782456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  10,
+                  1
+                ],
+                "weight": 17725786378804036968
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  21,
+                  4,
+                  12
+                ],
+                "weight": 42882488956214011155
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  7,
+                  18,
+                  4
+                ],
+                "weight": 37403110587509271941
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  7,
+                  23,
+                  14
+                ],
+                "weight": 3061404118924055824
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  9,
+                  6,
+                  17
+                ],
+                "weight": 32728401709905054705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  16,
+                  7
+                ],
+                "weight": 50192115120669586992
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  10,
+                  20
+                ],
+                "weight": 36584160911883713496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  15,
+                  14
+                ],
+                "weight": 7226177651319048097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  13,
+                  2
+                ],
+                "weight": 47424264828981154335
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  7,
+                  9
+                ],
+                "weight": 29536882118563624637
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  23,
+                  17
+                ],
+                "weight": 1530702059462027912
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  20,
+                  14
+                ],
+                "weight": 36584160911883713496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  2,
+                  10
+                ],
+                "weight": 13555446764763287221
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  24,
+                  1
+                ],
+                "weight": 8190449557120906818
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 4116072514751820357
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  10,
+                  20
+                ],
+                "weight": 40540342022540901321
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  2,
+                  24,
+                  10
+                ],
+                "weight": 13555446764763287221
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  21,
+                  4
+                ],
+                "weight": 12626248700167924850
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  7,
+                  15
+                ],
+                "weight": 31019434962507105728
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  15,
+                  23
+                ],
+                "weight": 1530702059462027912
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  18,
+                  15,
+                  23
+                ],
+                "weight": 2648012255291893246
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  18,
+                  4,
+                  1
+                ],
+                "weight": 13564166485398137065
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  18,
+                  9,
+                  14
+                ],
+                "weight": 1277997025762275365
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  4,
+                  12,
+                  3
+                ],
+                "weight": 937917785230212215
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 4605964752667771815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  2,
+                  23
+                ],
+                "weight": 15148853637764070049
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  24,
+                  18
+                ],
+                "weight": 21228601006934470574
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  1,
+                  6
+                ],
+                "weight": 8607625247449942002
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  24,
+                  17
+                ],
+                "weight": 2196513706608923504
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  10,
+                  23
+                ],
+                "weight": 12952339931155146545
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  10,
+                  12
+                ],
+                "weight": 22907383283114700916
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  4,
+                  20
+                ],
+                "weight": 36584160911883713496
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  10,
+                  21,
+                  4
+                ],
+                "weight": 23198797144656745752
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  18,
+                  15
+                ],
+                "weight": 12805449267183562299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  12,
+                  9
+                ],
+                "weight": 43136363203618525570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  7,
+                  4
+                ],
+                "weight": 20934993069881944538
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  7,
+                  18,
+                  17
+                ],
+                "weight": 8423151739750908275
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  7,
+                  3,
+                  14
+                ],
+                "weight": 12681927938747619815
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  15,
+                  9,
+                  17
+                ],
+                "weight": 23730092909322270406
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  4,
+                  1,
+                  20
+                ],
+                "weight": 15649167842001768958
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  21,
+                  7
+                ],
+                "weight": 80349380452138138
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  1,
+                  17
+                ],
+                "weight": 1530702059462027912
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  24,
+                  9
+                ],
+                "weight": 33369887998282933531
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  10,
+                  15
+                ],
+                "weight": 8429956489671040982
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  10,
+                  1
+                ],
+                "weight": 3012987497916227238
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  3
+                ],
+                "weight": 1302785457093142225
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  21,
+                  18
+                ],
+                "weight": 12745729444680410445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  10,
+                  15,
+                  6
+                ],
+                "weight": 29680607651762253548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  21,
+                  15,
+                  1
+                ],
+                "weight": 1530702059462027912
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  15,
+                  9,
+                  3
+                ],
+                "weight": 2749726303050630082
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  4,
+                  9,
+                  3
+                ],
+                "weight": 441793288290799986
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  23,
+                  20,
+                  17
+                ],
+                "weight": 13618151578302042137
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  20,
+                  6,
+                  3
+                ],
+                "weight": 29680607651762253548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  10,
+                  4
+                ],
+                "weight": 5125490275092246239
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  7,
+                  14
+                ],
+                "weight": 5839755384273480262
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  4,
+                  17
+                ],
+                "weight": 1530702059462027912
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  12,
+                  20
+                ],
+                "weight": 50850635337047520669
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  7
+                ],
+                "weight": 5920104764725618400
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  21,
+                  17
+                ],
+                "weight": 80349380452138138
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  4,
+                  12
+                ],
+                "weight": 35825045844824670602
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  21,
+                  6,
+                  3
+                ],
+                "weight": 1582276121325088852
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  7,
+                  18,
+                  9
+                ],
+                "weight": 20419967920488561292
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  1,
+                  12
+                ],
+                "weight": 6055361831653681129
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  4,
+                  12,
+                  23
+                ],
+                "weight": 12344215909233126292
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  1,
+                  23,
+                  6
+                ],
+                "weight": 4107484081862618033
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  12,
+                  9,
+                  17
+                ],
+                "weight": 21314443569802295230
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  12,
+                  20,
+                  6
+                ],
+                "weight": 10310293314506619348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  18,
+                  6
+                ],
+                "weight": 17317307648960651801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  9
+                ],
+                "weight": 8643592478820247344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  6,
+                  3
+                ],
+                "weight": 11997282423794220778
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  21,
+                  1,
+                  3
+                ],
+                "weight": 7200629158798975097
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  21,
+                  23,
+                  17
+                ],
+                "weight": 8643592478820247344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  7,
+                  18,
+                  6
+                ],
+                "weight": 20253883758616997017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  7,
+                  1,
+                  14
+                ],
+                "weight": 7703363267308955970
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  18,
+                  15,
+                  1
+                ],
+                "weight": 820384546361952118
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  12,
+                  23
+                ],
+                "weight": 17488448328112775856
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  1,
+                  3,
+                  14
+                ],
+                "weight": 17334303699557720167
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  23,
+                  20,
+                  6
+                ],
+                "weight": 4107484081862618033
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 1863607883035475708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  7,
+                  18
+                ],
+                "weight": 59719822503151854
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  1,
+                  20
+                ],
+                "weight": 9553570931878978298
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  23,
+                  17
+                ],
+                "weight": 16293463929203806858
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  7,
+                  18,
+                  20
+                ],
+                "weight": 25690205244817505583
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  7,
+                  12,
+                  14
+                ],
+                "weight": 5979824587228770254
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  9,
+                  6
+                ],
+                "weight": 18591888134487830572
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  9,
+                  3
+                ],
+                "weight": 110546844036734135
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  12,
+                  6,
+                  3
+                ],
+                "weight": 3235949523138153934
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  21,
+                  7,
+                  18
+                ],
+                "weight": 12745729444680410445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  7,
+                  14
+                ],
+                "weight": 18333425340329847137
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  12,
+                  9
+                ],
+                "weight": 31834248362991125570
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  1,
+                  20,
+                  6
+                ],
+                "weight": 30986771090661923023
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 37558981633712655331
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  12,
+                  6,
+                  17
+                ],
+                "weight": 10310293314506619348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  4,
+                  9
+                ],
+                "weight": 45146293030988812369
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  18,
+                  1,
+                  17
+                ],
+                "weight": 8329189200106408054
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  1,
+                  9,
+                  14
+                ],
+                "weight": 13312044667997686799
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  12,
+                  23,
+                  3
+                ],
+                "weight": 6626809318780348106
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  9,
+                  6,
+                  17
+                ],
+                "weight": 234053898261701152
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  18,
+                  15,
+                  9
+                ],
+                "weight": 12542682230959922970
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  15,
+                  4,
+                  12
+                ],
+                "weight": 9481278112035867146
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  1,
+                  9
+                ],
+                "weight": 36383321984318927511
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  4,
+                  17,
+                  14
+                ],
+                "weight": 29426519912209401863
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  1,
+                  12,
+                  9
+                ],
+                "weight": 28679958717009971541
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  1,
+                  23,
+                  17
+                ],
+                "weight": 37849671651960310138
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 25690205244817505583
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  3,
+                  14
+                ],
+                "weight": 1277997025762275365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  1,
+                  9,
+                  3
+                ],
+                "weight": 15367914049012284742
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  23,
+                  17,
+                  3
+                ],
+                "weight": 16622571137846255420
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  12,
+                  23
+                ],
+                "weight": 1951808384423227581
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  23,
+                  14
+                ],
+                "weight": 2648012255291893246
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 14650032087636053386
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  1,
+                  12,
+                  14
+                ],
+                "weight": 21825494021268993438
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  12,
+                  9,
+                  14
+                ],
+                "weight": 8879022916702683790
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  23,
+                  9,
+                  17
+                ],
+                "weight": 11648012038364460627
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 1370015229529617881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  20,
+                  14
+                ],
+                "weight": 51642635168616474437
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  6,
+                  14
+                ],
+                "weight": 7638928373628768584
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 217,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 3027502429779891889772
+          },
+          "certificate_sha256": "5b301a6a521648c99fa3fcfed8758fe3fc868517f92a8fa6ff4933ca61483860",
+          "max_weight": 61952928483123093785,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 217,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 217,
+          "weight_sum": 3027502429779891889772,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 5,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          13,
+          2,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "2bebdc8929cdb6568112fd5ded9f71b307f5e37eedce75f7ea00b36fce059f49",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 79
+      },
+      {
+        "dihedral_order_sha256": "fbdd7460b4666dc782b093769bacb46ac3a4fc15a894e038bd05034379cf92d7",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "17325414f9f8ac1c58849c32697c0d80a4ff91852c2815e0028fdf013da6f060",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 6,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              16,
+              5,
+              13,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "source_unique_ordered_quad_count": 219,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              16,
+              5,
+              13,
+              2,
+              24,
+              10,
+              21,
+              7,
+              18,
+              15,
+              4,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              17,
+              3,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  16
+                ],
+                "weight": 17644011773500928883
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  3
+                ],
+                "weight": 3154935029355739899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  6
+                ],
+                "weight": 1485088777088208151
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  13,
+                  14
+                ],
+                "weight": 2995373446071075217
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  21,
+                  20
+                ],
+                "weight": 4413133310018122435
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  21,
+                  17
+                ],
+                "weight": 30962055066798149817
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  4,
+                  14
+                ],
+                "weight": 1733488981396178823
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  10
+                ],
+                "weight": 720439542853489802
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  2,
+                  20
+                ],
+                "weight": 20798946802856668782
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  7,
+                  23
+                ],
+                "weight": 2732009504039320890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  18,
+                  14
+                ],
+                "weight": 7674237331370001842
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  1,
+                  6
+                ],
+                "weight": 298592584997573090
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  19,
+                  7
+                ],
+                "weight": 1783681362085781241
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  12
+                ],
+                "weight": 2205528319941697953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  15,
+                  4
+                ],
+                "weight": 1733488981396178823
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  23,
+                  17
+                ],
+                "weight": 23076870265351763343
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  6,
+                  3
+                ],
+                "weight": 1783681362085781241
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  16,
+                  5,
+                  4
+                ],
+                "weight": 11226492403233719913
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  12,
+                  20
+                ],
+                "weight": 13023486637116808876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  3,
+                  14
+                ],
+                "weight": 8220757437550205234
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  13,
+                  18
+                ],
+                "weight": 3996406231412153615
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  24
+                ],
+                "weight": 1737343251212060671
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  24,
+                  15
+                ],
+                "weight": 1737343251212060671
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  10,
+                  7
+                ],
+                "weight": 948328141953539649
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  21,
+                  20
+                ],
+                "weight": 6991779677483228832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  13,
+                  18,
+                  15
+                ],
+                "weight": 1961377580496228670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  24,
+                  1,
+                  14
+                ],
+                "weight": 14557520242803985019
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  15,
+                  14
+                ],
+                "weight": 227888599100049847
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  18,
+                  6
+                ],
+                "weight": 42366968054299501084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  20,
+                  14
+                ],
+                "weight": 11072043938616370991
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  23,
+                  17
+                ],
+                "weight": 32521481663586963979
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  20,
+                  14
+                ],
+                "weight": 19481101302578767617
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  17,
+                  3
+                ],
+                "weight": 8220757437550205234
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  17,
+                  3
+                ],
+                "weight": 14856112827801558109
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  9,
+                  20
+                ],
+                "weight": 13023486637116808876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  19
+                ],
+                "weight": 6184755371767685396
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  13,
+                  20
+                ],
+                "weight": 11863096809618030017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  2,
+                  7
+                ],
+                "weight": 4937537823981018843
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  2,
+                  9
+                ],
+                "weight": 10408041499344281074
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  19,
+                  2
+                ],
+                "weight": 244007021793862377
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  19,
+                  4
+                ],
+                "weight": 5940748349973823019
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  18,
+                  12
+                ],
+                "weight": 7011545011423785497
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  20,
+                  3
+                ],
+                "weight": 4455659572885614868
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  5,
+                  17
+                ],
+                "weight": 30962055066798149817
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  20,
+                  14
+                ],
+                "weight": 4728862427467254040
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  24,
+                  3
+                ],
+                "weight": 3154935029355739899
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  7,
+                  18
+                ],
+                "weight": 4937537823981018843
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  24,
+                  14
+                ],
+                "weight": 28693247300950559778
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  12,
+                  20
+                ],
+                "weight": 37966727223558967806
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  12,
+                  6
+                ],
+                "weight": 2268807765847590039
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  2,
+                  4
+                ],
+                "weight": 22078604569435429921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  21,
+                  18
+                ],
+                "weight": 2074007187442766654
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  13,
+                  4,
+                  1
+                ],
+                "weight": 12300922788168244083
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  21,
+                  23
+                ],
+                "weight": 2339126122575355781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  1,
+                  9
+                ],
+                "weight": 2701328657800111931
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  23,
+                  6
+                ],
+                "weight": 9086763349964855490
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  10,
+                  9
+                ],
+                "weight": 7735526629927295625
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  10,
+                  17
+                ],
+                "weight": 1864067500440836527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  24,
+                  15,
+                  1
+                ],
+                "weight": 22248588199938167525
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  4,
+                  23
+                ],
+                "weight": 17451919112637187680
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  1,
+                  23
+                ],
+                "weight": 9599594130368132152
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  15,
+                  9,
+                  20
+                ],
+                "weight": 22248588199938167525
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  1,
+                  23,
+                  9
+                ],
+                "weight": 7115492656983542338
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  12,
+                  23,
+                  3
+                ],
+                "weight": 33223989977982772348
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  23,
+                  20,
+                  6
+                ],
+                "weight": 31974326872293982496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  16,
+                  5
+                ],
+                "weight": 2025614889849782501
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  4,
+                  14
+                ],
+                "weight": 7674237331370001842
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  5,
+                  21
+                ],
+                "weight": 15352138828237436469
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  2,
+                  1
+                ],
+                "weight": 42868234503288336
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  19,
+                  10,
+                  4
+                ],
+                "weight": 2724530008761956657
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  19,
+                  23,
+                  20
+                ],
+                "weight": 6184755371767685396
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  5,
+                  23
+                ],
+                "weight": 11809400155497979771
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  13,
+                  10
+                ],
+                "weight": 2025614889849782501
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  13,
+                  9
+                ],
+                "weight": 14992854711619421826
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  17,
+                  3
+                ],
+                "weight": 3161238648802025149
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  2,
+                  10
+                ],
+                "weight": 7722455939943760242
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  24,
+                  9
+                ],
+                "weight": 15194416704272637276
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  18,
+                  23
+                ],
+                "weight": 3625333711455231415
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  3,
+                  14
+                ],
+                "weight": 6316173678157765048
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  10,
+                  3
+                ],
+                "weight": 8862299600603454535
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  13,
+                  18,
+                  1
+                ],
+                "weight": 4048903619914770427
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  2,
+                  21,
+                  6
+                ],
+                "weight": 13488071327796599942
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  15,
+                  12
+                ],
+                "weight": 2205528319941697953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  24,
+                  21,
+                  15
+                ],
+                "weight": 1864067500440836527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  10,
+                  9,
+                  6
+                ],
+                "weight": 4584813212275140752
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  21,
+                  6,
+                  17
+                ],
+                "weight": 35082425770523599815
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  12,
+                  14
+                ],
+                "weight": 2205528319941697953
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  15,
+                  1,
+                  14
+                ],
+                "weight": 341460819500861426
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  4,
+                  23,
+                  20
+                ],
+                "weight": 4949707322608045185
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  23,
+                  17,
+                  14
+                ],
+                "weight": 2057072042917071700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  7
+                ],
+                "weight": 15342943439966079661
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  16,
+                  15
+                ],
+                "weight": 2302800613501117300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  7,
+                  23
+                ],
+                "weight": 16302686890085282080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  13,
+                  14
+                ],
+                "weight": 3276064240007432284
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  10,
+                  12
+                ],
+                "weight": 9217073331365483450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  7,
+                  6
+                ],
+                "weight": 10439481164217541990
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  15,
+                  9
+                ],
+                "weight": 8789042759293748265
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  1,
+                  17
+                ],
+                "weight": 5021801114818677702
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  16,
+                  9,
+                  3
+                ],
+                "weight": 1904583759392440186
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  20,
+                  14
+                ],
+                "weight": 1061338825790632915
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  2,
+                  14
+                ],
+                "weight": 2025614889849782501
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  23,
+                  6
+                ],
+                "weight": 18618188423074653241
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  3,
+                  14
+                ],
+                "weight": 6612898505579368927
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  2,
+                  24,
+                  23
+                ],
+                "weight": 2269621911643644878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  2,
+                  7,
+                  18
+                ],
+                "weight": 8447678379505264584
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 18966842032050354084
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  10,
+                  15,
+                  3
+                ],
+                "weight": 566141541933062834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  18,
+                  17
+                ],
+                "weight": 15459223390929050081
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  23,
+                  3
+                ],
+                "weight": 3507618641121304003
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  7,
+                  15,
+                  1
+                ],
+                "weight": 18006685763843515811
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  15,
+                  1,
+                  17
+                ],
+                "weight": 25628381083674148087
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  1,
+                  23,
+                  20
+                ],
+                "weight": 1061338825790632915
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  1,
+                  6,
+                  3
+                ],
+                "weight": 30650182198492825789
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 6884458999901308079
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  13,
+                  21
+                ],
+                "weight": 286875256297150713
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  24,
+                  3
+                ],
+                "weight": 22478529634511176613
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  21,
+                  20
+                ],
+                "weight": 1455892944300431356
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  12,
+                  9
+                ],
+                "weight": 12247094126884228595
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  9,
+                  14
+                ],
+                "weight": 4885550444004135099
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  2,
+                  7
+                ],
+                "weight": 286875256297150713
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  7,
+                  18
+                ],
+                "weight": 583498426680008316
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  24,
+                  18,
+                  12
+                ],
+                "weight": 583498426680008316
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  12,
+                  3
+                ],
+                "weight": 8629889481039051874
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  23,
+                  14
+                ],
+                "weight": 14135727058146574759
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  10,
+                  7,
+                  4
+                ],
+                "weight": 376245023439194103
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  15,
+                  1
+                ],
+                "weight": 26579358126667869317
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  21,
+                  15,
+                  1
+                ],
+                "weight": 3551704820409620413
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  21,
+                  4,
+                  23
+                ],
+                "weight": 2934976275479343855
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  15,
+                  4,
+                  12
+                ],
+                "weight": 20876983607923280469
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  15,
+                  6,
+                  17
+                ],
+                "weight": 32433863560578607030
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  4,
+                  1,
+                  12
+                ],
+                "weight": 26536489892164580981
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  23,
+                  9,
+                  14
+                ],
+                "weight": 7361543682880093496
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  17,
+                  3
+                ],
+                "weight": 32433863560578607030
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  5,
+                  13,
+                  23
+                ],
+                "weight": 14992854711619421826
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  5,
+                  24,
+                  15
+                ],
+                "weight": 1737343251212060671
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  24,
+                  4
+                ],
+                "weight": 27811677607603431322
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  20,
+                  17
+                ],
+                "weight": 8493630324482869117
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  10,
+                  14
+                ],
+                "weight": 2025614889849782501
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  18
+                ],
+                "weight": 29464970120215174129
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  21,
+                  20
+                ],
+                "weight": 20455778135809045078
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  18,
+                  3
+                ],
+                "weight": 17576517543186327431
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  24,
+                  10,
+                  23
+                ],
+                "weight": 26394085829459752094
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  15,
+                  4
+                ],
+                "weight": 17850987738825603938
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  12,
+                  6
+                ],
+                "weight": 3806413305751325426
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  21,
+                  15
+                ],
+                "weight": 21228242277793833646
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  21,
+                  7,
+                  1
+                ],
+                "weight": 39145411540349183249
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  7,
+                  18,
+                  9
+                ],
+                "weight": 1155124683215834515
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  7,
+                  4,
+                  23
+                ],
+                "weight": 34436172943195315347
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  15,
+                  1,
+                  3
+                ],
+                "weight": 5021801114818677702
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 22626772787697335576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 6633067858466216564
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  2,
+                  6
+                ],
+                "weight": 9459799191155820913
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  4,
+                  9
+                ],
+                "weight": 22555960387152730772
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  18,
+                  20
+                ],
+                "weight": 39422620167859399162
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  7,
+                  4
+                ],
+                "weight": 19436556532937910944
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  18,
+                  15,
+                  1
+                ],
+                "weight": 4632402046594778743
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  18,
+                  12,
+                  9
+                ],
+                "weight": 38786624352676774034
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  4,
+                  12
+                ],
+                "weight": 8107088549018900085
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  15,
+                  1,
+                  6
+                ],
+                "weight": 22218158398961901720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  1,
+                  12,
+                  6
+                ],
+                "weight": 22218158398961901720
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  12,
+                  6,
+                  17
+                ],
+                "weight": 10790961401195479353
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  12,
+                  17,
+                  14
+                ],
+                "weight": 10790961401195479353
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  10,
+                  17
+                ],
+                "weight": 7179343973545966762
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  15,
+                  9
+                ],
+                "weight": 7631312220423982676
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  21,
+                  4
+                ],
+                "weight": 2360882443739917367
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  18,
+                  12
+                ],
+                "weight": 583498426680008316
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  10,
+                  1,
+                  9
+                ],
+                "weight": 4205400941742644612
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  7,
+                  15,
+                  1
+                ],
+                "weight": 21138725776505667438
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  7,
+                  9,
+                  20
+                ],
+                "weight": 1235203398250690362
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  18,
+                  1,
+                  12
+                ],
+                "weight": 583498426680008316
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  15,
+                  12,
+                  23
+                ],
+                "weight": 1166996853360016632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  1,
+                  20,
+                  14
+                ],
+                "weight": 341460819500861426
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 16159851564979438458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  12,
+                  20,
+                  6
+                ],
+                "weight": 13023486637116808876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  23,
+                  17,
+                  3
+                ],
+                "weight": 2249401095024085608
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 3563687445960987963
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  10,
+                  3
+                ],
+                "weight": 17501116922066140964
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  18
+                ],
+                "weight": 20455778135809045078
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  10,
+                  4,
+                  3
+                ],
+                "weight": 8296158058670391701
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  20,
+                  6
+                ],
+                "weight": 22574834677761455432
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  21,
+                  1,
+                  17
+                ],
+                "weight": 2701328657800111931
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  2,
+                  7,
+                  15,
+                  20
+                ],
+                "weight": 9836840540365680629
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  4,
+                  20
+                ],
+                "weight": 22231666010713831728
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  4,
+                  9,
+                  3
+                ],
+                "weight": 75400621120186467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  1,
+                  23,
+                  17
+                ],
+                "weight": 4478015315745854831
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  10,
+                  21,
+                  17
+                ],
+                "weight": 1864067500440836527
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  7,
+                  17
+                ],
+                "weight": 583498426680008316
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  21,
+                  20,
+                  3
+                ],
+                "weight": 3652476768594016225
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  18,
+                  9,
+                  20
+                ],
+                "weight": 7458890074345341651
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  23,
+                  17
+                ],
+                "weight": 1280569073760828211
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  4,
+                  12,
+                  23
+                ],
+                "weight": 11269305933430360668
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 3806413305751325426
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  4,
+                  20
+                ],
+                "weight": 17075674089197993577
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  20,
+                  14
+                ],
+                "weight": 227888599100049847
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  7,
+                  18,
+                  17
+                ],
+                "weight": 18966842032050354084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  15,
+                  12,
+                  6
+                ],
+                "weight": 27817075303582163922
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  1,
+                  9,
+                  20
+                ],
+                "weight": 3530125688184651013
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  23,
+                  6,
+                  14
+                ],
+                "weight": 657427413545567738
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  7,
+                  18,
+                  9
+                ],
+                "weight": 29464970120215174129
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  7,
+                  15,
+                  17
+                ],
+                "weight": 21228242277793833646
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  4,
+                  12,
+                  9
+                ],
+                "weight": 7160095409715320228
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  1,
+                  9,
+                  3
+                ],
+                "weight": 7160095409715320228
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  20,
+                  6,
+                  14
+                ],
+                "weight": 6203529044020698673
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 227888599100049847
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  18,
+                  15,
+                  6
+                ],
+                "weight": 42366968054299501084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  4,
+                  6
+                ],
+                "weight": 34812417966634509450
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  4,
+                  23,
+                  17
+                ],
+                "weight": 8220757437550205234
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  23,
+                  6,
+                  17
+                ],
+                "weight": 31974326872293982496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  20,
+                  6,
+                  14
+                ],
+                "weight": 13277572258558068944
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  9,
+                  17,
+                  3
+                ],
+                "weight": 1904583759392440186
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  17,
+                  3,
+                  14
+                ],
+                "weight": 19481101302578767617
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  23,
+                  14
+                ],
+                "weight": 113572220400811579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  9,
+                  17
+                ],
+                "weight": 2796555886317067091
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  9,
+                  6,
+                  17
+                ],
+                "weight": 2796555886317067091
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  20,
+                  17,
+                  3
+                ],
+                "weight": 4455659572885614868
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  9,
+                  6,
+                  14
+                ],
+                "weight": 113572220400811579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  12,
+                  23,
+                  6
+                ],
+                "weight": 22254440928888162236
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 4250003694474422502
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  20,
+                  6,
+                  17
+                ],
+                "weight": 891972126924626905
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 219,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 2386924090814282105169
+          },
+          "certificate_sha256": "fa872ff087f04ce0a2c28c7ad7741f53c2fff1bdfe557fe505fcd4490b425ccf",
+          "max_weight": 42366968054299501084,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 219,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 219,
+          "weight_sum": 2386924090814282105169,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 6,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          16,
+          5,
+          13,
+          2,
+          24,
+          10,
+          21,
+          7,
+          18,
+          15,
+          4,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "fbdd7460b4666dc782b093769bacb46ac3a4fc15a894e038bd05034379cf92d7",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 80
+      },
+      {
+        "dihedral_order_sha256": "dabafcb478e73d1c280a281636af93593e2b879ea0a775cc4188e11cce2f7986",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "f0597aa4d4a7ec9b6930586b24ff1dfc1f1fb8a8a27073d060e2bb493b66eb2c",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 7,
+            "source_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              5,
+              16,
+              13,
+              2,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              15,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              3,
+              17,
+              14
+            ],
+            "source_unique_ordered_quad_count": 210,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              11,
+              22,
+              8,
+              19,
+              5,
+              16,
+              13,
+              2,
+              24,
+              10,
+              21,
+              18,
+              7,
+              4,
+              15,
+              1,
+              12,
+              23,
+              9,
+              20,
+              6,
+              3,
+              17,
+              14
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  22,
+                  23
+                ],
+                "weight": 1123158700666627860
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  8,
+                  9
+                ],
+                "weight": 1277021050681049820
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  19,
+                  13
+                ],
+                "weight": 1457275313485003456
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  13,
+                  7
+                ],
+                "weight": 1457275313485003456
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  24,
+                  14
+                ],
+                "weight": 9656909528183140041
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  11,
+                  15,
+                  17
+                ],
+                "weight": 1347645806694809283
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  11,
+                  3,
+                  14
+                ],
+                "weight": 2673065376763874708
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  5
+                ],
+                "weight": 2127826214521920227
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  22,
+                  8,
+                  16
+                ],
+                "weight": 1123158700666627860
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  22,
+                  17,
+                  14
+                ],
+                "weight": 4058124900475651122
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  19,
+                  12
+                ],
+                "weight": 2552439791729742932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  2,
+                  24
+                ],
+                "weight": 7642050696090996755
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  8,
+                  24,
+                  20
+                ],
+                "weight": 1975566174139854975
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  16,
+                  17
+                ],
+                "weight": 4009715105214746388
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  2,
+                  7
+                ],
+                "weight": 553050290888250015
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  19,
+                  15,
+                  20
+                ],
+                "weight": 611780864245148745
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  2,
+                  17
+                ],
+                "weight": 2710479093780841839
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  5,
+                  10,
+                  20
+                ],
+                "weight": 647650881920113226
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  21,
+                  4
+                ],
+                "weight": 246166665748840357
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  16,
+                  10,
+                  7
+                ],
+                "weight": 1616564303736634847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  9,
+                  6
+                ],
+                "weight": 2919232042512715065
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  18,
+                  15
+                ],
+                "weight": 3990425006231998261
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  9,
+                  20
+                ],
+                "weight": 2264215185656748073
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  3,
+                  17
+                ],
+                "weight": 246166665748840357
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  7,
+                  12
+                ],
+                "weight": 2169614594624884862
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  17
+                ],
+                "weight": 3780237082547071427
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  15,
+                  1
+                ],
+                "weight": 210187923684926834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  1,
+                  17
+                ],
+                "weight": 210187923684926834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  20,
+                  3
+                ],
+                "weight": 3780237082547071427
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  6,
+                  3
+                ],
+                "weight": 2919232042512715065
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  12,
+                  6
+                ],
+                "weight": 2169614594624884862
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  18
+                ],
+                "weight": 2659710596380405531
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  8,
+                  23
+                ],
+                "weight": 5739963720716800202
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  22,
+                  10,
+                  17
+                ],
+                "weight": 2215386885359735414
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  19,
+                  20
+                ],
+                "weight": 7339902903379611098
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  5,
+                  3
+                ],
+                "weight": 1634175219539727345
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  18,
+                  4
+                ],
+                "weight": 9470290601469538738
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  8,
+                  1,
+                  12
+                ],
+                "weight": 1059771413717594635
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  8,
+                  20,
+                  17
+                ],
+                "weight": 8102790004919238027
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  19,
+                  13,
+                  24
+                ],
+                "weight": 5882627589894607642
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  24,
+                  18
+                ],
+                "weight": 3383605397295966512
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  19,
+                  10,
+                  6
+                ],
+                "weight": 1279617662887162201
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  5,
+                  13,
+                  15
+                ],
+                "weight": 1424280182478803439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  5,
+                  10,
+                  3
+                ],
+                "weight": 1634175219539727345
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  24,
+                  12
+                ],
+                "weight": 3632065284976856162
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  4,
+                  15
+                ],
+                "weight": 3467619741052741439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  16,
+                  1,
+                  20
+                ],
+                "weight": 569502198910378709
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  16,
+                  6,
+                  3
+                ],
+                "weight": 1725268601823123246
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  13,
+                  24,
+                  20
+                ],
+                "weight": 2641238845910317367
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  2,
+                  7,
+                  1
+                ],
+                "weight": 518907650188244143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  2,
+                  4,
+                  14
+                ],
+                "weight": 4026487896743549700
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  24,
+                  23,
+                  20
+                ],
+                "weight": 4616805020050172342
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  10,
+                  21,
+                  14
+                ],
+                "weight": 5129179767786624960
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  10,
+                  3,
+                  17
+                ],
+                "weight": 3359443821362850591
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  21,
+                  15,
+                  23
+                ],
+                "weight": 5129179767786624960
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  18,
+                  6,
+                  14
+                ],
+                "weight": 6086685204173572226
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  7,
+                  4,
+                  9
+                ],
+                "weight": 1976182963673247599
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  4,
+                  15,
+                  12
+                ],
+                "weight": 1110365962439729201
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  11,
+                  1,
+                  12,
+                  14
+                ],
+                "weight": 1110365962439729201
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  11,
+                  1,
+                  17,
+                  14
+                ],
+                "weight": 12329974904947014749
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  8,
+                  19,
+                  18
+                ],
+                "weight": 1724229300622673393
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  16,
+                  21
+                ],
+                "weight": 72465015963942716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  13,
+                  23
+                ],
+                "weight": 4975800322918862797
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  10,
+                  15
+                ],
+                "weight": 1283071047986181548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  8,
+                  6,
+                  14
+                ],
+                "weight": 4058124900475651122
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  19,
+                  16,
+                  2
+                ],
+                "weight": 1724229300622673393
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  16,
+                  9
+                ],
+                "weight": 665910000950602748
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  5,
+                  13,
+                  7
+                ],
+                "weight": 2649019990256721221
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  5,
+                  2,
+                  12
+                ],
+                "weight": 1461916213571317479
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  16,
+                  24,
+                  10
+                ],
+                "weight": 1389451197607374763
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  16,
+                  4,
+                  14
+                ],
+                "weight": 3585763018203846717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  13,
+                  15,
+                  23
+                ],
+                "weight": 1283071047986181548
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  21,
+                  12
+                ],
+                "weight": 72465015963942716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  2,
+                  1,
+                  6
+                ],
+                "weight": 518907650188244143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  10,
+                  18
+                ],
+                "weight": 2321767034980928629
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  24,
+                  18,
+                  17
+                ],
+                "weight": 285948329438137201
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  21,
+                  7,
+                  4
+                ],
+                "weight": 6531421944022389449
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  18,
+                  4,
+                  3
+                ],
+                "weight": 2945658925818542732
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  7,
+                  12,
+                  20
+                ],
+                "weight": 3882401953765668228
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  22,
+                  15,
+                  23,
+                  9
+                ],
+                "weight": 518907650188244143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  1,
+                  9,
+                  6
+                ],
+                "weight": 518907650188244143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  22,
+                  12,
+                  20,
+                  17
+                ],
+                "weight": 3809936937801725512
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  5,
+                  9
+                ],
+                "weight": 6393250133260950543
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  2,
+                  12
+                ],
+                "weight": 4824890278047565613
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  19,
+                  10,
+                  17
+                ],
+                "weight": 6949860031740834521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  1,
+                  3
+                ],
+                "weight": 965972954677409258
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  19,
+                  9,
+                  14
+                ],
+                "weight": 4058124900475651122
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  16,
+                  6
+                ],
+                "weight": 1195623716630570576
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  5,
+                  21,
+                  9
+                ],
+                "weight": 2781103849794601302
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  5,
+                  21,
+                  17
+                ],
+                "weight": 3563451197090652622
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  2,
+                  23
+                ],
+                "weight": 2817160418043431142
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  16,
+                  12,
+                  20
+                ],
+                "weight": 1212679072600228046
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 2824012641199551579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  21,
+                  17
+                ],
+                "weight": 547040881516461033
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  13,
+                  18,
+                  15
+                ],
+                "weight": 3441710952861613203
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  24,
+                  10,
+                  23
+                ],
+                "weight": 5494700617964351818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  24,
+                  6,
+                  17
+                ],
+                "weight": 1325406525141973587
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  10,
+                  7,
+                  1
+                ],
+                "weight": 965972954677409258
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  21,
+                  18,
+                  1
+                ],
+                "weight": 6964060944365657673
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  8,
+                  18,
+                  15,
+                  23
+                ],
+                "weight": 2158639904875431655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  7,
+                  4,
+                  6
+                ],
+                "weight": 965972954677409258
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  8,
+                  4,
+                  6,
+                  14
+                ],
+                "weight": 10436263556146947996
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  16,
+                  13
+                ],
+                "weight": 6574603586766836057
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  13,
+                  1
+                ],
+                "weight": 3663053672964738016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  24,
+                  23
+                ],
+                "weight": 9342404651595781
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  5,
+                  24,
+                  3
+                ],
+                "weight": 3375269532304298086
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  21,
+                  7
+                ],
+                "weight": 553050290888250015
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  5,
+                  15,
+                  12
+                ],
+                "weight": 1389909967539918245
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  13,
+                  6
+                ],
+                "weight": 2920892318453693822
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  16,
+                  2,
+                  10
+                ],
+                "weight": 3653711268313142235
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  16,
+                  21,
+                  15
+                ],
+                "weight": 778129103294769500
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  13,
+                  10,
+                  9
+                ],
+                "weight": 5876572946335609483
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  13,
+                  23,
+                  3
+                ],
+                "weight": 9342404651595781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  24,
+                  1,
+                  17
+                ],
+                "weight": 83432435899504822
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  21,
+                  18
+                ],
+                "weight": 4106869205908156890
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  10,
+                  18,
+                  17
+                ],
+                "weight": 2447493109234863771
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  10,
+                  9,
+                  3
+                ],
+                "weight": 3541447713550310062
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  21,
+                  6,
+                  17
+                ],
+                "weight": 3317284531341812265
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  7,
+                  20,
+                  17
+                ],
+                "weight": 6728122039134462353
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  4,
+                  1,
+                  12
+                ],
+                "weight": 882540518777904436
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  20,
+                  6,
+                  3
+                ],
+                "weight": 7590174020348796939
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  6,
+                  3,
+                  17
+                ],
+                "weight": 12187076214577771405
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  16,
+                  7,
+                  17
+                ],
+                "weight": 4009715105214746388
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  13,
+                  2,
+                  10
+                ],
+                "weight": 2501303414031311397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  2,
+                  14
+                ],
+                "weight": 4367937250742651389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  13,
+                  21,
+                  4
+                ],
+                "weight": 7273305855876422527
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  2,
+                  24,
+                  23
+                ],
+                "weight": 4158761570993120947
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  10,
+                  4
+                ],
+                "weight": 2550746471752700248
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  10,
+                  6
+                ],
+                "weight": 1325406525141973587
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  24,
+                  18,
+                  23
+                ],
+                "weight": 1495863694506002783
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  24,
+                  4,
+                  14
+                ],
+                "weight": 2824012641199551579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  10,
+                  20,
+                  17
+                ],
+                "weight": 2264215185656748073
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  15,
+                  20
+                ],
+                "weight": 2911866067576861299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  21,
+                  23,
+                  6
+                ],
+                "weight": 1195623716630570576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  18,
+                  7,
+                  6
+                ],
+                "weight": 965972954677409258
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  18,
+                  4,
+                  1
+                ],
+                "weight": 6753873020680730839
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  18,
+                  12,
+                  20
+                ],
+                "weight": 529890739828593525
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  5,
+                  7,
+                  1,
+                  12
+                ],
+                "weight": 3381716920939829249
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  15,
+                  9,
+                  20
+                ],
+                "weight": 2946236282515746493
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  5,
+                  1,
+                  23,
+                  20
+                ],
+                "weight": 290897573223836426
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  2,
+                  15
+                ],
+                "weight": 4245748844347510939
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  13,
+                  4,
+                  9
+                ],
+                "weight": 3467619741052741439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  2,
+                  24,
+                  12
+                ],
+                "weight": 1389451197607374763
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  7,
+                  20
+                ],
+                "weight": 1782181271510606755
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  23,
+                  9
+                ],
+                "weight": 11125072196407175
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  21,
+                  1
+                ],
+                "weight": 2828285490239838317
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  10,
+                  18,
+                  12
+                ],
+                "weight": 3426598162183882151
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  21,
+                  18,
+                  3
+                ],
+                "weight": 2950762911951278314
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  21,
+                  7,
+                  15
+                ],
+                "weight": 2911866067576861299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  15,
+                  1,
+                  23
+                ],
+                "weight": 2828285490239838317
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  1,
+                  9,
+                  3
+                ],
+                "weight": 1725268601823123246
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  12,
+                  9,
+                  20
+                ],
+                "weight": 2419386212376628116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  21,
+                  9
+                ],
+                "weight": 9622797313074893205
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  2,
+                  4,
+                  3
+                ],
+                "weight": 3753810199241243760
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  23,
+                  20
+                ],
+                "weight": 2362634220223775084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  6,
+                  14
+                ],
+                "weight": 7191949891942202968
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  3,
+                  17
+                ],
+                "weight": 108104931031287128
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  10,
+                  3
+                ],
+                "weight": 3375269532304298086
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  21,
+                  12
+                ],
+                "weight": 3326729192104615315
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  18,
+                  1
+                ],
+                "weight": 1785102170927228261
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  10,
+                  7,
+                  3
+                ],
+                "weight": 1452171327352267874
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  21,
+                  1,
+                  14
+                ],
+                "weight": 5129179767786624960
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  18,
+                  7,
+                  3
+                ],
+                "weight": 5103986132735582
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  4,
+                  6,
+                  17
+                ],
+                "weight": 438935950485173905
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  15,
+                  1,
+                  12
+                ],
+                "weight": 318976076105341317
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  1,
+                  12,
+                  23
+                ],
+                "weight": 3645705268209956632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  1,
+                  9,
+                  20
+                ],
+                "weight": 278604625686542283
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  6,
+                  3,
+                  14
+                ],
+                "weight": 4709993523973683051
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  10,
+                  21
+                ],
+                "weight": 6155014682344453632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  24,
+                  15,
+                  23
+                ],
+                "weight": 1785002278572938688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  7
+                ],
+                "weight": 4631839222697536885
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  10,
+                  21,
+                  14
+                ],
+                "weight": 11218437788685752668
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  21,
+                  4,
+                  9
+                ],
+                "weight": 6285255278273549092
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  18,
+                  7,
+                  15
+                ],
+                "weight": 6359252834792356750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  7,
+                  15,
+                  9
+                ],
+                "weight": 429435064485036223
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  4,
+                  15,
+                  20
+                ],
+                "weight": 4144815491734381839
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  15,
+                  6,
+                  3
+                ],
+                "weight": 3645705268209956632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  1,
+                  6,
+                  17
+                ],
+                "weight": 108104931031287128
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  10,
+                  9,
+                  17
+                ],
+                "weight": 1694787290479615610
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  18,
+                  15,
+                  23
+                ],
+                "weight": 825903340474925846
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  4,
+                  15,
+                  1
+                ],
+                "weight": 4384334655524622617
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  15,
+                  12,
+                  9
+                ],
+                "weight": 1694787290479615610
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  21,
+                  12,
+                  6
+                ],
+                "weight": 4291275409336126551
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  7,
+                  15,
+                  9
+                ],
+                "weight": 2213694940667859753
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  7,
+                  1,
+                  17
+                ],
+                "weight": 2816079374993243524
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  4,
+                  23,
+                  9
+                ],
+                "weight": 5494700617964351818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  12,
+                  9,
+                  14
+                ],
+                "weight": 10730935621994277490
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  9,
+                  6,
+                  14
+                ],
+                "weight": 5616681934478100138
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  18,
+                  7,
+                  9
+                ],
+                "weight": 8569059332715019155
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  15,
+                  12,
+                  20
+                ],
+                "weight": 628062013135391236
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  12,
+                  23,
+                  6
+                ],
+                "weight": 5120377506576163176
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  12,
+                  6,
+                  3
+                ],
+                "weight": 2950762911951278314
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  23,
+                  9,
+                  20
+                ],
+                "weight": 2283804054441470063
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  9,
+                  14
+                ],
+                "weight": 2845720085368794125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  15,
+                  20,
+                  6
+                ],
+                "weight": 4206938073482187359
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  1,
+                  12,
+                  17
+                ],
+                "weight": 1256983567558997289
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  23,
+                  6,
+                  14
+                ],
+                "weight": 3240965118804778101
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  9,
+                  20,
+                  6
+                ],
+                "weight": 9376554703471122382
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  4,
+                  15,
+                  17
+                ],
+                "weight": 3341301132061897522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  15,
+                  1,
+                  17
+                ],
+                "weight": 6197796295933072773
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  12,
+                  23,
+                  9
+                ],
+                "weight": 9493843730699164918
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  12,
+                  3,
+                  17
+                ],
+                "weight": 5103986132735582
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  9,
+                  20,
+                  14
+                ],
+                "weight": 2845720085368794125
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  1,
+                  23,
+                  14
+                ],
+                "weight": 3501794136746718181
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  12,
+                  23,
+                  20
+                ],
+                "weight": 1992906481217633637
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  12,
+                  9
+                ],
+                "weight": 2003873227509665529
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  23,
+                  3
+                ],
+                "weight": 3645705268209956632
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  6,
+                  17,
+                  14
+                ],
+                "weight": 11812955236346837171
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  9,
+                  6
+                ],
+                "weight": 3240965118804778101
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  20,
+                  3,
+                  17
+                ],
+                "weight": 3809936937801725512
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 210,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 674771600482023120015
+          },
+          "certificate_sha256": "06862ba18305f7ab9370ec1da3fb687a53da351938c99a8ad6dd68b4a9fb71f1",
+          "max_weight": 12329974904947014749,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 210,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 210,
+          "weight_sum": 674771600482023120015,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 15094,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 7,
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          13,
+          2,
+          24,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17,
+          14
+        ],
+        "order_sha256": "dabafcb478e73d1c280a281636af93593e2b879ea0a775cc4188e11cce2f7986",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 81
+      }
+    ],
+    "new_full_certificate_count": 8,
+    "new_unique_affine_orbit_clause_count": 200,
+    "solver_result": "bounded_after_new_exact_certificates",
+    "status": "BOUNDED_C25_SELECTED_RESIDUAL_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+  },
+  "selected_persistent_seed_template": {
+    "affine_clause_orbit": {
+      "affine_map_count": 25,
+      "affine_stabilizer_size": 1,
+      "canonical_clause_sha256": "e6d0b98cba90d29f3aa607bf13cfd6beb0b3bf9b7bd4a2acec69c7d04feec52a",
+      "quotient_automorphism_multipliers": [
+        1
+      ],
+      "source_model_index": 0,
+      "source_order": [
+        0,
+        22,
+        14,
+        11,
+        8,
+        19,
+        5,
+        2,
+        24,
+        16,
+        13,
+        10,
+        21,
+        7,
+        4,
+        1,
+        18,
+        15,
+        12,
+        23,
+        9,
+        20,
+        6,
+        17,
+        3
+      ],
+      "source_unique_ordered_quad_count": 4,
+      "unique_orbit_clause_count": 25
+    },
+    "compressed_certificate_sha256": "d1c462bafbb1dc530029d3478fb4cde3c3dcbf4191586250b641453eba85638c",
+    "max_weight": 1,
+    "ordered_quad_count": 4,
+    "positive_inequalities": 4,
+    "seed_id": "persistent_compressed:0",
+    "seed_role": "PRIMARY_MINIMUM_NEW_MARGINAL_COVER",
+    "source_model_index": 0,
+    "source_screen_target_id": "probe:0",
+    "source_target_id": "transfer_cegar_probe:0",
+    "weight_sum": 4
+  },
+  "selected_residual_seed_template": {
+    "affine_clause_orbit": {
+      "affine_map_count": 25,
+      "affine_stabilizer_size": 1,
+      "canonical_clause_sha256": "331502132efb300f9a073f3bf4059c569cae9f36554fca716167c503a01f0a33",
+      "quotient_automorphism_multipliers": [
+        1
+      ],
+      "source_model_index": 2,
+      "source_order": [
+        0,
+        14,
+        3,
+        17,
+        6,
+        9,
+        12,
+        20,
+        15,
+        23,
+        1,
+        4,
+        7,
+        18,
+        21,
+        10,
+        13,
+        24,
+        2,
+        5,
+        8,
+        16,
+        19,
+        11,
+        22
+      ],
+      "source_unique_ordered_quad_count": 3,
+      "unique_orbit_clause_count": 25
+    },
+    "compressed_certificate_sha256": "6c380d9cbb866ebd3892fd29a0a90fc3fd3fa6260761274ab9f5f1a32139e8be",
+    "max_weight": 1,
+    "ordered_quad_count": 3,
+    "positive_inequalities": 3,
+    "seed_id": "persistent_augmented_residual_compressed:2",
+    "seed_role": "EXACT_MINIMUM_ACTIVE_SEED_ESCAPE_COVER",
+    "source_certificate_sha256": "6ba89b8f4192e6815c71669baae002d5e3790f81fd8959ff702119f5f1264c57",
+    "source_model_index": 2,
+    "source_target_id": "residual:2",
+    "weight_sum": 3
+  },
+  "source_residual_compression_artifact": "data/runs/sparse_full_cone_c25_persistent_augmented_residual_compression_2026-07-30/summary.json",
+  "source_residual_compression_sha256": "b4d620a5039365b63fa16c906e604f45e0bdacb364a8fb4a9a5e42a7c040526e",
+  "status": "BOUNDED_C25_SELECTED_RESIDUAL_WIDTH3_AUGMENTED_CEGAR",
+  "transferred_seed_templates": [
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 28,
+        "source_order": [
+          0,
+          14,
+          17,
+          3,
+          6,
+          9,
+          20,
+          23,
+          12,
+          15,
+          1,
+          4,
+          7,
+          18,
+          10,
+          21,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 3,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "208e5267b8492857aee1419ecfe360c84ef365b86496726caed2e6f832aee6db",
+      "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+      "max_weight": 1,
+      "ordered_quad_count": 3,
+      "positive_inequalities": 3,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 28,
+      "source_target_id": "fresh:28",
+      "template_id": "C25_sidon_2_5_9_14:fresh-28:w3:6459e9d4dd618172",
+      "weight_sum": 3
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 19,
+        "source_order": [
+          0,
+          3,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          1,
+          12,
+          4,
+          15,
+          18,
+          7,
+          21,
+          10,
+          24,
+          2,
+          13,
+          5,
+          16,
+          19,
+          22,
+          8,
+          11
+        ],
+        "source_unique_ordered_quad_count": 5,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f68d46d4978292392c65fda379bf7ab80d51230f1aaa0b03f856506902b3399e",
+      "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+      "max_weight": 1,
+      "ordered_quad_count": 5,
+      "positive_inequalities": 5,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 19,
+      "source_target_id": "fresh:19",
+      "template_id": "C25_sidon_2_5_9_14:fresh-19:w5:e0b19b1c4bee1919",
+      "weight_sum": 5
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 15,
+        "source_order": [
+          0,
+          14,
+          3,
+          6,
+          17,
+          20,
+          23,
+          1,
+          9,
+          12,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          19,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 14,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f22b31f1c564b1456c9f0882bcedee26fe51161cdd64141ff4f96f06f79e71f1",
+      "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+      "max_weight": 1,
+      "ordered_quad_count": 14,
+      "positive_inequalities": 14,
+      "seed_role": "SECONDARY_PRIOR_PACKET_TRANSFER",
+      "source_model_index": 15,
+      "source_target_id": "fresh:15",
+      "template_id": "C25_sidon_2_5_9_14:fresh-15:w14:0b360a662009eea4",
+      "weight_sum": 14
+    }
+  ],
+  "trust": "EXACT_CLAUSES_IN_BOUNDED_168_HISTORY_C25_CEGAR",
+  "type": "sparse_full_cone_c25_selected_residual_augmented_cegar_v1",
+  "unique_active_seed_orbit_clause_count": 125
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -759,11 +759,19 @@ and must not assume that the finite `n=9` pivot census generalizes.
    `docs/sparse-full-cone-c25-persistent-augmented-residual-compression.md`
    reduces them to exact widths `3`--`8`, replays 200 affine images and 54
    affine cross-edges, and finds that `residual:2` alone is the exact
-   one-source minimum cover of all eight active-seed escapes. Next run a
-   bounded 168-history-blocked C25 CEGAR with the three transferred seeds,
-   persistent width-4 seed, and only this width-3 residual orbit. Stop the
-   current C29 template-mining route. This is still not an all-order
-   obstruction.
+   one-source minimum cover of all eight active-seed escapes. The completed
+   follow-up in
+   `docs/sparse-full-cone-c25-selected-residual-augmented-cegar.md` blocks 168
+   history classes and activates the three transferred seeds, persistent
+   width-4 seed, and only this selected width-3 residual orbit. The four
+   parent seeds cover all 16 fresh probe orders; width 3 covers four of those
+   same orders and adds zero marginal coverage. Five-seed CEGAR nevertheless
+   learns eight further exact full-cone certificates of widths `210`--`220`
+   before its configured limit, with no unresolved model. Next compress those
+   eight certificates and compare their affine marginal coverage against the
+   four parent seeds and selected width 3 before choosing a possible
+   192-history seed packet. Stop the current C29 template-mining route. This
+   is still not an all-order obstruction.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external

--- a/docs/index.md
+++ b/docs/index.md
@@ -1011,6 +1011,10 @@ put detailed reconciliation in the canonical synthesis.
   exact compression of those eight residual certificates to widths 3--8; one
   new width-3 orbit is the minimum affine cover of all eight residual orders
   and is the only residual orbit selected for the next bounded C25 CEGAR.
+- [`sparse-full-cone-c25-selected-residual-augmented-cegar.md`](sparse-full-cone-c25-selected-residual-augmented-cegar.md):
+  168-history-blocked five-seed C25 CEGAR; the selected width-3 orbit adds zero
+  fresh-probe marginal coverage, while the search learns eight new exact
+  width-210--220 certificates before its configured limit.
 - [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
   cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
   numerical evidence only, not an exact coordinate certificate.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -747,9 +747,15 @@ benchmarks for the larger frontier:
   `docs/sparse-full-cone-c25-persistent-augmented-residual-compression.md`
   as the exact seed-selection decision: the eight certificates compress to
   widths `3`--`8`, and the affine orbit of `residual:2` is the one-source
-  minimum cover of all eight active-seed escapes. Add only that width-3 orbit
-  before a bounded 168-history-blocked C25 CEGAR; keep the current C29
-  template family stopped;
+  minimum cover of all eight active-seed escapes;
+- use `docs/sparse-full-cone-c25-selected-residual-augmented-cegar.md` as the
+  outside-packet transfer check: after 168 history blocks, the four parent
+  seeds cover all 16 fresh probe orders and the selected width-3 orbit covers
+  four already-covered orders, hence adds zero marginal coverage. The
+  five-seed CEGAR still learns eight exact width-`210`--`220` certificates
+  before its configured limit. Compress those eight and reassess marginal
+  coverage before choosing a possible 192-history packet; keep the current
+  C29 template family stopped;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 

--- a/docs/sparse-full-cone-c25-persistent-augmented-residual-compression.md
+++ b/docs/sparse-full-cone-c25-persistent-augmented-residual-compression.md
@@ -65,12 +65,16 @@ overlaps are zero.
 
 The predeclared stopping rule returns
 `ADD_MINIMUM_COMPRESSED_RESIDUAL_COVER_BEFORE_NEXT_C25_ORDER_SEARCH`.
-The next bounded experiment should block the complete 168-order history and
-activate:
+The completed follow-up in
+`docs/sparse-full-cone-c25-selected-residual-augmented-cegar.md` blocks 168
+history classes and activates the three transferred orbits, persistent
+width-4 orbit, and only this selected width-3 orbit. The four parent seeds
+cover all 16 fresh probe orders; width 3 covers four of those same orders and
+therefore adds zero marginal coverage outside its source packet.
 
-- the three transferred exact seed orbits;
-- the persistent width-4 seed orbit;
-- only the selected width-3 orbit from `residual:2`.
+Five-seed CEGAR nevertheless learns eight new exact full-cone certificates of
+widths `210`--`220` before its configured limit. Compress those eight and
+reassess marginal coverage before choosing a possible 192-history seed packet.
 
 This is finite clause engineering for one fixed quotient, not evidence of an
 all-order C25 obstruction.

--- a/docs/sparse-full-cone-c25-selected-residual-augmented-cegar.md
+++ b/docs/sparse-full-cone-c25-selected-residual-augmented-cegar.md
@@ -1,0 +1,93 @@
+# C25 selected-residual width-3 augmented CEGAR
+
+Status: bounded fixed-pattern, history-blocked exact-clause diagnostic. No
+general proof, all-order C25 obstruction, geometric counterexample, or
+official-status change is claimed.
+
+## Target
+
+The compression in
+`docs/sparse-full-cone-c25-persistent-augmented-residual-compression.md`
+selected the affine orbit of `residual:2`, an exact width-3 positive circuit,
+as the one-source minimum cover of all eight active-seed escapes in its
+24-order source packet.
+
+This follow-up tests that selection outside the source packet. It blocks the
+complete current 168-order C25 history under rotation and reversal, activates
+the three transferred seed orbits, persistent width-4 orbit, and only the
+selected residual width-3 orbit, and leaves sixteen other exact seed summaries
+inactive.
+
+The five active certificates have widths `3, 5, 14, 4, 3` and produce 125
+exact quotient-preserving affine images.
+
+## Deterministic bounded protocol
+
+`scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py`
+uses random seed `20260731`, conflict cap `1024`, and two limits:
+
+1. collect 16 history-disjoint inverse-pair-escape orders within at most 12,000
+   Z3 iterations and compare exact seed coverage;
+2. activate all five seed orbits and learn at most eight new exact full-cone
+   certificate orbits within at most 12,000 iterations.
+
+The numerical LP is only a certificate finder. Every stored certificate is
+exactified and replayed with integer arithmetic. The checker also replays all
+history identities, seed certificates, affine images, clause matches, and
+learned-clause exclusions.
+
+## Fresh 16-order transfer result
+
+The fresh probe reaches its 16-order limit after 497 iterations and 14,485
+inverse-pair clauses. All 16 orders survive the stored vertex-circle and both
+Altman lightweight filters.
+
+| Seed packet | Covered probe orders | New over parent four |
+| --- | ---: | ---: |
+| Four parent seed orbits | 16/16 | -- |
+| Selected width-3 orbit only | 4/16 | 0 |
+| Parent plus selected width 3 | 16/16 | 0 |
+
+The selected width-3 orbit covers probe indices `0, 1, 2, 3`, but all four are
+already covered by the parent seeds. Its one-source minimum-cover role in the
+24-order source packet therefore does not transfer as marginal coverage to
+this fresh bounded probe.
+
+## Five-seed CEGAR result
+
+With all five active seed orbits, bounded CEGAR finds eight further
+history-disjoint orders. Every order is a strong lightweight survivor, escapes
+all active and previously learned affine clauses at discovery, and has an
+exact positive full-Kalmanson-cone certificate.
+
+| Learned model | Z3 iteration | Exact certificate width |
+| ---: | ---: | ---: |
+| 0 | 74 | 219 |
+| 1 | 75 | 220 |
+| 2 | 76 | 214 |
+| 3 | 77 | 216 |
+| 4 | 78 | 211 |
+| 5 | 79 | 217 |
+| 6 | 80 | 219 |
+| 7 | 81 | 210 |
+
+The run stops at the configured eight-certificate limit with no unresolved
+model. The learned orbits add 200 unique affine clauses. Together with 125
+active seed images, the checker replays 325 exact affine certificate images.
+
+## Decision and next target
+
+The route decision is
+`COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES`.
+
+Compress the eight new width-210--220 certificates, construct their exact
+quotient-preserving affine orbits, and compare marginal coverage against both
+the four parent seeds and the selected width-3 seed before choosing the seed
+packet for a possible 192-history C25 CEGAR.
+
+Replay:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py \
+  --check data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/summary.json
+```

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -3183,6 +3183,16 @@
         "data/runs/sparse_full_cone_c25_persistent_augmented_residual_compression_2026-07-30/summary.json"
       ],
       "claim_scope": "Replay eight exact compressed C25 positive-circuit certificates of widths 3 through 8, 200 exact quotient-preserving affine images, exact coverage over 16 probe and eight active-seed-escaping residual orders, 22 direct plus 54 affine cross-source reuse edges, and exhaustive minimum-source covers inside that finite packet. The objective search is deterministic-budget but non-exhaustive; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
+    },
+    {
+      "id": "sparse_full_cone_c25_selected_residual_augmented_cegar",
+      "command": [
+        "python",
+        "scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py",
+        "--check",
+        "data/runs/sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30/summary.json"
+      ],
+      "claim_scope": "Replay five active exact C25 seed certificates, sixteen explicitly inactive exact seed summaries, 168 blocked order identities, 16 history-disjoint probe orders, eight newly learned exact full-cone certificates, 200 new affine clauses, and 325 exact affine certificate images. The selected width-three seed has zero fresh-probe marginal coverage and the run stops at configured finite limits; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
     }
   ],
   "make_targets": {

--- a/scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py
@@ -671,6 +671,8 @@ def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     if payload["type"] != expected_type:
         raise AssertionError("selected residual artifact type drifted")
     source_path = ROOT / str(payload["source_residual_compression_artifact"])
+    if source_path.resolve() != DEFAULT_SOURCE.resolve():
+        raise AssertionError("selected residual source artifact drifted")
     if file_sha256(source_path) != str(
         payload["source_residual_compression_sha256"]
     ):

--- a/scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_selected_residual_augmented_cegar.py
@@ -1,0 +1,906 @@
+#!/usr/bin/env python3
+"""Run C25 CEGAR with the selected compressed residual width-three seed.
+
+The source compression packet selects the affine orbit of residual:2 as the
+exact one-source minimum cover of all eight active-seed escapes in its
+24-order source packet.  This bounded follow-up blocks the complete current
+168-order history, activates the three transferred seeds, the persistent
+width-four seed, and only that selected residual width-three seed, then tests
+fresh-order transfer and learns new exact full-cone certificate orbits.
+
+History blocking and finite limits make this a fixed-pattern search diagnostic
+only.  No solver status here is an all-order obstruction, geometric
+realizability result, counterexample, or proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+EXPLORATION = Path(__file__).resolve().parent
+for path in (SCRIPTS, EXPLORATION):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_kalmanson_certificate import check_certificate_dict  # noqa: E402
+from compress_sparse_full_cone_c25_persistent_augmented_residuals import (  # noqa: E402
+    check_payload as check_compression_payload,
+)
+from compress_sparse_full_cone_c25_persistent_escapes import (  # noqa: E402
+    stable_json_sha256,
+)
+from compress_sparse_full_cone_certificates import (  # noqa: E402
+    order_satisfies_quads,
+)
+from pilot_sparse_full_cone_order_cegar import (  # noqa: E402
+    PATTERNS,
+    certificate_order_quads,
+)
+from probe_sparse_full_cone_small_templates import (  # noqa: E402
+    dihedral_order_key,
+)
+from run_sparse_full_cone_c25_persistent_augmented_cegar import (  # noqa: E402
+    PATTERN,
+    blocked_history as parent_blocked_history,
+    check_order_record,
+    check_payload as check_parent_payload,
+    check_probe,
+    collect_history_disjoint_probe,
+    coverage_for,
+    history_identity,
+    load_sources as load_parent_sources,
+    run_history_disjoint_seeded_cegar,
+    seed_selection as parent_seed_selection,
+)
+from run_sparse_full_cone_seeded_cegar import (  # noqa: E402
+    ClauseOrbit,
+    FullClause,
+    build_clause_orbit,
+    clause_matches,
+    file_sha256,
+    unique_clauses,
+)
+
+
+DEFAULT_SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_persistent_augmented_residual_compression_2026-07-30"
+    / "summary.json"
+)
+DEFAULT_PROBE_ORDER_LIMIT = 16
+DEFAULT_PROBE_MAX_ITERATIONS = 12_000
+DEFAULT_FULL_CERTIFICATE_LIMIT = 8
+DEFAULT_MAX_ITERATIONS = 12_000
+DEFAULT_CONFLICT_CAP = 1_024
+DEFAULT_RANDOM_SEED = 20_260_731
+SELECTED_RESIDUAL_SOURCE_TARGET_ID = "residual:2"
+CERTIFICATE_LIMIT_STATUS = (
+    "BOUNDED_C25_SELECTED_RESIDUAL_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+)
+CONTINUE_DECISION = (
+    "COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES"
+)
+REVIEW_DECISION = (
+    "REVIEW_C25_SELECTED_RESIDUAL_AUGMENTED_CEGAR_BEFORE_CONTINUING"
+)
+
+
+def load_sources(
+    source_path: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    """Replay the compression and return its complete parent provenance."""
+
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    check_compression_payload(source)
+    parent_path = ROOT / str(source["source_artifact"])
+    parent = json.loads(parent_path.read_text(encoding="utf-8"))
+    check_parent_payload(parent)
+    parent_source_path = ROOT / str(parent["source_compression_artifact"])
+    (
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = load_parent_sources(parent_source_path)
+    return (
+        source,
+        parent,
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    )
+
+
+def blocked_history(
+    parent: Mapping[str, Any],
+    augmentation: Mapping[str, Any],
+    prior_cegar: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+    first: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    """Return 144 parent histories plus its 16 probe and 8 residual orders."""
+
+    history = parent_blocked_history(
+        augmentation,
+        prior_cegar,
+        transfer,
+        first,
+    )
+    streams = (
+        (
+            "persistent_augmented_probe",
+            "probe_model_index",
+            parent["counterfactual_probe"]["models"],
+        ),
+        (
+            "persistent_augmented_residual",
+            "model_index",
+            parent["seeded_cegar"]["models"],
+        ),
+    )
+    for packet, index_key, models in streams:
+        for model in models:
+            model_index = int(model[index_key])
+            history.append(
+                {
+                    "history_id": f"{packet}:{model_index}",
+                    "packet": packet,
+                    "order": [int(label) for label in model["order"]],
+                    "order_sha256": str(model["order_sha256"]),
+                    "dihedral_order_sha256": str(
+                        model["dihedral_order_sha256"]
+                    ),
+                }
+            )
+    keys = {dihedral_order_key(record["order"]) for record in history}
+    if len(history) != 168 or len(keys) != len(history):
+        raise AssertionError("selected-residual history must have 168 classes")
+    return history
+
+
+def selected_residual_seed_record(
+    row: Mapping[str, Any],
+    orbit: ClauseOrbit,
+) -> dict[str, object]:
+    """Return an exact summary of the selected width-three seed."""
+
+    certificate = row["compressed_certificate"]
+    checked = check_certificate_dict(certificate)
+    if not checked.zero_sum_verified:
+        raise AssertionError("selected residual seed failed exact replay")
+    if int(row["compressed_unique_ordered_quad_count"]) != 3:
+        raise AssertionError("selected residual seed width drifted")
+    return {
+        "seed_id": "persistent_augmented_residual_compressed:2",
+        "seed_role": "EXACT_MINIMUM_ACTIVE_SEED_ESCAPE_COVER",
+        "source_target_id": str(row["source_target_id"]),
+        "source_model_index": int(row["source_model_index"]),
+        "ordered_quad_count": int(row["compressed_unique_ordered_quad_count"]),
+        "source_certificate_sha256": str(row["source_certificate_sha256"]),
+        "compressed_certificate_sha256": str(
+            row["compressed_certificate_sha256"]
+        ),
+        "positive_inequalities": checked.positive_inequalities,
+        "weight_sum": checked.weight_sum,
+        "max_weight": checked.max_weight,
+        "affine_clause_orbit": orbit.summary(),
+    }
+
+
+def inactive_new_residual_records(
+    rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, object]]:
+    """Summarize the seven compressed residual orbits not selected."""
+
+    return [
+        {
+            "seed_id": (
+                "persistent_augmented_residual_compressed:"
+                f"{int(row['source_model_index'])}"
+            ),
+            "source_target_id": str(row["source_target_id"]),
+            "source_model_index": int(row["source_model_index"]),
+            "ordered_quad_count": int(
+                row["compressed_unique_ordered_quad_count"]
+            ),
+            "compressed_certificate_sha256": str(
+                row["compressed_certificate_sha256"]
+            ),
+            "canonical_clause_sha256": str(
+                row["affine_clause_orbit"]["canonical_clause_sha256"]
+            ),
+            "inactive_reason": (
+                "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER"
+            ),
+        }
+        for row in rows
+        if str(row["source_target_id"]) != SELECTED_RESIDUAL_SOURCE_TARGET_ID
+    ]
+
+
+def seed_selection(
+    source: Mapping[str, Any],
+    parent_source: Mapping[str, Any],
+    residual_compression: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+) -> tuple[
+    list[dict[str, object]],
+    dict[str, object],
+    dict[str, object],
+    list[ClauseOrbit],
+    list[dict[str, object]],
+]:
+    """Return the five active orbits and sixteen inactive summaries."""
+
+    (
+        transferred_records,
+        parent_orbits,
+        persistent_record,
+        inherited_inactive,
+    ) = parent_seed_selection(
+        parent_source,
+        residual_compression,
+        transfer,
+    )
+    residual_cover = source["run"]["coverage_comparison"][
+        "minimum_affine_source_covers"
+    ]["residual_targets"]
+    if residual_cover["selected_source_target_ids"] != [
+        SELECTED_RESIDUAL_SOURCE_TARGET_ID
+    ]:
+        raise AssertionError("selected residual minimum cover drifted")
+    rows = {
+        str(row["source_target_id"]): row
+        for row in source["run"]["compressed_models"]
+    }
+    expected_ids = {f"residual:{index}" for index in range(8)}
+    if set(rows) != expected_ids:
+        raise AssertionError("selected residual compressed packet drifted")
+
+    selected_row = rows[SELECTED_RESIDUAL_SOURCE_TARGET_ID]
+    selected_orbit = build_clause_orbit(
+        PATTERN,
+        int(selected_row["source_model_index"]),
+        selected_row["compressed_certificate"],
+    )
+    if selected_orbit.summary() != selected_row["affine_clause_orbit"]:
+        raise AssertionError("selected residual affine orbit drifted")
+    active_orbits = [*parent_orbits, selected_orbit]
+    hashes = [orbit.canonical_clause_sha256 for orbit in active_orbits]
+    if len(hashes) != len(set(hashes)):
+        raise AssertionError("selected residual active seed orbit duplicated")
+
+    selected_record = selected_residual_seed_record(
+        selected_row,
+        selected_orbit,
+    )
+    inactive_new = inactive_new_residual_records(list(rows.values()))
+    if len(inherited_inactive) != 9 or len(inactive_new) != 7:
+        raise AssertionError("selected residual inactive packet drifted")
+    return (
+        transferred_records,
+        persistent_record,
+        selected_record,
+        active_orbits,
+        [*inherited_inactive, *inactive_new],
+    )
+
+
+def probe_packet_comparison(
+    models: Sequence[Mapping[str, Any]],
+    parent_orbits: Sequence[ClauseOrbit],
+    selected_orbit: ClauseOrbit,
+) -> dict[str, object]:
+    """Compare the four parent seeds with the selected residual orbit."""
+
+    active_orbits = [*parent_orbits, selected_orbit]
+    parent = coverage_for(models, parent_orbits)
+    selected = coverage_for(models, [selected_orbit])
+    active = coverage_for(models, active_orbits)
+    model_indices = {int(model["probe_model_index"]) for model in models}
+    parent_covered = {
+        int(model["probe_model_index"])
+        for model in models
+        if clause_matches(model["order"], parent_orbits)
+    }
+    selected_covered = {
+        int(model["probe_model_index"])
+        for model in models
+        if clause_matches(model["order"], [selected_orbit])
+    }
+    return {
+        "parent_four_seeds": parent,
+        "selected_width3_only": selected,
+        "parent_plus_selected_width3": active,
+        "parent_covered_probe_model_indices": sorted(parent_covered),
+        "selected_width3_covered_probe_model_indices": sorted(
+            selected_covered
+        ),
+        "selected_width3_marginal_over_parent_probe_model_indices": sorted(
+            selected_covered - parent_covered
+        ),
+        "selected_width3_overlap_with_parent_probe_model_indices": sorted(
+            selected_covered & parent_covered
+        ),
+        "parent_uncovered_probe_model_indices": sorted(
+            model_indices - parent_covered
+        ),
+        "active_uncovered_probe_model_indices": sorted(
+            model_indices - (parent_covered | selected_covered)
+        ),
+    }
+
+
+def route_decision(
+    probe: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+    seeded: Mapping[str, Any],
+    *,
+    full_certificate_limit: int,
+) -> str:
+    """Return the predeclared finite-packet continuation decision."""
+
+    probe_count = int(probe["inverse_pair_escape_order_count"])
+    parent_covered = int(
+        comparison["parent_four_seeds"]["covered_probe_order_count"]
+    )
+    selected_covered = int(
+        comparison["selected_width3_only"]["covered_probe_order_count"]
+    )
+    active_covered = int(
+        comparison["parent_plus_selected_width3"]["covered_probe_order_count"]
+    )
+    marginal = comparison[
+        "selected_width3_marginal_over_parent_probe_model_indices"
+    ]
+    certificates = int(seeded["new_full_certificate_count"])
+    unresolved = sum(
+        "certificate" not in model["full_kalmanson"]
+        for model in seeded["models"]
+    )
+    if (
+        probe_count > 0
+        and parent_covered == probe_count
+        and 0 < selected_covered < probe_count
+        and active_covered == probe_count
+        and not marginal
+        and certificates == full_certificate_limit
+        and unresolved == 0
+        and seeded["status"] == CERTIFICATE_LIMIT_STATUS
+    ):
+        return CONTINUE_DECISION
+    return REVIEW_DECISION
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    (
+        source,
+        parent,
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = load_sources(source_path)
+    history = blocked_history(
+        parent,
+        augmentation,
+        prior_cegar,
+        transfer,
+        first,
+    )
+    (
+        transferred_records,
+        persistent_record,
+        selected_record,
+        active_orbits,
+        inactive_records,
+    ) = seed_selection(
+        source,
+        parent_source,
+        residual_compression,
+        transfer,
+    )
+    parent_orbits = active_orbits[:-1]
+    selected_orbit = active_orbits[-1]
+
+    probe, inverse_clauses = collect_history_disjoint_probe(
+        active_orbits,
+        history,
+        order_limit=args.probe_order_limit,
+        max_iterations=args.probe_max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+    )
+    comparison = probe_packet_comparison(
+        probe["models"],
+        parent_orbits,
+        selected_orbit,
+    )
+    seeded = run_history_disjoint_seeded_cegar(
+        active_orbits,
+        history,
+        inverse_clauses,
+        full_certificate_limit=args.full_certificate_limit,
+        max_iterations=args.max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+        certificate_limit_status=CERTIFICATE_LIMIT_STATUS,
+    )
+    decision = route_decision(
+        probe,
+        comparison,
+        seeded,
+        full_certificate_limit=args.full_certificate_limit,
+    )
+    n, offsets = PATTERNS[PATTERN]
+    return {
+        "type": "sparse_full_cone_c25_selected_residual_augmented_cegar_v1",
+        "trust": "EXACT_CLAUSES_IN_BOUNDED_168_HISTORY_C25_CEGAR",
+        "status": "BOUNDED_C25_SELECTED_RESIDUAL_WIDTH3_AUGMENTED_CEGAR",
+        "claim_scope": (
+            "Three transferred exact C25 certificate orbits, one persistent "
+            "width-four seed, and the selected exact residual width-three "
+            "orbit seed a bounded order CEGAR after 168 known C25 orders are "
+            "blocked under rotation and reversal. Probe coverage, newly "
+            "learned certificates, and affine images are exact, but finite "
+            "limits and history blocking preclude any all-order obstruction, "
+            "geometric realizability result, counterexample, proof of Erdos "
+            "Problem #97, or official/global status update."
+        ),
+        "source_residual_compression_artifact": (
+            source_path.relative_to(ROOT).as_posix()
+        ),
+        "source_residual_compression_sha256": file_sha256(source_path),
+        "configuration": {
+            "pattern": PATTERN,
+            "probe_order_limit": args.probe_order_limit,
+            "probe_max_iterations": args.probe_max_iterations,
+            "full_certificate_limit": args.full_certificate_limit,
+            "max_iterations": args.max_iterations,
+            "conflict_cap": args.conflict_cap,
+            "random_seed": args.random_seed,
+            "tolerance": 1.0e-9,
+            "history_equivalence": "cyclic rotation and reversal",
+            "active_seed_policy": (
+                "three transferred orbits plus persistent width-four orbit "
+                "plus exact minimum residual-cover width-three orbit only"
+            ),
+            "inactive_seed_policy": (
+                "nine inherited inactive orbits plus seven nonselected "
+                "persistent-augmented compressed residual orbits"
+            ),
+        },
+        "pattern": PATTERN,
+        "n": n,
+        "circulant_offsets": list(offsets),
+        "transferred_seed_templates": transferred_records,
+        "selected_persistent_seed_template": persistent_record,
+        "selected_residual_seed_template": selected_record,
+        "inactive_seed_templates": inactive_records,
+        "active_seed_orbit_count": len(active_orbits),
+        "active_exact_affine_seed_image_count": sum(
+            orbit.affine_map_count for orbit in active_orbits
+        ),
+        "distinct_active_seed_orbit_class_count": len(
+            {orbit.canonical_clause_sha256 for orbit in active_orbits}
+        ),
+        "unique_active_seed_orbit_clause_count": len(
+            unique_clauses(active_orbits)
+        ),
+        "blocked_history": {
+            "order_count": len(history),
+            "dihedral_order_count": len(
+                {dihedral_order_key(record["order"]) for record in history}
+            ),
+            "packet_histogram": dict(
+                sorted(
+                    Counter(
+                        str(record["packet"]) for record in history
+                    ).items()
+                )
+            ),
+            "identities": history_identity(history),
+        },
+        "counterfactual_probe": probe,
+        "counterfactual_seed_packet_coverage": comparison,
+        "seeded_cegar": seeded,
+        "decision": decision,
+        "next_target": (
+            "Compress the eight newly learned exact C25 certificates, build "
+            "their quotient-preserving affine orbits, and compare marginal "
+            "coverage against the four parent seeds and the selected width-"
+            "three orbit before choosing a 192-history CEGAR seed packet."
+        ),
+    }
+
+
+def check_seeded_cegar(
+    seeded: Mapping[str, Any],
+    history: Sequence[Mapping[str, Any]],
+    active_orbits: Sequence[ClauseOrbit],
+    *,
+    initial_inverse_count: int,
+    full_certificate_limit: int,
+    max_iterations: int,
+    conflict_cap: int,
+) -> dict[str, int]:
+    """Replay the bounded learned certificate packet exactly."""
+
+    n, offsets = PATTERNS[PATTERN]
+    history_keys = {dihedral_order_key(record["order"]) for record in history}
+    if int(seeded["blocked_history_dihedral_order_count"]) != len(history_keys):
+        raise AssertionError("selected residual seeded history drifted")
+    if int(seeded["active_unique_seed_orbit_clause_count"]) != len(
+        unique_clauses(active_orbits)
+    ):
+        raise AssertionError("selected residual active clauses drifted")
+    iterations = int(seeded["iterations"])
+    if not 1 <= iterations <= max_iterations:
+        raise AssertionError("selected residual seeded iterations drifted")
+    if int(seeded["initial_probe_inverse_clause_count"]) != initial_inverse_count:
+        raise AssertionError("selected residual initial clauses drifted")
+    final_inverse_count = int(seeded["final_inverse_pair_clause_count"])
+    if not initial_inverse_count <= final_inverse_count <= (
+        initial_inverse_count + iterations * conflict_cap
+    ):
+        raise AssertionError("selected residual final clauses drifted")
+
+    learned_clauses: set[FullClause] = set()
+    seen = set(history_keys)
+    verified_certificates = 0
+    verified_images = sum(orbit.affine_map_count for orbit in active_orbits)
+    previous_iteration = 0
+    previous_clause_count = initial_inverse_count
+    models = seeded["models"]
+    for expected_index, model in enumerate(models):
+        if int(model["model_index"]) != expected_index:
+            raise AssertionError("selected residual model index drifted")
+        iteration = int(model["z3_iteration"])
+        if not previous_iteration < iteration <= iterations:
+            raise AssertionError("selected residual model provenance drifted")
+        previous_iteration = iteration
+        discovery_count = int(model["inverse_clause_count_at_discovery"])
+        if not previous_clause_count <= discovery_count <= final_inverse_count:
+            raise AssertionError("selected residual clause provenance drifted")
+        previous_clause_count = discovery_count
+        order = check_order_record(model, n=n, offsets=offsets)
+        key = dihedral_order_key(order)
+        if key in seen:
+            raise AssertionError("selected residual model is not disjoint")
+        seen.add(key)
+        expected_matches = clause_matches(order, active_orbits)
+        if model["seed_orbit_matches"] != expected_matches or expected_matches:
+            raise AssertionError("selected residual active seed match drifted")
+        prior_matches = sum(
+            order_satisfies_quads(order, clause) for clause in learned_clauses
+        )
+        if int(model["prior_learned_orbit_clause_matches"]) != prior_matches:
+            raise AssertionError("selected residual learned match drifted")
+        if prior_matches:
+            raise AssertionError("selected residual prior clause admitted model")
+
+        full = model["full_kalmanson"]
+        certificate = full.get("certificate")
+        if certificate is None:
+            raise AssertionError("selected residual stored unresolved model")
+        checked = check_certificate_dict(certificate)
+        if not checked.zero_sum_verified:
+            raise AssertionError("selected residual certificate failed")
+        for field, value in {
+            "status": checked.status,
+            "positive_inequalities": checked.positive_inequalities,
+            "weight_sum": checked.weight_sum,
+            "max_weight": checked.max_weight,
+            "zero_sum_verified": checked.zero_sum_verified,
+        }.items():
+            if full[field] != value:
+                raise AssertionError(
+                    f"selected residual certificate {field} drifted"
+                )
+        if stable_json_sha256(certificate) != full["certificate_sha256"]:
+            raise AssertionError("selected residual certificate hash drifted")
+        quads = certificate_order_quads(certificate, order)
+        if len(quads) != int(full["unique_ordered_quad_count"]):
+            raise AssertionError("selected residual certificate width drifted")
+        orbit = build_clause_orbit(PATTERN, expected_index, certificate)
+        if orbit.summary() != full["affine_clause_orbit"]:
+            raise AssertionError("selected residual learned orbit drifted")
+        new_clauses = [
+            clause for clause in orbit.clauses if clause not in learned_clauses
+        ]
+        if len(new_clauses) != int(
+            full["new_unique_affine_orbit_clauses_added"]
+        ):
+            raise AssertionError("selected residual learned clauses drifted")
+        learned_clauses.update(new_clauses)
+        verified_certificates += 1
+        verified_images += orbit.affine_map_count
+
+    if verified_certificates != full_certificate_limit:
+        raise AssertionError("selected residual certificate limit drifted")
+    if int(seeded["new_full_certificate_count"]) != verified_certificates:
+        raise AssertionError("selected residual certificate count drifted")
+    if int(seeded["new_unique_affine_orbit_clause_count"]) != len(
+        learned_clauses
+    ):
+        raise AssertionError("selected residual learned clause total drifted")
+    if seeded["status"] != CERTIFICATE_LIMIT_STATUS:
+        raise AssertionError("selected residual terminal status drifted")
+    if seeded["solver_result"] != "bounded_after_new_exact_certificates":
+        raise AssertionError("selected residual terminal result drifted")
+    if iterations != previous_iteration:
+        raise AssertionError("selected residual terminal iteration drifted")
+    return {
+        "verified_certificates": verified_certificates,
+        "verified_images": verified_images,
+        "verified_learned_clauses": len(learned_clauses),
+    }
+
+
+def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    expected_type = (
+        "sparse_full_cone_c25_selected_residual_augmented_cegar_v1"
+    )
+    if payload["type"] != expected_type:
+        raise AssertionError("selected residual artifact type drifted")
+    source_path = ROOT / str(payload["source_residual_compression_artifact"])
+    if file_sha256(source_path) != str(
+        payload["source_residual_compression_sha256"]
+    ):
+        raise AssertionError("selected residual source hash drifted")
+    (
+        source,
+        parent,
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = load_sources(source_path)
+    configuration = payload["configuration"]
+    expected_configuration = {
+        "pattern": PATTERN,
+        "probe_order_limit": DEFAULT_PROBE_ORDER_LIMIT,
+        "probe_max_iterations": DEFAULT_PROBE_MAX_ITERATIONS,
+        "full_certificate_limit": DEFAULT_FULL_CERTIFICATE_LIMIT,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
+        "conflict_cap": DEFAULT_CONFLICT_CAP,
+        "random_seed": DEFAULT_RANDOM_SEED,
+        "tolerance": 1.0e-9,
+        "history_equivalence": "cyclic rotation and reversal",
+        "active_seed_policy": (
+            "three transferred orbits plus persistent width-four orbit "
+            "plus exact minimum residual-cover width-three orbit only"
+        ),
+        "inactive_seed_policy": (
+            "nine inherited inactive orbits plus seven nonselected "
+            "persistent-augmented compressed residual orbits"
+        ),
+    }
+    if configuration != expected_configuration:
+        raise AssertionError("selected residual configuration drifted")
+    n, offsets = PATTERNS[PATTERN]
+    if payload["pattern"] != PATTERN or int(payload["n"]) != n:
+        raise AssertionError("selected residual pattern drifted")
+    if payload["circulant_offsets"] != list(offsets):
+        raise AssertionError("selected residual offsets drifted")
+
+    history = blocked_history(
+        parent,
+        augmentation,
+        prior_cegar,
+        transfer,
+        first,
+    )
+    expected_history = {
+        "order_count": len(history),
+        "dihedral_order_count": len(
+            {dihedral_order_key(record["order"]) for record in history}
+        ),
+        "packet_histogram": dict(
+            sorted(Counter(str(record["packet"]) for record in history).items())
+        ),
+        "identities": history_identity(history),
+    }
+    if payload["blocked_history"] != expected_history:
+        raise AssertionError("selected residual history drifted")
+
+    (
+        transferred_records,
+        persistent_record,
+        selected_record,
+        active_orbits,
+        inactive_records,
+    ) = seed_selection(
+        source,
+        parent_source,
+        residual_compression,
+        transfer,
+    )
+    if payload["transferred_seed_templates"] != transferred_records:
+        raise AssertionError("selected residual transferred seeds drifted")
+    if payload["selected_persistent_seed_template"] != persistent_record:
+        raise AssertionError("selected residual persistent seed drifted")
+    if payload["selected_residual_seed_template"] != selected_record:
+        raise AssertionError("selected residual selected seed drifted")
+    if payload["inactive_seed_templates"] != inactive_records:
+        raise AssertionError("selected residual inactive seeds drifted")
+    if int(payload["active_seed_orbit_count"]) != len(active_orbits):
+        raise AssertionError("selected residual active count drifted")
+    if int(payload["active_exact_affine_seed_image_count"]) != sum(
+        orbit.affine_map_count for orbit in active_orbits
+    ):
+        raise AssertionError("selected residual seed images drifted")
+    if int(payload["distinct_active_seed_orbit_class_count"]) != len(
+        {orbit.canonical_clause_sha256 for orbit in active_orbits}
+    ):
+        raise AssertionError("selected residual seed classes drifted")
+    if int(payload["unique_active_seed_orbit_clause_count"]) != len(
+        unique_clauses(active_orbits)
+    ):
+        raise AssertionError("selected residual seed clauses drifted")
+
+    probe = payload["counterfactual_probe"]
+    initial_inverse_count = check_probe(
+        probe,
+        history,
+        active_orbits,
+        order_limit=DEFAULT_PROBE_ORDER_LIMIT,
+        max_iterations=DEFAULT_PROBE_MAX_ITERATIONS,
+        conflict_cap=DEFAULT_CONFLICT_CAP,
+    )
+    expected_comparison = probe_packet_comparison(
+        probe["models"],
+        active_orbits[:-1],
+        active_orbits[-1],
+    )
+    if payload["counterfactual_seed_packet_coverage"] != expected_comparison:
+        raise AssertionError("selected residual coverage drifted")
+
+    seeded = payload["seeded_cegar"]
+    seeded_audit = check_seeded_cegar(
+        seeded,
+        history,
+        active_orbits,
+        initial_inverse_count=initial_inverse_count,
+        full_certificate_limit=DEFAULT_FULL_CERTIFICATE_LIMIT,
+        max_iterations=DEFAULT_MAX_ITERATIONS,
+        conflict_cap=DEFAULT_CONFLICT_CAP,
+    )
+    decision = route_decision(
+        probe,
+        expected_comparison,
+        seeded,
+        full_certificate_limit=DEFAULT_FULL_CERTIFICATE_LIMIT,
+    )
+    if payload["decision"] != decision:
+        raise AssertionError("selected residual decision drifted")
+    return {
+        "status": "OK",
+        "verified_blocked_history_orders": len(history),
+        "verified_active_seed_certificates": len(active_orbits),
+        "verified_inactive_seed_certificates": len(inactive_records),
+        "verified_counterfactual_probe_orders": len(probe["models"]),
+        "verified_new_exact_full_cone_certificates": seeded_audit[
+            "verified_certificates"
+        ],
+        "verified_exact_affine_certificate_images": seeded_audit[
+            "verified_images"
+        ],
+        "verified_new_unique_affine_orbit_clauses": seeded_audit[
+            "verified_learned_clauses"
+        ],
+        "decision": decision,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument(
+        "--probe-order-limit",
+        type=int,
+        default=DEFAULT_PROBE_ORDER_LIMIT,
+    )
+    parser.add_argument(
+        "--probe-max-iterations",
+        type=int,
+        default=DEFAULT_PROBE_MAX_ITERATIONS,
+    )
+    parser.add_argument(
+        "--full-certificate-limit",
+        type=int,
+        default=DEFAULT_FULL_CERTIFICATE_LIMIT,
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=DEFAULT_MAX_ITERATIONS,
+    )
+    parser.add_argument("--conflict-cap", type=int, default=DEFAULT_CONFLICT_CAP)
+    parser.add_argument("--random-seed", type=int, default=DEFAULT_RANDOM_SEED)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    limits = (
+        args.probe_order_limit,
+        args.probe_max_iterations,
+        args.full_certificate_limit,
+        args.max_iterations,
+        args.conflict_cap,
+    )
+    if any(value <= 0 for value in limits):
+        raise SystemExit("all selected residual CEGAR limits must be positive")
+    if args.check is not None:
+        path = args.check if args.check.is_absolute() else ROOT / args.check
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        print(json.dumps(check_payload(payload), indent=2, sort_keys=True))
+        return 0
+
+    payload = build_payload(args)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        path = args.out if args.out.is_absolute() else ROOT / args.out
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+    if args.json or args.out is None:
+        print(text, end="")
+    else:
+        comparison = payload["counterfactual_seed_packet_coverage"]
+        seeded = payload["seeded_cegar"]
+        probe_count = payload["counterfactual_probe"][
+            "inverse_pair_escape_order_count"
+        ]
+        print(
+            f"{PATTERN}: "
+            f"history={payload['blocked_history']['order_count']} "
+            f"probe_parent="
+            f"{comparison['parent_four_seeds']['covered_probe_order_count']}/"
+            f"{probe_count} "
+            f"probe_width3="
+            f"{comparison['selected_width3_only']['covered_probe_order_count']}/"
+            f"{probe_count} "
+            f"width3_marginal="
+            f"{len(comparison['selected_width3_marginal_over_parent_probe_model_indices'])} "
+            f"new_certificates={seeded['new_full_certificate_count']} "
+            f"status={seeded['status']} "
+            f"decision={payload['decision']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sparse_full_cone_c25_selected_residual_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_selected_residual_augmented_cegar.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "exploration"
+    / "run_sparse_full_cone_c25_selected_residual_augmented_cegar.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_full_cone_c25_selected_residual_augmented_cegar",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+CEGAR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CEGAR
+SPEC.loader.exec_module(CEGAR)
+
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_selected_residual_augmented_cegar_2026-07-30"
+    / "summary.json"
+)
+
+
+def artifact_payload() -> dict[str, object]:
+    return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def test_stored_packet_blocks_the_complete_168_order_history() -> None:
+    history = artifact_payload()["blocked_history"]
+
+    assert history["order_count"] == 168
+    assert history["dihedral_order_count"] == 168
+    assert history["packet_histogram"] == {
+        "augmentation_probe": 32,
+        "first_fresh": 32,
+        "persistent_augmented_probe": 16,
+        "persistent_augmented_residual": 8,
+        "prior": 24,
+        "second_fresh": 32,
+        "transfer_cegar_probe": 16,
+        "transfer_cegar_residual": 8,
+    }
+    assert len(history["identities"]) == 168
+    assert len(
+        {record["dihedral_order_sha256"] for record in history["identities"]}
+    ) == 168
+
+
+def test_seed_policy_adds_only_selected_residual_two_width_three() -> None:
+    payload = artifact_payload()
+
+    assert [
+        record["ordered_quad_count"]
+        for record in payload["transferred_seed_templates"]
+    ] == [3, 5, 14]
+    assert payload["selected_persistent_seed_template"][
+        "ordered_quad_count"
+    ] == 4
+    selected = payload["selected_residual_seed_template"]
+    assert selected["source_target_id"] == "residual:2"
+    assert selected["source_model_index"] == 2
+    assert selected["ordered_quad_count"] == 3
+    assert selected["seed_role"] == "EXACT_MINIMUM_ACTIVE_SEED_ESCAPE_COVER"
+    assert payload["active_seed_orbit_count"] == 5
+    assert payload["active_exact_affine_seed_image_count"] == 125
+    assert payload["unique_active_seed_orbit_clause_count"] == 125
+    assert len(payload["inactive_seed_templates"]) == 16
+
+
+def test_selected_width_three_has_no_fresh_probe_marginal_coverage() -> None:
+    payload = artifact_payload()
+    probe = payload["counterfactual_probe"]
+    comparison = payload["counterfactual_seed_packet_coverage"]
+
+    assert probe["status"] == "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+    assert probe["iterations"] == 497
+    assert probe["inverse_pair_clause_count"] == 14485
+    assert probe["inverse_pair_escape_order_count"] == 16
+    assert all(model["lightweight_filters"]["survives"] for model in probe["models"])
+    assert comparison["parent_four_seeds"]["covered_probe_order_count"] == 16
+    assert comparison["selected_width3_only"]["covered_probe_order_count"] == 4
+    assert comparison["parent_plus_selected_width3"][
+        "covered_probe_order_count"
+    ] == 16
+    assert comparison["selected_width3_covered_probe_model_indices"] == [
+        0,
+        1,
+        2,
+        3,
+    ]
+    assert (
+        comparison[
+            "selected_width3_marginal_over_parent_probe_model_indices"
+        ]
+        == []
+    )
+    assert comparison["active_uncovered_probe_model_indices"] == []
+
+
+def test_five_seed_cegar_learns_eight_new_exact_wide_certificates() -> None:
+    payload = artifact_payload()
+    seeded = payload["seeded_cegar"]
+    models = seeded["models"]
+
+    assert seeded["status"] == (
+        "BOUNDED_C25_SELECTED_RESIDUAL_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+    )
+    assert seeded["solver_result"] == "bounded_after_new_exact_certificates"
+    assert seeded["iterations"] == 81
+    assert seeded["initial_probe_inverse_clause_count"] == 14485
+    assert seeded["final_inverse_pair_clause_count"] == 15094
+    assert seeded["new_full_certificate_count"] == 8
+    assert seeded["new_unique_affine_orbit_clause_count"] == 200
+    assert [
+        model["full_kalmanson"]["unique_ordered_quad_count"] for model in models
+    ] == [219, 220, 214, 216, 211, 217, 219, 210]
+    assert all(model["full_kalmanson"]["zero_sum_verified"] for model in models)
+    assert all(model["lightweight_filters"]["survives"] for model in models)
+    assert all(model["seed_orbit_matches"] == [] for model in models)
+    assert payload["decision"] == (
+        "COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES"
+    )
+
+
+def test_stored_selected_residual_augmented_cegar_replays_exactly() -> None:
+    assert CEGAR.check_payload(artifact_payload()) == {
+        "status": "OK",
+        "verified_blocked_history_orders": 168,
+        "verified_active_seed_certificates": 5,
+        "verified_inactive_seed_certificates": 16,
+        "verified_counterfactual_probe_orders": 16,
+        "verified_new_exact_full_cone_certificates": 8,
+        "verified_exact_affine_certificate_images": 325,
+        "verified_new_unique_affine_orbit_clauses": 200,
+        "decision": "COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES",
+    }

--- a/tests/test_sparse_full_cone_c25_selected_residual_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_selected_residual_augmented_cegar.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
@@ -144,3 +146,13 @@ def test_stored_selected_residual_augmented_cegar_replays_exactly() -> None:
         "verified_new_unique_affine_orbit_clauses": 200,
         "decision": "COMPRESS_NEW_C25_SELECTED_RESIDUAL_AUGMENTED_ESCAPES",
     }
+
+def test_checker_rejects_substituted_source_artifact(tmp_path: Path) -> None:
+    substitute = tmp_path / "summary.json"
+    substitute.write_bytes(CEGAR.DEFAULT_SOURCE.read_bytes())
+    payload = artifact_payload()
+    payload["source_residual_compression_artifact"] = str(substitute)
+    payload["source_residual_compression_sha256"] = CEGAR.file_sha256(substitute)
+
+    with pytest.raises(AssertionError, match="source artifact drifted"):
+        CEGAR.check_payload(payload)


### PR DESCRIPTION
## What changed

- add a deterministic 168-history-blocked C25 order probe and CEGAR using the three transferred seeds, persistent width-4 seed, and only the width-3 `residual:2` orbit selected by the preceding compression packet
- store and exactly replay the complete history, active/inactive seed policy, fresh-probe coverage comparison, eight new full-cone certificates, affine images, learned clauses, and route decision
- add the reproducible artifact, focused tests, research note, audit-registry entry, and navigation/backlog updates
- harden the checker to pin the exact source artifact and reject source substitution; the exact result artifact is unchanged

## Exact bounded result

- 168 dihedrally distinct C25 order classes are blocked
- the five active certificates have widths `3, 5, 14, 4, 3` and generate 125 exact affine seed images
- on 16 fresh history-disjoint probe orders, the four parent seeds cover `16/16`; the selected width-3 orbit covers indices `0,1,2,3`, all already covered by the parent seeds, so its marginal coverage is `0/16`
- five-seed CEGAR learns eight new exact certificates of widths `219, 220, 214, 216, 211, 217, 219, 210`, with no unresolved model
- the learned orbits add 200 unique affine clauses; exact replay covers 325 affine certificate images in total

The next bounded target is to compress those eight new certificates and compare affine marginal coverage before choosing a possible 192-history seed packet.

## Validation

- focused packet tests: `6 passed`
- complete fast tier: passed
- complete pytest suite, split into four non-overlapping shards: `1828 passed`
- all eleven required artifact-tier commands: passed
- exact replay of all seven new C25 artifacts: passed
- exact-head GitHub tests and artifact audit: passed

## Claim scope

This is exact finite, history-blocked clause engineering for one fixed C25 selected-witness quotient. It is not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update.
