### PR TITLE
Run 192-history C25 replacement CEGAR

### DIFF
--- a/data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/README.md
+++ b/data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/README.md
@@ -1,0 +1,45 @@
+# C25 width-4 replacement augmented CEGAR
+
+Status: bounded fixed-pattern, history-blocked exact-clause diagnostic. No
+all-order obstruction, geometric counterexample, general proof, or
+official-status update is claimed.
+
+This packet blocks the complete current 192-order C25 history and activates
+the three transferred exact seed orbits, persistent width-4 orbit, and only
+the new width-4 replacement selected by the preceding escape-compression
+packet. The old nonmarginal width-3 seed is inactive.
+
+## Result
+
+- Blocked dihedral order classes: `192`.
+- Active exact seed orbits: `5`, with widths `3, 5, 14, 4, 4`.
+- Inactive exact seed summaries: `24`.
+- Active exact affine seed images: `125`.
+- Fresh history-disjoint probe orders: `16`.
+- Four parent seeds cover `16/16` probe orders.
+- Replacement width-4 only also covers `16/16`, all already covered by the
+  parent seeds, so its fresh-probe marginal coverage is `0/16`.
+- Five-seed CEGAR learns eight new exact full-cone certificates of widths
+  `198, 193, 195, 195, 196, 200, 199, 201`.
+- The run reaches its eight-certificate limit with no unresolved model and
+  adds `200` unique affine clauses.
+- The checker replays `325` exact affine certificate images in total.
+- Decision: `COMPRESS_NEW_C25_REPLACEMENT_AUGMENTED_ESCAPES`.
+
+Generate:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py \
+  --out data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/summary.json
+```
+
+Replay:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py \
+  --check data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/summary.json
+```
+
+SHA-256 of `summary.json`:
+
+`cb3a06a79c21fa8ce3c883888458d3762b457fd8f7082f2535d5b88288d313ce`

--- a/data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/summary.json
+++ b/data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/summary.json
@@ -1,0 +1,19696 @@
+{
+  "active_exact_affine_seed_image_count": 125,
+  "active_seed_orbit_count": 5,
+  "blocked_history": {
+    "dihedral_order_count": 192,
+    "identities": [
+      {
+        "dihedral_order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "history_id": "prior:probe:0",
+        "order_sha256": "7183c7ca997b276f51dd3d6d2ef13d1a61329f114b0b590087ea5f73cbff9ecb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "e47ce1873ef7df7855de6ac947539b6b8cb08f69fe551b55db4dacd8594de6fa",
+        "history_id": "prior:probe:1",
+        "order_sha256": "efc4a292c226cfc11e313d0c4404977f0e4d67f8b6f44f92009cfc421b5fd29c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8a17cf46dc234917d8cfe36ff788438c4f49bf137c67a6edf37c6f305c1063df",
+        "history_id": "prior:probe:2",
+        "order_sha256": "c95c42099fef5ebc90a4037cad6d101892b494c64604c119a628293f7bf2331d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "82db3aad7af4566f9bf5624f50133b7cbe34e22b3cc2a81981c4777199a73adf",
+        "history_id": "prior:probe:3",
+        "order_sha256": "666ea584ade30a2e1f2c73701e959a53a5f62313940e4908b36c432228be554f",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "02ed07cd34ac32b87a770c4ef50acbaa24091fe89c0fed35a5d52989e08d6367",
+        "history_id": "prior:probe:4",
+        "order_sha256": "0e6cd6f07b0e787550f167b7b2618c093798a7daf6532ed7034883102e630f6a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "history_id": "prior:probe:5",
+        "order_sha256": "8d2b58bfd61772233efca5c46bf703a0ab4141146c43ffa2251fed1c4b18ef7e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "79babcff39c14382587e9985c2a7f29e9f235ec820f9be660d4a5b389a80c157",
+        "history_id": "prior:probe:6",
+        "order_sha256": "fff3141a6a0cb083c0c47caa9d503962f2e8df7d09b0cb7bd7feb48749db91cc",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "58ca3889b456993b7269bc29f804db9ae48ab1f1cba6e3b32fffc551643f18f2",
+        "history_id": "prior:probe:7",
+        "order_sha256": "4f1bd2dba49c94c3347c1f8d305a64c63909a7c554fb8dcae8d30043d81ff5f2",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ef45651dea4eb7f0dd109be674abd64408952f633702ede41bc2fde02d1cae72",
+        "history_id": "prior:probe:8",
+        "order_sha256": "e20270d7c562e00367c52995549417843bcef3d8603184d207639c904148c571",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "12332dd76c249041d5a28b9c81dbe613f45a41c5a2685910daa3517ad4b34027",
+        "history_id": "prior:probe:9",
+        "order_sha256": "dc61176ac8c0097851f2854c265eb7583663b5a6a2f66126bf5a03846d56e63e",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "0f6cc8e662af54f44907d245f9adbd6cca93dbdbb8c14ef9a99adfcb9ac1ed0d",
+        "history_id": "prior:probe:10",
+        "order_sha256": "754426e7bc885a0f2e8fb1c853807baed5351586254e29bb8c92b0d0f7cd25ef",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "15e5a1a1fea1a5c4c47229faa4ebc023063d8e2802139a23bd754d30c5c851ea",
+        "history_id": "prior:probe:11",
+        "order_sha256": "060fe21eab6ec94f7825cfb799fd2d022cee8a3f0db90f73fd69e6154d7da5fd",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "141cf222b3b0697645027b016fa45231adbca52849dc3f7d9523cb32061d7665",
+        "history_id": "prior:probe:12",
+        "order_sha256": "d09f13e9829115f310886304f784cb62e2385fd9dcf291bd1b0db6670624e40d",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "086627559e7a75648d34ad8dc52bd10baba93dabd028de442ad497dcc3c34818",
+        "history_id": "prior:probe:13",
+        "order_sha256": "2bc81b26171354d28295d62241623aadd68a98cff34fee7b7e0ec47465187abb",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "bb962a4708e2b29db9d7ed570225b789a34ccca8a14ce7121ba8f514dcecb481",
+        "history_id": "prior:probe:14",
+        "order_sha256": "581f88dbcd0fe62dd4b80be4521d5ba21399a400fd50945694dc2c01287cc430",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "74e24135b5924adfadf007c806b6aa922dd473ca0b82512b9699e83ee4395b8b",
+        "history_id": "prior:probe:15",
+        "order_sha256": "6ca9c08de031a639defe03c7f5aee697b8142cc1884460d9aa314df76e2d13ec",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "cf586c61dd9f421f025969fd3dc6342bd632daf4221e035c00af56f422f07b6a",
+        "history_id": "prior:seeded:0",
+        "order_sha256": "3d9f6fafb2bdc898aaefab174932d060919b4992440954d03266ac0c4c3a8c54",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2a2374e7b829f31f5a3afc50a6115620f53894bd7b47689f9ce838591a7d3145",
+        "history_id": "prior:seeded:1",
+        "order_sha256": "b143a0412b3d7179d2dfa5ab7056fc86f0f61678f29463343201cd3755310912",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "2664a62fd1f2df2ceb8c350104fbc18f01fb918c919f345a51234f0fc080a765",
+        "history_id": "prior:seeded:2",
+        "order_sha256": "7ddc43a26c71be6f9226d86a4094064ea2a56f1f87af69c787c9b50e7285fc18",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "87025881b3c0d75c80505a291d7206657e7cf8267543f6b1f4c9bfd897d402ac",
+        "history_id": "prior:seeded:3",
+        "order_sha256": "62af9cce7d384bb07a18bee0a5666e752f08ab91ff6cb8f28d94bdaec6de126a",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f9be89d8cca62869c2d7500e4d75ae8a28d5cd90e8315cc711ecdc6a76899523",
+        "history_id": "prior:seeded:4",
+        "order_sha256": "e7ff334e2ba96bd7861442773e354845c776db61d2723a7fe9229928c2af8a95",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "6198d5cd8e6689d0af6250c76d076db6606ff85eaaf14a9ca1125944ecbb0f8f",
+        "history_id": "prior:seeded:5",
+        "order_sha256": "9ca9bcb9f7ac3012eddcd1faa95a2e41c5c2062ac1b662d828938d902ba81902",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "history_id": "prior:seeded:6",
+        "order_sha256": "92912ff47eedf3cc55b6c3e42934ff1356770bd2330f4bdbadec545e8165503c",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "history_id": "prior:seeded:7",
+        "order_sha256": "ca820acccb981784ac7a8e52f4a7ec0f0863cd550803ba8ee4b1995feea1ba50",
+        "packet": "prior"
+      },
+      {
+        "dihedral_order_sha256": "f65bb867cbc8532d2c2c89682895ae8999d75de687ef6d03e8122039b88a60c1",
+        "history_id": "first_fresh:fresh:0",
+        "order_sha256": "b3fb01c68d5763b9f7e1145de43d85fa10593e255de1664502289aba9f2c18d5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1495f18db025b31993978b203d9884065a466f27754cbb6930c0349d027d6837",
+        "history_id": "first_fresh:fresh:1",
+        "order_sha256": "e5bbf6b4fe5c23b4d8660b0ee114ae5197a9d92f8b8a7817c809d66c67b6bc7f",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "14e2003e2113af6086da7654e7dad616e2b5b87fb06dfa1826f5e27d276da60a",
+        "history_id": "first_fresh:fresh:2",
+        "order_sha256": "fffc543b5fe7bd806e59be736acb34787451c354d733cb00cbc0d3e1d4a17ceb",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0b7138c621548805e187aa1d5f0b70c169765362a98c21535a3b7797b62c9fe",
+        "history_id": "first_fresh:fresh:3",
+        "order_sha256": "f1f588b6a76fe0727293f263ff3d40bbfe537e40293f68a9e14b7745d23a419c",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "120335beb6c2273c2f30312e297cd69ae2316e1a273044a0959d79f824424a5c",
+        "history_id": "first_fresh:fresh:4",
+        "order_sha256": "6bb23677f914747186d71bf861bd525e7f3788e608396f106b27bf70524c4637",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "history_id": "first_fresh:fresh:5",
+        "order_sha256": "639e2159c550feef6bd9cf9146e1627ace1c8a98fc89c81a626618b078bde5f6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "history_id": "first_fresh:fresh:6",
+        "order_sha256": "f6fd016a3753972fee8cf8a43b4017b7874a2c1020de8cf9bdd926ac08db9aa5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "history_id": "first_fresh:fresh:7",
+        "order_sha256": "dbd48c691bdb204cd2d1f402a2c64f0d22a4dcd6a61ff479c9ea5603b52ebbd5",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "history_id": "first_fresh:fresh:8",
+        "order_sha256": "35edfaafcf8fa341a2e840bc8bedca7696c22b70103901e089dbb73539318e3b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "history_id": "first_fresh:fresh:9",
+        "order_sha256": "e213d4bfc83a5f48184d3cccbc7c2575a459ce8af6befe6c7941d57ec3966360",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "history_id": "first_fresh:fresh:10",
+        "order_sha256": "7510eb78efeade7cdb96282c6f3487fb9dbb60b97d15c4ee929e877f557d3567",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "history_id": "first_fresh:fresh:11",
+        "order_sha256": "0b291fe26606a823525b3e10429142e437b8e9118b0a58f64c6ab1ba42c1ef48",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "169cb63c511b5342437e41bab670aca22fa1a8dd49197596a5b400c0df9aad93",
+        "history_id": "first_fresh:fresh:12",
+        "order_sha256": "7d26dac32a4f49b310623dc118741fd3eae62a98fddc3fc02343cda28982e0d2",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "history_id": "first_fresh:fresh:13",
+        "order_sha256": "32005227574dc4178a5ed0dc9a92532a4aca2c618695ab88abab279cf2e90eef",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "history_id": "first_fresh:fresh:14",
+        "order_sha256": "bcbba47865da74cce7026116c2ed0a10c0b08306440260fb953655a45cd4f9f0",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "history_id": "first_fresh:fresh:15",
+        "order_sha256": "bb3f6eab8819ac4e2fe9bf2869efbbcb098ff08433d8438c4d58ff46c8efa96b",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "history_id": "first_fresh:fresh:16",
+        "order_sha256": "2c0c348bc227e3416ae6baf8b02bd2635672b3880023fcee62d4b89007c5e022",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "history_id": "first_fresh:fresh:17",
+        "order_sha256": "d01ae7558e6b8c8c8fdab9643ff77b7495a35fb90fe205c7e00c0c7b9d1df97e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b2ea5b6ee6ac796d5383ae7260006a43c9ef172de728ce355103ad818c011870",
+        "history_id": "first_fresh:fresh:18",
+        "order_sha256": "ad2c330339c8d008ca9dddebd31e6e72a92f3a882529ef6afe1eb15687ac3a92",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "39344073585252f9a0c4b427237efa9eaff37765c4aebfeba914b69695fc05b3",
+        "history_id": "first_fresh:fresh:19",
+        "order_sha256": "f3ff2b091996877bb676eb68b61bd8740b052aa0b0cc11bf737b7921f33ce237",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "history_id": "first_fresh:fresh:20",
+        "order_sha256": "f53132101e7ebc6bb97285eda5c63a15bdbac44ce205fd7843bb9394a7418435",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ec5946bf2f40dc5430e51e9490586f5672dce0247712e3725efa519a53aca7de",
+        "history_id": "first_fresh:fresh:21",
+        "order_sha256": "9bca3aac19a02dae679142542a99e8f2691b6b621620d71a97ab7ae9cc651128",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "history_id": "first_fresh:fresh:22",
+        "order_sha256": "2698d071f7d4e7f968fc4fd54e45592946a7ab97d60f0a268dd8d9393be234a6",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "history_id": "first_fresh:fresh:23",
+        "order_sha256": "8dd6bdeefe428f1636d03e94a2f6a8d1613c58cf54b17d9f575da443006b9e22",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "history_id": "first_fresh:fresh:24",
+        "order_sha256": "eebb3863a6d7df62e23ba4ae84b69887aa0dc28f91ff1909312f8e0125de2498",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "history_id": "first_fresh:fresh:25",
+        "order_sha256": "f7f9ff4dec5acc19eccb3617bbebfd51c8de91ac9995ea01ed51c5e7640a40f1",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "history_id": "first_fresh:fresh:26",
+        "order_sha256": "d5f06651cba5bc1fea4fb741463b0a23882da46749d0428bf05043bbd1fee2db",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "history_id": "first_fresh:fresh:27",
+        "order_sha256": "fd00f4de36ac19dc608c032ddceceb873eadedd95e3a60e04860d1818d288273",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "history_id": "first_fresh:fresh:28",
+        "order_sha256": "68ed7c2cac3e460e5de8853d7df30002832ed27e3b5cebd9053d700dc9e7cbc3",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "history_id": "first_fresh:fresh:29",
+        "order_sha256": "fab70b9a93e3f71ad2c4cb6c3523fb1364b71f3fae64d78dff46f38ce9320d4e",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "history_id": "first_fresh:fresh:30",
+        "order_sha256": "52d3d48083519c9975f499dec5daf2a00b4aaf49cd7af51fe470eee6ad38c7de",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "history_id": "first_fresh:fresh:31",
+        "order_sha256": "0cf5694e97aad30fb027c2899287e1e73995c4dd8a7ef34101500a61eb7b5861",
+        "packet": "first_fresh"
+      },
+      {
+        "dihedral_order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "history_id": "second_fresh:fresh:0",
+        "order_sha256": "828a3f13fd039e97129295fd29548f53130265fe707996b11d4fb88215796243",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "79992c5f6bd66f15584ce60b9059f4f9adf6d6c3bbfe13a6c7e985e4cc98e934",
+        "history_id": "second_fresh:fresh:1",
+        "order_sha256": "813b0573bbb49d2ec6fdd5850c98a09faf809b8d202f75b9b5039304d45fc12a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "history_id": "second_fresh:fresh:2",
+        "order_sha256": "218459099c875bce39b5cf9192fc8947d5e68a732128334268dd2e7dddc109e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "history_id": "second_fresh:fresh:3",
+        "order_sha256": "c0f676575c9cb7ab3bb143ee2cdd9396b9fcf2f5b2723216d9b08a3a9f6ea626",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "history_id": "second_fresh:fresh:4",
+        "order_sha256": "c1f269238c885127e472e225ff203e1d9cfeecaf21479150d8af8a1c79a39dda",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "history_id": "second_fresh:fresh:5",
+        "order_sha256": "3a2f39b7265e4aef04cf243d2466b4b1a9f4dd61ab6c67eb2952ff35e76c253d",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "history_id": "second_fresh:fresh:6",
+        "order_sha256": "00589e11539bad5c749d22f0dd213e183240229a5573994e528208eab2225259",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "history_id": "second_fresh:fresh:7",
+        "order_sha256": "414752bf9c9ffaa43be173c354f1f29e8b5d05d0b4d81662a6235c044917d37a",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "history_id": "second_fresh:fresh:8",
+        "order_sha256": "f43c6d8a6f0ed26ca4b545de905b424f8488162d7d08c9e34b83a0649724a506",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "history_id": "second_fresh:fresh:9",
+        "order_sha256": "455c9472dfc8871ee85a21126c547da473f50f6f520f87f15df16031078b05be",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "history_id": "second_fresh:fresh:10",
+        "order_sha256": "e3d2f3ed299f067c2adc0fc2db3238e826170682493b023bd12230f80e3a2a25",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "history_id": "second_fresh:fresh:11",
+        "order_sha256": "06a56cfbcd14dcf2acd6381e766e0eaa9bd1e2fa2baf6a82d5dfb3d53a966415",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "history_id": "second_fresh:fresh:12",
+        "order_sha256": "790dcc2e4be3c9aeba645a38813cca5b45f890c753f31b07d80a3e79803707c0",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "history_id": "second_fresh:fresh:13",
+        "order_sha256": "eae4d01848fce568167cfcd86a5ec7976eb49d8058ac929659003e475a7ab547",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "history_id": "second_fresh:fresh:14",
+        "order_sha256": "28f866901a622fe1bf51ed36e3165aea6c6bb85e759b4fd0ae14b672465ba617",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "history_id": "second_fresh:fresh:15",
+        "order_sha256": "4a79ea8870c8cf60d6b6e6a3166ee3abf2d84ae07fca25be3b24c665d5b70eca",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "history_id": "second_fresh:fresh:16",
+        "order_sha256": "7556346ed49b6bd78833590965d49dc1809f064fd0b17de50b0c0da470d92e64",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "history_id": "second_fresh:fresh:17",
+        "order_sha256": "a64122b376e1165de6770c22526fb7be0659ed72899f298967ba8092e9070433",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2210ce735dc632ef83e03e7b2d4a3634375c2de67696f6a365b902a9b4bc3f86",
+        "history_id": "second_fresh:fresh:18",
+        "order_sha256": "fe45925710e246345dc057ea7c935ae9c3070ad9544efd0b19be6b546fa64220",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "194f3fd7909ff96ed4d2f5e2dfd692d275d2133f0855cd649b6d759e5aab8643",
+        "history_id": "second_fresh:fresh:19",
+        "order_sha256": "ec5c74f9b07ef5d4a791ebd149abe20ec81a42ebfc23d8121afcacd22fe5fe66",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "41c5ce250a21087b96de0cd9afe6e772afe256bfba0efb86dc4b9cd866ba1775",
+        "history_id": "second_fresh:fresh:20",
+        "order_sha256": "e5bfda8732de5ace04841e34b1683f96d951c7b3c720e01ae8fbca8252cee2e2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "1f94d235621cb6118fbcec853d4ce051fbc0da58aac1f6536f86c1a07a7c8ce3",
+        "history_id": "second_fresh:fresh:21",
+        "order_sha256": "f10f76dcdd591f5c4d36be49cea8e7b063f8aad6880f227da5b1541bd2fc65e6",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "91c0adb00ca0fc2c9c95e0a6231d9ee98bb106fd4e4be71d22321a23dd713102",
+        "history_id": "second_fresh:fresh:22",
+        "order_sha256": "c7c0cf5c2af1ee6ab12519d404279ed36f2b3c63a3f047b2f34208670ffa6a33",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "history_id": "second_fresh:fresh:23",
+        "order_sha256": "ed667a158b3bef6c80781e4e2d9f0f0e75d1b3062079ddb1726c85d47a5faa05",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "history_id": "second_fresh:fresh:24",
+        "order_sha256": "190fefa17714ec63b855f6265220183e7c89f94f08aa44e1ef59e1adcf06c37c",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "history_id": "second_fresh:fresh:25",
+        "order_sha256": "b39c2dffa5d7ab82c1ec9b7f0fd6ac8f9bcce0f4fa24b5980b23255ae4f0d1e7",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "history_id": "second_fresh:fresh:26",
+        "order_sha256": "277ba0a510be214c2842ed06f02c8cebac16ca432592ac6bf289832673b57e9b",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "history_id": "second_fresh:fresh:27",
+        "order_sha256": "2d98ddc21cd0d4e8a240b7c2433cae4a142d285250375716c25e6157ce1569ed",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "history_id": "second_fresh:fresh:28",
+        "order_sha256": "e6afce56ed5d411adda51133665dbaefb26f193f2efe9d745f7d354ee3861e49",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "history_id": "second_fresh:fresh:29",
+        "order_sha256": "a91a0e74e55cd34f96e31e5003454e55d2e976a27d31ef30e5891bb5f9d1fbc2",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "history_id": "second_fresh:fresh:30",
+        "order_sha256": "f14ad4a340732b2f19862e8c0bff21d04be1cbbf4f6900921dbe2f5f8b4e5952",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "history_id": "second_fresh:fresh:31",
+        "order_sha256": "c71708fb22fdecbad71b85a0056f3cf42ca46651134a5c5fb183f47f9030e7bf",
+        "packet": "second_fresh"
+      },
+      {
+        "dihedral_order_sha256": "21af0fdceaa2c7b6d6fd444590571ed04a48bd7e0dce5aeafecf86e80e6b2081",
+        "history_id": "transfer_cegar_probe:0",
+        "order_sha256": "01e5595550dc1a887be1e0a5745e1ea9ab38070460f5afa569ad45df8ae3a32c",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "2ec108f7f3fbc4f5b9dbc523095b381676452797aa2384d5d4e65eb375b22f3c",
+        "history_id": "transfer_cegar_probe:1",
+        "order_sha256": "793e8e7d2770941c399debc6a5e57e4c903561f826f10991922fb616d14081c4",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "892d53605b57f7e885514c3bc240208a75c949cd05d38d6b869f9a52a222fbda",
+        "history_id": "transfer_cegar_probe:2",
+        "order_sha256": "8477beb967b9eb08f3528689ba26bed083a58f98b3aa384414b5b625d0ed28f5",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "history_id": "transfer_cegar_probe:3",
+        "order_sha256": "557da207316ed3767b29d82b9af7cdfc716a9157e1cd1c98127670c44219243a",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "history_id": "transfer_cegar_probe:4",
+        "order_sha256": "6a4e358dde0d43b2ddcb8ec4256a3dd60bb7600a57e1f04dd022c85b1164d787",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "history_id": "transfer_cegar_probe:5",
+        "order_sha256": "c2c08082cabd3d645a6d67eef427b690b5f5a67e682821f2d6590282a1b28e79",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "11bec0ac6af6f23f784eb87a4829063a3fcafa5afe5f0312d6f596981dd16623",
+        "history_id": "transfer_cegar_probe:6",
+        "order_sha256": "c2be4b0fce6eeeab8dff1f8c2569d23305b998bdf248f09edb0c16adcbd739a1",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "history_id": "transfer_cegar_probe:7",
+        "order_sha256": "e61e3c68a98dab26e34930357a03a6abc9a8d1b80ee362d5c75d40fd24d03973",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "3f394554dde1776db09fd7018a91729b93c154520d599454bb8c00b9aaf6e7f4",
+        "history_id": "transfer_cegar_probe:8",
+        "order_sha256": "c60c083264a78b314734ec064a7dfc0d27f62cf6954b1652613439d313b74f00",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "history_id": "transfer_cegar_probe:9",
+        "order_sha256": "316614656efcf6339433c3baea495a354a5e194ecab969a186cefdb3778b9c58",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "b62b485b3882d8da27d08d57d4f9623cec3e06fb0cbab1100ef51f7d58af5760",
+        "history_id": "transfer_cegar_probe:10",
+        "order_sha256": "443391e50babb2e418cf3acce0b958bf584bbfbdd5d30cf538e5c5ed299f388e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "history_id": "transfer_cegar_probe:11",
+        "order_sha256": "0277aad58c8bfcaf8bac6056f8a94f91e4c06490fcd88c27a14ca38199fd2bfd",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5198401fb43886093718c4425e1cba2cd6ba7bc36a1e43ca52f68acb1467822",
+        "history_id": "transfer_cegar_probe:12",
+        "order_sha256": "918febc87d6907cc754ee5cfd79b8a5c258ab2c0d3045606b310f3a5e076e3cc",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "history_id": "transfer_cegar_probe:13",
+        "order_sha256": "a07433c64d3b2a05a3fb47011ab0179d0d915263cb8c460e454f235e6216009e",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "history_id": "transfer_cegar_probe:14",
+        "order_sha256": "c5f82aada80a376209e3dc2c96671d2f660de6b57a5c204af16e5983387de0f6",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "history_id": "transfer_cegar_probe:15",
+        "order_sha256": "51fb4fc7a10de7ff85c9619e4026239d1d0ea1032b8a385ce2a6a4761a6fabfb",
+        "packet": "transfer_cegar_probe"
+      },
+      {
+        "dihedral_order_sha256": "518976209920025e367b9beb159b8cdc524e485ef40fff87460cdc2959476cab",
+        "history_id": "transfer_cegar_residual:0",
+        "order_sha256": "e24c65ad7cd685c73d1cb969841fd4c72ecd0d56957a03239f4033de180555c6",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "5846cfb91ddf84cfda808e3f4c44d58a8cbb429d53db50f4e303fbada897be4f",
+        "history_id": "transfer_cegar_residual:1",
+        "order_sha256": "4ab9d66bab68c96f6804a8acbbb80d5e865a4e4cccbe628661f47c89878ae8cd",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "history_id": "transfer_cegar_residual:2",
+        "order_sha256": "924a1535e474a142650093c2851bba14ce38b4b59997c78298b6458a818d6c79",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "history_id": "transfer_cegar_residual:3",
+        "order_sha256": "17f661e7f2d03bb2fd1764bd0738969e256724d3a94471eaefcbcd09e191f3c7",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "history_id": "transfer_cegar_residual:4",
+        "order_sha256": "c2fa9cf10eef566114c1e45d86032509c80bb317c42f7258b51b127c82a2d70a",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "history_id": "transfer_cegar_residual:5",
+        "order_sha256": "2bcfbfd1dca23f27883e22d940950a85959fb29c040558ad67dab889c067f010",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "history_id": "transfer_cegar_residual:6",
+        "order_sha256": "656fa8655ca5bbdc588bb687c124f4badfd17a5cf5593a8986c4463aa963c644",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "history_id": "transfer_cegar_residual:7",
+        "order_sha256": "334f49c6708f1e9c8fa138609b5b95e00b2a483610ef0b462d514f63fa3193d3",
+        "packet": "transfer_cegar_residual"
+      },
+      {
+        "dihedral_order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "history_id": "augmentation_probe:0",
+        "order_sha256": "6f5090289ad6b1d04a92f3946e888903e2de50f45d3791e97fc7b4b5eec09cae",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "history_id": "augmentation_probe:1",
+        "order_sha256": "f133de44f4eb1a6cf1b035848d89cd9eb74c0fb2cabb06b51508078c6db622e9",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "1c386c157cf50020135c32b97b2bd1252a10e0a76acc05739ebd1f79813cab0b",
+        "history_id": "augmentation_probe:2",
+        "order_sha256": "2968b0a163e6b15c9a4fd3ae309091089b864290224eff954088809fea1786aa",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "6dc35b1d65c62e2042ff2f2274085bb0d5e54b8f93048bdcb02beff769356f7e",
+        "history_id": "augmentation_probe:3",
+        "order_sha256": "c98f9fda4a774c274f83baf63ad5fe0be5e64d5110323e63decf1b243e42b4a6",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f8f07b4dfa0c7b5b1cdb5e52ec58e09f720179fe9c2bd6e15132f3adf1e94023",
+        "history_id": "augmentation_probe:4",
+        "order_sha256": "9cfffb312b0cbe7074847072c804ef7890f0de69cd2a3475901941885ef11098",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "history_id": "augmentation_probe:5",
+        "order_sha256": "84c12d409c3d7d8f78073f8d5370e6452cec9e55c5a21dc3c6ed26435255ba4f",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "ba04e21c82460534a05f784da7af74b5db4579daf575969d2f3664c64527d8c2",
+        "history_id": "augmentation_probe:6",
+        "order_sha256": "58ef1145544aba90699ee3949e67dac9f93ee20e108de7a7ed81c3a50ce1f882",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "eaff5f7030f3780b3ac105f0031dab52a5aa483dc42d156895a227713fd3d357",
+        "history_id": "augmentation_probe:7",
+        "order_sha256": "aa82c870cdec719876a50964d030d7c13da82a632c3a0f16ce05efaa8a41a6aa",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "history_id": "augmentation_probe:8",
+        "order_sha256": "d5f31d1f086aa6ce1119b97232fb0b266ba25c24541a349ec9399f68e2f0bd1a",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "history_id": "augmentation_probe:9",
+        "order_sha256": "fc55d4e73c614be48b7aec5fce8f612d849828084eddbcbc596936ad1bcd7120",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "history_id": "augmentation_probe:10",
+        "order_sha256": "f598a410441edc2badee2524290930fe416f8aa8f0f98fdbd791242382d60e55",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "history_id": "augmentation_probe:11",
+        "order_sha256": "3a7374904137b66030f0ab016080e8bdc1fc99b17d19a6afb12727276af9aa01",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "30f362230bc2ecc4c569923228b5a4ce003220f93c3869bcd57bad5a6f8240fe",
+        "history_id": "augmentation_probe:12",
+        "order_sha256": "fd1d0c8af17efe869c2a5eaa37f44d2ff196df14e2f4e2b5d645d1fa3f7ebf2e",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "history_id": "augmentation_probe:13",
+        "order_sha256": "5e38c4613d3c78e84dd1fd675c63d42f0aba4ae01ede146cf157810b195fda68",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "4a99c5a82c42e9253460d4e3612a3b4d30d567e71749a417bb9378be8a3ebc52",
+        "history_id": "augmentation_probe:14",
+        "order_sha256": "a343ff07c8321bf23451fe9b7cefad97adaa8f48e9557f25187f4cab5d732760",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "history_id": "augmentation_probe:15",
+        "order_sha256": "7497ded949d58d528c5055e5963634189b2db3029878d8557410c284fba39074",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "history_id": "augmentation_probe:16",
+        "order_sha256": "c2ae18915b6600f5af9596867d7a6ac1a036bd82ba009af1c65be380cb23cf08",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "history_id": "augmentation_probe:17",
+        "order_sha256": "afa4768234aee3dcd2f41cb29fb74ff7b6acb199c05343f2a0b51e54da8a160b",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "history_id": "augmentation_probe:18",
+        "order_sha256": "ffa56585261f0d1f09431787cca928146d6dacaf9714865496d92a52676df684",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "history_id": "augmentation_probe:19",
+        "order_sha256": "f35958fc1bf405022c3fa55c3fa77db9d59d1aa687d500969bfa5bd415fce0e7",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "history_id": "augmentation_probe:20",
+        "order_sha256": "8d032942ad3541bde501950233098507b23faca5fee98bb8f9a66441a6f60ae9",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "e71b60f92693ae63a66e0e0805134f1436381cd85e61e4cfcf0fb9c7843d4fd3",
+        "history_id": "augmentation_probe:21",
+        "order_sha256": "383b5131a68b22240a74ec5281be3ba01a372dc02241d9b706d11a80e66bae0c",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "7ae8308d62d26f3fbefa7a9862f88a26c3a1aa2cc4a51f07c5e2cfd0fd7b67e2",
+        "history_id": "augmentation_probe:22",
+        "order_sha256": "47cbe888ff88b45b833d8fd1f8dc89bca00656bf9795ef484a3a481345b027f3",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "8ccd5b799ffa1e43f5b47f14a140bb0a6484ff859f9621f0a41bfb294c9a6869",
+        "history_id": "augmentation_probe:23",
+        "order_sha256": "4c6f5a3aea2e6afe78c2ae409b429cd35c9c06ea7cc1ac23a355ac50f97ca0bd",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "715ff051ef4e9563096c2798eaa5894890379a3089e5875874e624b9799cabb7",
+        "history_id": "augmentation_probe:24",
+        "order_sha256": "e4706b5d6ecbd1b1f03ae78cf2f130f9b962e32236ada16185baf6b25f4d40f7",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "history_id": "augmentation_probe:25",
+        "order_sha256": "cb6d435b587f27168c19b9da51551cd888c79576e83360b947910a80db11a11d",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "history_id": "augmentation_probe:26",
+        "order_sha256": "bccf56a7da4c6b01edcb4a9cf3f681bab2a3d9bdfb1b7b728d615735156225b6",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "history_id": "augmentation_probe:27",
+        "order_sha256": "60ae765827e5493d48e5231b8af57232035628704a6fd681584eee46ee1f6669",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "history_id": "augmentation_probe:28",
+        "order_sha256": "eef09fd90a77d1ecad75c3c0e508eb5efbb6bf986d4089a2b8d2f39ab4d36336",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "history_id": "augmentation_probe:29",
+        "order_sha256": "751224077ca35453f2ebca18e657448234d41b7b37ba3953356c0f95528e6119",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "history_id": "augmentation_probe:30",
+        "order_sha256": "b8c66884c2fc586a7406df7647497f6c883860ab452f36c558f01eeabc4396f5",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "history_id": "augmentation_probe:31",
+        "order_sha256": "e4ad42c4b2a1695f3e66f579f953691a52e15c0a16f522d277b27d5b7418cde4",
+        "packet": "augmentation_probe"
+      },
+      {
+        "dihedral_order_sha256": "5ef345f1349ff914bcf3bcf459fa62203386351a2c723979b5ff8699028e0402",
+        "history_id": "persistent_augmented_probe:0",
+        "order_sha256": "5ef345f1349ff914bcf3bcf459fa62203386351a2c723979b5ff8699028e0402",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "5ddbaeff0aeeede2790d73f42e3b2f4d0f5c6d117c5e26984674ecf8abdd7726",
+        "history_id": "persistent_augmented_probe:1",
+        "order_sha256": "5ddbaeff0aeeede2790d73f42e3b2f4d0f5c6d117c5e26984674ecf8abdd7726",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "37f73c3cf6ff91b10b5246de93ea8e08ebb1b574edde9a364becddac7d2c7ca8",
+        "history_id": "persistent_augmented_probe:2",
+        "order_sha256": "a97a21ca890dbb3cede13d40a49b3cd3c80de3739ee22fc1539c27f7a2c9ff55",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "e545f59d547cb4eb16eb05f6f005cb5eb81a686f2b8316cb82739be659c5a8f3",
+        "history_id": "persistent_augmented_probe:3",
+        "order_sha256": "c4ba39e59e4c4bfc0384ad21fa13f5409990000ac475de2e49c5ee7d449bc1fc",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "d01d8a2d708f94901e3c82ce71c4cbb576ffd85bf3527edca38d5557e4e2bed9",
+        "history_id": "persistent_augmented_probe:4",
+        "order_sha256": "2040570e16bad06ccb17f53583fee3437e24528ad579074b1cc1f90d62b1226d",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "0aadb2e30d2093eb0d54ef2ba26477212a4838c3eb7c11795e5a4783dfeb52fb",
+        "history_id": "persistent_augmented_probe:5",
+        "order_sha256": "8a0e23f99c788d5ddfcbce03e64fdd5a670757c2d9f285084dde56c019d112c9",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "e3b7e4b11cc8876bb0c2b2a8a845fad3919ec4f548167266c9a7c1159acaa7cf",
+        "history_id": "persistent_augmented_probe:6",
+        "order_sha256": "c19090f55d494cdf88cc62828d3f4ac1725e571b9ad9d1ffb898104085504e0c",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "fa936ef8774e4ac5ee1e28b74b40472027e67a63373150d54384715f1eebb25a",
+        "history_id": "persistent_augmented_probe:7",
+        "order_sha256": "cfc8b5c7172ce19b98f64af0ddca23b74caecaf10c77f520786967af46237551",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "2832320261578a148556886137ceac035b359ac0144c8f3a2b38bcd6ff28cb29",
+        "history_id": "persistent_augmented_probe:8",
+        "order_sha256": "2b21e2d8946e6ac3eab28de470203b7087e85eccdfbbea71f516e60950816ba0",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "994dcfacd99ef5e89dce19f8c4b55340744813f26d4382fd5ef1e11ffb0798d7",
+        "history_id": "persistent_augmented_probe:9",
+        "order_sha256": "d2558f98e57e8713c96f183a33d6f267400acb9507249cc6cfca3af7d5bd31fa",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "c15c6171b383b87320dec07cf0a520c0ff82afc545deeced2b4a70d1cccdc2f5",
+        "history_id": "persistent_augmented_probe:10",
+        "order_sha256": "11f5903dbcc4c0363747842df6060739e22027b66c17029f4115ef7b286f6e10",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "1e6edfeee8c2a8c9aa09b1c1464126ceaa8f4047b4b01d746204536bd0e5a4b1",
+        "history_id": "persistent_augmented_probe:11",
+        "order_sha256": "0325aff35bca425d6cdf128772fa9184aa63903356fe4a35c82d369bdd961da3",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "6e4b8d2b6f199af5da0d25043f232d352b667439e5b8adb1e2784f24a61b45d9",
+        "history_id": "persistent_augmented_probe:12",
+        "order_sha256": "f7e9ad983fb5473c0ca2f1a9229c71e65a24473ce415437a15a1cf04baa11f7d",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "92981ebf7bafb1138f1db7b0f7c035b8055e31dbe73b38fc8a1c6492ba51eae2",
+        "history_id": "persistent_augmented_probe:13",
+        "order_sha256": "af99cf38492e495b31ce644fe86d4d564fdea23e6bde20ef65321f69274ce099",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "d250a8468ba4f6dcf76c13ceb832ff74cf6ce83a7b5aae837fcee8b663f8757d",
+        "history_id": "persistent_augmented_probe:14",
+        "order_sha256": "9d1d5c00d4b3bbe90ba30b80a0d1c119bba06a1b47f3554b0e8696e0cf1a1f33",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "ec12a86d316165551a7e0da91fefdf023021a7bd3fa1aa7362d787d7fad699dc",
+        "history_id": "persistent_augmented_probe:15",
+        "order_sha256": "eae5019a4c4ff562c07cfdd815ae7b390c8482d0911418583d09f04b8befc64e",
+        "packet": "persistent_augmented_probe"
+      },
+      {
+        "dihedral_order_sha256": "55db65a812422826d3953cc6ad5a34d108f4bd1b1a1d1b6bbf1cee8185bf36f2",
+        "history_id": "persistent_augmented_residual:0",
+        "order_sha256": "55db65a812422826d3953cc6ad5a34d108f4bd1b1a1d1b6bbf1cee8185bf36f2",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "5130eb5b4f4b45105f5365b91ffe649d866eb8b2039eaafbb9108386201f7316",
+        "history_id": "persistent_augmented_residual:1",
+        "order_sha256": "5130eb5b4f4b45105f5365b91ffe649d866eb8b2039eaafbb9108386201f7316",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "7d73aa04a3840408e2a9250b347d54a0a96720e6d2c9c485d3912890d47f536e",
+        "history_id": "persistent_augmented_residual:2",
+        "order_sha256": "7d73aa04a3840408e2a9250b347d54a0a96720e6d2c9c485d3912890d47f536e",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "7ca60b4094c81d67ce63bc047e16ecc90dbbb9ba3fa4e9787198e259995c7542",
+        "history_id": "persistent_augmented_residual:3",
+        "order_sha256": "7ca60b4094c81d67ce63bc047e16ecc90dbbb9ba3fa4e9787198e259995c7542",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "a62219f86227c146e1169b27697de6488957a23f0df7182b347bed2fe13830be",
+        "history_id": "persistent_augmented_residual:4",
+        "order_sha256": "a62219f86227c146e1169b27697de6488957a23f0df7182b347bed2fe13830be",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "b794577f9b684ad39dfc20bf8c49ceb4007a340c1a949f1d1ae9553367265642",
+        "history_id": "persistent_augmented_residual:5",
+        "order_sha256": "b794577f9b684ad39dfc20bf8c49ceb4007a340c1a949f1d1ae9553367265642",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "21e13c0d8d493dec39d581382440e682b367c863bd076be5db0f6481365cd6df",
+        "history_id": "persistent_augmented_residual:6",
+        "order_sha256": "21e13c0d8d493dec39d581382440e682b367c863bd076be5db0f6481365cd6df",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "7878fbe6f726d920f08ac5c0d6e0ab5ee52a85cf5d9e9f99dd65dc385a1fb241",
+        "history_id": "persistent_augmented_residual:7",
+        "order_sha256": "090fbe04e428d5c9f63a576cd1f89ba16b37ac3b8d9618f71d1bf54e01999a7e",
+        "packet": "persistent_augmented_residual"
+      },
+      {
+        "dihedral_order_sha256": "9e9942503d8326886c1fc092a25ae8f71dd463725708aa7884049b2148b8dbdd",
+        "history_id": "selected_residual_probe:0",
+        "order_sha256": "9e9942503d8326886c1fc092a25ae8f71dd463725708aa7884049b2148b8dbdd",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "531643184f51441dbd88a25c684aed28cff41893d27f62f501c7e5b07913d05e",
+        "history_id": "selected_residual_probe:1",
+        "order_sha256": "30584c2826d14a34fb1754a4b4eee389e0cfeb9decf1adfbc2631656586d679d",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "1e3367b3ad0722e8dad98d1bc1ef4735c77d5d688d169017bbf3302ee4775bfd",
+        "history_id": "selected_residual_probe:2",
+        "order_sha256": "d728eafd0dbd649d5451b5ddf669d8705a9942323b252338792ef2227525d526",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "bb3773624a3787d41f9ae8d9c166829c9de1763e0b993607fa10a867c1d0fb5c",
+        "history_id": "selected_residual_probe:3",
+        "order_sha256": "bb3773624a3787d41f9ae8d9c166829c9de1763e0b993607fa10a867c1d0fb5c",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "d07d0c3bbc5257b5147290b15a9c21ada2558deb9e35669a4f76c77fc50e9c37",
+        "history_id": "selected_residual_probe:4",
+        "order_sha256": "b9a91b3f8bebf9b67f30563b17af166cc111f25f6be5210c64b903fdb2d2cbda",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "17342cdd2bf3dce538024cb84374950cea4fea3eb71cd40200329d792f536722",
+        "history_id": "selected_residual_probe:5",
+        "order_sha256": "17342cdd2bf3dce538024cb84374950cea4fea3eb71cd40200329d792f536722",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "415bb579d8af0acefb7defb5815feedadee692dfda99e142e9ad3584395625c0",
+        "history_id": "selected_residual_probe:6",
+        "order_sha256": "415bb579d8af0acefb7defb5815feedadee692dfda99e142e9ad3584395625c0",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "b30808379af6404c5d6ce4ce993e58417983b43adb018ea880ebbe735ef8784a",
+        "history_id": "selected_residual_probe:7",
+        "order_sha256": "ad7162b38bc6a4b81720129ed8cd661106030e1a0f77779ea46f8ab42dba70c8",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "f366a8313a78ffbd74198bec3557fbe7fd032ef918f546a2b9278fd95d77a376",
+        "history_id": "selected_residual_probe:8",
+        "order_sha256": "9a8fe41c57528ff4636f314d34b3959bc1fc493dc8aae2007640cc9920589b5f",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "576fceed3d90c2fb794664163d2415b2fc3533855a71397399fd52eb10a1dffd",
+        "history_id": "selected_residual_probe:9",
+        "order_sha256": "4836d1d7c3baefd980d2f86ac6bcf9d17ebe6570152763ac17d33980c4c76332",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "eefc193614d35cc47d5b2594106f909c06f3669dea5a26a021d96b04e5221c9a",
+        "history_id": "selected_residual_probe:10",
+        "order_sha256": "17211b47a0f84b7998518989a70fbb94ebd3b042a605e2bd602a5d49f198c744",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "fb1b5258eac6b7f84f213c7f36680368aa0644a8bec2a0e80ec82f145e55ec57",
+        "history_id": "selected_residual_probe:11",
+        "order_sha256": "498d4906b5edd357fcdf3c776b1446eaee9ac80276cd50b77c380c6b35a74de6",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "380cee06e9a5961300f1f48361c4d51085b505e611d7bb9a305b6170b94e78b0",
+        "history_id": "selected_residual_probe:12",
+        "order_sha256": "1ff9bd64e103bb6c0d2a2496ab96e328cab46b1ffdf84e43822f50ddfe42b178",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "57c5b4cac6f3afd5dc5e92a496082434afe8371cc2960705bb72ac8176529c7b",
+        "history_id": "selected_residual_probe:13",
+        "order_sha256": "1577f685ba3d1b667090592bc43493c40e4864adac22c2564a443ac1f45246df",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "6fa4c4f4a93452bf8339f25281142379a18c191b65eae5c44c50e66df6f631ea",
+        "history_id": "selected_residual_probe:14",
+        "order_sha256": "c80b4cf93f08d2847adb385f5414589217aedd666653f91c06a8dd95cb395378",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "7a418f66b1c2b15c2adc093b9bb224916b8d37211aa342787cfc194c4f4eeada",
+        "history_id": "selected_residual_probe:15",
+        "order_sha256": "1ac3d22cdc916dfe78f7edd78bc1a10c994d1d65b84e5f757668b1fd883f2e28",
+        "packet": "selected_residual_probe"
+      },
+      {
+        "dihedral_order_sha256": "0c51120774bdecd9e7cb71cff2477aaf06c4e6c923aaeb821fd92124ade0f0f0",
+        "history_id": "selected_residual_escape:0",
+        "order_sha256": "0c51120774bdecd9e7cb71cff2477aaf06c4e6c923aaeb821fd92124ade0f0f0",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "2c01223fc713b5e71f5b20bd5ea76e7e9ea829f5eeaf40dc90578681783e387b",
+        "history_id": "selected_residual_escape:1",
+        "order_sha256": "2c01223fc713b5e71f5b20bd5ea76e7e9ea829f5eeaf40dc90578681783e387b",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "7a844de5b47bc27fafa790fb4de59dd3c5fb08f89356333036fc98f0df98f7f8",
+        "history_id": "selected_residual_escape:2",
+        "order_sha256": "7a844de5b47bc27fafa790fb4de59dd3c5fb08f89356333036fc98f0df98f7f8",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "3c278ac529881595d138bdfdf0dba52105b9856da609a4f92e0364c0595002b8",
+        "history_id": "selected_residual_escape:3",
+        "order_sha256": "3c278ac529881595d138bdfdf0dba52105b9856da609a4f92e0364c0595002b8",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "e94b21cf5be2c3145b9746a7bc68723415fd28176c99103846304bb2385a1e1f",
+        "history_id": "selected_residual_escape:4",
+        "order_sha256": "e94b21cf5be2c3145b9746a7bc68723415fd28176c99103846304bb2385a1e1f",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "2bebdc8929cdb6568112fd5ded9f71b307f5e37eedce75f7ea00b36fce059f49",
+        "history_id": "selected_residual_escape:5",
+        "order_sha256": "2bebdc8929cdb6568112fd5ded9f71b307f5e37eedce75f7ea00b36fce059f49",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "fbdd7460b4666dc782b093769bacb46ac3a4fc15a894e038bd05034379cf92d7",
+        "history_id": "selected_residual_escape:6",
+        "order_sha256": "fbdd7460b4666dc782b093769bacb46ac3a4fc15a894e038bd05034379cf92d7",
+        "packet": "selected_residual_escape"
+      },
+      {
+        "dihedral_order_sha256": "dabafcb478e73d1c280a281636af93593e2b879ea0a775cc4188e11cce2f7986",
+        "history_id": "selected_residual_escape:7",
+        "order_sha256": "dabafcb478e73d1c280a281636af93593e2b879ea0a775cc4188e11cce2f7986",
+        "packet": "selected_residual_escape"
+      }
+    ],
+    "order_count": 192,
+    "packet_histogram": {
+      "augmentation_probe": 32,
+      "first_fresh": 32,
+      "persistent_augmented_probe": 16,
+      "persistent_augmented_residual": 8,
+      "prior": 24,
+      "second_fresh": 32,
+      "selected_residual_escape": 8,
+      "selected_residual_probe": 16,
+      "transfer_cegar_probe": 16,
+      "transfer_cegar_residual": 8
+    }
+  },
+  "circulant_offsets": [
+    2,
+    5,
+    9,
+    14
+  ],
+  "claim_scope": "Five exact C25 seed orbits drive a bounded order CEGAR after 192 known order classes are blocked. Exact finite clauses only; not an all-order obstruction, geometric result, proof, counterexample, or official/global status update.",
+  "configuration": {
+    "active_seed_policy": "four parent seeds plus selected width-four replacement only",
+    "conflict_cap": 1024,
+    "full_certificate_limit": 8,
+    "history_equivalence": "cyclic rotation and reversal",
+    "max_iterations": 12000,
+    "pattern": "C25_sidon_2_5_9_14",
+    "probe_max_iterations": 12000,
+    "probe_order_limit": 16,
+    "random_seed": 20260802
+  },
+  "counterfactual_probe": {
+    "blocked_history_dihedral_order_count": 192,
+    "inverse_pair_clause_count": 13708,
+    "inverse_pair_escape_order_count": 16,
+    "iterations": 421,
+    "models": [
+      {
+        "dihedral_order_sha256": "69994ba66c0a0212e004779ddcc822e7d40dba48d6d9cbb0358e43dee5258dc5",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          17,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3
+        ],
+        "order_sha256": "acc0e4bc0e8991496b0b18ad942acd11e47e695ff901f59cb48a433bfdce3394",
+        "probe_model_index": 0,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 405
+      },
+      {
+        "dihedral_order_sha256": "8ff202ca8e99ee81f05fbe900740b544d7dca002e22e4d8de6396dbce4bb42e9",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          17,
+          22,
+          14,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3
+        ],
+        "order_sha256": "e5eb8629877dfb967b8b07921901cef8266506733d77e054438871ab1731b02d",
+        "probe_model_index": 1,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 406
+      },
+      {
+        "dihedral_order_sha256": "5c361ce35a575e5d6040f6fd5cabeb75b13852438e29b86cebdf0b91bf56847b",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          17,
+          14,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3
+        ],
+        "order_sha256": "8ae043bb1cfd993738c2ca16af3a64e83e9a94fcfd1a570f5a1ff62768aee39b",
+        "probe_model_index": 2,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 407
+      },
+      {
+        "dihedral_order_sha256": "a69bab1fa79a62be11e232b3df5074f193767dae0cc23d18a6034f7f866a034a",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          14,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17
+        ],
+        "order_sha256": "161fe9efd20e3b1d16b283eef85c41f1906efc193731c58636dd3a646811736a",
+        "probe_model_index": 3,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 408
+      },
+      {
+        "dihedral_order_sha256": "1a464c3a4af356ebfb3686640422f403b859618b91b4a37a65cfc7c6508c14c9",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17,
+          14
+        ],
+        "order_sha256": "872dc4bc5985f0c89cd9008a647c95948d1013cb031b79796ca9894d52fcafc1",
+        "probe_model_index": 4,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 409
+      },
+      {
+        "dihedral_order_sha256": "983e91b5f26bc771d7e26d7a52bbf65af01b07ee9c6987fb637994efe407817b",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          17,
+          6,
+          3,
+          14
+        ],
+        "order_sha256": "a06189754529eddc1d8aa012525b76647ba60112f594973974387c1308808d19",
+        "probe_model_index": 5,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 410
+      },
+      {
+        "dihedral_order_sha256": "0c382485dbfb8b3ecf90f7421789bc6e9d353edd5b823fd6aceff78a701dc81e",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3,
+          14
+        ],
+        "order_sha256": "2e4a66e4ba65c186d7a03d10ee5addd4dc24fc299b1d98cb615a2d9ac5b56cdb",
+        "probe_model_index": 6,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 411
+      },
+      {
+        "dihedral_order_sha256": "886d3552381248f69ab16669da6359ac47f7c08ffd888b282695e81045029bf8",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          17,
+          6,
+          3
+        ],
+        "order_sha256": "74f63ba42318684d3676682e7e91a2d033c60ee24f2db6c40324142f20975ab0",
+        "probe_model_index": 7,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 412
+      },
+      {
+        "dihedral_order_sha256": "3e758f194355bd5059eca8232f37604545b054a32f79f91543c2827807e38684",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          17,
+          14,
+          6,
+          3
+        ],
+        "order_sha256": "3c21ae0200c4b18b6264ab328b09a10ec1d0648d0dcc625e192e91870e5ab176",
+        "probe_model_index": 8,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 413
+      },
+      {
+        "dihedral_order_sha256": "7ac79f4523c9b060cf837a71d8ef2c1ed23aeb61da5fd504cef87fc9206ee03e",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          17,
+          6,
+          3
+        ],
+        "order_sha256": "b1407d1acb782704982d283e1ca5c7af32d3ca014f2895c87bd715f37af9e8e8",
+        "probe_model_index": 9,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 414
+      },
+      {
+        "dihedral_order_sha256": "6f4df1f04883a8b5d5ad4e637cbe79d13a9df0926ffafce79b8463c82fc1c595",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          14,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          17,
+          6,
+          3
+        ],
+        "order_sha256": "635368d5009db9a37a591152bffadb204f2f941cdc5a817410f98222f22e4072",
+        "probe_model_index": 10,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 415
+      },
+      {
+        "dihedral_order_sha256": "9276f509481152ec5d284d02a5295e4e21bdf46e7b1b5482228e9650ad80b1e1",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          14,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          17,
+          3
+        ],
+        "order_sha256": "957f6445c5117d33f579e52b5e4cd9f8b6e52885a392bdb07d782a1ca8ddce61",
+        "probe_model_index": 11,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 2,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 416
+      },
+      {
+        "dihedral_order_sha256": "a41db1b8a29c09b03436bc705df1bd450c1e3b2c04d0d5a584dc6cd0664669aa",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17
+        ],
+        "order_sha256": "a41db1b8a29c09b03436bc705df1bd450c1e3b2c04d0d5a584dc6cd0664669aa",
+        "probe_model_index": 12,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 417
+      },
+      {
+        "dihedral_order_sha256": "34a7e4dcc9aae9848a6f2290cf1cab7b42e177f2a6f1bc84cbdd145ec969eddd",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          22,
+          11,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          17,
+          14,
+          6,
+          3
+        ],
+        "order_sha256": "01b04c66cd3eca72091a2281a2c5ece63324039d4d04b9385dbeb948fb2e9fc2",
+        "probe_model_index": 13,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 418
+      },
+      {
+        "dihedral_order_sha256": "a18b573f1965fe1b728f2f01817eb0bd46c3edcdec3c9f2cd2cedf7332c5132e",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17,
+          14
+        ],
+        "order_sha256": "a18b573f1965fe1b728f2f01817eb0bd46c3edcdec3c9f2cd2cedf7332c5132e",
+        "probe_model_index": 14,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 3,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 419
+      },
+      {
+        "dihedral_order_sha256": "808e72d07eba0cf9ee6966a69c0823da3fa9e5239795ee3cb2613165b133afdc",
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "order": [
+          0,
+          14,
+          11,
+          22,
+          8,
+          19,
+          5,
+          16,
+          2,
+          24,
+          13,
+          10,
+          21,
+          18,
+          7,
+          4,
+          15,
+          1,
+          12,
+          23,
+          9,
+          20,
+          6,
+          3,
+          17
+        ],
+        "order_sha256": "808e72d07eba0cf9ee6966a69c0823da3fa9e5239795ee3cb2613165b133afdc",
+        "probe_model_index": 15,
+        "seed_orbit_matches": [
+          {
+            "matching_orbit_clause_count": 1,
+            "source_model_index": 0
+          },
+          {
+            "matching_orbit_clause_count": 4,
+            "source_model_index": 2
+          }
+        ],
+        "z3_iteration": 421
+      }
+    ],
+    "solver_result": "bounded_after_inverse_pair_escape_models",
+    "status": "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+  },
+  "counterfactual_seed_packet_coverage": {
+    "active_uncovered_probe_model_indices": [],
+    "parent_four_seeds": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 16,
+          "matched_strong_probe_orders": 16,
+          "matching_orbit_clause_occurrences": 28,
+          "source_model_index": 0
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 15
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 19
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 28
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "1": 16
+      },
+      "strong_probe_order_count": 16
+    },
+    "parent_plus_replacement": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 16,
+          "matched_strong_probe_orders": 16,
+          "matching_orbit_clause_occurrences": 28,
+          "source_model_index": 0
+        },
+        {
+          "matched_probe_orders": 16,
+          "matched_strong_probe_orders": 16,
+          "matching_orbit_clause_occurrences": 45,
+          "source_model_index": 2
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 15
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 19
+        },
+        {
+          "matched_probe_orders": 0,
+          "matched_strong_probe_orders": 0,
+          "matching_orbit_clause_occurrences": 0,
+          "source_model_index": 28
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "2": 16
+      },
+      "strong_probe_order_count": 16
+    },
+    "replacement_covered_probe_model_indices": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "replacement_marginal_over_parent_probe_model_indices": [],
+    "replacement_overlap_with_parent_probe_model_indices": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "replacement_width4_only": {
+      "by_seed_source": [
+        {
+          "matched_probe_orders": 16,
+          "matched_strong_probe_orders": 16,
+          "matching_orbit_clause_occurrences": 45,
+          "source_model_index": 2
+        }
+      ],
+      "covered_probe_order_count": 16,
+      "covered_probe_order_fraction": 1.0,
+      "covered_strong_probe_order_count": 16,
+      "covered_strong_probe_order_fraction": 1.0,
+      "probe_order_count": 16,
+      "seed_source_overlap_histogram": {
+        "1": 16
+      },
+      "strong_probe_order_count": 16
+    }
+  },
+  "decision": "COMPRESS_NEW_C25_REPLACEMENT_AUGMENTED_ESCAPES",
+  "inactive_seed_templates": [
+    {
+      "compressed_certificate_sha256": "927e35f69e86103e506d9551848bd6a409dccd8b8567708397064941bf8d5877",
+      "inactive_reason": "ZERO_MARGINAL_TARGETS_BEYOND_SELECTED_WIDTH4_ON_144_ORDER_PACKET",
+      "ordered_quad_count": 5,
+      "seed_id": "persistent_compressed:1",
+      "source_model_index": 1,
+      "source_screen_target_id": "probe:1",
+      "source_target_id": "transfer_cegar_probe:1"
+    },
+    {
+      "canonical_clause_sha256": "2a1134337269121a8b4079afa9888294b5c6529a6ddd902656d6ac01f6058a01",
+      "compressed_certificate_sha256": "f8362079fc6ea9df386ca8b3cc210f3758db59850e2f108ad6c63017cc5b774a",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 7,
+      "seed_id": "residual:0",
+      "source_model_index": 0,
+      "source_target_id": "seeded:0"
+    },
+    {
+      "canonical_clause_sha256": "688754a4f2259235dee0ce04f4b92bf61a6318b4eb02aa8e6bc4d8af6171d985",
+      "compressed_certificate_sha256": "e9efcb62532b22e33a1488b4087ed4fc29d3c763b47293de7331b909113dd98d",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 9,
+      "seed_id": "residual:1",
+      "source_model_index": 1,
+      "source_target_id": "seeded:1"
+    },
+    {
+      "canonical_clause_sha256": "30e4470c4e78617f43f5a3dad6cb61d5ef815069dc51cfb6ed0851cac4ac8867",
+      "compressed_certificate_sha256": "3a3abbda9514b96acaf4ad09c589c2b1a087e08924456ca6fcf33eb9d8d35ef8",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 5,
+      "seed_id": "residual:2",
+      "source_model_index": 2,
+      "source_target_id": "seeded:2"
+    },
+    {
+      "canonical_clause_sha256": "08c7e636bc3eefd93c58b8f58a864916e9f84975e4ad67dab4ecae3402e8fc32",
+      "compressed_certificate_sha256": "721ded29b8624d830c7ed6ff2c15ec544b8c8662701e03f7aadcb1863b96ccae",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 3,
+      "seed_id": "residual:3",
+      "source_model_index": 3,
+      "source_target_id": "seeded:3"
+    },
+    {
+      "canonical_clause_sha256": "844f79396e7613092e180c74a09acabf7ea09e34faeea3525a7846b5dedf37c2",
+      "compressed_certificate_sha256": "58873106a85fd064758c92dab5ed86e479b6de082e9964e0d939e3f7617c36c3",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 7,
+      "seed_id": "residual:4",
+      "source_model_index": 4,
+      "source_target_id": "seeded:4"
+    },
+    {
+      "canonical_clause_sha256": "9443f651b1c48564f709c3a3f6b31982163e24554d34cb161368838e8f0a82bc",
+      "compressed_certificate_sha256": "fc724cd90b08c77c9e596e081bf5de1b03fb9f34fe32486a7daddf39eebb9cb9",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 4,
+      "seed_id": "residual:5",
+      "source_model_index": 5,
+      "source_target_id": "seeded:5"
+    },
+    {
+      "canonical_clause_sha256": "b0a00925436f41f730b62d9d038110d3d2f378b6bc7a315cd89e28915b934e68",
+      "compressed_certificate_sha256": "1b589e8f5a2740c1ffb0244713b246e8cb9d48bc72d3caf358a280528f1b9805",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 6,
+      "seed_id": "residual:6",
+      "source_model_index": 6,
+      "source_target_id": "seeded:6"
+    },
+    {
+      "canonical_clause_sha256": "46e63bc7b5da9b7781532a95387b53cee9065d4becae5aa8409b1a102cc9b4aa",
+      "compressed_certificate_sha256": "75509de4030d9b89c00358503d3ed00f9d1733e07666eb1c2035f7cfbbae9814",
+      "inactive_reason": "ZERO_MARGINAL_COVERAGE_ON_32_ORDER_AUGMENTATION_PROBE",
+      "ordered_quad_count": 4,
+      "seed_id": "residual:7",
+      "source_model_index": 7,
+      "source_target_id": "seeded:7"
+    },
+    {
+      "canonical_clause_sha256": "031f49008a7141bfeca38e246b980d5ff9c9ceafbd1906a06dd5dd04d00d3d99",
+      "compressed_certificate_sha256": "624bf38bbc9768b5cbea7dbb2fe4b2d902037856e331b1e5dfb5e039b7327e72",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 6,
+      "seed_id": "persistent_augmented_residual_compressed:0",
+      "source_model_index": 0,
+      "source_target_id": "residual:0"
+    },
+    {
+      "canonical_clause_sha256": "3454cf41222ca2a2f424f1a3f2f7e1dc011bd0c70ee7de0fd2816caccd4e66a5",
+      "compressed_certificate_sha256": "641e516995a9334447704b904acbd304ed08f3542df6bf6a0df7e13f1160490f",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 6,
+      "seed_id": "persistent_augmented_residual_compressed:1",
+      "source_model_index": 1,
+      "source_target_id": "residual:1"
+    },
+    {
+      "canonical_clause_sha256": "f2220c1fe3b90b137b2cb4b9679c4ca1ea814fa341a635a6fd84c1c19921b550",
+      "compressed_certificate_sha256": "e36ccbea23b58810856633af7c9fd5341a346661a22e358c8136efc8ed63cbb7",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 8,
+      "seed_id": "persistent_augmented_residual_compressed:3",
+      "source_model_index": 3,
+      "source_target_id": "residual:3"
+    },
+    {
+      "canonical_clause_sha256": "6349022671fa2f0217254acb0534b027422893a203abb0af6e0565a46216ce2e",
+      "compressed_certificate_sha256": "fbe2c4404bca7188fa903eea6704171144e454df454cbb558467d01416509c3a",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 4,
+      "seed_id": "persistent_augmented_residual_compressed:4",
+      "source_model_index": 4,
+      "source_target_id": "residual:4"
+    },
+    {
+      "canonical_clause_sha256": "716297fef78455ed9ff7468de591e121b2fcb79bf2f4a8faaee291c7c85b0d5f",
+      "compressed_certificate_sha256": "b02ae34b4ba9cf837f30512e581498efc6e929957c8188a17bd29c2e029627bc",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 7,
+      "seed_id": "persistent_augmented_residual_compressed:5",
+      "source_model_index": 5,
+      "source_target_id": "residual:5"
+    },
+    {
+      "canonical_clause_sha256": "0e9df79690878d0f014b022dbd13d22de8c7c53e5683020918d6ed1341789cae",
+      "compressed_certificate_sha256": "55e031c4337784b357928248a8e9ad6fcfc2181fc220cb6e6389be62c7ed7f43",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 3,
+      "seed_id": "persistent_augmented_residual_compressed:6",
+      "source_model_index": 6,
+      "source_target_id": "residual:6"
+    },
+    {
+      "canonical_clause_sha256": "c130f5e2411d4dc4e5b3ec1f834ba5fc0f52f24429e572d41828190e554cc791",
+      "compressed_certificate_sha256": "b23307341ba52bef07383b32b1f0265580666c1735a3e50da423c578af6d4981",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_RESIDUAL_AFFINE_COVER",
+      "ordered_quad_count": 4,
+      "seed_id": "persistent_augmented_residual_compressed:7",
+      "source_model_index": 7,
+      "source_target_id": "residual:7"
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "331502132efb300f9a073f3bf4059c569cae9f36554fca716167c503a01f0a33",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 2,
+        "source_order": [
+          0,
+          14,
+          3,
+          17,
+          6,
+          9,
+          12,
+          20,
+          15,
+          23,
+          1,
+          4,
+          7,
+          18,
+          21,
+          10,
+          13,
+          24,
+          2,
+          5,
+          8,
+          16,
+          19,
+          11,
+          22
+        ],
+        "source_unique_ordered_quad_count": 3,
+        "unique_orbit_clause_count": 25
+      },
+      "compressed_certificate_sha256": "6c380d9cbb866ebd3892fd29a0a90fc3fd3fa6260761274ab9f5f1a32139e8be",
+      "inactive_reason": "ZERO_MARGINAL_TARGETS_OVER_FOUR_PARENT_SEEDS",
+      "max_weight": 1,
+      "ordered_quad_count": 3,
+      "positive_inequalities": 3,
+      "seed_id": "persistent_augmented_residual_compressed:2",
+      "seed_role": "EXACT_MINIMUM_ACTIVE_SEED_ESCAPE_COVER",
+      "source_certificate_sha256": "6ba89b8f4192e6815c71669baae002d5e3790f81fd8959ff702119f5f1264c57",
+      "source_model_index": 2,
+      "source_target_id": "residual:2",
+      "weight_sum": 3
+    },
+    {
+      "compressed_certificate_sha256": "b8b8cf2c29185f3cca6c1c04f237ec9e63fd69477ca51e060fa9a7d8d3caebab",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 7,
+      "seed_id": "replacement_escape_compressed:0",
+      "source_model_index": 0,
+      "source_target_id": "residual:0"
+    },
+    {
+      "compressed_certificate_sha256": "3028e5552fa5a52d1a403de3f99ef234dd2750ad123949117b4f6450fa97b55c",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 6,
+      "seed_id": "replacement_escape_compressed:1",
+      "source_model_index": 1,
+      "source_target_id": "residual:1"
+    },
+    {
+      "compressed_certificate_sha256": "3c98c549a7cbb9baa36475c2d149e47d622ec8c62046b8fbd5193c4785366376",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 4,
+      "seed_id": "replacement_escape_compressed:3",
+      "source_model_index": 3,
+      "source_target_id": "residual:3"
+    },
+    {
+      "compressed_certificate_sha256": "b69714e4889a80410e09421201575ecf807e624c5b36034259c142988e51b2c3",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 9,
+      "seed_id": "replacement_escape_compressed:4",
+      "source_model_index": 4,
+      "source_target_id": "residual:4"
+    },
+    {
+      "compressed_certificate_sha256": "c6f1df6e5c0398eef9822b994fcfac4768711a73e305f23593e8cf9d11f34ae5",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 6,
+      "seed_id": "replacement_escape_compressed:5",
+      "source_model_index": 5,
+      "source_target_id": "residual:5"
+    },
+    {
+      "compressed_certificate_sha256": "13365e39751ef8543d1ad69d636c5ef4788000f4522fb8b6d4fe52c3f78f7f41",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 4,
+      "seed_id": "replacement_escape_compressed:6",
+      "source_model_index": 6,
+      "source_target_id": "residual:6"
+    },
+    {
+      "compressed_certificate_sha256": "52226e804072e982288dc0581ffe88235f40715241c17fc9c53f042909194528",
+      "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+      "ordered_quad_count": 3,
+      "seed_id": "replacement_escape_compressed:7",
+      "source_model_index": 7,
+      "source_target_id": "residual:7"
+    }
+  ],
+  "n": 25,
+  "next_target": "Compress the eight newly learned exact replacement-seed escapes and reassess marginal affine coverage before more order search.",
+  "pattern": "C25_sidon_2_5_9_14",
+  "seeded_cegar": {
+    "active_unique_seed_orbit_clause_count": 125,
+    "blocked_history_dihedral_order_count": 192,
+    "final_inverse_pair_clause_count": 14178,
+    "initial_probe_inverse_clause_count": 13708,
+    "iterations": 53,
+    "models": [
+      {
+        "dihedral_order_sha256": "49ed4b44ca522f32a906c266fa223df9b336d36194acf78b0fdee1ca7b894e3b",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "c271067c916257a395f2ee6e46ab7280c14be9ebf1ca23066d9f2a360f1146eb",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 0,
+            "source_order": [
+              0,
+              3,
+              17,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              18,
+              1,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "source_unique_ordered_quad_count": 198,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              3,
+              17,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              18,
+              1,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  17,
+                  4
+                ],
+                "weight": 663324826607761566
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  1,
+                  24
+                ],
+                "weight": 48396580537106105
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  13,
+                  19
+                ],
+                "weight": 426386823877286140
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  24,
+                  2
+                ],
+                "weight": 16547752270311799
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  8,
+                  11
+                ],
+                "weight": 1085006351415032324
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  6,
+                  2
+                ],
+                "weight": 548355932439507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  20,
+                  4
+                ],
+                "weight": 347709539996955400
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  23,
+                  14
+                ],
+                "weight": 30510724238616712
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  18,
+                  22
+                ],
+                "weight": 661679758810443045
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  13,
+                  8
+                ],
+                "weight": 122916921279860970
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  17,
+                  13,
+                  14
+                ],
+                "weight": 1096711864879014
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  13
+                ],
+                "weight": 550400457022026124
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  21,
+                  11
+                ],
+                "weight": 548355932439507
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  9,
+                  23
+                ],
+                "weight": 500814184079854319
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  12,
+                  2
+                ],
+                "weight": 122912766692027182
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  15,
+                  7
+                ],
+                "weight": 550400457022026124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  23,
+                  18
+                ],
+                "weight": 707818740855821813
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  21,
+                  8
+                ],
+                "weight": 962089430135171354
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  24,
+                  14
+                ],
+                "weight": 84804819471586639
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  4,
+                  21
+                ],
+                "weight": 962637786067610861
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  16,
+                  24
+                ],
+                "weight": 114538460577169753
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  23,
+                  24
+                ],
+                "weight": 76773784646648414
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  18,
+                  19
+                ],
+                "weight": 46138982045378768
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  19
+                ],
+                "weight": 431382051871701733
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  10,
+                  14
+                ],
+                "weight": 121022293261922598
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  24,
+                  2
+                ],
+                "weight": 61582469372377420
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  2,
+                  22
+                ],
+                "weight": 57435935777946971
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  4,
+                  8
+                ],
+                "weight": 48396580537106105
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  10,
+                  19,
+                  5
+                ],
+                "weight": 426386823877286140
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  5,
+                  14
+                ],
+                "weight": 121022293261922598
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  6,
+                  1
+                ],
+                "weight": 470883396592233892
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  20,
+                  4
+                ],
+                "weight": 111797554097840124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  12,
+                  24
+                ],
+                "weight": 32705205550335065
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  18,
+                  1
+                ],
+                "weight": 479915337375072232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  17,
+                  1,
+                  14
+                ],
+                "weight": 361933722461824707
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  17,
+                  1,
+                  22
+                ],
+                "weight": 11975249043462439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  8
+                ],
+                "weight": 470335040659794385
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  9,
+                  4
+                ],
+                "weight": 959849116011955260
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  18,
+                  11
+                ],
+                "weight": 237801044052645755
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  21,
+                  14
+                ],
+                "weight": 548355932439507
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  15,
+                  1
+                ],
+                "weight": 582132594757634509
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  7,
+                  13
+                ],
+                "weight": 10463999250456366
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  12,
+                  4
+                ],
+                "weight": 959849116011955260
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  13,
+                  8
+                ],
+                "weight": 60729635751594995
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  16,
+                  11
+                ],
+                "weight": 219707632485926237
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  23,
+                  18
+                ],
+                "weight": 601391543695023610
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  4,
+                  21
+                ],
+                "weight": 116873193665133884
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  4,
+                  21
+                ],
+                "weight": 163850647820399746
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  13,
+                  8
+                ],
+                "weight": 341417122475895891
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  16,
+                  22
+                ],
+                "weight": 76864824461338872
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  8,
+                  11
+                ],
+                "weight": 627497674876460332
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  4,
+                  16
+                ],
+                "weight": 15800447918660064
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  2,
+                  11
+                ],
+                "weight": 18156312629939821
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  21,
+                  22
+                ],
+                "weight": 116324837732694377
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  5,
+                  14
+                ],
+                "weight": 312781620476940791
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  19,
+                  14
+                ],
+                "weight": 10463999250456366
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  21,
+                  13,
+                  2
+                ],
+                "weight": 34704064900251620
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  16,
+                  24,
+                  19
+                ],
+                "weight": 296572456947265109
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  19,
+                  11
+                ],
+                "weight": 295716079663724350
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  20,
+                  12
+                ],
+                "weight": 31574873683298450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  20,
+                  5
+                ],
+                "weight": 796050003688729182
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  7
+                ],
+                "weight": 550400457022026124
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  19
+                ],
+                "weight": 371851048919961018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  19,
+                  22
+                ],
+                "weight": 953958541999801953
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  13
+                ],
+                "weight": 199351098024866551
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  18,
+                  11
+                ],
+                "weight": 479915337375072232
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  16,
+                  24
+                ],
+                "weight": 53671493139879154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  23,
+                  22
+                ],
+                "weight": 30510724238616712
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  7,
+                  22
+                ],
+                "weight": 199351098024866551
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  4,
+                  10
+                ],
+                "weight": 124193619874995769
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  7,
+                  11
+                ],
+                "weight": 187198711176759827
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  24,
+                  14
+                ],
+                "weight": 393541158565320433
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  1,
+                  4
+                ],
+                "weight": 470156917820440370
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  21,
+                  19
+                ],
+                "weight": 63381763740286467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  4,
+                  13
+                ],
+                "weight": 50306851671048823
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  21,
+                  5
+                ],
+                "weight": 124398436115467391
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  4,
+                  7,
+                  21
+                ],
+                "weight": 163850647820399746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  4,
+                  13,
+                  24
+                ],
+                "weight": 372574870975776344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  21,
+                  10,
+                  2
+                ],
+                "weight": 124193619874995769
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 63586579980758089
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  10,
+                  2,
+                  8
+                ],
+                "weight": 193790718239150468
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  16,
+                  5,
+                  22
+                ],
+                "weight": 53671493139879154
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  2,
+                  5,
+                  14
+                ],
+                "weight": 70726942975588237
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  2,
+                  11,
+                  22
+                ],
+                "weight": 123612131196001738
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  13
+                ],
+                "weight": 364941181326501804
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  22
+                ],
+                "weight": 1105698846801442117
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  15,
+                  24
+                ],
+                "weight": 266442303601414850
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  1,
+                  21
+                ],
+                "weight": 984791073420279171
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  10,
+                  22
+                ],
+                "weight": 28210232214468119
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  23,
+                  13
+                ],
+                "weight": 217229596834094102
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  9,
+                  24,
+                  14
+                ],
+                "weight": 510790912115988661
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  18,
+                  24
+                ],
+                "weight": 244950771473260143
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  13,
+                  5
+                ],
+                "weight": 213942510608888247
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  16,
+                  22
+                ],
+                "weight": 31574873683298450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  4,
+                  11
+                ],
+                "weight": 217229596834094102
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  13,
+                  22
+                ],
+                "weight": 50306851671048823
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  21,
+                  16
+                ],
+                "weight": 167813853418996149
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  10,
+                  13
+                ],
+                "weight": 468330970152785781
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  16,
+                  8
+                ],
+                "weight": 7149727420614388
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  21,
+                  10
+                ],
+                "weight": 816977220001283022
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  24,
+                  22
+                ],
+                "weight": 321038180592715454
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  10,
+                  24
+                ],
+                "weight": 320436017634029122
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 129089252315083311
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  19,
+                  5
+                ],
+                "weight": 582107493079840935
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  2,
+                  14
+                ],
+                "weight": 548355932439507
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  23,
+                  16
+                ],
+                "weight": 15800447918660064
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  19
+                ],
+                "weight": 191204108857307430
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  1,
+                  7
+                ],
+                "weight": 470949820827924910
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  4,
+                  13
+                ],
+                "weight": 574756278601824721
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  21,
+                  10
+                ],
+                "weight": 31133326331707485
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  16,
+                  14
+                ],
+                "weight": 53671493139879154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  19,
+                  2
+                ],
+                "weight": 122912766692027182
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  10,
+                  14
+                ],
+                "weight": 31133326331707485
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  19,
+                  5
+                ],
+                "weight": 68291342165280248
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  5,
+                  14
+                ],
+                "weight": 68986636943644848
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 53834969616815302
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  5,
+                  8
+                ],
+                "weight": 727063366745084334
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 235308977269707365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  1,
+                  21
+                ],
+                "weight": 211775667397910946
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  19,
+                  2
+                ],
+                "weight": 237343090902686198
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  7,
+                  21
+                ],
+                "weight": 750862118669699915
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  16,
+                  5
+                ],
+                "weight": 9622049191156630
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  1,
+                  8
+                ],
+                "weight": 37014994174425124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  4,
+                  24
+                ],
+                "weight": 76773784646648414
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  10,
+                  8
+                ],
+                "weight": 18903616981591556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  10,
+                  22
+                ],
+                "weight": 3364641468830331
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  13,
+                  22
+                ],
+                "weight": 208441220244002697
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  16,
+                  19
+                ],
+                "weight": 308823595953279296
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  24,
+                  5
+                ],
+                "weight": 177310156521742972
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  19,
+                  22
+                ],
+                "weight": 71480505050593098
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  5,
+                  8
+                ],
+                "weight": 4811024595578315
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  4,
+                  5,
+                  14
+                ],
+                "weight": 4811024595578315
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  11,
+                  22
+                ],
+                "weight": 21420602019480566
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  2,
+                  11
+                ],
+                "weight": 22268258450421887
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  24,
+                  2,
+                  14
+                ],
+                "weight": 215074832452264311
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  18,
+                  5
+                ],
+                "weight": 213942510608888247
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  13,
+                  8
+                ],
+                "weight": 146956982414646401
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  16,
+                  11
+                ],
+                "weight": 71816602445411876
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  1,
+                  14
+                ],
+                "weight": 607903398536120137
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  4,
+                  21
+                ],
+                "weight": 630532646721433199
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  4,
+                  22
+                ],
+                "weight": 570383282830651714
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  13,
+                  8
+                ],
+                "weight": 66985528194241846
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  2,
+                  14
+                ],
+                "weight": 402447335932449147
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  8,
+                  11
+                ],
+                "weight": 115382108731347951
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  21,
+                  2
+                ],
+                "weight": 516877660143108163
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  8,
+                  22
+                ],
+                "weight": 31574873683298450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  16,
+                  24,
+                  8
+                ],
+                "weight": 71816602445411876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  18,
+                  21
+                ],
+                "weight": 820197676418105709
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  7,
+                  2
+                ],
+                "weight": 443630012280333191
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  1,
+                  11
+                ],
+                "weight": 606255165809217462
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  7,
+                  10
+                ],
+                "weight": 307232106389366724
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  10,
+                  11
+                ],
+                "weight": 699314277321872208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  24,
+                  22
+                ],
+                "weight": 134300760239285843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  16,
+                  24
+                ],
+                "weight": 135110144776447660
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  2,
+                  5
+                ],
+                "weight": 259134776215928589
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  10,
+                  8,
+                  14
+                ],
+                "weight": 174693786401801752
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  5,
+                  8
+                ],
+                "weight": 35570216415883712
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  1,
+                  5
+                ],
+                "weight": 37014994174425124
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  4,
+                  2
+                ],
+                "weight": 157289614927269208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  21,
+                  2
+                ],
+                "weight": 338320357186969659
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  19,
+                  8
+                ],
+                "weight": 111155951518491697
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  7,
+                  11
+                ],
+                "weight": 30208978609571971
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  10,
+                  19
+                ],
+                "weight": 18903616981591556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  8,
+                  11
+                ],
+                "weight": 55237340362475017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  2,
+                  11
+                ],
+                "weight": 233820062241438060
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  5,
+                  22
+                ],
+                "weight": 53671493139879154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  24,
+                  19,
+                  2
+                ],
+                "weight": 339129717334801592
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  5,
+                  11,
+                  22
+                ],
+                "weight": 53671493139879154
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  10,
+                  16
+                ],
+                "weight": 15800447918660064
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  2,
+                  8
+                ],
+                "weight": 118305678939106085
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  10,
+                  14
+                ],
+                "weight": 145298415844758993
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  13,
+                  24
+                ],
+                "weight": 10188271068311333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  11,
+                  22
+                ],
+                "weight": 25028361752903046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  24,
+                  19
+                ],
+                "weight": 10188271068311333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  16,
+                  19,
+                  14
+                ],
+                "weight": 167483204632181798
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  19,
+                  5,
+                  11
+                ],
+                "weight": 151368190187048276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  13,
+                  11
+                ],
+                "weight": 208441220244002697
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  19,
+                  22
+                ],
+                "weight": 93623739979169851
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  16,
+                  5
+                ],
+                "weight": 208586504512598096
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  14,
+                  22
+                ],
+                "weight": 174322736271963505
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 100237091440681200
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  19,
+                  2,
+                  22
+                ],
+                "weight": 402447335932449147
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  5,
+                  14
+                ],
+                "weight": 4811024595578315
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 34704064900251620
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  19,
+                  8
+                ],
+                "weight": 74720122997578295
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  10,
+                  24
+                ],
+                "weight": 145298415844758993
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  21,
+                  13,
+                  24
+                ],
+                "weight": 10188271068311333
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  19,
+                  8,
+                  14
+                ],
+                "weight": 55237340362475017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  11,
+                  14
+                ],
+                "weight": 548355932439507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  16,
+                  14,
+                  22
+                ],
+                "weight": 1096711864879014
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  24,
+                  19,
+                  22
+                ],
+                "weight": 475922704547099448
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  24,
+                  2,
+                  8
+                ],
+                "weight": 100237091440681200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  13,
+                  2,
+                  11
+                ],
+                "weight": 317984338114146237
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  24,
+                  11,
+                  14
+                ],
+                "weight": 295716079663724350
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  19,
+                  22
+                ],
+                "weight": 442829969696446291
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 144955873665243399
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  2,
+                  5
+                ],
+                "weight": 177310156521742972
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  19,
+                  2,
+                  11,
+                  14
+                ],
+                "weight": 144347889476676074
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 198,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 48418549806118308018
+          },
+          "certificate_sha256": "e000e9bd6b9c2ecf6fbf8f712a5c84afe3b839cddc2662a18f5681245b1b1da1",
+          "max_weight": 1105698846801442117,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 198,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 198,
+          "weight_sum": 48418549806118308018,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 0,
+        "order": [
+          0,
+          3,
+          17,
+          6,
+          20,
+          9,
+          12,
+          15,
+          23,
+          18,
+          1,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          19,
+          2,
+          5,
+          8,
+          11,
+          14,
+          22
+        ],
+        "order_sha256": "49ed4b44ca522f32a906c266fa223df9b336d36194acf78b0fdee1ca7b894e3b",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 46
+      },
+      {
+        "dihedral_order_sha256": "30094a6f568f815646533c426b1af746f6c4d7791664396ecbdd96fcf7dc54ee",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "46ac39eb34991b6fb5da529448f0431b98648312fea46d29b5cfd1e102278585",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 1,
+            "source_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              18,
+              1,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "source_unique_ordered_quad_count": 193,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              18,
+              1,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  3,
+                  18
+                ],
+                "weight": 141383579735176130
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  12,
+                  1
+                ],
+                "weight": 22006861476032453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  18,
+                  10
+                ],
+                "weight": 101728204366559584
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  4,
+                  24
+                ],
+                "weight": 69518298126833282
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  7,
+                  10
+                ],
+                "weight": 21372752447544299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  13,
+                  5
+                ],
+                "weight": 34632904869940250
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  19,
+                  2
+                ],
+                "weight": 170970017268487587
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  9,
+                  2
+                ],
+                "weight": 141383579735176130
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  21,
+                  14
+                ],
+                "weight": 8397872251615949
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  16,
+                  8
+                ],
+                "weight": 67845901780864923
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  2,
+                  11
+                ],
+                "weight": 373566497162772084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  14
+                ],
+                "weight": 10647769512940490
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  13,
+                  24
+                ],
+                "weight": 50346650149378307
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  9,
+                  5
+                ],
+                "weight": 90482960845054455
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  15,
+                  4
+                ],
+                "weight": 57637399883045381
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  15,
+                  11
+                ],
+                "weight": 10208501897819542
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  13
+                ],
+                "weight": 84979555019318557
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  16,
+                  19
+                ],
+                "weight": 42712858352271155
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  23,
+                  16
+                ],
+                "weight": 283687192994950690
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  10,
+                  5
+                ],
+                "weight": 39092135543540843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  16,
+                  14
+                ],
+                "weight": 58005145301526860
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  23,
+                  18
+                ],
+                "weight": 22006861476032453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  10,
+                  19
+                ],
+                "weight": 34389317206718947
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  8,
+                  22
+                ],
+                "weight": 67845901780864923
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  18,
+                  7
+                ],
+                "weight": 117000076979803346
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  1,
+                  21
+                ],
+                "weight": 22006861476032453
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  10
+                ],
+                "weight": 51280816384764095
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  2
+                ],
+                "weight": 77344701611186800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  24,
+                  19
+                ],
+                "weight": 93867841709497485
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  21,
+                  5
+                ],
+                "weight": 140506416239738796
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  10,
+                  24
+                ],
+                "weight": 100900320448608188
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  24,
+                  2
+                ],
+                "weight": 25997106566714104
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  18,
+                  4
+                ],
+                "weight": 106352307466862856
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  21,
+                  2
+                ],
+                "weight": 274446722510954784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  11,
+                  22
+                ],
+                "weight": 332443488201890221
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  20,
+                  5
+                ],
+                "weight": 134497794095810336
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  9,
+                  21
+                ],
+                "weight": 12630474443265844
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  23,
+                  10
+                ],
+                "weight": 51394218613246370
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  4,
+                  19
+                ],
+                "weight": 8854228410200864
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  21,
+                  5
+                ],
+                "weight": 2317204440980268
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  10,
+                  16
+                ],
+                "weight": 101833998555793264
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  19,
+                  11
+                ],
+                "weight": 9096749724753178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  21
+                ],
+                "weight": 50616262735679740
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  10,
+                  22
+                ],
+                "weight": 134497794095810336
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  23,
+                  24
+                ],
+                "weight": 41873984731401285
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  7,
+                  14
+                ],
+                "weight": 21372752447544299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  19,
+                  8
+                ],
+                "weight": 115114890498168668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  15,
+                  5
+                ],
+                "weight": 27583957385724994
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  13,
+                  8
+                ],
+                "weight": 34632904869940250
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  16,
+                  24
+                ],
+                "weight": 101833998555793264
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  1,
+                  14
+                ],
+                "weight": 44014833250755881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  4,
+                  21
+                ],
+                "weight": 226147664216255312
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  2,
+                  11
+                ],
+                "weight": 10208501897819542
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  2,
+                  22
+                ],
+                "weight": 93268203344647655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  18,
+                  1,
+                  16
+                ],
+                "weight": 146007682835479402
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  24,
+                  5
+                ],
+                "weight": 32315700428959982
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  4,
+                  10,
+                  14
+                ],
+                "weight": 59131287032760038
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  4,
+                  8,
+                  11
+                ],
+                "weight": 313138236579317501
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  10,
+                  19,
+                  8
+                ],
+                "weight": 367169817885221151
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  5,
+                  14,
+                  22
+                ],
+                "weight": 44014833250755881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  13,
+                  14
+                ],
+                "weight": 175352740070326365
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  24,
+                  22
+                ],
+                "weight": 76616881874289819
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  18,
+                  7
+                ],
+                "weight": 84979555019318557
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  8,
+                  14
+                ],
+                "weight": 74225320970600351
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  19,
+                  22
+                ],
+                "weight": 255826606327600402
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  15,
+                  8
+                ],
+                "weight": 51501534870712667
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  18,
+                  8
+                ],
+                "weight": 21372752447544299
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  1,
+                  24
+                ],
+                "weight": 51501534870712667
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  4,
+                  24
+                ],
+                "weight": 76616881874289819
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  21,
+                  16
+                ],
+                "weight": 282844594762570733
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  7,
+                  21
+                ],
+                "weight": 178080600267832186
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  10,
+                  2
+                ],
+                "weight": 42263805083358830
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  8,
+                  11
+                ],
+                "weight": 41123008960881863
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  1,
+                  10,
+                  11
+                ],
+                "weight": 63420092211496481
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  1,
+                  13,
+                  8
+                ],
+                "weight": 14677982865506422
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  16,
+                  22
+                ],
+                "weight": 182969189341152675
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  10,
+                  24
+                ],
+                "weight": 93101045248513629
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  16,
+                  5
+                ],
+                "weight": 167721307202282981
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  5,
+                  14
+                ],
+                "weight": 31063635341085959
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  13,
+                  19,
+                  11
+                ],
+                "weight": 190030722935832787
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  18
+                ],
+                "weight": 49853008458741604
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  23,
+                  22
+                ],
+                "weight": 51394218613246370
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  9,
+                  18,
+                  19
+                ],
+                "weight": 49853008458741604
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  1,
+                  14
+                ],
+                "weight": 98002322607100617
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  24,
+                  19
+                ],
+                "weight": 44741784177628556
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  8,
+                  22
+                ],
+                "weight": 40756258733988426
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  18,
+                  16
+                ],
+                "weight": 23660761356379800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  7,
+                  19
+                ],
+                "weight": 61087549455487384
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  4,
+                  14
+                ],
+                "weight": 73513769815121404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  5,
+                  14
+                ],
+                "weight": 87998186976166238
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  7,
+                  10,
+                  22
+                ],
+                "weight": 50439779942546894
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  13,
+                  19
+                ],
+                "weight": 225699390219704672
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  16,
+                  5
+                ],
+                "weight": 243284737965673886
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  21,
+                  19,
+                  11
+                ],
+                "weight": 10313270002285576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  16,
+                  19,
+                  14
+                ],
+                "weight": 321457975165087350
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 18471552452717044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  2,
+                  5,
+                  14
+                ],
+                "weight": 18471552452717044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  12,
+                  11
+                ],
+                "weight": 37080645149802659
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  23,
+                  21
+                ],
+                "weight": 125737541340662564
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  1,
+                  2
+                ],
+                "weight": 101932548567820781
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  4,
+                  16
+                ],
+                "weight": 50664656495975080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  14
+                ],
+                "weight": 65827361141672673
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  18,
+                  24
+                ],
+                "weight": 37080645149802659
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  2,
+                  8
+                ],
+                "weight": 26363221889452934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  1
+                ],
+                "weight": 101932548567820781
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  14
+                ],
+                "weight": 96155850618332986
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  5,
+                  22
+                ],
+                "weight": 44014833250755881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  11,
+                  22
+                ],
+                "weight": 105805698459720771
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  10,
+                  11
+                ],
+                "weight": 107977746931079516
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  21,
+                  10
+                ],
+                "weight": 75121278604982824
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  13,
+                  14
+                ],
+                "weight": 8397959828927678
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  7,
+                  8,
+                  11
+                ],
+                "weight": 100588542860053285
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  21,
+                  24,
+                  19
+                ],
+                "weight": 100900320448608188
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  24,
+                  14
+                ],
+                "weight": 32856468326096692
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  10,
+                  19,
+                  2
+                ],
+                "weight": 58187462096337033
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  13,
+                  16,
+                  22
+                ],
+                "weight": 93377514848246235
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 133756788774704880
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  4,
+                  5
+                ],
+                "weight": 61716241595883108
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  24,
+                  2
+                ],
+                "weight": 36571723787272476
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  1,
+                  2
+                ],
+                "weight": 230014232535331761
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  4,
+                  13
+                ],
+                "weight": 63783285701455568
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  7,
+                  11
+                ],
+                "weight": 64682689498838908
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  2,
+                  8
+                ],
+                "weight": 115114890498168668
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  13,
+                  24
+                ],
+                "weight": 33703924341045205
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  11,
+                  22
+                ],
+                "weight": 155341389852150808
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  10,
+                  2
+                ],
+                "weight": 39092135543540843
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  13,
+                  5
+                ],
+                "weight": 30079361360410363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  14,
+                  22
+                ],
+                "weight": 100485216475449594
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  5,
+                  14
+                ],
+                "weight": 113107066897396720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  16,
+                  19,
+                  22
+                ],
+                "weight": 276346704189398910
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  13,
+                  8
+                ],
+                "weight": 101200767622945847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  16,
+                  24
+                ],
+                "weight": 289602947087948272
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  1,
+                  4
+                ],
+                "weight": 22006861476032453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  1,
+                  8
+                ],
+                "weight": 14677982865506422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  7,
+                  16
+                ],
+                "weight": 187768948532155008
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  13,
+                  2
+                ],
+                "weight": 18471552452717044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  4,
+                  22
+                ],
+                "weight": 22006861476032453
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  21,
+                  22
+                ],
+                "weight": 94765627565193212
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  13,
+                  19
+                ],
+                "weight": 8854228410200864
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  2,
+                  14
+                ],
+                "weight": 18471552452717044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  5,
+                  22
+                ],
+                "weight": 3675613584185767
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  24,
+                  5
+                ],
+                "weight": 56794659766428844
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 93893643615923505
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  13,
+                  8,
+                  14
+                ],
+                "weight": 34449834168737057
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  24,
+                  11,
+                  22
+                ],
+                "weight": 37080645149802659
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  19,
+                  5,
+                  14
+                ],
+                "weight": 25535088796518083
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  18,
+                  7
+                ],
+                "weight": 23660761356379800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  10,
+                  19
+                ],
+                "weight": 91717792568172921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  7,
+                  16
+                ],
+                "weight": 84748310811867184
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  21,
+                  10
+                ],
+                "weight": 56696930546315421
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  19,
+                  14
+                ],
+                "weight": 44014833250755881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  13,
+                  5
+                ],
+                "weight": 110194738851844228
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  16,
+                  22
+                ],
+                "weight": 67845901780864923
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  24,
+                  19
+                ],
+                "weight": 13384590138070344
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  5,
+                  8
+                ],
+                "weight": 76062454641686114
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  4,
+                  11
+                ],
+                "weight": 47363642921071292
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 129560262947214921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  16,
+                  2
+                ],
+                "weight": 95918244462795682
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  1,
+                  4,
+                  5
+                ],
+                "weight": 57918825615755875
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  21,
+                  22
+                ],
+                "weight": 63506044311404052
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  13,
+                  8
+                ],
+                "weight": 88669864402793227
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  24,
+                  2
+                ],
+                "weight": 79716455110443285
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 225699390219704672
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  10,
+                  13,
+                  19
+                ],
+                "weight": 91717792568172921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  24,
+                  19
+                ],
+                "weight": 91717792568172921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  14,
+                  22
+                ],
+                "weight": 243088735055124307
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  7,
+                  21,
+                  10
+                ],
+                "weight": 186257193493530342
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  8,
+                  14
+                ],
+                "weight": 21372752447544299
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  2,
+                  22
+                ],
+                "weight": 25997106566714104
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  5,
+                  22
+                ],
+                "weight": 151351144761469157
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  16,
+                  2,
+                  5
+                ],
+                "weight": 183666845190429139
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  16,
+                  19
+                ],
+                "weight": 8854228410200864
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  16,
+                  11
+                ],
+                "weight": 73733362213782057
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  2,
+                  14
+                ],
+                "weight": 5984522953433688
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  13,
+                  14
+                ],
+                "weight": 8854228410200864
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 10313270002285576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  10,
+                  16,
+                  11
+                ],
+                "weight": 63420092211496481
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  2,
+                  22
+                ],
+                "weight": 184937574038357230
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  16,
+                  5
+                ],
+                "weight": 82587590623982921
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  2,
+                  11
+                ],
+                "weight": 339507955872028266
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 224468372176524274
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  8,
+                  22
+                ],
+                "weight": 121961295307597584
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  10,
+                  13,
+                  5
+                ],
+                "weight": 186257193493530342
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  13,
+                  16,
+                  8
+                ],
+                "weight": 76062454641686114
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  24,
+                  19,
+                  11
+                ],
+                "weight": 35905853361214377
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  19,
+                  2,
+                  11
+                ],
+                "weight": 49290443499284721
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  10,
+                  8,
+                  14
+                ],
+                "weight": 121961295307597584
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  24,
+                  19,
+                  5
+                ],
+                "weight": 216634150176576220
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  24,
+                  2,
+                  14
+                ],
+                "weight": 126750111942020197
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  5,
+                  8
+                ],
+                "weight": 367687699615409862
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  19,
+                  14,
+                  22
+                ],
+                "weight": 123599485680664609
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  19,
+                  2,
+                  22
+                ],
+                "weight": 152747218508734301
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  19,
+                  5,
+                  11
+                ],
+                "weight": 151053549438833642
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 193,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 18092327937629830020
+          },
+          "certificate_sha256": "e1dd3f909cc47e3668579da661d88dd2774eccc1abf0be2c075e2c4e45faa257",
+          "max_weight": 373566497162772084,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 193,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 193,
+          "weight_sum": 18092327937629830020,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 1,
+        "order": [
+          0,
+          17,
+          3,
+          6,
+          20,
+          9,
+          12,
+          15,
+          23,
+          18,
+          1,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          19,
+          2,
+          5,
+          8,
+          11,
+          14,
+          22
+        ],
+        "order_sha256": "30094a6f568f815646533c426b1af746f6c4d7791664396ecbdd96fcf7dc54ee",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 47
+      },
+      {
+        "dihedral_order_sha256": "cb62d3ef162785cec9ed2a4e4e9dbc20c114b483a20fd664fbf93121ce065c32",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "f8a23b867a6529009a541d10434fd0cb5bf984c8c27baf6c9148f9d5a94187fc",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 2,
+            "source_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "source_unique_ordered_quad_count": 195,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  3,
+                  24
+                ],
+                "weight": 29420969829919071
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  9,
+                  19
+                ],
+                "weight": 26479861767670301
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  22
+                ],
+                "weight": 14404873096033904
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  15
+                ],
+                "weight": 67384699105206520
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  7,
+                  11
+                ],
+                "weight": 59807507584220334
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  13,
+                  14
+                ],
+                "weight": 15016096733885167
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  24,
+                  19
+                ],
+                "weight": 36467054584572296
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  18
+                ],
+                "weight": 59366823098175531
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  1,
+                  2
+                ],
+                "weight": 7202436548016952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  13,
+                  5
+                ],
+                "weight": 7202436548016952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  15,
+                  18
+                ],
+                "weight": 67384699105206520
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  10,
+                  13
+                ],
+                "weight": 27334166876938891
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  9,
+                  23,
+                  11
+                ],
+                "weight": 77591642502786797
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  19,
+                  8
+                ],
+                "weight": 58809280408126256
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  23,
+                  18
+                ],
+                "weight": 54095557496728611
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  1,
+                  4
+                ],
+                "weight": 38875244941680670
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  18,
+                  22
+                ],
+                "weight": 13289141608477909
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  4,
+                  11
+                ],
+                "weight": 39027798974913914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  16,
+                  24
+                ],
+                "weight": 7046084754653225
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  19,
+                  5
+                ],
+                "weight": 4137635944116341
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  18,
+                  21
+                ],
+                "weight": 46077681489697622
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  21,
+                  8
+                ],
+                "weight": 152554033233244
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  13,
+                  11
+                ],
+                "weight": 26998870453616902
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  13,
+                  14
+                ],
+                "weight": 36926043549546126
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  5,
+                  14
+                ],
+                "weight": 32808637130603432
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  10,
+                  2
+                ],
+                "weight": 152554033233244
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  16,
+                  11
+                ],
+                "weight": 27486720910172135
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  8,
+                  22
+                ],
+                "weight": 58809280408126256
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  15,
+                  22
+                ],
+                "weight": 109948748481017421
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  18,
+                  4
+                ],
+                "weight": 110249566004526897
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  10,
+                  16
+                ],
+                "weight": 35917148960046934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  20,
+                  13
+                ],
+                "weight": 46386825720046541
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  9,
+                  24
+                ],
+                "weight": 26479861767670301
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  12,
+                  13
+                ],
+                "weight": 27106427453982892
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  4,
+                  5
+                ],
+                "weight": 46386825720046541
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  10,
+                  24
+                ],
+                "weight": 51277805721261389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  16,
+                  14
+                ],
+                "weight": 44416214589282290
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  1,
+                  16
+                ],
+                "weight": 31368813827939356
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  4,
+                  13
+                ],
+                "weight": 55363674655245000
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  1,
+                  10
+                ],
+                "weight": 96516287474690054
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  15,
+                  7,
+                  11
+                ],
+                "weight": 20901717621896886
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  4,
+                  16
+                ],
+                "weight": 8499065629235356
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  18,
+                  7,
+                  16
+                ],
+                "weight": 102725018961168242
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  18,
+                  11,
+                  22
+                ],
+                "weight": 7524547043358655
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  4,
+                  13,
+                  24
+                ],
+                "weight": 73493253174029433
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  7,
+                  10,
+                  22
+                ],
+                "weight": 9321332793381731
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  7,
+                  24,
+                  5
+                ],
+                "weight": 114305403789683397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  10,
+                  24,
+                  11
+                ],
+                "weight": 7524547043358655
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  2,
+                  14,
+                  22
+                ],
+                "weight": 44416214589282290
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  14
+                ],
+                "weight": 130745730153282213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  24,
+                  5
+                ],
+                "weight": 88407281143504598
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  9,
+                  4
+                ],
+                "weight": 48815087783594784
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  12,
+                  2
+                ],
+                "weight": 57759264102408932
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  18,
+                  19
+                ],
+                "weight": 24171378267278497
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  2,
+                  14
+                ],
+                "weight": 60193453218743880
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  8,
+                  22
+                ],
+                "weight": 124353621577051325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  15,
+                  7
+                ],
+                "weight": 42564049375810901
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  21,
+                  2
+                ],
+                "weight": 97819357041526018
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  13,
+                  22
+                ],
+                "weight": 6251038407783883
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  1,
+                  21
+                ],
+                "weight": 129550161772895641
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  13,
+                  16
+                ],
+                "weight": 35917148960046934
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  18,
+                  13
+                ],
+                "weight": 69120594930795391
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  8,
+                  11
+                ],
+                "weight": 3100064399169932
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  1,
+                  18,
+                  11
+                ],
+                "weight": 39417575265633354
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  7,
+                  2
+                ],
+                "weight": 7202436548016952
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  21,
+                  10
+                ],
+                "weight": 96127555026389228
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  7,
+                  24
+                ],
+                "weight": 22459982459180345
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  10,
+                  24
+                ],
+                "weight": 51940226558932302
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  7,
+                  8
+                ],
+                "weight": 30145088577023037
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  14
+                ],
+                "weight": 80104477427503860
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  21,
+                  19,
+                  11
+                ],
+                "weight": 121104193480070007
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 64396750295019605
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  13,
+                  19,
+                  14
+                ],
+                "weight": 42168187367830817
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  19,
+                  2,
+                  14
+                ],
+                "weight": 44828340370799090
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  22
+                ],
+                "weight": 85846684865845832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  12,
+                  18
+                ],
+                "weight": 112885426402248116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  1,
+                  16
+                ],
+                "weight": 60239878033333065
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  18,
+                  7
+                ],
+                "weight": 6097152831720016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  13,
+                  19
+                ],
+                "weight": 54440594330921783
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  24,
+                  2
+                ],
+                "weight": 61927419375834297
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  2,
+                  22
+                ],
+                "weight": 59137545789862630
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  16,
+                  5
+                ],
+                "weight": 28871064205393709
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  5,
+                  22
+                ],
+                "weight": 79595646458061949
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  15,
+                  14
+                ],
+                "weight": 85162310894063235
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  22
+                ],
+                "weight": 27723115508184881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  8,
+                  14
+                ],
+                "weight": 91328154887648859
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  23,
+                  24
+                ],
+                "weight": 111134497822395922
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  18,
+                  10
+                ],
+                "weight": 37647497556752093
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  4,
+                  5
+                ],
+                "weight": 146334299944189790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  13,
+                  2
+                ],
+                "weight": 66339982337879582
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  19,
+                  22
+                ],
+                "weight": 18675507017975619
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  4,
+                  11
+                ],
+                "weight": 74491578103616865
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  21,
+                  22
+                ],
+                "weight": 31368813827939356
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  13,
+                  19
+                ],
+                "weight": 5274105890839701
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  1,
+                  18,
+                  4
+                ],
+                "weight": 9773952915600476
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  11,
+                  14
+                ],
+                "weight": 39417575265633354
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  10,
+                  8
+                ],
+                "weight": 37647497556752093
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  4,
+                  7,
+                  11
+                ],
+                "weight": 6097152831720016
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  21,
+                  16,
+                  22
+                ],
+                "weight": 31368813827939356
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 121104193480070007
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  13,
+                  11,
+                  22
+                ],
+                "weight": 172441508279687607
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  16,
+                  19,
+                  8
+                ],
+                "weight": 35765087312946164
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  12,
+                  10
+                ],
+                "weight": 186444080637110800
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  1,
+                  5
+                ],
+                "weight": 57139813634163133
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  10,
+                  19
+                ],
+                "weight": 78611972598200280
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  2
+                ],
+                "weight": 46452226780879792
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  18,
+                  4
+                ],
+                "weight": 64324160274037251
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  11,
+                  14
+                ],
+                "weight": 104609667808026170
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  1,
+                  8
+                ],
+                "weight": 3100064399169932
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  7,
+                  19
+                ],
+                "weight": 43352162381709860
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  8,
+                  11
+                ],
+                "weight": 18200140642789158
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  16,
+                  5
+                ],
+                "weight": 49449315213429876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  24,
+                  2
+                ],
+                "weight": 65628663127117370
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  16,
+                  2,
+                  11
+                ],
+                "weight": 65272978657480651
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  16,
+                  5,
+                  8
+                ],
+                "weight": 10752987914116592
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 116906468848378759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  4,
+                  24
+                ],
+                "weight": 64171606240804007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  13,
+                  19
+                ],
+                "weight": 55363674655245000
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  1,
+                  13
+                ],
+                "weight": 3917235619724117
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  10,
+                  8
+                ],
+                "weight": 58809280408126256
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  16,
+                  2
+                ],
+                "weight": 28871064205393709
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  5,
+                  11
+                ],
+                "weight": 65032443168153665
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  1,
+                  13
+                ],
+                "weight": 53222578014439016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  18,
+                  2
+                ],
+                "weight": 40663378679805884
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  7,
+                  10
+                ],
+                "weight": 120268470441031641
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  24,
+                  2
+                ],
+                "weight": 64171606240804007
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  19,
+                  5
+                ],
+                "weight": 71447674549648558
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  7,
+                  21,
+                  10
+                ],
+                "weight": 97819357041526018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 51446439035520883
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  19,
+                  2,
+                  11
+                ],
+                "weight": 35886692084477582
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  19,
+                  8
+                ],
+                "weight": 20059901289769954
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  18,
+                  24
+                ],
+                "weight": 10228602777308640
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  24,
+                  14
+                ],
+                "weight": 50133797548879390
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  7,
+                  22
+                ],
+                "weight": 14400248179651182
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  7,
+                  21
+                ],
+                "weight": 85105480464611536
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  21,
+                  11
+                ],
+                "weight": 39027798974913914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  10,
+                  19
+                ],
+                "weight": 106792389772954310
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  8,
+                  22
+                ],
+                "weight": 8389689709264556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  16,
+                  19,
+                  22
+                ],
+                "weight": 31368813827939356
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  24,
+                  2,
+                  5
+                ],
+                "weight": 114305403789683397
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  24,
+                  5,
+                  22
+                ],
+                "weight": 114305403789683397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  19,
+                  14,
+                  22
+                ],
+                "weight": 32622567407398234
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  2,
+                  8,
+                  22
+                ],
+                "weight": 102998366468154257
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  7,
+                  2
+                ],
+                "weight": 52338002291411377
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  10,
+                  5
+                ],
+                "weight": 85439492720152466
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  18,
+                  10
+                ],
+                "weight": 105032196661958613
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  4,
+                  21
+                ],
+                "weight": 9773952915600476
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  13,
+                  8
+                ],
+                "weight": 98316538611859145
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  8,
+                  14
+                ],
+                "weight": 19447356913962935
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  11,
+                  22
+                ],
+                "weight": 18675507017975619
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  7,
+                  21,
+                  13
+                ],
+                "weight": 9773952915600476
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  10,
+                  24
+                ],
+                "weight": 70667266407580368
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  10,
+                  19,
+                  2
+                ],
+                "weight": 42873044251861914
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  10,
+                  13
+                ],
+                "weight": 164015659065154814
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  14,
+                  22
+                ],
+                "weight": 20525303876550651
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  4,
+                  16
+                ],
+                "weight": 1253753579458878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  5,
+                  22
+                ],
+                "weight": 10843509951388705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  21,
+                  10
+                ],
+                "weight": 78576166345002348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  16,
+                  19
+                ],
+                "weight": 49880021852008439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  19,
+                  22
+                ],
+                "weight": 1253753579458878
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  24,
+                  2
+                ],
+                "weight": 101159670741958233
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  13,
+                  5
+                ],
+                "weight": 41672486119920407
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  10,
+                  2,
+                  5
+                ],
+                "weight": 54610516551620764
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  16,
+                  24,
+                  19
+                ],
+                "weight": 49880021852008439
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  7,
+                  19
+                ],
+                "weight": 7202436548016952
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  16,
+                  14
+                ],
+                "weight": 18892271389082703
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 95216474212689213
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  5,
+                  22
+                ],
+                "weight": 7202436548016952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 12476542438856653
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  13,
+                  19,
+                  5
+                ],
+                "weight": 7202436548016952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  4,
+                  10,
+                  8
+                ],
+                "weight": 74351450336611367
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  13,
+                  14
+                ],
+                "weight": 8603846962574230
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  19,
+                  22
+                ],
+                "weight": 5078915386269451
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  5,
+                  14
+                ],
+                "weight": 10843509951388705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  10,
+                  19,
+                  2
+                ],
+                "weight": 11890026332992094
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 17810364352069718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  21,
+                  8
+                ],
+                "weight": 78576166345002348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 51133775431467317
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  10,
+                  24,
+                  19
+                ],
+                "weight": 78576166345002348
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  19,
+                  22
+                ],
+                "weight": 19929260597434497
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  19,
+                  11
+                ],
+                "weight": 1638392100205622
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  11,
+                  14
+                ],
+                "weight": 88708324390078090
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 25060848829602017
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  16,
+                  14
+                ],
+                "weight": 16782293886591348
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  10,
+                  13,
+                  14
+                ],
+                "weight": 27152090633945650
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  10,
+                  24,
+                  14
+                ],
+                "weight": 52952386793558210
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  24,
+                  19,
+                  8
+                ],
+                "weight": 48431077767979311
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  2,
+                  22
+                ],
+                "weight": 193890633484354168
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  16,
+                  8,
+                  14
+                ],
+                "weight": 46518075227062756
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  24,
+                  19,
+                  2
+                ],
+                "weight": 194043187517587412
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  19,
+                  5,
+                  8
+                ],
+                "weight": 89109606916032273
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  24,
+                  11,
+                  22
+                ],
+                "weight": 17810364352069718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  19,
+                  8,
+                  11
+                ],
+                "weight": 52821632305600508
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 230088308372582935
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  5,
+                  14,
+                  22
+                ],
+                "weight": 89244554960081380
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 195,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 10443006455390912216
+          },
+          "certificate_sha256": "f9e157f192cafc579b7b602b8d69fe78e247508bcb0e6f48cfd8a4f31d233ed2",
+          "max_weight": 230088308372582935,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 195,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 195,
+          "weight_sum": 10443006455390912216,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 2,
+        "order": [
+          0,
+          17,
+          3,
+          6,
+          20,
+          9,
+          12,
+          15,
+          23,
+          1,
+          18,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          19,
+          2,
+          5,
+          8,
+          11,
+          14,
+          22
+        ],
+        "order_sha256": "cb62d3ef162785cec9ed2a4e4e9dbc20c114b483a20fd664fbf93121ce065c32",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 48
+      },
+      {
+        "dihedral_order_sha256": "48e3ae8870e6f4ac43d0ac3c5127843323d39c5f2d3f90dc5e1e9cc64d817372",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "01778047eb6a0181f441fe6760493ded5cffda635277c672344c1f2e6a67e169",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 3,
+            "source_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              2,
+              19,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "source_unique_ordered_quad_count": 195,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              2,
+              19,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  3,
+                  20
+                ],
+                "weight": 10887609668956300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  6,
+                  23
+                ],
+                "weight": 25338384877910208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  15,
+                  8
+                ],
+                "weight": 797248671273746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  23,
+                  5
+                ],
+                "weight": 15315620872071221
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  18,
+                  24
+                ],
+                "weight": 2192001501400604
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  7,
+                  16
+                ],
+                "weight": 66060389311656
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  13,
+                  14
+                ],
+                "weight": 3616654908221651
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  2,
+                  11
+                ],
+                "weight": 20598371165400618
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  20
+                ],
+                "weight": 571030803720450
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  19
+                ],
+                "weight": 5684315146459420
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  23,
+                  21
+                ],
+                "weight": 4632263718776430
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  19,
+                  11
+                ],
+                "weight": 70525988752276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  20,
+                  1
+                ],
+                "weight": 3920783061146721
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  20,
+                  10
+                ],
+                "weight": 25909415681630658
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  23,
+                  13
+                ],
+                "weight": 2028347609568339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  10
+                ],
+                "weight": 5072166796516667
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  23,
+                  4
+                ],
+                "weight": 2768965177210631
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  14
+                ],
+                "weight": 3852324065634344
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  1,
+                  7
+                ],
+                "weight": 3920783061146721
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  18,
+                  24
+                ],
+                "weight": 576963675810027
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  24,
+                  11
+                ],
+                "weight": 1186568409502672
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  23,
+                  14
+                ],
+                "weight": 797248671273746
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  21,
+                  13
+                ],
+                "weight": 1588307298653312
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  4,
+                  11
+                ],
+                "weight": 2768965177210631
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  10,
+                  11
+                ],
+                "weight": 8990551251462667
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  8,
+                  14
+                ],
+                "weight": 2968091355970194
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  21,
+                  10,
+                  8
+                ],
+                "weight": 2170842684696448
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  16,
+                  2
+                ],
+                "weight": 1588307298653312
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  21,
+                  24,
+                  19
+                ],
+                "weight": 70525988752276
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  24,
+                  14
+                ],
+                "weight": 6089227139642448
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  2,
+                  5
+                ],
+                "weight": 5154320036496792
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  20,
+                  15
+                ],
+                "weight": 571030803720450
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  13,
+                  11
+                ],
+                "weight": 942349385363226
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  3,
+                  16,
+                  22
+                ],
+                "weight": 416243632146165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  2,
+                  5
+                ],
+                "weight": 4520238406293206
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  9,
+                  18
+                ],
+                "weight": 508728967609143
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  23
+                ],
+                "weight": 3714445559225936
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  4,
+                  5
+                ],
+                "weight": 891634223137832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  4,
+                  14
+                ],
+                "weight": 151194059604162
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  10,
+                  11
+                ],
+                "weight": 19656021780037392
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  13,
+                  16
+                ],
+                "weight": 2674305522858425
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  1
+                ],
+                "weight": 11458640472676750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  21,
+                  19
+                ],
+                "weight": 910689832064987
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  12,
+                  11
+                ],
+                "weight": 11967369440285893
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  18,
+                  21
+                ],
+                "weight": 208612942783236
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  9,
+                  7,
+                  19
+                ],
+                "weight": 66060389311656
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  12,
+                  1,
+                  5
+                ],
+                "weight": 5582837583196864
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  21,
+                  10
+                ],
+                "weight": 8906724522725665
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  15,
+                  8,
+                  22
+                ],
+                "weight": 1775906688507950
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  1,
+                  22
+                ],
+                "weight": 3304447948130544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  18,
+                  4
+                ],
+                "weight": 1042828282741994
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  16,
+                  24
+                ],
+                "weight": 2192001501400604
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  2,
+                  11
+                ],
+                "weight": 3003870498482507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  2,
+                  14
+                ],
+                "weight": 3465460848617489
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  1,
+                  18,
+                  8
+                ],
+                "weight": 1449289243484517
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  21,
+                  2,
+                  22
+                ],
+                "weight": 9608801412007416
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  10,
+                  19,
+                  8
+                ],
+                "weight": 10749297257311727
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  24,
+                  19,
+                  5
+                ],
+                "weight": 10795382465778015
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  9,
+                  15
+                ],
+                "weight": 2508005515063688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  15,
+                  10
+                ],
+                "weight": 6674915850701332
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  2,
+                  22
+                ],
+                "weight": 416243632146165
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  12,
+                  5
+                ],
+                "weight": 2508005515063688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  23,
+                  7
+                ],
+                "weight": 14816514220037876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  5,
+                  14
+                ],
+                "weight": 3769171692687820
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  24,
+                  11
+                ],
+                "weight": 506437687057751
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  4,
+                  16
+                ],
+                "weight": 963336617965335
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  4,
+                  8
+                ],
+                "weight": 4737941139358094
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  18,
+                  24
+                ],
+                "weight": 8560193678407285
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  10,
+                  14
+                ],
+                "weight": 6089227139642448
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  7,
+                  21
+                ],
+                "weight": 24463080361799951
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  1,
+                  16,
+                  2
+                ],
+                "weight": 4454868841375719
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  4,
+                  16
+                ],
+                "weight": 8560193678407285
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  21,
+                  16
+                ],
+                "weight": 10184250501261446
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  24
+                ],
+                "weight": 4077220934469268
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  21,
+                  22
+                ],
+                "weight": 9646566141762075
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  7,
+                  13,
+                  16
+                ],
+                "weight": 3491532223410384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  21,
+                  2,
+                  14
+                ],
+                "weight": 4103994774147041
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  13,
+                  2
+                ],
+                "weight": 3491532223410384
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  13,
+                  19,
+                  22
+                ],
+                "weight": 6040715061457542
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  24,
+                  19,
+                  11
+                ],
+                "weight": 506437687057751
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  19,
+                  8,
+                  11
+                ],
+                "weight": 506437687057751
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  19
+                ],
+                "weight": 508728967609143
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  12,
+                  4
+                ],
+                "weight": 6899370285680227
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  12,
+                  2
+                ],
+                "weight": 5412501804774266
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  4,
+                  22
+                ],
+                "weight": 10604374205873601
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  24,
+                  5
+                ],
+                "weight": 2539573809270122
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  19,
+                  8
+                ],
+                "weight": 5432206731626378
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  23,
+                  14
+                ],
+                "weight": 151194059604162
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  4,
+                  21
+                ],
+                "weight": 6330373701238616
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  4,
+                  10
+                ],
+                "weight": 5450884079649488
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  4,
+                  14
+                ],
+                "weight": 6860988010805005
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  16,
+                  2
+                ],
+                "weight": 2464734082408518
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  5,
+                  8
+                ],
+                "weight": 1647939586132290
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  7,
+                  11
+                ],
+                "weight": 7701923911669136
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  19,
+                  22
+                ],
+                "weight": 3759283122123890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  18,
+                  7
+                ],
+                "weight": 2629757115152469
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  16,
+                  2
+                ],
+                "weight": 1837292009261759
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  13,
+                  16
+                ],
+                "weight": 6976331614528702
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  24,
+                  22
+                ],
+                "weight": 3026906775937339
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  21,
+                  13
+                ],
+                "weight": 6330373701238616
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  10,
+                  22
+                ],
+                "weight": 3138486082761612
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  2,
+                  19
+                ],
+                "weight": 7877235887182784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  10,
+                  19
+                ],
+                "weight": 805524998958341
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  10,
+                  24,
+                  5
+                ],
+                "weight": 15269571779829886
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 20836052365037347
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  12,
+                  18
+                ],
+                "weight": 21561927275500667
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  23,
+                  13
+                ],
+                "weight": 374757083554389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  1,
+                  2
+                ],
+                "weight": 972006538456564
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  18,
+                  4
+                ],
+                "weight": 13728249761573937
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  16,
+                  24
+                ],
+                "weight": 374757083554389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  19,
+                  14
+                ],
+                "weight": 1473214122682126
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  16
+                ],
+                "weight": 1838686566673801
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  16
+                ],
+                "weight": 555521526982441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  1,
+                  18
+                ],
+                "weight": 22737540942184950
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  21,
+                  11
+                ],
+                "weight": 14310738904052600
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  7,
+                  2
+                ],
+                "weight": 2902450294204465
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  8,
+                  14
+                ],
+                "weight": 2198345499524166
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  18,
+                  7
+                ],
+                "weight": 29333737194376551
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  7,
+                  22
+                ],
+                "weight": 949873771429879
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  10,
+                  13
+                ],
+                "weight": 5834450758941713
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  13,
+                  14
+                ],
+                "weight": 5834450758941713
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  24,
+                  8
+                ],
+                "weight": 1792529552857439
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  16,
+                  14
+                ],
+                "weight": 180764443428052
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  10,
+                  5
+                ],
+                "weight": 13400049071987613
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  24,
+                  2
+                ],
+                "weight": 1121801339967072
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  19,
+                  5
+                ],
+                "weight": 2539573809270122
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  8,
+                  11,
+                  22
+                ],
+                "weight": 5838022678293105
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  1,
+                  4
+                ],
+                "weight": 12430647011133314
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  19,
+                  8
+                ],
+                "weight": 1407153733370470
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  7,
+                  21
+                ],
+                "weight": 7087864704608120
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  10,
+                  5
+                ],
+                "weight": 1877887667312441
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  21,
+                  11
+                ],
+                "weight": 6879251761824884
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  10,
+                  24
+                ],
+                "weight": 3078095971402095
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  4,
+                  10
+                ],
+                "weight": 1817497555952924
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  24,
+                  2
+                ],
+                "weight": 2703338887847706
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  2,
+                  8
+                ],
+                "weight": 1731332349391142
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  4,
+                  5,
+                  11
+                ],
+                "weight": 3139053844936573
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  8,
+                  22
+                ],
+                "weight": 3138486082761612
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  13,
+                  16,
+                  8
+                ],
+                "weight": 374757083554389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  13,
+                  5
+                ],
+                "weight": 1426892482000886
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  4,
+                  13
+                ],
+                "weight": 2277982008311461
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  10,
+                  2
+                ],
+                "weight": 1613644556097943
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  21,
+                  8
+                ],
+                "weight": 2587086316842613
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  8,
+                  11
+                ],
+                "weight": 4036375560327130
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  4,
+                  7
+                ],
+                "weight": 9776148311923099
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  4,
+                  11
+                ],
+                "weight": 1175613666684283
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  10,
+                  14
+                ],
+                "weight": 1817497555952924
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  13,
+                  2
+                ],
+                "weight": 851089526310575
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  7,
+                  21,
+                  11
+                ],
+                "weight": 4979144929005224
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  16,
+                  24
+                ],
+                "weight": 70525988752276
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  19,
+                  8
+                ],
+                "weight": 5684315146459420
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  21,
+                  5
+                ],
+                "weight": 6004274228521200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  13,
+                  11
+                ],
+                "weight": 7701923911669136
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  21,
+                  2
+                ],
+                "weight": 2902450294204465
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  8,
+                  14
+                ],
+                "weight": 797248671273746
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  7,
+                  22
+                ],
+                "weight": 10604374205873601
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  24,
+                  22
+                ],
+                "weight": 957808064111526
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  19,
+                  8
+                ],
+                "weight": 5166436855494360
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  10,
+                  16
+                ],
+                "weight": 963336617965335
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 4577381746520314
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  4,
+                  22
+                ],
+                "weight": 1235153725569467
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  7,
+                  5
+                ],
+                "weight": 4642474543459790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  16,
+                  5
+                ],
+                "weight": 4030688068074405
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  19,
+                  11
+                ],
+                "weight": 805524998958341
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  24
+                ],
+                "weight": 10752195179807889
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  10,
+                  13
+                ],
+                "weight": 3491532223410384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  2,
+                  19
+                ],
+                "weight": 14524283257787
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  8,
+                  11
+                ],
+                "weight": 2198345499524166
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  24,
+                  14,
+                  22
+                ],
+                "weight": 2069294222561077
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 791000715700554
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  19,
+                  22
+                ],
+                "weight": 672332599236674
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  10,
+                  16
+                ],
+                "weight": 2587395688648296
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  21,
+                  14
+                ],
+                "weight": 251613175744849
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  10,
+                  11
+                ],
+                "weight": 19289883833057824
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  13,
+                  2
+                ],
+                "weight": 8843804767256125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  5,
+                  14
+                ],
+                "weight": 5582837583196864
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  16,
+                  2,
+                  14
+                ],
+                "weight": 4388935925880406
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  19,
+                  11,
+                  22
+                ],
+                "weight": 672332599236674
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  4,
+                  21,
+                  14
+                ],
+                "weight": 9686832357343905
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  24,
+                  5
+                ],
+                "weight": 4642474543459790
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  2,
+                  19
+                ],
+                "weight": 9819649515172780
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  21,
+                  8,
+                  22
+                ],
+                "weight": 454008361900824
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  10,
+                  24,
+                  11
+                ],
+                "weight": 8990551251462667
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  19,
+                  14
+                ],
+                "weight": 2614746227226670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  11,
+                  22
+                ],
+                "weight": 5045972407567753
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 8843804767256125
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  24,
+                  8,
+                  14
+                ],
+                "weight": 3006608789966952
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  21,
+                  10,
+                  2
+                ],
+                "weight": 3491532223410384
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  2,
+                  11
+                ],
+                "weight": 16168041679992057
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  5,
+                  14
+                ],
+                "weight": 3219704531715043
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  24,
+                  19,
+                  14
+                ],
+                "weight": 5151912572236573
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  16,
+                  8,
+                  22
+                ],
+                "weight": 416243632146165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  5,
+                  11
+                ],
+                "weight": 680130722444921
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  2,
+                  19,
+                  5
+                ],
+                "weight": 5154320036496792
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  2,
+                  11,
+                  14
+                ],
+                "weight": 4388935925880406
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 791000715700554
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 196,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 993672343485635587
+          },
+          "certificate_sha256": "8a8b3b9fb07d13e7e97e74eda24080a4334deb7cddfe561a6249f18d6d93290f",
+          "max_weight": 29333737194376551,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 196,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 195,
+          "weight_sum": 993672343485635587,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 3,
+        "order": [
+          0,
+          17,
+          3,
+          6,
+          20,
+          9,
+          12,
+          15,
+          23,
+          1,
+          18,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          2,
+          19,
+          5,
+          8,
+          11,
+          14,
+          22
+        ],
+        "order_sha256": "48e3ae8870e6f4ac43d0ac3c5127843323d39c5f2d3f90dc5e1e9cc64d817372",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 49
+      },
+      {
+        "dihedral_order_sha256": "e620e04f9e30776e7aa9f78d5a92b2eb38b1940f562972644abef237f394bf05",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "c8735acbde983338bfa81ef8a9d33b3d81c33e1cf79e0f46df2adc769e365883",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 4,
+            "source_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              18,
+              1,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              2,
+              19,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "source_unique_ordered_quad_count": 196,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              17,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              18,
+              1,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              2,
+              19,
+              5,
+              8,
+              11,
+              14,
+              22
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  3,
+                  8
+                ],
+                "weight": 192421770896054589
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  6,
+                  14
+                ],
+                "weight": 81245646188034775
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  20,
+                  21
+                ],
+                "weight": 270946724375458116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  7,
+                  19
+                ],
+                "weight": 48063616271373717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  17,
+                  2,
+                  11
+                ],
+                "weight": 188857673836437824
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  9,
+                  8
+                ],
+                "weight": 93751335412448352
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  13
+                ],
+                "weight": 743283416066776
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  22
+                ],
+                "weight": 97927152067539461
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  4,
+                  11
+                ],
+                "weight": 85521083001964194
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  7,
+                  14
+                ],
+                "weight": 105419325636005993
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  21,
+                  10
+                ],
+                "weight": 270203440959391340
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  15,
+                  19
+                ],
+                "weight": 362494187915736466
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  7,
+                  24
+                ],
+                "weight": 133425228835140208
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  5,
+                  14
+                ],
+                "weight": 81245646188034775
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  9,
+                  5
+                ],
+                "weight": 10626671436709345
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  1,
+                  10
+                ],
+                "weight": 1761569325414883
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  23,
+                  7
+                ],
+                "weight": 390262099696851811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  8,
+                  11
+                ],
+                "weight": 192421770896054589
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  7,
+                  16
+                ],
+                "weight": 49142166616938499
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  21,
+                  14
+                ],
+                "weight": 743283416066776
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  18,
+                  5
+                ],
+                "weight": 103762288518482766
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  7,
+                  19
+                ],
+                "weight": 299831924961273968
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  10,
+                  14
+                ],
+                "weight": 160589415022001959
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  18,
+                  13
+                ],
+                "weight": 66903639365537954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  13,
+                  16
+                ],
+                "weight": 150338619725606360
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  16,
+                  22
+                ],
+                "weight": 208621586301719314
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  13,
+                  14
+                ],
+                "weight": 170665927884020720
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  10,
+                  11
+                ],
+                "weight": 1761569325414883
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  2,
+                  5
+                ],
+                "weight": 85521083001964194
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  4,
+                  5,
+                  11
+                ],
+                "weight": 240982654654039227
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  10,
+                  2
+                ],
+                "weight": 245620162623880574
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  16,
+                  24
+                ],
+                "weight": 187579318774486872
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  11,
+                  22
+                ],
+                "weight": 137767706011906076
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  11
+                ],
+                "weight": 321004547609627080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  19,
+                  5
+                ],
+                "weight": 410557804187110183
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  20,
+                  10
+                ],
+                "weight": 386559394284027670
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  3,
+                  10,
+                  8
+                ],
+                "weight": 656762835243419010
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  20,
+                  15
+                ],
+                "weight": 469803633743845890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  12,
+                  10
+                ],
+                "weight": 365937852085822050
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  6,
+                  15,
+                  5
+                ],
+                "weight": 103762288518482766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  7,
+                  16
+                ],
+                "weight": 48063616271373717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  13,
+                  5
+                ],
+                "weight": 87065451183741108
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  6,
+                  24,
+                  14
+                ],
+                "weight": 27213232573627359
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  9,
+                  2
+                ],
+                "weight": 189748373792892507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  23,
+                  21
+                ],
+                "weight": 116805816943219816
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  18,
+                  19
+                ],
+                "weight": 78549227844416633
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  20,
+                  10,
+                  8
+                ],
+                "weight": 317118702015106304
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  24,
+                  11
+                ],
+                "weight": 1747679036167716
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  20,
+                  5,
+                  8
+                ],
+                "weight": 2204624467849480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  12,
+                  11
+                ],
+                "weight": 187109994800270108
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  9,
+                  23,
+                  18
+                ],
+                "weight": 2638378992622399
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  4,
+                  21
+                ],
+                "weight": 154140907432238300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  12,
+                  8,
+                  11
+                ],
+                "weight": 187109994800270108
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  23,
+                  19,
+                  8
+                ],
+                "weight": 119444195935842215
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  23,
+                  19,
+                  22
+                ],
+                "weight": 31174972086710576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  18,
+                  24,
+                  14
+                ],
+                "weight": 78549227844416633
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  5,
+                  14
+                ],
+                "weight": 84860826715891628
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  18,
+                  14,
+                  22
+                ],
+                "weight": 30828413101484212
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  1,
+                  2,
+                  19
+                ],
+                "weight": 236921290107811541
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  4,
+                  10,
+                  22
+                ],
+                "weight": 154140907432238300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  7,
+                  16,
+                  2
+                ],
+                "weight": 78686061106413763
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  17,
+                  21,
+                  24,
+                  8
+                ],
+                "weight": 184952670493576542
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  10,
+                  13,
+                  2
+                ],
+                "weight": 375525198320913894
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  13,
+                  24,
+                  8
+                ],
+                "weight": 462590649504655002
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  16,
+                  2,
+                  14
+                ],
+                "weight": 30622444835040046
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  17,
+                  24,
+                  19,
+                  22
+                ],
+                "weight": 755053459452443252
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  12
+                ],
+                "weight": 557820382702896183
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  9,
+                  18
+                ],
+                "weight": 704531785107173965
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  1,
+                  16
+                ],
+                "weight": 35222138938253497
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  1,
+                  2
+                ],
+                "weight": 171260988418868513
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  24,
+                  22
+                ],
+                "weight": 97927152067539461
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  15,
+                  7
+                ],
+                "weight": 41934443252727439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  4,
+                  14
+                ],
+                "weight": 392393900895055186
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  21,
+                  8
+                ],
+                "weight": 270203440959391340
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  23,
+                  18
+                ],
+                "weight": 81423746185946845
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  18,
+                  24
+                ],
+                "weight": 81423746185946845
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  13,
+                  19
+                ],
+                "weight": 17975449640594105
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  7,
+                  22
+                ],
+                "weight": 41934443252727439
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  18,
+                  21
+                ],
+                "weight": 623108038921227120
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  1,
+                  4
+                ],
+                "weight": 243387935509812438
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  16,
+                  24
+                ],
+                "weight": 16503405881592616
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  19,
+                  5
+                ],
+                "weight": 4369353872933939
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  7,
+                  8
+                ],
+                "weight": 63484882383278554
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  13,
+                  16,
+                  2
+                ],
+                "weight": 18718733056660881
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  19,
+                  5,
+                  11
+                ],
+                "weight": 85521083001964194
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  18
+                ],
+                "weight": 1314857442650691686
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  4,
+                  14
+                ],
+                "weight": 179901962231453676
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  7,
+                  11
+                ],
+                "weight": 62865318328895767
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  20,
+                  7,
+                  22
+                ],
+                "weight": 118623526777618158
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  9,
+                  12,
+                  1
+                ],
+                "weight": 454090323653736098
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  9,
+                  15,
+                  19
+                ],
+                "weight": 156235333889781623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  18,
+                  1
+                ],
+                "weight": 220056326577120481
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  16,
+                  22
+                ],
+                "weight": 160557970030345597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  23,
+                  5
+                ],
+                "weight": 109256900949934818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  21
+                ],
+                "weight": 251088545689225636
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  12,
+                  4,
+                  8
+                ],
+                "weight": 645972854270810231
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  13,
+                  2
+                ],
+                "weight": 132318781257528273
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  18,
+                  7
+                ],
+                "weight": 281012430016462422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  11,
+                  14
+                ],
+                "weight": 108458878761662134
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  18,
+                  5
+                ],
+                "weight": 109256900949934818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  10,
+                  13
+                ],
+                "weight": 177572111331315438
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  19,
+                  8
+                ],
+                "weight": 65047363227075712
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  4,
+                  21,
+                  19
+                ],
+                "weight": 383407326946753909
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  21,
+                  13,
+                  19
+                ],
+                "weight": 132318781257528273
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  11,
+                  22
+                ],
+                "weight": 41537497133660034
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  10,
+                  19,
+                  11
+                ],
+                "weight": 543509963417137488
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  24,
+                  5
+                ],
+                "weight": 81570838752289056
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  13,
+                  2,
+                  19
+                ],
+                "weight": 132318781257528273
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  16,
+                  11,
+                  22
+                ],
+                "weight": 208621586301719314
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  19,
+                  14
+                ],
+                "weight": 187782835013801905
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  19,
+                  8,
+                  22
+                ],
+                "weight": 643108241369469389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  4,
+                  21
+                ],
+                "weight": 675207130189910583
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  10,
+                  13
+                ],
+                "weight": 25164295713327810
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  1,
+                  2
+                ],
+                "weight": 262628607269438860
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  23,
+                  10
+                ],
+                "weight": 116805816943219816
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 55992708814812022
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  21,
+                  10
+                ],
+                "weight": 239077986763734983
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  10,
+                  16
+                ],
+                "weight": 212152121724992290
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  4,
+                  21
+                ],
+                "weight": 227406468331185363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  21,
+                  8
+                ],
+                "weight": 319323326482955784
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  13,
+                  24
+                ],
+                "weight": 25164295713327810
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  11,
+                  14
+                ],
+                "weight": 63484882383278554
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  7,
+                  11
+                ],
+                "weight": 62865318328895767
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  24,
+                  5
+                ],
+                "weight": 124839126817034987
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  21,
+                  16,
+                  2
+                ],
+                "weight": 176929982786738793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  10,
+                  2,
+                  19
+                ],
+                "weight": 78549227844416633
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  5,
+                  14
+                ],
+                "weight": 116417079848175122
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  4,
+                  19
+                ],
+                "weight": 156235333889781623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  13,
+                  24
+                ],
+                "weight": 160557970030345597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  16,
+                  11
+                ],
+                "weight": 108458878761662134
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  5,
+                  8
+                ],
+                "weight": 14652779485928445
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  7,
+                  21
+                ],
+                "weight": 623108038921227120
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  18,
+                  10,
+                  22
+                ],
+                "weight": 25164295713327810
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  4,
+                  2
+                ],
+                "weight": 674146650230856579
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 189748373792892507
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  7,
+                  24,
+                  22
+                ],
+                "weight": 160557970030345597
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  16,
+                  14
+                ],
+                "weight": 52099091268683463
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  13,
+                  5,
+                  22
+                ],
+                "weight": 185722265743673407
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  2,
+                  8,
+                  14
+                ],
+                "weight": 30622444835040046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  13,
+                  8
+                ],
+                "weight": 205286362350034752
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  4,
+                  10
+                ],
+                "weight": 310376241322019923
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  10,
+                  2
+                ],
+                "weight": 394947388526967133
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  24,
+                  8
+                ],
+                "weight": 98454960813106942
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  5,
+                  14
+                ],
+                "weight": 94604121464006373
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  7,
+                  24
+                ],
+                "weight": 287801622362679872
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  21,
+                  16
+                ],
+                "weight": 103391014652784097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  19,
+                  8
+                ],
+                "weight": 155121536307398429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  24,
+                  5
+                ],
+                "weight": 107922915363626085
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  10,
+                  19
+                ],
+                "weight": 425270426888089263
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  13,
+                  16,
+                  14
+                ],
+                "weight": 54248848035845598
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  24,
+                  19,
+                  5
+                ],
+                "weight": 95938107050315106
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  18,
+                  1
+                ],
+                "weight": 103762288518482766
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  13,
+                  2
+                ],
+                "weight": 219812588982776363
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  10,
+                  8
+                ],
+                "weight": 129070364438750734
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  2,
+                  19
+                ],
+                "weight": 143596591071492345
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  2,
+                  8
+                ],
+                "weight": 76215997911284018
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  24,
+                  14
+                ],
+                "weight": 269048293783664093
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  7,
+                  21,
+                  11
+                ],
+                "weight": 239077986763734983
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  10,
+                  24,
+                  14
+                ],
+                "weight": 109233607169385272
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  13,
+                  16,
+                  5
+                ],
+                "weight": 108458878761662134
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  1,
+                  10
+                ],
+                "weight": 375379424135141954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  4,
+                  2
+                ],
+                "weight": 614759977509743496
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  7,
+                  11
+                ],
+                "weight": 86887608771191481
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  1,
+                  21,
+                  8
+                ],
+                "weight": 235753777143812282
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  19,
+                  8
+                ],
+                "weight": 232551936234877602
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  7,
+                  21
+                ],
+                "weight": 858147913019555934
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  13,
+                  16
+                ],
+                "weight": 303247569342844769
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  10,
+                  19
+                ],
+                "weight": 201376964148167026
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  24,
+                  19
+                ],
+                "weight": 98454960813106942
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  16,
+                  11
+                ],
+                "weight": 152908949617238409
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  11,
+                  22
+                ],
+                "weight": 239796558388429890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  1,
+                  16,
+                  11
+                ],
+                "weight": 86887608771191481
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  1,
+                  5,
+                  8
+                ],
+                "weight": 194117727665826446
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  16,
+                  14
+                ],
+                "weight": 303247569342844769
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  13,
+                  24
+                ],
+                "weight": 144386449002763364
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  10,
+                  24
+                ],
+                "weight": 143415173359916508
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  13,
+                  11
+                ],
+                "weight": 25164295713327810
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  24,
+                  14
+                ],
+                "weight": 63484882383278554
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 1057962765438756132
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 63042123580403261
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  21,
+                  10,
+                  11
+                ],
+                "weight": 247334117741616662
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  2,
+                  19
+                ],
+                "weight": 228285790639355480
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  2,
+                  5,
+                  8
+                ],
+                "weight": 30622444835040046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  2,
+                  11,
+                  22
+                ],
+                "weight": 154140907432238300
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  19,
+                  8,
+                  11
+                ],
+                "weight": 457988880415173294
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  10,
+                  11
+                ],
+                "weight": 201376964148167026
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  21,
+                  13,
+                  5
+                ],
+                "weight": 169550744716091174
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  19,
+                  8,
+                  14
+                ],
+                "weight": 63484882383278554
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  10,
+                  24,
+                  22
+                ],
+                "weight": 41537497133660034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  10,
+                  2,
+                  14
+                ],
+                "weight": 51355807852616687
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  13,
+                  19,
+                  22
+                ],
+                "weight": 63042123580403261
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  24,
+                  8,
+                  11
+                ],
+                "weight": 321004547609627080
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  2,
+                  5,
+                  11
+                ],
+                "weight": 294414276350105943
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 174987341663377124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  5,
+                  8
+                ],
+                "weight": 95938107050315106
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  16,
+                  5,
+                  11,
+                  22
+                ],
+                "weight": 360709607407050531
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 196,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 39236389004137546131
+          },
+          "certificate_sha256": "69ef0c8a8b266f76a029e9dccd54da457c3730e4d50857b4d8090784b399ef5e",
+          "max_weight": 1314857442650691686,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 196,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 196,
+          "weight_sum": 39236389004137546131,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 4,
+        "order": [
+          0,
+          17,
+          3,
+          6,
+          20,
+          9,
+          12,
+          15,
+          23,
+          18,
+          1,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          2,
+          19,
+          5,
+          8,
+          11,
+          14,
+          22
+        ],
+        "order_sha256": "e620e04f9e30776e7aa9f78d5a92b2eb38b1940f562972644abef237f394bf05",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 50
+      },
+      {
+        "dihedral_order_sha256": "e016d54db86f94cb3aca6ea8333c2981be396ba176f86dd2729361d7cdc781c3",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "cd6ce964239e9ca9f835ebe13b107b964a409ea431b053bdf8093ebff37570d8",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 5,
+            "source_order": [
+              0,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              22,
+              11,
+              14,
+              17
+            ],
+            "source_unique_ordered_quad_count": 200,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              3,
+              6,
+              20,
+              9,
+              12,
+              15,
+              23,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              22,
+              11,
+              14,
+              17
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  20,
+                  11
+                ],
+                "weight": 1674272199417477944
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  18
+                ],
+                "weight": 1167829448460398691
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  7
+                ],
+                "weight": 147836904183473282
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  18,
+                  21
+                ],
+                "weight": 35967285135640506
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  16,
+                  11
+                ],
+                "weight": 2446984514272098434
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  9,
+                  16
+                ],
+                "weight": 151711290277033594
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  15,
+                  13
+                ],
+                "weight": 619779618103770939
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  15,
+                  11
+                ],
+                "weight": 987631851709693911
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  18,
+                  17
+                ],
+                "weight": 1131862163324758185
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  21,
+                  8
+                ],
+                "weight": 520094146689485675
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  24,
+                  19
+                ],
+                "weight": 153748829846115595
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  16,
+                  14
+                ],
+                "weight": 566814882041735352
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  23,
+                  21
+                ],
+                "weight": 1146106776017853302
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  1,
+                  8
+                ],
+                "weight": 21722672442545389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  22,
+                  11
+                ],
+                "weight": 435056888070349081
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  16,
+                  17
+                ],
+                "weight": 1384240172924999608
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  19,
+                  22
+                ],
+                "weight": 821679880719074552
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  2,
+                  14
+                ],
+                "weight": 223171296888465242
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  7,
+                  19
+                ],
+                "weight": 147836904183473282
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  13,
+                  14
+                ],
+                "weight": 390899637602753491
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  17
+                ],
+                "weight": 21722672442545389
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  10,
+                  17
+                ],
+                "weight": 484126861553845169
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  13,
+                  22
+                ],
+                "weight": 228879980501017448
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  10,
+                  22,
+                  11
+                ],
+                "weight": 255246881052827721
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  2,
+                  14
+                ],
+                "weight": 153748829846115595
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  19,
+                  8,
+                  22
+                ],
+                "weight": 520094146689485675
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  5,
+                  22,
+                  17
+                ],
+                "weight": 131376111595897750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  20,
+                  19
+                ],
+                "weight": 1881554464007041820
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  12,
+                  16
+                ],
+                "weight": 582964942458061397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  15,
+                  4
+                ],
+                "weight": 311221413332435324
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  24,
+                  5
+                ],
+                "weight": 172370265436402057
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  11,
+                  14
+                ],
+                "weight": 348759413234587012
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  12,
+                  2
+                ],
+                "weight": 183554480381028684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  20,
+                  7,
+                  14
+                ],
+                "weight": 207282264589563876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  23,
+                  18
+                ],
+                "weight": 1914471711360126932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  1,
+                  8
+                ],
+                "weight": 69650412549767198
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  13,
+                  14
+                ],
+                "weight": 576426265521131178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  4,
+                  21
+                ],
+                "weight": 311221413332435324
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  18,
+                  11
+                ],
+                "weight": 311221413332435324
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  2,
+                  11
+                ],
+                "weight": 183554480381028684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  18,
+                  8
+                ],
+                "weight": 435420849567292917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  19,
+                  11
+                ],
+                "weight": 1839477132271036272
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  8,
+                  22
+                ],
+                "weight": 581438263850877475
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  21,
+                  13
+                ],
+                "weight": 576426265521131178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  10,
+                  24
+                ],
+                "weight": 182841380495835627
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  16,
+                  8
+                ],
+                "weight": 207282264589563876
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  21,
+                  10,
+                  8
+                ],
+                "weight": 265204852188695854
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  21,
+                  24,
+                  17
+                ],
+                "weight": 10471115059433570
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  16,
+                  14
+                ],
+                "weight": 375682677868497521
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  8,
+                  17
+                ],
+                "weight": 72363554816033960
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  19,
+                  22,
+                  17
+                ],
+                "weight": 581438263850877475
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  9,
+                  1
+                ],
+                "weight": 730801846641534679
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  23,
+                  24
+                ],
+                "weight": 513657178784901305
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  18,
+                  17
+                ],
+                "weight": 802085406479650561
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  13,
+                  8
+                ],
+                "weight": 124274384636782578
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  20,
+                  2,
+                  11
+                ],
+                "weight": 183554480381028684
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  9,
+                  12,
+                  11
+                ],
+                "weight": 582964942458061397
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  24,
+                  19
+                ],
+                "weight": 302707465616716109
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  13
+                ],
+                "weight": 124274384636782578
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  16,
+                  19
+                ],
+                "weight": 1864019571814037037
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  8,
+                  22
+                ],
+                "weight": 230009375883374927
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  18,
+                  14
+                ],
+                "weight": 63586839810875686
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  1,
+                  11
+                ],
+                "weight": 43361468109184891
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  4,
+                  10
+                ],
+                "weight": 168965212092059706
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  23,
+                  4,
+                  14
+                ],
+                "weight": 470295710675716414
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  1,
+                  7,
+                  19
+                ],
+                "weight": 184926520996504487
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  7,
+                  21
+                ],
+                "weight": 35967285135640506
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  10,
+                  2
+                ],
+                "weight": 168965212092059706
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  24,
+                  2
+                ],
+                "weight": 14589268288968978
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  19,
+                  14
+                ],
+                "weight": 285172573423711326
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  22,
+                  17
+                ],
+                "weight": 829704961154885741
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  7,
+                  24,
+                  11
+                ],
+                "weight": 368730710315618275
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  5,
+                  8,
+                  14
+                ],
+                "weight": 172370265436402057
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  12,
+                  10
+                ],
+                "weight": 36080628869313688
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  12,
+                  17
+                ],
+                "weight": 1153497448661819762
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  18,
+                  7
+                ],
+                "weight": 1335659156288449927
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  8,
+                  22
+                ],
+                "weight": 88193755767468890
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  2
+                ],
+                "weight": 1002523043447570762
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  18,
+                  16
+                ],
+                "weight": 793073446508756794
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  18,
+                  14
+                ],
+                "weight": 3500553702534004
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  1,
+                  24
+                ],
+                "weight": 359908348938785710
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  4,
+                  16
+                ],
+                "weight": 488865864662669457
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  16,
+                  19
+                ],
+                "weight": 857587240433430043
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  7,
+                  24
+                ],
+                "weight": 1090710195580320389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  21,
+                  13
+                ],
+                "weight": 495505233466988361
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  7,
+                  16
+                ],
+                "weight": 244948960708129538
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  21,
+                  17
+                ],
+                "weight": 24588913222497314
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  10,
+                  8
+                ],
+                "weight": 28723876506422695
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  10,
+                  16,
+                  19
+                ],
+                "weight": 28723876506422695
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  10,
+                  19,
+                  5
+                ],
+                "weight": 703838410587314448
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  13,
+                  5,
+                  8
+                ],
+                "weight": 703838410587314448
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  16,
+                  22,
+                  17
+                ],
+                "weight": 1909358656581911432
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  2,
+                  22,
+                  14
+                ],
+                "weight": 207282264589563876
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  13,
+                  22
+                ],
+                "weight": 124274384636782578
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  24,
+                  5
+                ],
+                "weight": 254394090828961738
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  16,
+                  11
+                ],
+                "weight": 492855957996229903
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  1,
+                  14
+                ],
+                "weight": 69650412549767198
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  21,
+                  5
+                ],
+                "weight": 231566208518600263
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  11,
+                  17
+                ],
+                "weight": 1153497448661819762
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  7,
+                  13
+                ],
+                "weight": 285172573423711326
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  19,
+                  5
+                ],
+                "weight": 428720994495282597
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  8,
+                  14
+                ],
+                "weight": 18543343217701692
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  13,
+                  24
+                ],
+                "weight": 5895994196061220
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  13,
+                  2
+                ],
+                "weight": 731428460111998706
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  21,
+                  16,
+                  19
+                ],
+                "weight": 225670214322539043
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  22,
+                  17
+                ],
+                "weight": 36080628869313688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 48313374787754371
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  19,
+                  2,
+                  11
+                ],
+                "weight": 731428460111998706
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  19,
+                  5,
+                  11
+                ],
+                "weight": 914681293842844598
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  4,
+                  19
+                ],
+                "weight": 1864019571814037037
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  4,
+                  2
+                ],
+                "weight": 183554480381028684
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  7,
+                  16
+                ],
+                "weight": 1258221959378218916
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  21,
+                  17
+                ],
+                "weight": 1701037602187250518
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  18,
+                  16
+                ],
+                "weight": 793073446508756794
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  7,
+                  13
+                ],
+                "weight": 257672644390390522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  16,
+                  14
+                ],
+                "weight": 604667239104419600
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  7,
+                  21
+                ],
+                "weight": 576426265521131178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  10,
+                  5
+                ],
+                "weight": 46107387388132200
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  16,
+                  2
+                ],
+                "weight": 818968563066542078
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  16,
+                  17
+                ],
+                "weight": 1159926373341499219
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  11,
+                  17
+                ],
+                "weight": 147908054387712316
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  22,
+                  14
+                ],
+                "weight": 80773127550191576
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  16,
+                  24,
+                  19
+                ],
+                "weight": 254394090828961738
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 208286703440829538
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  18,
+                  21
+                ],
+                "weight": 701468224160066410
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  7,
+                  13
+                ],
+                "weight": 665709201202426366
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  10,
+                  19
+                ],
+                "weight": 834052987654132947
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  23,
+                  8,
+                  14
+                ],
+                "weight": 286758136699340928
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  18,
+                  4
+                ],
+                "weight": 108380203672717421
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  4,
+                  13
+                ],
+                "weight": 108380203672717421
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  7,
+                  11
+                ],
+                "weight": 592512758175792550
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  18,
+                  10,
+                  5
+                ],
+                "weight": 432788246465608367
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  24,
+                  14
+                ],
+                "weight": 153748829846115595
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  21,
+                  11
+                ],
+                "weight": 701468224160066410
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  13,
+                  8
+                ],
+                "weight": 286758136699340928
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  24,
+                  5
+                ],
+                "weight": 597178337694295723
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  16,
+                  24,
+                  8
+                ],
+                "weight": 765366001381989013
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  5,
+                  22
+                ],
+                "weight": 821679880719074552
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 208286703440829538
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  4,
+                  24
+                ],
+                "weight": 449290919457276046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  2,
+                  11
+                ],
+                "weight": 119668133915763313
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  22,
+                  17
+                ],
+                "weight": 277568288947375130
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  4,
+                  7,
+                  8
+                ],
+                "weight": 280325707365216340
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  17
+                ],
+                "weight": 2144191210918769664
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  10,
+                  5
+                ],
+                "weight": 948766981183581257
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  2,
+                  5
+                ],
+                "weight": 23848356733554844
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  10,
+                  16,
+                  5
+                ],
+                "weight": 283679205621508016
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  16,
+                  8
+                ],
+                "weight": 85042170149252570
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  24,
+                  11
+                ],
+                "weight": 449290919457276046
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  13,
+                  5,
+                  11
+                ],
+                "weight": 609673017802638088
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  5,
+                  17
+                ],
+                "weight": 131376111595897750
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  2,
+                  22
+                ],
+                "weight": 859006552798252605
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  8,
+                  17
+                ],
+                "weight": 432775550982925486
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  7,
+                  19
+                ],
+                "weight": 285172573423711326
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  24,
+                  5
+                ],
+                "weight": 558092840980052477
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  5,
+                  22
+                ],
+                "weight": 129371846484769880
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  11,
+                  14
+                ],
+                "weight": 553560169772354094
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  2,
+                  11
+                ],
+                "weight": 510198701663169203
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 1258411513970942424
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  10,
+                  13,
+                  22
+                ],
+                "weight": 111680859017134794
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  16,
+                  19,
+                  22
+                ],
+                "weight": 188406207404337194
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  16,
+                  8,
+                  22
+                ],
+                "weight": 40266015660247081
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  24,
+                  19,
+                  2
+                ],
+                "weight": 340560839518152242
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  2,
+                  22,
+                  14
+                ],
+                "weight": 169637862145016961
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  24,
+                  22
+                ],
+                "weight": 123391189811745409
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  7,
+                  21,
+                  16
+                ],
+                "weight": 590375086644524881
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  21,
+                  10,
+                  24
+                ],
+                "weight": 601753458557668073
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  13,
+                  5
+                ],
+                "weight": 526983053858943718
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  8,
+                  14
+                ],
+                "weight": 435420849567292917
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  13,
+                  2,
+                  5
+                ],
+                "weight": 463898033586717126
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  8,
+                  22,
+                  11
+                ],
+                "weight": 400959478759120539
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  10,
+                  13
+                ],
+                "weight": 257672644390390522
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  16,
+                  17
+                ],
+                "weight": 1307834427729211535
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  2,
+                  22
+                ],
+                "weight": 252763036296515289
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  10,
+                  2,
+                  8
+                ],
+                "weight": 595807720570979963
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  24,
+                  19
+                ],
+                "weight": 424806697401617705
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  13,
+                  19,
+                  5
+                ],
+                "weight": 424806697401617705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  5,
+                  14
+                ],
+                "weight": 83264459096637680
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  10,
+                  17
+                ],
+                "weight": 1206439625573971779
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  2,
+                  11
+                ],
+                "weight": 454817067081928573
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  21,
+                  8,
+                  11
+                ],
+                "weight": 73043442775652464
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  10,
+                  14,
+                  17
+                ],
+                "weight": 375682677868497521
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  24,
+                  17
+                ],
+                "weight": 888677856878658480
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  16,
+                  24,
+                  17
+                ],
+                "weight": 202032338701661909
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  24,
+                  19,
+                  22
+                ],
+                "weight": 981225478326853419
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  19,
+                  2,
+                  17
+                ],
+                "weight": 796298957330348932
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  19,
+                  22,
+                  17
+                ],
+                "weight": 981225478326853419
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  22,
+                  11,
+                  14
+                ],
+                "weight": 168400413278933645
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  8,
+                  14
+                ],
+                "weight": 342586262814999120
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  16,
+                  19,
+                  11
+                ],
+                "weight": 2070916451356461009
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  19,
+                  5,
+                  22
+                ],
+                "weight": 344360174182725770
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  8,
+                  22,
+                  14
+                ],
+                "weight": 172370265436402057
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  22,
+                  11,
+                  14
+                ],
+                "weight": 173607714302485373
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  13,
+                  2,
+                  11
+                ],
+                "weight": 255246881052827721
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  24,
+                  2,
+                  22
+                ],
+                "weight": 340560839518152242
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  5,
+                  8,
+                  11
+                ],
+                "weight": 424806697401617705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  24,
+                  22,
+                  17
+                ],
+                "weight": 1020053968474556230
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  19,
+                  5,
+                  11
+                ],
+                "weight": 424806697401617705
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  2,
+                  11,
+                  17
+                ],
+                "weight": 818021629772894321
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  19,
+                  8,
+                  22,
+                  11
+                ],
+                "weight": 96890661418149630
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 200,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 101287554151893823587
+          },
+          "certificate_sha256": "fbafdcff8806b178694c83671ad2363cf43830b62a80dba9476647f782d07adb",
+          "max_weight": 2446984514272098434,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 200,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 200,
+          "weight_sum": 101287554151893823587,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 5,
+        "order": [
+          0,
+          3,
+          6,
+          20,
+          9,
+          12,
+          15,
+          23,
+          1,
+          18,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          19,
+          2,
+          5,
+          8,
+          22,
+          11,
+          14,
+          17
+        ],
+        "order_sha256": "e016d54db86f94cb3aca6ea8333c2981be396ba176f86dd2729361d7cdc781c3",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 51
+      },
+      {
+        "dihedral_order_sha256": "4d9714d62fe5c0c95b1ab9c45b42fade2625e78e5cac3b18dfdeea83cc14c7b9",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "8c9040f629be9808072b49130de270daed9771367f6c589b9be19badcd6dc5cc",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 6,
+            "source_order": [
+              0,
+              20,
+              3,
+              6,
+              9,
+              12,
+              23,
+              15,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              22,
+              11,
+              14,
+              17
+            ],
+            "source_unique_ordered_quad_count": 199,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              20,
+              3,
+              6,
+              9,
+              12,
+              23,
+              15,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              22,
+              11,
+              14,
+              17
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  3,
+                  14
+                ],
+                "weight": 607630475606088623
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  6,
+                  21
+                ],
+                "weight": 169247775119868301
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  12,
+                  1
+                ],
+                "weight": 72072639035894266
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  7,
+                  19
+                ],
+                "weight": 64142092554359351
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  16,
+                  14
+                ],
+                "weight": 262766664117881901
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  16,
+                  17
+                ],
+                "weight": 164957935842788713
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  5,
+                  22
+                ],
+                "weight": 1856540742108596
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  6,
+                  21
+                ],
+                "weight": 519169235029816151
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  12,
+                  5
+                ],
+                "weight": 76924107536901619
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  3,
+                  10,
+                  22
+                ],
+                "weight": 11537133039370853
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  13,
+                  16
+                ],
+                "weight": 14002040203826296
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  9,
+                  23
+                ],
+                "weight": 311760839506829655
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  23,
+                  15
+                ],
+                "weight": 311760839506829655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  15,
+                  7
+                ],
+                "weight": 326124986112006987
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  6,
+                  18,
+                  11
+                ],
+                "weight": 50531184530847810
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  2,
+                  5
+                ],
+                "weight": 181087384709458067
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  9,
+                  21,
+                  2
+                ],
+                "weight": 194528036548856821
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  15,
+                  13
+                ],
+                "weight": 78781989281775329
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  7,
+                  14
+                ],
+                "weight": 70214757291020556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  1,
+                  16
+                ],
+                "weight": 72072639035894266
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  13,
+                  19
+                ],
+                "weight": 61629910876476622
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  22,
+                  17
+                ],
+                "weight": 51996593092641651
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  18,
+                  10
+                ],
+                "weight": 93146135886952661
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  24,
+                  22
+                ],
+                "weight": 50140052350533055
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  5,
+                  22
+                ],
+                "weight": 143677320417800471
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  7,
+                  21,
+                  10
+                ],
+                "weight": 140215480604918592
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  21,
+                  11
+                ],
+                "weight": 5678502279832168
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  10,
+                  17
+                ],
+                "weight": 128678347565547739
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 171174244313739280
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 75631951080302918
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  24,
+                  19,
+                  8
+                ],
+                "weight": 125772003430835973
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  3,
+                  12,
+                  2
+                ],
+                "weight": 119701530896668824
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  10,
+                  17
+                ],
+                "weight": 11554838603020676
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  2,
+                  14
+                ],
+                "weight": 344331666160448101
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  23,
+                  10
+                ],
+                "weight": 257162652892671044
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  23,
+                  5
+                ],
+                "weight": 115766663466059528
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  4,
+                  17
+                ],
+                "weight": 153403097239768037
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  7,
+                  2
+                ],
+                "weight": 133366835360300997
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  18,
+                  4
+                ],
+                "weight": 47628891860774558
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  1,
+                  5
+                ],
+                "weight": 150494448844471216
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  24
+                ],
+                "weight": 222434867514259356
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  24,
+                  2
+                ],
+                "weight": 91263299903478280
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  22,
+                  14
+                ],
+                "weight": 526065473563522423
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  13,
+                  16
+                ],
+                "weight": 60616408017649194
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  16,
+                  5
+                ],
+                "weight": 100815984255165613
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  16,
+                  11
+                ],
+                "weight": 222567087880365482
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  1,
+                  19,
+                  5
+                ],
+                "weight": 49678464589305603
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  5,
+                  8
+                ],
+                "weight": 167301668797473727
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  10,
+                  13
+                ],
+                "weight": 129841150823590840
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  7,
+                  13,
+                  2
+                ],
+                "weight": 69224742805941646
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  10,
+                  2
+                ],
+                "weight": 115766663466059528
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  8,
+                  11
+                ],
+                "weight": 53481111653808773
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  22,
+                  11
+                ],
+                "weight": 91263299903478280
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  8,
+                  14
+                ],
+                "weight": 113820557143664954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  4,
+                  24
+                ],
+                "weight": 71936837111572133
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  7,
+                  11
+                ],
+                "weight": 63289372612817144
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  10,
+                  16
+                ],
+                "weight": 14002040203826296
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  13,
+                  2
+                ],
+                "weight": 73303867028293840
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  1,
+                  21
+                ],
+                "weight": 713697271578672972
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  24,
+                  2
+                ],
+                "weight": 32527455432651782
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  23,
+                  15
+                ],
+                "weight": 447997889944813045
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  15,
+                  21
+                ],
+                "weight": 447997889944813045
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  18,
+                  22
+                ],
+                "weight": 25407341475094055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  4,
+                  13
+                ],
+                "weight": 59301826824467544
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  8,
+                  14
+                ],
+                "weight": 1108569193774696084
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  23,
+                  19,
+                  17
+                ],
+                "weight": 617793880470115834
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  10,
+                  22
+                ],
+                "weight": 25407341475094055
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  11,
+                  14
+                ],
+                "weight": 63289372612817144
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  4,
+                  21,
+                  14
+                ],
+                "weight": 131238663936039677
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  7,
+                  21,
+                  22
+                ],
+                "weight": 63289372612817144
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  24,
+                  14
+                ],
+                "weight": 39409381678920351
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  2,
+                  22,
+                  14
+                ],
+                "weight": 13870208435723202
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  15,
+                  16
+                ],
+                "weight": 173100245091157311
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  7,
+                  14
+                ],
+                "weight": 77059569893668454
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  21,
+                  17
+                ],
+                "weight": 519169235029816151
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  19
+                ],
+                "weight": 83958428158565040
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  18,
+                  5
+                ],
+                "weight": 181087384709458067
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  16,
+                  8
+                ],
+                "weight": 184655083694177987
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  4,
+                  7
+                ],
+                "weight": 519615538185594657
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  2,
+                  22
+                ],
+                "weight": 338690088519664611
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  1,
+                  22
+                ],
+                "weight": 394902661689867126
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  19,
+                  8
+                ],
+                "weight": 3723122182570436
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  2,
+                  8
+                ],
+                "weight": 113425095321947717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  11,
+                  14
+                ],
+                "weight": 267272096266779647
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  7,
+                  16
+                ],
+                "weight": 179720354792736360
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  13,
+                  24
+                ],
+                "weight": 73303867028293840
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  24,
+                  14
+                ],
+                "weight": 1367029916721707
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  19,
+                  17
+                ],
+                "weight": 80235305975994604
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  10,
+                  16
+                ],
+                "weight": 25556878806846972
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  1,
+                  8
+                ],
+                "weight": 1237097318939062562
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  19,
+                  17
+                ],
+                "weight": 556163969593639212
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  15,
+                  8
+                ],
+                "weight": 247426788616186331
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  7,
+                  22
+                ],
+                "weight": 52068662986907833
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  16,
+                  24
+                ],
+                "weight": 387426944720353343
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  24,
+                  19
+                ],
+                "weight": 556163969593639212
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  18,
+                  10
+                ],
+                "weight": 267317627538651371
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  10,
+                  14
+                ],
+                "weight": 74326543525029020
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  1,
+                  18,
+                  8
+                ],
+                "weight": 523400047360389590
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  24,
+                  2
+                ],
+                "weight": 476188990807869128
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  2,
+                  5
+                ],
+                "weight": 115766663466059528
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  10,
+                  8,
+                  11
+                ],
+                "weight": 64171568879048693
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  16,
+                  24,
+                  8
+                ],
+                "weight": 425220467754560675
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  16,
+                  8,
+                  22
+                ],
+                "weight": 135306722056949979
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  16,
+                  22,
+                  11
+                ],
+                "weight": 135306722056949979
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 1037619028003063890
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  24,
+                  11,
+                  17
+                ],
+                "weight": 116408362675944976
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  23,
+                  1,
+                  13
+                ],
+                "weight": 99195368138981415
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  5,
+                  11
+                ],
+                "weight": 149991643519775012
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  15,
+                  18,
+                  22
+                ],
+                "weight": 343846754567317717
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  15,
+                  4,
+                  2
+                ],
+                "weight": 104151135377495328
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  18,
+                  10
+                ],
+                "weight": 313597299668680088
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  7,
+                  16
+                ],
+                "weight": 72072639035894266
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  7,
+                  8
+                ],
+                "weight": 313183208858544465
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  19,
+                  2
+                ],
+                "weight": 15979571093730818
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  22,
+                  11
+                ],
+                "weight": 44705008386414165
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  7,
+                  21
+                ],
+                "weight": 450249673800597069
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  10,
+                  22
+                ],
+                "weight": 70112349861508220
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  10,
+                  17
+                ],
+                "weight": 450949328051445683
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  21,
+                  17
+                ],
+                "weight": 48889430224990555
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  16,
+                  5
+                ],
+                "weight": 43588770188811787
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  16,
+                  14
+                ],
+                "weight": 104205178206460981
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  4,
+                  11,
+                  17
+                ],
+                "weight": 69850071158880861
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  10,
+                  19
+                ],
+                "weight": 140215480604918592
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  7,
+                  24,
+                  5
+                ],
+                "weight": 48632832533529045
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  10,
+                  13,
+                  14
+                ],
+                "weight": 34917161846108669
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 247543731527200655
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  10,
+                  19,
+                  5
+                ],
+                "weight": 596441450946261946
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 73805609813370127
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  16,
+                  2,
+                  17
+                ],
+                "weight": 36944474514464908
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 25145062772466696
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  24,
+                  5,
+                  22
+                ],
+                "weight": 296176564060729700
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  2,
+                  5,
+                  14
+                ],
+                "weight": 46109966193200786
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  1,
+                  21
+                ],
+                "weight": 200480873291153688
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  4,
+                  17
+                ],
+                "weight": 519615538185594657
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  1,
+                  21,
+                  17
+                ],
+                "weight": 101285505152172273
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  18,
+                  21,
+                  8
+                ],
+                "weight": 247171888199756225
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  10,
+                  13
+                ],
+                "weight": 37565457262504793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  4,
+                  2,
+                  8
+                ],
+                "weight": 247426788616186331
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  14
+                ],
+                "weight": 557315502044113383
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  16,
+                  5
+                ],
+                "weight": 315354305684459077
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  5,
+                  11
+                ],
+                "weight": 14684921462825033
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  21,
+                  5,
+                  17
+                ],
+                "weight": 150174935377162828
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  10,
+                  24,
+                  5
+                ],
+                "weight": 37565457262504793
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  16,
+                  22,
+                  11
+                ],
+                "weight": 135306722056949979
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  18,
+                  17
+                ],
+                "weight": 450949328051445683
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  1,
+                  4,
+                  22
+                ],
+                "weight": 494117360538663207
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  21,
+                  13
+                ],
+                "weight": 65658035683036421
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  21,
+                  14
+                ],
+                "weight": 181858980970622936
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  10,
+                  5
+                ],
+                "weight": 100815984255165613
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  7,
+                  14
+                ],
+                "weight": 183631700512794312
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  7,
+                  13
+                ],
+                "weight": 142493285599212675
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  10,
+                  16
+                ],
+                "weight": 60616408017649194
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  4,
+                  19,
+                  8
+                ],
+                "weight": 3723122182570436
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  24,
+                  17
+                ],
+                "weight": 67244977835152564
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  21,
+                  10,
+                  22
+                ],
+                "weight": 738749416257184843
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  16,
+                  2,
+                  17
+                ],
+                "weight": 9273959944452389
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  19,
+                  8,
+                  11
+                ],
+                "weight": 130278571111668178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  5,
+                  14,
+                  17
+                ],
+                "weight": 237811008557262094
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  22,
+                  11,
+                  14
+                ],
+                "weight": 130278571111668178
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  4,
+                  14
+                ],
+                "weight": 449131077237402583
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  7,
+                  22
+                ],
+                "weight": 54509690462381916
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  18,
+                  21,
+                  10
+                ],
+                "weight": 450249673800597069
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  4,
+                  7,
+                  22
+                ],
+                "weight": 258673518396162549
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  4,
+                  10,
+                  19
+                ],
+                "weight": 190457558841240034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  10,
+                  24,
+                  8
+                ],
+                "weight": 852562827312664873
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  13,
+                  19,
+                  17
+                ],
+                "weight": 65658035683036421
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  2,
+                  8,
+                  11
+                ],
+                "weight": 15979571093730818
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  4,
+                  7,
+                  11
+                ],
+                "weight": 5678502279832168
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  4,
+                  10,
+                  11
+                ],
+                "weight": 64171568879048693
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  24,
+                  5
+                ],
+                "weight": 675460043644367699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  8,
+                  14
+                ],
+                "weight": 108926490363159638
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  13,
+                  19,
+                  11
+                ],
+                "weight": 130278571111668178
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  13,
+                  5,
+                  17
+                ],
+                "weight": 237811008557262094
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  16,
+                  19,
+                  14
+                ],
+                "weight": 474672132772911154
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  19,
+                  5,
+                  14
+                ],
+                "weight": 604950703884579332
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  8,
+                  11,
+                  14
+                ],
+                "weight": 113820557143664954
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  16,
+                  5
+                ],
+                "weight": 43588770188811787
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  24,
+                  8
+                ],
+                "weight": 369889412182628183
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  21,
+                  10,
+                  19
+                ],
+                "weight": 190457558841240034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  22,
+                  14
+                ],
+                "weight": 235443842142500658
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  8,
+                  17
+                ],
+                "weight": 118739501383871416
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  13,
+                  14
+                ],
+                "weight": 579627675616993422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 122436603412374945
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  13,
+                  24,
+                  5
+                ],
+                "weight": 437134390017780747
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  14,
+                  17
+                ],
+                "weight": 276158631376694907
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  19,
+                  2,
+                  14
+                ],
+                "weight": 59980174628923988
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  8,
+                  22,
+                  11
+                ],
+                "weight": 247452808770253238
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  21,
+                  10,
+                  13,
+                  17
+                ],
+                "weight": 579627675616993422
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  24,
+                  22
+                ],
+                "weight": 675460043644367699
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  13,
+                  8,
+                  11
+                ],
+                "weight": 62487530836801638
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  13,
+                  2,
+                  5
+                ],
+                "weight": 152711137980524436
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  2,
+                  22,
+                  17
+                ],
+                "weight": 36944474514464908
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  19,
+                  8,
+                  17
+                ],
+                "weight": 73805609813370127
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  2,
+                  22,
+                  11
+                ],
+                "weight": 240812458182004292
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 439853884478530171
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  5,
+                  22,
+                  11
+                ],
+                "weight": 149991643519775012
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  19,
+                  2
+                ],
+                "weight": 548477742586281281
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  2,
+                  5
+                ],
+                "weight": 523332679813814585
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  24,
+                  22,
+                  14,
+                  17
+                ],
+                "weight": 116408362675944976
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 199,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 42428775347749730364
+          },
+          "certificate_sha256": "753d16ec219c1342b4234c61d7de3853f4616a3c2b8e8b5a74bbb45d96cbb2a9",
+          "max_weight": 1237097318939062562,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 199,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 199,
+          "weight_sum": 42428775347749730364,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 6,
+        "order": [
+          0,
+          20,
+          3,
+          6,
+          9,
+          12,
+          23,
+          15,
+          1,
+          18,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          19,
+          2,
+          5,
+          8,
+          22,
+          11,
+          14,
+          17
+        ],
+        "order_sha256": "080ae93883576acc5a5eb938769e60e3c02fcb267372b83729eef711c13288d8",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 52
+      },
+      {
+        "dihedral_order_sha256": "294dfcf6e734caaa2ea762e55fbf258ccc91eee75b5a5c26dd178010b4d9ea25",
+        "full_kalmanson": {
+          "affine_clause_orbit": {
+            "affine_map_count": 25,
+            "affine_stabilizer_size": 1,
+            "canonical_clause_sha256": "e6e0370564cf3cdf50c5d3258589773f45e1bafd0c902abb4b5cfba8a4b5e1db",
+            "quotient_automorphism_multipliers": [
+              1
+            ],
+            "source_model_index": 7,
+            "source_order": [
+              0,
+              3,
+              20,
+              6,
+              9,
+              12,
+              23,
+              15,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              22,
+              11,
+              14,
+              17
+            ],
+            "source_unique_ordered_quad_count": 201,
+            "unique_orbit_clause_count": 25
+          },
+          "certificate": {
+            "certificate_logic": "the listed positive integer combination of Kalmanson strict inequalities has zero total coefficient after quotienting by selected-distance equalities, giving 0 > 0",
+            "certificate_type": "kalmanson_strict_inequality_farkas",
+            "claim_strength": "Exact obstruction for this fixed selected-witness pattern and fixed cyclic order only; not an abstract all-order obstruction.",
+            "cyclic_order": [
+              0,
+              3,
+              20,
+              6,
+              9,
+              12,
+              23,
+              15,
+              1,
+              18,
+              4,
+              7,
+              21,
+              10,
+              13,
+              16,
+              24,
+              19,
+              2,
+              5,
+              8,
+              22,
+              11,
+              14,
+              17
+            ],
+            "distance_equalities": "for each row i, all distances d(i,w), w in S_i, are identified",
+            "inequalities": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  15,
+                  10
+                ],
+                "weight": 165645127388371016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  3,
+                  1,
+                  11
+                ],
+                "weight": 341560440688793844
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  12,
+                  19
+                ],
+                "weight": 203850095422589458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  20,
+                  1,
+                  19
+                ],
+                "weight": 123258971478249556
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  24,
+                  17
+                ],
+                "weight": 47024502716005336
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  20,
+                  19,
+                  22
+                ],
+                "weight": 102868836874324512
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  6,
+                  10,
+                  8
+                ],
+                "weight": 165645127388371016
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  4,
+                  24
+                ],
+                "weight": 51041202575889139
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  12,
+                  13,
+                  22
+                ],
+                "weight": 203850095422589458
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  12,
+                  8,
+                  22
+                ],
+                "weight": 176185557522906265
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  23,
+                  15,
+                  21
+                ],
+                "weight": 2656583301589279
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  21,
+                  13
+                ],
+                "weight": 19009494867091429
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  23,
+                  19,
+                  8
+                ],
+                "weight": 20390134603925044
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  18,
+                  11
+                ],
+                "weight": 79278584396195376
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  15,
+                  4,
+                  13
+                ],
+                "weight": 174990896086108234
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  15,
+                  5,
+                  17
+                ],
+                "weight": 89023126293764919
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  18,
+                  8
+                ],
+                "weight": 464819412167043400
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  1,
+                  11,
+                  14
+                ],
+                "weight": 49519174255136337
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  7,
+                  21
+                ],
+                "weight": 169331749514495464
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  18,
+                  16,
+                  5
+                ],
+                "weight": 374766247048743312
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  18,
+                  22,
+                  14
+                ],
+                "weight": 82950662285678613
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  7,
+                  11
+                ],
+                "weight": 182585388414947342
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  4,
+                  2,
+                  17
+                ],
+                "weight": 43446710247050031
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  7,
+                  21,
+                  2
+                ],
+                "weight": 351917137929442806
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  16,
+                  8
+                ],
+                "weight": 366909932936650432
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  21,
+                  24,
+                  22
+                ],
+                "weight": 4016699859883803
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  13,
+                  8,
+                  11
+                ],
+                "weight": 9849704469389795
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  8,
+                  22,
+                  11
+                ],
+                "weight": 93234895237227652
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  6,
+                  7
+                ],
+                "weight": 146056650881110379
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  15,
+                  17
+                ],
+                "weight": 208098545990720919
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  1,
+                  2
+                ],
+                "weight": 31360705140481847
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  20,
+                  5,
+                  22
+                ],
+                "weight": 215881472541786188
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  6,
+                  9,
+                  21
+                ],
+                "weight": 146056650881110379
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  6,
+                  7,
+                  21
+                ],
+                "weight": 107755759079875513
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  12,
+                  15
+                ],
+                "weight": 28432179449055145
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  9,
+                  18,
+                  5
+                ],
+                "weight": 117624471432055234
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  16,
+                  19
+                ],
+                "weight": 29738032193939175
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  9,
+                  24,
+                  2
+                ],
+                "weight": 35973324406230364
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  12,
+                  23,
+                  18
+                ],
+                "weight": 629131335806732398
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  12,
+                  22,
+                  17
+                ],
+                "weight": 483502861145444440
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  23,
+                  7,
+                  11
+                ],
+                "weight": 38300891801234866
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  15,
+                  1,
+                  2
+                ],
+                "weight": 42453418602349903
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  2,
+                  5
+                ],
+                "weight": 68462628276372740
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  15,
+                  8,
+                  22
+                ],
+                "weight": 141607695819986832
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  13,
+                  24
+                ],
+                "weight": 37101923135890893
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  1,
+                  5,
+                  14
+                ],
+                "weight": 399744397846109097
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  21,
+                  13
+                ],
+                "weight": 37065913085452647
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  18,
+                  16,
+                  14
+                ],
+                "weight": 117624471432055234
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  24,
+                  2
+                ],
+                "weight": 1128598729660529
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  18,
+                  8,
+                  11
+                ],
+                "weight": 341560440688793844
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  21,
+                  10
+                ],
+                "weight": 70689845994422866
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  13,
+                  16
+                ],
+                "weight": 147362503625994409
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  4,
+                  8,
+                  14
+                ],
+                "weight": 261969184873539391
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  10,
+                  22,
+                  14
+                ],
+                "weight": 94955281393948150
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  3,
+                  13,
+                  19,
+                  11
+                ],
+                "weight": 147398513676432655
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  3,
+                  16,
+                  19,
+                  22
+                ],
+                "weight": 220968974177619570
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  9,
+                  18
+                ],
+                "weight": 45387789011107054
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  12,
+                  2
+                ],
+                "weight": 88990327226746116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  6,
+                  13,
+                  24
+                ],
+                "weight": 12201103452679869
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  6,
+                  13,
+                  14
+                ],
+                "weight": 101579824360961414
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  1,
+                  8
+                ],
+                "weight": 162813978276421000
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  18,
+                  14
+                ],
+                "weight": 378105893077632477
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  9,
+                  21,
+                  19
+                ],
+                "weight": 134431865957234001
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  9,
+                  13,
+                  17
+                ],
+                "weight": 19560389097001435
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  12,
+                  23,
+                  16
+                ],
+                "weight": 88990327226746116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  15,
+                  7
+                ],
+                "weight": 333222018042535783
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  12,
+                  4,
+                  13
+                ],
+                "weight": 82112248424903813
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  23,
+                  18,
+                  4
+                ],
+                "weight": 88990327226746116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  23,
+                  4,
+                  21
+                ],
+                "weight": 103474705857073945
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  15,
+                  1,
+                  16
+                ],
+                "weight": 279309899708392574
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  15,
+                  8,
+                  14
+                ],
+                "weight": 162813978276421000
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  1,
+                  4,
+                  2
+                ],
+                "weight": 287504201366082171
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  18,
+                  4,
+                  2
+                ],
+                "weight": 101345830273700939
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  4,
+                  7,
+                  21
+                ],
+                "weight": 187165367161425404
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  4,
+                  14,
+                  17
+                ],
+                "weight": 186018249874602175
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  21,
+                  16,
+                  11
+                ],
+                "weight": 30957160100160056
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  10,
+                  19,
+                  14
+                ],
+                "weight": 23204271598181175
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  20,
+                  10,
+                  11,
+                  17
+                ],
+                "weight": 69104798832124080
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  13,
+                  16,
+                  19
+                ],
+                "weight": 51229068485738905
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  16,
+                  24,
+                  14
+                ],
+                "weight": 82186228585898961
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  24,
+                  2,
+                  11
+                ],
+                "weight": 69985125133219092
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  20,
+                  19,
+                  5,
+                  17
+                ],
+                "weight": 215881472541786188
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  1,
+                  13
+                ],
+                "weight": 127979528456162124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  7,
+                  5
+                ],
+                "weight": 4910483255680702
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  9,
+                  10,
+                  22
+                ],
+                "weight": 330848900289854504
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  1,
+                  2
+                ],
+                "weight": 107887679855734854
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  12,
+                  13,
+                  19
+                ],
+                "weight": 101579824360961414
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  1,
+                  21
+                ],
+                "weight": 452652629176155820
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  23,
+                  18,
+                  10
+                ],
+                "weight": 165203772901483488
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  21,
+                  14
+                ],
+                "weight": 198840219215169928
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  13,
+                  5
+                ],
+                "weight": 38600807547880579
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  15,
+                  16,
+                  17
+                ],
+                "weight": 7111857045034099
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  15,
+                  22,
+                  11
+                ],
+                "weight": 141607695819986832
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  1,
+                  18,
+                  4
+                ],
+                "weight": 463867555417798541
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  7,
+                  16
+                ],
+                "weight": 102845275824194811
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  1,
+                  11,
+                  17
+                ],
+                "weight": 709870194930775668
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  18,
+                  4,
+                  2
+                ],
+                "weight": 674459117330389083
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  19,
+                  14
+                ],
+                "weight": 101579824360961414
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  18,
+                  2,
+                  5
+                ],
+                "weight": 6696249176308869
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  7,
+                  16,
+                  5
+                ],
+                "weight": 95733418779160712
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  21,
+                  22,
+                  17
+                ],
+                "weight": 765628623272161748
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  6,
+                  16,
+                  5,
+                  8
+                ],
+                "weight": 145940958759030862
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  6,
+                  24,
+                  2,
+                  22
+                ],
+                "weight": 12201103452679869
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  1,
+                  4
+                ],
+                "weight": 290793506732583124
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  12,
+                  18,
+                  22
+                ],
+                "weight": 103467208199948717
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  4,
+                  17
+                ],
+                "weight": 229464960121652206
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  7,
+                  10
+                ],
+                "weight": 125577377978938177
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  23,
+                  21,
+                  14
+                ],
+                "weight": 254712920690878514
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  23,
+                  11,
+                  17
+                ],
+                "weight": 19560389097001435
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  15,
+                  18,
+                  21
+                ],
+                "weight": 28432179449055145
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  15,
+                  21,
+                  10
+                ],
+                "weight": 25775596147465866
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  4,
+                  16
+                ],
+                "weight": 292940145051200301
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  10,
+                  13
+                ],
+                "weight": 92006204049931760
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 122534954687735936
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  10,
+                  8
+                ],
+                "weight": 162813978276421000
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  18,
+                  10,
+                  22
+                ],
+                "weight": 227381692089905787
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  9,
+                  21,
+                  16,
+                  2
+                ],
+                "weight": 322678177245139476
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  13,
+                  24,
+                  14
+                ],
+                "weight": 35973324406230364
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  9,
+                  19,
+                  2,
+                  14
+                ],
+                "weight": 164169898151173176
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  23,
+                  15,
+                  14
+                ],
+                "weight": 361654197491590928
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  15,
+                  7,
+                  2
+                ],
+                "weight": 18897352628988738
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  1,
+                  5,
+                  17
+                ],
+                "weight": 101624038354491999
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  1,
+                  8,
+                  11
+                ],
+                "weight": 377748361564794347
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  7,
+                  17
+                ],
+                "weight": 97161447678238367
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  18,
+                  21,
+                  17
+                ],
+                "weight": 525664127606783681
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  18,
+                  10,
+                  16
+                ],
+                "weight": 239324062782895293
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  4,
+                  7,
+                  10
+                ],
+                "weight": 157640055731790172
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  13,
+                  17
+                ],
+                "weight": 33951954566385430
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  7,
+                  16,
+                  8
+                ],
+                "weight": 150333735556149177
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  10,
+                  13
+                ],
+                "weight": 14484378630327829
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  21,
+                  10,
+                  5
+                ],
+                "weight": 101624038354491999
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  13,
+                  19,
+                  8
+                ],
+                "weight": 51229068485738905
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  12,
+                  24,
+                  19,
+                  5
+                ],
+                "weight": 51041202575889139
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  12,
+                  5,
+                  11,
+                  14
+                ],
+                "weight": 377748361564794347
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  1,
+                  18
+                ],
+                "weight": 75950934998937216
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  15,
+                  1,
+                  10
+                ],
+                "weight": 391186072807546433
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  1,
+                  4,
+                  19
+                ],
+                "weight": 14484378630327829
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  13,
+                  17
+                ],
+                "weight": 69388659544368696
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  1,
+                  2,
+                  22
+                ],
+                "weight": 122515828075996332
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  21,
+                  24
+                ],
+                "weight": 1128598729660529
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  18,
+                  19,
+                  2
+                ],
+                "weight": 22110906148871564
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  24
+                ],
+                "weight": 100942285233379148
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  21,
+                  17
+                ],
+                "weight": 179636689674284945
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  10,
+                  5
+                ],
+                "weight": 100404921927124768
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  7,
+                  16,
+                  19
+                ],
+                "weight": 88990327226746116
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  10,
+                  8,
+                  11
+                ],
+                "weight": 102125693472071288
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  13,
+                  24,
+                  8
+                ],
+                "weight": 88398154411460125
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  24,
+                  19,
+                  22
+                ],
+                "weight": 87269555681799596
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  2,
+                  5,
+                  22
+                ],
+                "weight": 100404921927124768
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  23,
+                  8,
+                  22,
+                  14
+                ],
+                "weight": 122515828075996332
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  23,
+                  8,
+                  11,
+                  14
+                ],
+                "weight": 83385190767837857
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  1,
+                  7,
+                  24
+                ],
+                "weight": 68082134542403429
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  18,
+                  4,
+                  14
+                ],
+                "weight": 75950934998937216
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  4,
+                  13,
+                  19
+                ],
+                "weight": 70552544660033031
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  7,
+                  10,
+                  19
+                ],
+                "weight": 49184781913414691
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  19,
+                  8
+                ],
+                "weight": 70552544660033031
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  7,
+                  8,
+                  11
+                ],
+                "weight": 220886280216182208
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  15,
+                  13,
+                  5,
+                  17
+                ],
+                "weight": 47024502716005336
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  16,
+                  24,
+                  19
+                ],
+                "weight": 272198042663358475
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  16,
+                  2,
+                  17
+                ],
+                "weight": 7111857045034099
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  15,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 154087938540258655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  4,
+                  7,
+                  24
+                ],
+                "weight": 170927410366598240
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  4,
+                  21,
+                  16
+                ],
+                "weight": 116475521167002538
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  7,
+                  22,
+                  14
+                ],
+                "weight": 67622564480127776
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  1,
+                  21,
+                  10,
+                  19
+                ],
+                "weight": 602237246732123246
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  21,
+                  13,
+                  19
+                ],
+                "weight": 14484378630327829
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  19,
+                  5,
+                  8
+                ],
+                "weight": 277209443158373161
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  19,
+                  8,
+                  22
+                ],
+                "weight": 190138392556124108
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  1,
+                  22,
+                  11,
+                  14
+                ],
+                "weight": 381641007621117658
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  10,
+                  11
+                ],
+                "weight": 262281856292598468
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  16,
+                  5
+                ],
+                "weight": 263838024792996947
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  4,
+                  19,
+                  8
+                ],
+                "weight": 56068166029705202
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  7,
+                  21,
+                  10
+                ],
+                "weight": 291996932225300370
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  7,
+                  19,
+                  22
+                ],
+                "weight": 67622564480127776
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  21,
+                  10,
+                  22
+                ],
+                "weight": 394701990475627513
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  21,
+                  8,
+                  22
+                ],
+                "weight": 366909932936650432
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  10,
+                  13,
+                  17
+                ],
+                "weight": 27464113619003901
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  18,
+                  19,
+                  8,
+                  17
+                ],
+                "weight": 622825575285022048
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  18,
+                  8,
+                  22,
+                  17
+                ],
+                "weight": 290101467612551034
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  7,
+                  10,
+                  13
+                ],
+                "weight": 33951954566385430
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  13,
+                  2,
+                  22
+                ],
+                "weight": 502804250656708568
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  16,
+                  5,
+                  11
+                ],
+                "weight": 187864240267701959
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  4,
+                  2,
+                  22,
+                  11
+                ],
+                "weight": 257003004439843851
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  5,
+                  8,
+                  14
+                ],
+                "weight": 205901018843834189
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  4,
+                  5,
+                  22,
+                  11
+                ],
+                "weight": 245801246216864717
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  21,
+                  16,
+                  17
+                ],
+                "weight": 213588644240670375
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  7,
+                  21,
+                  24,
+                  11
+                ],
+                "weight": 69985125133219092
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  7,
+                  13,
+                  2,
+                  14
+                ],
+                "weight": 67622564480127776
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  10,
+                  24,
+                  11
+                ],
+                "weight": 100942285233379148
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  24,
+                  2,
+                  5
+                ],
+                "weight": 29238960684303330
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  21,
+                  5,
+                  14,
+                  17
+                ],
+                "weight": 453553139906048442
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  24,
+                  2,
+                  14
+                ],
+                "weight": 118159552992129325
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  19,
+                  2,
+                  17
+                ],
+                "weight": 46010345159043851
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  10,
+                  2,
+                  22,
+                  14
+                ],
+                "weight": 164169898151173176
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  2,
+                  22,
+                  17
+                ],
+                "weight": 96568912451127981
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  10,
+                  5,
+                  22,
+                  11
+                ],
+                "weight": 133963179873326356
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  13,
+                  24,
+                  5,
+                  17
+                ],
+                "weight": 47024502716005336
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  13,
+                  5,
+                  11,
+                  14
+                ],
+                "weight": 2016064525396726
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  16,
+                  24,
+                  8,
+                  22
+                ],
+                "weight": 220968974177619570
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  19,
+                  2,
+                  11
+                ],
+                "weight": 147398513676432655
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  24,
+                  5,
+                  8,
+                  22
+                ],
+                "weight": 80280163260192469
+              }
+            ],
+            "inequality_lemma": "for every convex quadrilateral a,b,c,d in cyclic order, d(a,c)+d(b,d)>d(a,b)+d(c,d) and d(a,c)+d(b,d)>d(a,d)+d(b,c)",
+            "num_inequalities": 201,
+            "pattern": {
+              "circulant_offsets": [
+                2,
+                5,
+                9,
+                14
+              ],
+              "n": 25,
+              "name": "C25_sidon_2_5_9_14"
+            },
+            "selected_witness_rule": "S_i={(i+d) mod n: d in circulant_offsets}",
+            "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+            "weight_sum": 32484487867254663872
+          },
+          "certificate_sha256": "9a73be40e2b341b809d4bafa5e05bbc083dad34c12d79f36040f63d67ecd9592",
+          "max_weight": 765628623272161748,
+          "new_unique_affine_orbit_clauses_added": 25,
+          "positive_inequalities": 201,
+          "status": "EXACT_OBSTRUCTION_FOR_FIXED_PATTERN_AND_FIXED_CYCLIC_ORDER",
+          "unique_ordered_quad_count": 201,
+          "weight_sum": 32484487867254663872,
+          "zero_sum_verified": true
+        },
+        "inverse_clause_count_at_discovery": 14178,
+        "inverse_pair_audit": {
+          "full_kalmanson_rows_seen": 25300,
+          "inverse_pair_conflicts": 0,
+          "status": "FIXED_ORDER_ESCAPES_TWO_INEQUALITY_KALMANSON_INVERSE_PAIR_FILTER"
+        },
+        "lightweight_filters": {
+          "altman_linear_method": "none",
+          "altman_linear_obstructed": false,
+          "altman_signature_obstructed": false,
+          "survives": true,
+          "vertex_circle_obstructed": false
+        },
+        "model_index": 7,
+        "order": [
+          0,
+          3,
+          20,
+          6,
+          9,
+          12,
+          23,
+          15,
+          1,
+          18,
+          4,
+          7,
+          21,
+          10,
+          13,
+          16,
+          24,
+          19,
+          2,
+          5,
+          8,
+          22,
+          11,
+          14,
+          17
+        ],
+        "order_sha256": "294dfcf6e734caaa2ea762e55fbf258ccc91eee75b5a5c26dd178010b4d9ea25",
+        "prior_learned_orbit_clause_matches": 0,
+        "seed_orbit_matches": [],
+        "z3_iteration": 53
+      }
+    ],
+    "new_full_certificate_count": 8,
+    "new_unique_affine_orbit_clause_count": 200,
+    "solver_result": "bounded_after_new_exact_certificates",
+    "status": "BOUNDED_C25_REPLACEMENT_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+  },
+  "selected_persistent_seed_template": {
+    "affine_clause_orbit": {
+      "affine_map_count": 25,
+      "affine_stabilizer_size": 1,
+      "canonical_clause_sha256": "e6d0b98cba90d29f3aa607bf13cfd6beb0b3bf9b7bd4a2acec69c7d04feec52a",
+      "quotient_automorphism_multipliers": [
+        1
+      ],
+      "source_model_index": 0,
+      "source_order": [
+        0,
+        22,
+        14,
+        11,
+        8,
+        19,
+        5,
+        2,
+        24,
+        16,
+        13,
+        10,
+        21,
+        7,
+        4,
+        1,
+        18,
+        15,
+        12,
+        23,
+        9,
+        20,
+        6,
+        17,
+        3
+      ],
+      "source_unique_ordered_quad_count": 4,
+      "unique_orbit_clause_count": 25
+    },
+    "compressed_certificate_sha256": "d1c462bafbb1dc530029d3478fb4cde3c3dcbf4191586250b641453eba85638c",
+    "max_weight": 1,
+    "ordered_quad_count": 4,
+    "positive_inequalities": 4,
+    "seed_id": "persistent_compressed:0",
+    "seed_role": "PRIMARY_MINIMUM_NEW_MARGINAL_COVER",
+    "source_model_index": 0,
+    "source_screen_target_id": "probe:0",
+    "source_target_id": "transfer_cegar_probe:0",
+    "weight_sum": 4
+  },
+  "selected_replacement_seed_template": {
+    "affine_clause_orbit": {
+      "affine_map_count": 25,
+      "affine_stabilizer_size": 1,
+      "canonical_clause_sha256": "9cb437cde3f0b8195893861722d86601bb7d4742b19b29cb5ea861a549e7ad8b",
+      "quotient_automorphism_multipliers": [
+        1
+      ],
+      "source_model_index": 2,
+      "source_order": [
+        0,
+        11,
+        22,
+        8,
+        5,
+        19,
+        16,
+        2,
+        13,
+        24,
+        10,
+        21,
+        7,
+        18,
+        15,
+        4,
+        1,
+        12,
+        23,
+        9,
+        20,
+        6,
+        17,
+        3,
+        14
+      ],
+      "source_unique_ordered_quad_count": 4,
+      "unique_orbit_clause_count": 25
+    },
+    "compressed_certificate_sha256": "5cd1403e864cc8d8b18b53371933e4db5f511e89d09ea028a582294fa9cc929c",
+    "max_weight": 1,
+    "ordered_quad_count": 4,
+    "positive_inequalities": 4,
+    "seed_id": "replacement_escape_compressed:2",
+    "seed_role": "EXACT_MINIMUM_FIVE_SEED_ESCAPE_COVER",
+    "source_model_index": 2,
+    "source_target_id": "residual:2",
+    "weight_sum": 4
+  },
+  "source_artifact": "data/runs/sparse_full_cone_c25_selected_residual_augmented_escape_compression_2026-07-30/summary.json",
+  "source_sha256": "8098645542bcfa4775295baf4262b9abf10e0f8b13aaa13b87badfbef1976a4f",
+  "status": "BOUNDED_C25_WIDTH4_REPLACEMENT_AUGMENTED_CEGAR",
+  "transferred_seed_templates": [
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 28,
+        "source_order": [
+          0,
+          14,
+          17,
+          3,
+          6,
+          9,
+          20,
+          23,
+          12,
+          15,
+          1,
+          4,
+          7,
+          18,
+          10,
+          21,
+          24,
+          13,
+          2,
+          16,
+          5,
+          19,
+          8,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 3,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "208e5267b8492857aee1419ecfe360c84ef365b86496726caed2e6f832aee6db",
+      "canonical_clause_sha256": "6459e9d4dd618172d2be426d4bdebc2067794bfbb83bcc0067a4c803cc827de7",
+      "max_weight": 1,
+      "ordered_quad_count": 3,
+      "positive_inequalities": 3,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 28,
+      "source_target_id": "fresh:28",
+      "template_id": "C25_sidon_2_5_9_14:fresh-28:w3:6459e9d4dd618172",
+      "weight_sum": 3
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 19,
+        "source_order": [
+          0,
+          3,
+          14,
+          17,
+          6,
+          20,
+          9,
+          23,
+          1,
+          12,
+          4,
+          15,
+          18,
+          7,
+          21,
+          10,
+          24,
+          2,
+          13,
+          5,
+          16,
+          19,
+          22,
+          8,
+          11
+        ],
+        "source_unique_ordered_quad_count": 5,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f68d46d4978292392c65fda379bf7ab80d51230f1aaa0b03f856506902b3399e",
+      "canonical_clause_sha256": "e0b19b1c4bee1919b267b45c3b27b41fb30565fd06f64c62cc2870e9f4304027",
+      "max_weight": 1,
+      "ordered_quad_count": 5,
+      "positive_inequalities": 5,
+      "seed_role": "PRIMARY_CROSS_STREAM_TRANSFER",
+      "source_model_index": 19,
+      "source_target_id": "fresh:19",
+      "template_id": "C25_sidon_2_5_9_14:fresh-19:w5:e0b19b1c4bee1919",
+      "weight_sum": 5
+    },
+    {
+      "affine_clause_orbit": {
+        "affine_map_count": 25,
+        "affine_stabilizer_size": 1,
+        "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+        "quotient_automorphism_multipliers": [
+          1
+        ],
+        "source_model_index": 15,
+        "source_order": [
+          0,
+          14,
+          3,
+          6,
+          17,
+          20,
+          23,
+          1,
+          9,
+          12,
+          15,
+          4,
+          18,
+          7,
+          21,
+          10,
+          24,
+          13,
+          2,
+          5,
+          8,
+          16,
+          19,
+          22,
+          11
+        ],
+        "source_unique_ordered_quad_count": 14,
+        "unique_orbit_clause_count": 25
+      },
+      "canonical_certificate_sha256": "f22b31f1c564b1456c9f0882bcedee26fe51161cdd64141ff4f96f06f79e71f1",
+      "canonical_clause_sha256": "0b360a662009eea4051c37822d80f64a91f237a9234eb8de290788352c45d474",
+      "max_weight": 1,
+      "ordered_quad_count": 14,
+      "positive_inequalities": 14,
+      "seed_role": "SECONDARY_PRIOR_PACKET_TRANSFER",
+      "source_model_index": 15,
+      "source_target_id": "fresh:15",
+      "template_id": "C25_sidon_2_5_9_14:fresh-15:w14:0b360a662009eea4",
+      "weight_sum": 14
+    }
+  ],
+  "trust": "EXACT_CLAUSES_IN_BOUNDED_192_HISTORY_C25_CEGAR",
+  "type": "sparse_full_cone_c25_replacement_augmented_cegar_v1",
+  "unique_active_seed_orbit_clause_count": 125
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -773,10 +773,17 @@ and must not assume that the finite `n=9` pivot census generalizes.
    reduces them to exact widths `3`--`9`, replays 200 affine images and 129
    affine cross-edges, and finds that the new width-4 `residual:2` orbit alone
    is the exact minimum cover of all eight residuals. The old width-3 seed has
-   zero marginal targets over the four parent seeds and is retired. Next run a
-   bounded 192-history C25 CEGAR with the four parent seeds plus only this new
-   width-4 replacement. Stop the current C29 template-mining route. This is
-   still not an all-order obstruction.
+   zero marginal targets over the four parent seeds and is retired. The
+   completed follow-up in
+   `docs/sparse-full-cone-c25-replacement-augmented-cegar.md` blocks 192
+   history classes and activates the four parent seeds plus only this new
+   width-4 replacement. Both the parent packet and replacement alone cover all
+   16 fresh probe orders, so the replacement adds zero marginal coverage.
+   Five-seed CEGAR nevertheless learns eight further exact full-cone
+   certificates of widths `193`--`201` before its configured limit, with no
+   unresolved model. Next compress those eight exact escapes and reassess
+   marginal affine coverage. Stop the current C29 template-mining route. This
+   is still not an all-order obstruction.
    The C19 order-CNF export
    `python scripts/export_c19_kalmanson_order_cnf.py --assert-expected --check-artifact reports/c19_kalmanson_order_cnf_summary.json`
    gives a standard SAT target for the stored Z3 clauses, but the external

--- a/docs/index.md
+++ b/docs/index.md
@@ -1019,6 +1019,11 @@ put detailed reconciliation in the canonical synthesis.
   exact compression of those eight escapes to widths 3--9; one new width-4
   orbit is the minimum residual cover and replaces the old nonmarginal width-3
   seed for the next bounded C25 packet.
+- [`sparse-full-cone-c25-replacement-augmented-cegar.md`](sparse-full-cone-c25-replacement-augmented-cegar.md):
+  192-history-blocked five-seed C25 CEGAR with the new width-4 replacement;
+  it adds zero fresh-probe marginal coverage over the four parent seeds, while
+  the search learns eight new exact width-193--201 certificates before its
+  configured limit.
 - [`fr-cut-homotopy.md`](fr-cut-homotopy.md): Fishburn--Reeds decimal
   cut-matrix nearest-fourth mixed-radius homotopy diagnostic; failed-route
   numerical evidence only, not an exact coordinate certificate.

--- a/docs/review-priorities.md
+++ b/docs/review-priorities.md
@@ -759,9 +759,14 @@ benchmarks for the larger frontier:
   as the exact replacement decision: the eight escapes compress to widths
   `3`--`9`; the new width-4 `residual:2` orbit is the one-source minimum cover
   of all eight residuals, while the old width-3 seed has zero marginal targets
-  over the four parent seeds. Use the four parent seeds plus only the new
-  width-4 replacement for a bounded 192-history packet; keep the current C29
-  template family stopped;
+  over the four parent seeds;
+- use `docs/sparse-full-cone-c25-replacement-augmented-cegar.md` as the
+  outside-packet replacement check: after 192 history blocks, both the four
+  parent seeds and the replacement width-4 orbit cover all 16 fresh probe
+  orders, so the replacement adds zero marginal coverage. The five-seed CEGAR
+  still learns eight exact width-`193`--`201` certificates before its
+  configured limit. Compress those eight escapes and reassess exact marginal
+  affine coverage; keep the current C29 template family stopped;
 - look for a bridge from arbitrary selected-witness counterexamples to a
   classified family where Kalmanson/SMT certificates can be applied.
 

--- a/docs/sparse-full-cone-c25-replacement-augmented-cegar.md
+++ b/docs/sparse-full-cone-c25-replacement-augmented-cegar.md
@@ -1,0 +1,92 @@
+# C25 width-4 replacement augmented CEGAR
+
+Status: bounded fixed-pattern, history-blocked exact-clause diagnostic. No
+general proof, all-order C25 obstruction, geometric counterexample, or
+official-status change is claimed.
+
+## Target
+
+The compression in
+`docs/sparse-full-cone-c25-selected-residual-augmented-escape-compression.md`
+found that the old width-3 seed has no marginal target over the four parent
+seeds. It selected a new width-4 orbit, also sourced from `residual:2`, as the
+one-source minimum cover of all eight five-seed escapes.
+
+This follow-up tests the replacement outside that source packet. It blocks the
+complete current 192-order C25 history under rotation and reversal, retires the
+old width-3 seed, and activates the three transferred seed orbits, persistent
+width-4 orbit, and only the new replacement width-4 orbit. Twenty-four other
+exact seed summaries remain inactive.
+
+The five active certificates have widths `3, 5, 14, 4, 4` and produce 125
+exact quotient-preserving affine images.
+
+## Deterministic bounded protocol
+
+`scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py`
+uses random seed `20260802`, conflict cap `1024`, and two limits:
+
+1. collect 16 history-disjoint inverse-pair-escape orders within at most 12,000
+   Z3 iterations and compare exact seed coverage;
+2. activate all five seed orbits and learn at most eight new exact full-cone
+   certificate orbits within at most 12,000 iterations.
+
+The numerical LP is only a certificate finder. Every stored certificate is
+exactified and replayed with integer arithmetic. The checker also replays all
+history identities, active and inactive seed certificates, affine images,
+clause matches, and learned-clause exclusions.
+
+## Fresh 16-order transfer result
+
+The fresh probe reaches its 16-order limit after 421 iterations and 13,708
+inverse-pair clauses. All 16 orders survive the stored vertex-circle and both
+Altman lightweight filters.
+
+| Seed packet | Covered probe orders | New over parent four |
+| --- | ---: | ---: |
+| Four parent seed orbits | 16/16 | -- |
+| Replacement width-4 orbit only | 16/16 | 0 |
+| Parent plus replacement | 16/16 | 0 |
+
+The replacement orbit covers every probe order, but the four parent seeds
+already cover the same 16 orders. Its one-source minimum-cover role in the
+eight-order source packet therefore has zero marginal coverage on this fresh
+bounded probe.
+
+## Five-seed CEGAR result
+
+With all five active seed orbits, bounded CEGAR finds eight further
+history-disjoint orders. Every order is a strong lightweight survivor, escapes
+all active and previously learned affine clauses at discovery, and has an
+exact positive full-Kalmanson-cone certificate.
+
+| Learned model | Z3 iteration | Exact certificate width |
+| ---: | ---: | ---: |
+| 0 | 46 | 198 |
+| 1 | 47 | 193 |
+| 2 | 48 | 195 |
+| 3 | 49 | 195 |
+| 4 | 50 | 196 |
+| 5 | 51 | 200 |
+| 6 | 52 | 199 |
+| 7 | 53 | 201 |
+
+The run stops at the configured eight-certificate limit with no unresolved
+model. The learned orbits add 200 unique affine clauses. Together with 125
+active seed images, the checker replays 325 exact affine certificate images.
+
+## Decision and next target
+
+The route decision is
+`COMPRESS_NEW_C25_REPLACEMENT_AUGMENTED_ESCAPES`.
+
+The next target is to compress these eight exact escapes and reassess marginal
+affine coverage before any further order search. This remains a finite
+fixed-pattern research packet, not evidence of an all-order obstruction.
+
+Replay:
+
+```bash
+python scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py \
+  --check data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/summary.json
+```

--- a/docs/sparse-full-cone-c25-selected-residual-augmented-escape-compression.md
+++ b/docs/sparse-full-cone-c25-selected-residual-augmented-escape-compression.md
@@ -68,9 +68,17 @@ with no cross-certificate hash reuse.
 The route decision is
 `REPLACE_NONMARGINAL_WIDTH3_WITH_MINIMUM_COMPRESSED_ESCAPE_COVER`.
 
-A possible 192-history C25 CEGAR should activate the four parent seed orbits
-and only the new width-4 `residual:2` orbit selected here. The prior width-3
-seed is retired because it adds no target marginal in this packet.
+The completed 192-history follow-up in
+`docs/sparse-full-cone-c25-replacement-augmented-cegar.md` activates the four
+parent seed orbits and only the new width-4 `residual:2` replacement selected
+here. The prior width-3 seed is retired.
+
+On 16 fresh probe orders, both the four parent seeds and the replacement alone
+cover 16/16, so the replacement adds zero marginal fresh-probe coverage.
+Bounded five-seed CEGAR nevertheless learns eight new exact certificates of
+widths `193`--`201` before its configured limit. The next target is to compress
+those eight replacement-seed escapes and reassess exact marginal affine
+coverage.
 
 Replay without rerunning the numerical objective search:
 

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -3203,6 +3203,16 @@
         "data/runs/sparse_full_cone_c25_selected_residual_augmented_escape_compression_2026-07-30/summary.json"
       ],
       "claim_scope": "Replay eight exact compressed C25 positive-circuit certificates of widths 3 through 9, 200 exact quotient-preserving affine images, exact coverage over 16 probe and eight five-seed-escaping residual orders, 31 direct plus 129 affine cross-source reuse edges, and exhaustive minimum-source covers inside that finite packet. The old selected width-three seed has zero marginal targets and the objective search is deterministic-budget but non-exhaustive; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
+    },
+    {
+      "id": "sparse_full_cone_c25_replacement_augmented_cegar",
+      "command": [
+        "python",
+        "scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py",
+        "--check",
+        "data/runs/sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31/summary.json"
+      ],
+      "claim_scope": "Replay five active exact C25 seed certificates, twenty-four explicitly inactive exact seed summaries, 192 blocked order identities, 16 history-disjoint probe orders, eight newly learned exact full-cone certificates, 200 new affine clauses, and 325 exact affine certificate images. The replacement width-four seed has zero fresh-probe marginal coverage over the four parent seeds and the run stops at configured finite limits; not an all-order C25 obstruction, geometric realizability result, proof of Erdos Problem #97, counterexample, or official/global status update."
     }
   ],
   "make_targets": {

--- a/scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py
@@ -454,7 +454,14 @@ def build_payload(args: argparse.Namespace) -> dict[str, object]:
 def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     if payload["type"] != "sparse_full_cone_c25_replacement_augmented_cegar_v1":
         raise AssertionError("replacement artifact type drifted")
+    n, offsets = prior.PATTERNS[PATTERN]
+    if payload["pattern"] != PATTERN or int(payload["n"]) != n:
+        raise AssertionError("replacement pattern drifted")
+    if payload["circulant_offsets"] != list(offsets):
+        raise AssertionError("replacement offsets drifted")
     source_path = ROOT / str(payload["source_artifact"])
+    if source_path.resolve() != DEFAULT_SOURCE.resolve():
+        raise AssertionError("replacement source artifact drifted")
     if file_sha256(source_path) != str(payload["source_sha256"]):
         raise AssertionError("replacement source hash drifted")
     unpacked = unpack_for_run(source_path)

--- a/scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py
+++ b/scripts/exploration/run_sparse_full_cone_c25_replacement_augmented_cegar.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Run 192-history C25 CEGAR with the selected width-four replacement seed.
+
+This bounded follow-up activates the three transferred seeds, the persistent
+width-four seed, and only the new width-four replacement selected by the
+preceding compression. It blocks 192 known C25 order classes, measures fresh
+transfer, and learns at most eight new exact full-cone certificate orbits.
+
+This is a fixed-pattern finite diagnostic, not an all-order obstruction,
+geometric realizability result, counterexample, or proof of Erdos Problem #97.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+EXPLORATION = Path(__file__).resolve().parent
+for path in (SCRIPTS, EXPLORATION):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_kalmanson_certificate import check_certificate_dict  # noqa: E402
+from compress_sparse_full_cone_c25_selected_residual_augmented_escapes import (  # noqa: E402
+    check_payload as check_compression_payload,
+)
+from probe_sparse_full_cone_small_templates import (  # noqa: E402
+    dihedral_order_key,
+)
+import run_sparse_full_cone_c25_selected_residual_augmented_cegar as prior  # noqa: E402
+from run_sparse_full_cone_seeded_cegar import (  # noqa: E402
+    ClauseOrbit,
+    build_clause_orbit,
+    clause_matches,
+    file_sha256,
+    unique_clauses,
+)
+
+
+PATTERN = prior.PATTERN
+DEFAULT_SOURCE = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_selected_residual_augmented_escape_compression_2026-07-30"
+    / "summary.json"
+)
+DEFAULT_PROBE_ORDER_LIMIT = 16
+DEFAULT_PROBE_MAX_ITERATIONS = 12_000
+DEFAULT_FULL_CERTIFICATE_LIMIT = 8
+DEFAULT_MAX_ITERATIONS = 12_000
+DEFAULT_CONFLICT_CAP = 1_024
+DEFAULT_RANDOM_SEED = 20_260_802
+SELECTED_REPLACEMENT_SOURCE_TARGET_ID = "residual:2"
+CERTIFICATE_LIMIT_STATUS = (
+    "BOUNDED_C25_REPLACEMENT_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+)
+CONTINUE_DECISION = "COMPRESS_NEW_C25_REPLACEMENT_AUGMENTED_ESCAPES"
+REVIEW_DECISION = "REVIEW_C25_REPLACEMENT_AUGMENTED_CEGAR"
+
+
+def load_sources(
+    source_path: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    check_compression_payload(source)
+    cegar_path = ROOT / str(source["source_artifact"])
+    cegar = json.loads(cegar_path.read_text(encoding="utf-8"))
+    prior.check_payload(cegar)
+    old_compression_path = ROOT / str(
+        cegar["source_residual_compression_artifact"]
+    )
+    (
+        old_compression,
+        parent,
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = prior.load_sources(old_compression_path)
+    return (
+        source,
+        cegar,
+        old_compression,
+        parent,
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    )
+
+
+def blocked_history(
+    cegar: Mapping[str, Any],
+    parent: Mapping[str, Any],
+    augmentation: Mapping[str, Any],
+    prior_cegar: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+    first: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    history = prior.blocked_history(
+        parent,
+        augmentation,
+        prior_cegar,
+        transfer,
+        first,
+    )
+    streams = (
+        (
+            "selected_residual_probe",
+            "probe_model_index",
+            cegar["counterfactual_probe"]["models"],
+        ),
+        (
+            "selected_residual_escape",
+            "model_index",
+            cegar["seeded_cegar"]["models"],
+        ),
+    )
+    for packet, index_key, models in streams:
+        for model in models:
+            index = int(model[index_key])
+            history.append(
+                {
+                    "history_id": f"{packet}:{index}",
+                    "packet": packet,
+                    "order": [int(label) for label in model["order"]],
+                    "order_sha256": str(model["order_sha256"]),
+                    "dihedral_order_sha256": str(
+                        model["dihedral_order_sha256"]
+                    ),
+                }
+            )
+    keys = {dihedral_order_key(row["order"]) for row in history}
+    if len(history) != 192 or len(keys) != 192:
+        raise AssertionError("replacement history must have 192 classes")
+    return history
+
+
+def replacement_record(
+    row: Mapping[str, Any],
+    orbit: ClauseOrbit,
+) -> dict[str, object]:
+    checked = check_certificate_dict(row["compressed_certificate"])
+    if not checked.zero_sum_verified:
+        raise AssertionError("replacement certificate failed exact replay")
+    return {
+        "seed_id": "replacement_escape_compressed:2",
+        "seed_role": "EXACT_MINIMUM_FIVE_SEED_ESCAPE_COVER",
+        "source_target_id": str(row["source_target_id"]),
+        "source_model_index": int(row["source_model_index"]),
+        "ordered_quad_count": int(row["compressed_unique_ordered_quad_count"]),
+        "compressed_certificate_sha256": str(
+            row["compressed_certificate_sha256"]
+        ),
+        "positive_inequalities": checked.positive_inequalities,
+        "weight_sum": checked.weight_sum,
+        "max_weight": checked.max_weight,
+        "affine_clause_orbit": orbit.summary(),
+    }
+
+
+def seed_selection(
+    source: Mapping[str, Any],
+    cegar: Mapping[str, Any],
+    old_compression: Mapping[str, Any],
+    parent_source: Mapping[str, Any],
+    residual_compression: Mapping[str, Any],
+    transfer: Mapping[str, Any],
+) -> tuple[
+    list[dict[str, object]],
+    dict[str, object],
+    dict[str, object],
+    list[ClauseOrbit],
+    list[dict[str, object]],
+]:
+    (
+        transferred,
+        persistent,
+        old_selected,
+        old_active,
+        inherited_inactive,
+    ) = prior.seed_selection(
+        old_compression,
+        parent_source,
+        residual_compression,
+        transfer,
+    )
+    cover = source["run"]["coverage_comparison"][
+        "minimum_affine_source_covers"
+    ]["residual_targets"]
+    if cover["selected_source_target_ids"] != [
+        SELECTED_REPLACEMENT_SOURCE_TARGET_ID
+    ]:
+        raise AssertionError("replacement minimum cover drifted")
+    rows = {
+        str(row["source_target_id"]): row
+        for row in source["run"]["compressed_models"]
+    }
+    selected = rows[SELECTED_REPLACEMENT_SOURCE_TARGET_ID]
+    orbit = build_clause_orbit(
+        PATTERN,
+        int(selected["source_model_index"]),
+        selected["compressed_certificate"],
+    )
+    if orbit.summary() != selected["affine_clause_orbit"]:
+        raise AssertionError("replacement orbit drifted")
+    active = [*old_active[:-1], orbit]
+    if len({item.canonical_clause_sha256 for item in active}) != 5:
+        raise AssertionError("replacement active orbit duplicated")
+    inactive_new = [
+        {
+            "seed_id": f"replacement_escape_compressed:{row['source_model_index']}",
+            "source_target_id": str(row["source_target_id"]),
+            "source_model_index": int(row["source_model_index"]),
+            "ordered_quad_count": int(
+                row["compressed_unique_ordered_quad_count"]
+            ),
+            "compressed_certificate_sha256": str(
+                row["compressed_certificate_sha256"]
+            ),
+            "inactive_reason": "NOT_SELECTED_BY_EXACT_MINIMUM_ESCAPE_COVER",
+        }
+        for row in rows.values()
+        if str(row["source_target_id"])
+        != SELECTED_REPLACEMENT_SOURCE_TARGET_ID
+    ]
+    old_inactive = {
+        **old_selected,
+        "inactive_reason": "ZERO_MARGINAL_TARGETS_OVER_FOUR_PARENT_SEEDS",
+    }
+    inactive = [*inherited_inactive, old_inactive, *inactive_new]
+    if len(inactive) != 24:
+        raise AssertionError("replacement inactive packet drifted")
+    return (
+        transferred,
+        persistent,
+        replacement_record(selected, orbit),
+        active,
+        inactive,
+    )
+
+
+def probe_comparison(
+    models: Sequence[Mapping[str, Any]],
+    parent_orbits: Sequence[ClauseOrbit],
+    replacement: ClauseOrbit,
+) -> dict[str, object]:
+    active = [*parent_orbits, replacement]
+    summaries = {
+        "parent_four_seeds": prior.coverage_for(models, parent_orbits),
+        "replacement_width4_only": prior.coverage_for(
+            models,
+            [replacement],
+        ),
+        "parent_plus_replacement": prior.coverage_for(models, active),
+    }
+    parent_ids = {
+        int(model["probe_model_index"])
+        for model in models
+        if clause_matches(model["order"], parent_orbits)
+    }
+    replacement_ids = {
+        int(model["probe_model_index"])
+        for model in models
+        if clause_matches(model["order"], [replacement])
+    }
+    return {
+        **summaries,
+        "replacement_covered_probe_model_indices": sorted(replacement_ids),
+        "replacement_marginal_over_parent_probe_model_indices": sorted(
+            replacement_ids - parent_ids
+        ),
+        "replacement_overlap_with_parent_probe_model_indices": sorted(
+            replacement_ids & parent_ids
+        ),
+        "active_uncovered_probe_model_indices": sorted(
+            set(range(len(models))) - (parent_ids | replacement_ids)
+        ),
+    }
+
+
+def route_decision(
+    probe: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+    seeded: Mapping[str, Any],
+) -> str:
+    count = int(probe["inverse_pair_escape_order_count"])
+    if (
+        count > 0
+        and int(
+            comparison["parent_four_seeds"]["covered_probe_order_count"]
+        )
+        == count
+        and int(
+            comparison["replacement_width4_only"]["covered_probe_order_count"]
+        )
+        == count
+        and not comparison[
+            "replacement_marginal_over_parent_probe_model_indices"
+        ]
+        and int(seeded["new_full_certificate_count"])
+        == DEFAULT_FULL_CERTIFICATE_LIMIT
+        and seeded["status"] == CERTIFICATE_LIMIT_STATUS
+        and all(
+            "certificate" in model["full_kalmanson"]
+            for model in seeded["models"]
+        )
+    ):
+        return CONTINUE_DECISION
+    return REVIEW_DECISION
+
+
+def unpack_for_run(source_path: Path) -> tuple[Any, ...]:
+    loaded = load_sources(source_path)
+    (
+        source,
+        cegar,
+        old_compression,
+        parent,
+        parent_source,
+        augmentation,
+        residual_compression,
+        prior_cegar,
+        transfer,
+        first,
+    ) = loaded
+    history = blocked_history(
+        cegar,
+        parent,
+        augmentation,
+        prior_cegar,
+        transfer,
+        first,
+    )
+    seeds = seed_selection(
+        source,
+        cegar,
+        old_compression,
+        parent_source,
+        residual_compression,
+        transfer,
+    )
+    return (*loaded, history, *seeds)
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, object]:
+    source_path = args.source if args.source.is_absolute() else ROOT / args.source
+    unpacked = unpack_for_run(source_path)
+    source, cegar = unpacked[:2]
+    history = unpacked[10]
+    transferred, persistent, replacement, active, inactive = unpacked[11:]
+    probe, inverse = prior.collect_history_disjoint_probe(
+        active,
+        history,
+        order_limit=args.probe_order_limit,
+        max_iterations=args.probe_max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+    )
+    comparison = probe_comparison(probe["models"], active[:-1], active[-1])
+    seeded = prior.run_history_disjoint_seeded_cegar(
+        active,
+        history,
+        inverse,
+        full_certificate_limit=args.full_certificate_limit,
+        max_iterations=args.max_iterations,
+        conflict_cap=args.conflict_cap,
+        random_seed=args.random_seed,
+        certificate_limit_status=CERTIFICATE_LIMIT_STATUS,
+    )
+    decision = route_decision(probe, comparison, seeded)
+    n, offsets = prior.PATTERNS[PATTERN]
+    return {
+        "type": "sparse_full_cone_c25_replacement_augmented_cegar_v1",
+        "trust": "EXACT_CLAUSES_IN_BOUNDED_192_HISTORY_C25_CEGAR",
+        "status": "BOUNDED_C25_WIDTH4_REPLACEMENT_AUGMENTED_CEGAR",
+        "claim_scope": (
+            "Five exact C25 seed orbits drive a bounded order CEGAR after 192 "
+            "known order classes are blocked. Exact finite clauses only; not "
+            "an all-order obstruction, geometric result, proof, counterexample, "
+            "or official/global status update."
+        ),
+        "source_artifact": source_path.relative_to(ROOT).as_posix(),
+        "source_sha256": file_sha256(source_path),
+        "configuration": {
+            "pattern": PATTERN,
+            "probe_order_limit": args.probe_order_limit,
+            "probe_max_iterations": args.probe_max_iterations,
+            "full_certificate_limit": args.full_certificate_limit,
+            "max_iterations": args.max_iterations,
+            "conflict_cap": args.conflict_cap,
+            "random_seed": args.random_seed,
+            "history_equivalence": "cyclic rotation and reversal",
+            "active_seed_policy": (
+                "four parent seeds plus selected width-four replacement only"
+            ),
+        },
+        "pattern": PATTERN,
+        "n": n,
+        "circulant_offsets": list(offsets),
+        "transferred_seed_templates": transferred,
+        "selected_persistent_seed_template": persistent,
+        "selected_replacement_seed_template": replacement,
+        "inactive_seed_templates": inactive,
+        "active_seed_orbit_count": len(active),
+        "active_exact_affine_seed_image_count": sum(
+            orbit.affine_map_count for orbit in active
+        ),
+        "unique_active_seed_orbit_clause_count": len(unique_clauses(active)),
+        "blocked_history": {
+            "order_count": len(history),
+            "dihedral_order_count": len(
+                {dihedral_order_key(row["order"]) for row in history}
+            ),
+            "packet_histogram": dict(
+                sorted(Counter(row["packet"] for row in history).items())
+            ),
+            "identities": prior.history_identity(history),
+        },
+        "counterfactual_probe": probe,
+        "counterfactual_seed_packet_coverage": comparison,
+        "seeded_cegar": seeded,
+        "decision": decision,
+        "next_target": (
+            "Compress the eight newly learned exact replacement-seed escapes "
+            "and reassess marginal affine coverage before more order search."
+        ),
+    }
+
+
+def check_payload(payload: Mapping[str, Any]) -> dict[str, object]:
+    if payload["type"] != "sparse_full_cone_c25_replacement_augmented_cegar_v1":
+        raise AssertionError("replacement artifact type drifted")
+    source_path = ROOT / str(payload["source_artifact"])
+    if file_sha256(source_path) != str(payload["source_sha256"]):
+        raise AssertionError("replacement source hash drifted")
+    unpacked = unpack_for_run(source_path)
+    history = unpacked[10]
+    transferred, persistent, replacement, active, inactive = unpacked[11:]
+    expected_config = {
+        "pattern": PATTERN,
+        "probe_order_limit": DEFAULT_PROBE_ORDER_LIMIT,
+        "probe_max_iterations": DEFAULT_PROBE_MAX_ITERATIONS,
+        "full_certificate_limit": DEFAULT_FULL_CERTIFICATE_LIMIT,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
+        "conflict_cap": DEFAULT_CONFLICT_CAP,
+        "random_seed": DEFAULT_RANDOM_SEED,
+        "history_equivalence": "cyclic rotation and reversal",
+        "active_seed_policy": (
+            "four parent seeds plus selected width-four replacement only"
+        ),
+    }
+    if payload["configuration"] != expected_config:
+        raise AssertionError("replacement configuration drifted")
+    expected_history = {
+        "order_count": len(history),
+        "dihedral_order_count": len(
+            {dihedral_order_key(row["order"]) for row in history}
+        ),
+        "packet_histogram": dict(
+            sorted(Counter(row["packet"] for row in history).items())
+        ),
+        "identities": prior.history_identity(history),
+    }
+    if payload["blocked_history"] != expected_history:
+        raise AssertionError("replacement history drifted")
+    if payload["transferred_seed_templates"] != transferred:
+        raise AssertionError("replacement transferred seeds drifted")
+    if payload["selected_persistent_seed_template"] != persistent:
+        raise AssertionError("replacement persistent seed drifted")
+    if payload["selected_replacement_seed_template"] != replacement:
+        raise AssertionError("replacement selected seed drifted")
+    if payload["inactive_seed_templates"] != inactive:
+        raise AssertionError("replacement inactive seeds drifted")
+    if int(payload["active_seed_orbit_count"]) != len(active):
+        raise AssertionError("replacement active count drifted")
+    if int(payload["active_exact_affine_seed_image_count"]) != sum(
+        orbit.affine_map_count for orbit in active
+    ):
+        raise AssertionError("replacement active images drifted")
+    if int(payload["unique_active_seed_orbit_clause_count"]) != len(
+        unique_clauses(active)
+    ):
+        raise AssertionError("replacement active clauses drifted")
+    probe = payload["counterfactual_probe"]
+    inverse_count = prior.check_probe(
+        probe,
+        history,
+        active,
+        order_limit=DEFAULT_PROBE_ORDER_LIMIT,
+        max_iterations=DEFAULT_PROBE_MAX_ITERATIONS,
+        conflict_cap=DEFAULT_CONFLICT_CAP,
+    )
+    comparison = probe_comparison(probe["models"], active[:-1], active[-1])
+    if payload["counterfactual_seed_packet_coverage"] != comparison:
+        raise AssertionError("replacement coverage drifted")
+    previous_status = prior.CERTIFICATE_LIMIT_STATUS
+    prior.CERTIFICATE_LIMIT_STATUS = CERTIFICATE_LIMIT_STATUS
+    try:
+        audit = prior.check_seeded_cegar(
+            payload["seeded_cegar"],
+            history,
+            active,
+            initial_inverse_count=inverse_count,
+            full_certificate_limit=DEFAULT_FULL_CERTIFICATE_LIMIT,
+            max_iterations=DEFAULT_MAX_ITERATIONS,
+            conflict_cap=DEFAULT_CONFLICT_CAP,
+        )
+    finally:
+        prior.CERTIFICATE_LIMIT_STATUS = previous_status
+    decision = route_decision(probe, comparison, payload["seeded_cegar"])
+    if payload["decision"] != decision:
+        raise AssertionError("replacement decision drifted")
+    return {
+        "status": "OK",
+        "verified_blocked_history_orders": len(history),
+        "verified_active_seed_certificates": len(active),
+        "verified_inactive_seed_certificates": len(inactive),
+        "verified_counterfactual_probe_orders": len(probe["models"]),
+        "verified_new_exact_full_cone_certificates": audit[
+            "verified_certificates"
+        ],
+        "verified_exact_affine_certificate_images": audit["verified_images"],
+        "verified_new_unique_affine_orbit_clauses": audit[
+            "verified_learned_clauses"
+        ],
+        "decision": decision,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--probe-order-limit", type=int, default=16)
+    parser.add_argument("--probe-max-iterations", type=int, default=12_000)
+    parser.add_argument("--full-certificate-limit", type=int, default=8)
+    parser.add_argument("--max-iterations", type=int, default=12_000)
+    parser.add_argument("--conflict-cap", type=int, default=1_024)
+    parser.add_argument("--random-seed", type=int, default=DEFAULT_RANDOM_SEED)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--check", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.check:
+        path = args.check if args.check.is_absolute() else ROOT / args.check
+        print(
+            json.dumps(
+                check_payload(json.loads(path.read_text(encoding="utf-8"))),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    payload = build_payload(args)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        path = args.out if args.out.is_absolute() else ROOT / args.out
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+        comparison = payload["counterfactual_seed_packet_coverage"]
+        print(
+            f"history={payload['blocked_history']['order_count']} "
+            f"parent={comparison['parent_four_seeds']['covered_probe_order_count']}/16 "
+            f"replacement={comparison['replacement_width4_only']['covered_probe_order_count']}/16 "
+            f"marginal={len(comparison['replacement_marginal_over_parent_probe_model_indices'])} "
+            f"certificates={payload['seeded_cegar']['new_full_certificate_count']} "
+            f"decision={payload['decision']}"
+        )
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sparse_full_cone_c25_replacement_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_replacement_augmented_cegar.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "exploration"
+    / "run_sparse_full_cone_c25_replacement_augmented_cegar.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "sparse_full_cone_c25_replacement_augmented_cegar",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+CEGAR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CEGAR
+SPEC.loader.exec_module(CEGAR)
+
+ARTIFACT = (
+    ROOT
+    / "data"
+    / "runs"
+    / "sparse_full_cone_c25_replacement_augmented_cegar_2026-07-31"
+    / "summary.json"
+)
+
+
+def artifact_payload() -> dict[str, object]:
+    return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def test_stored_packet_blocks_the_complete_192_order_history() -> None:
+    history = artifact_payload()["blocked_history"]
+
+    assert history["order_count"] == 192
+    assert history["dihedral_order_count"] == 192
+    assert history["packet_histogram"] == {
+        "augmentation_probe": 32,
+        "first_fresh": 32,
+        "persistent_augmented_probe": 16,
+        "persistent_augmented_residual": 8,
+        "prior": 24,
+        "second_fresh": 32,
+        "selected_residual_escape": 8,
+        "selected_residual_probe": 16,
+        "transfer_cegar_probe": 16,
+        "transfer_cegar_residual": 8,
+    }
+    assert len(history["identities"]) == 192
+    assert len(
+        {record["dihedral_order_sha256"] for record in history["identities"]}
+    ) == 192
+
+
+def test_seed_policy_replaces_the_old_width_three_with_width_four() -> None:
+    payload = artifact_payload()
+
+    assert [
+        record["ordered_quad_count"]
+        for record in payload["transferred_seed_templates"]
+    ] == [3, 5, 14]
+    assert payload["selected_persistent_seed_template"][
+        "ordered_quad_count"
+    ] == 4
+    selected = payload["selected_replacement_seed_template"]
+    assert selected["source_target_id"] == "residual:2"
+    assert selected["source_model_index"] == 2
+    assert selected["ordered_quad_count"] == 4
+    assert selected["seed_role"] == "EXACT_MINIMUM_FIVE_SEED_ESCAPE_COVER"
+    assert payload["active_seed_orbit_count"] == 5
+    assert payload["active_exact_affine_seed_image_count"] == 125
+    assert payload["unique_active_seed_orbit_clause_count"] == 125
+    assert len(payload["inactive_seed_templates"]) == 24
+
+
+def test_replacement_width_four_has_no_fresh_probe_marginal_coverage() -> None:
+    payload = artifact_payload()
+    probe = payload["counterfactual_probe"]
+    comparison = payload["counterfactual_seed_packet_coverage"]
+
+    assert probe["status"] == "BOUNDED_HISTORY_DISJOINT_PROBE_ORDER_LIMIT_REACHED"
+    assert probe["iterations"] == 421
+    assert probe["inverse_pair_clause_count"] == 13708
+    assert probe["inverse_pair_escape_order_count"] == 16
+    assert all(model["lightweight_filters"]["survives"] for model in probe["models"])
+    assert comparison["parent_four_seeds"]["covered_probe_order_count"] == 16
+    assert comparison["replacement_width4_only"]["covered_probe_order_count"] == 16
+    assert comparison["parent_plus_replacement"]["covered_probe_order_count"] == 16
+    assert comparison["replacement_covered_probe_model_indices"] == list(range(16))
+    assert comparison[
+        "replacement_marginal_over_parent_probe_model_indices"
+    ] == []
+    assert comparison["replacement_overlap_with_parent_probe_model_indices"] == list(
+        range(16)
+    )
+    assert comparison["active_uncovered_probe_model_indices"] == []
+
+
+def test_replacement_cegar_learns_eight_new_exact_wide_certificates() -> None:
+    payload = artifact_payload()
+    seeded = payload["seeded_cegar"]
+    models = seeded["models"]
+
+    assert seeded["status"] == (
+        "BOUNDED_C25_REPLACEMENT_AUGMENTED_CERTIFICATE_LIMIT_REACHED"
+    )
+    assert seeded["solver_result"] == "bounded_after_new_exact_certificates"
+    assert seeded["iterations"] == 53
+    assert seeded["initial_probe_inverse_clause_count"] == 13708
+    assert seeded["final_inverse_pair_clause_count"] == 14178
+    assert seeded["new_full_certificate_count"] == 8
+    assert seeded["new_unique_affine_orbit_clause_count"] == 200
+    assert [
+        model["full_kalmanson"]["unique_ordered_quad_count"] for model in models
+    ] == [198, 193, 195, 195, 196, 200, 199, 201]
+    assert all(model["full_kalmanson"]["zero_sum_verified"] for model in models)
+    assert all(model["lightweight_filters"]["survives"] for model in models)
+    assert all(model["seed_orbit_matches"] == [] for model in models)
+    assert payload["decision"] == (
+        "COMPRESS_NEW_C25_REPLACEMENT_AUGMENTED_ESCAPES"
+    )
+
+
+def test_stored_replacement_augmented_cegar_replays_exactly() -> None:
+    assert CEGAR.check_payload(artifact_payload()) == {
+        "status": "OK",
+        "verified_blocked_history_orders": 192,
+        "verified_active_seed_certificates": 5,
+        "verified_inactive_seed_certificates": 24,
+        "verified_counterfactual_probe_orders": 16,
+        "verified_new_exact_full_cone_certificates": 8,
+        "verified_exact_affine_certificate_images": 325,
+        "verified_new_unique_affine_orbit_clauses": 200,
+        "decision": "COMPRESS_NEW_C25_REPLACEMENT_AUGMENTED_ESCAPES",
+    }

--- a/tests/test_sparse_full_cone_c25_replacement_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_replacement_augmented_cegar.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = (
@@ -33,6 +35,30 @@ ARTIFACT = (
 
 def artifact_payload() -> dict[str, object]:
     return json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+
+def test_checker_rejects_substituted_source_artifact(tmp_path: Path) -> None:
+    substitute = tmp_path / "summary.json"
+    substitute.write_bytes(CEGAR.DEFAULT_SOURCE.read_bytes())
+    payload = artifact_payload()
+    payload["source_artifact"] = str(substitute)
+    payload["source_sha256"] = CEGAR.file_sha256(substitute)
+
+    with pytest.raises(AssertionError, match="source artifact drifted"):
+        CEGAR.check_payload(payload)
+
+
+def test_checker_rejects_tampered_pattern_metadata() -> None:
+    mutations = (
+        ("pattern", "C25_wrong", "pattern drifted"),
+        ("n", 24, "pattern drifted"),
+        ("circulant_offsets", [1, 2, 3, 4], "offsets drifted"),
+    )
+    for field, value, message in mutations:
+        payload = artifact_payload()
+        payload[field] = value
+        with pytest.raises(AssertionError, match=message):
+            CEGAR.check_payload(payload)
 
 
 def test_stored_packet_blocks_the_complete_192_order_history() -> None:


### PR DESCRIPTION
## What changed

- add a deterministic 192-history C25 CEGAR using the four parent exact seed orbits plus only the selected width-4 replacement orbit
- store and replay the exact bounded artifact, including 192 history identities, 24 inactive seed summaries, 16 fresh probe orders, and eight new exact full-cone certificates
- document the zero fresh marginality result and register the checker in the artifact audit
- add focused regression tests and advance the next research target to exact compression of the eight new escapes
- harden the checker to require the canonical source artifact and pin the top-level pattern, `n`, and circulant offsets
- add source-substitution and pattern-metadata tamper regressions; the exact result artifact is unchanged

## Exact bounded result

- the four parent seeds cover `16/16` fresh probe orders
- the replacement width-4 orbit also covers `16/16`, but adds zero marginal coverage over the parent packet
- bounded five-seed CEGAR learns eight exact certificates of widths `198, 193, 195, 195, 196, 200, 199, 201`
- the run reaches its configured eight-certificate limit with no unresolved model and adds 200 unique affine clauses
- stored artifact SHA-256: `cb3a06a79c21fa8ce3c883888458d3762b457fd8f7082f2535d5b88288d313ce`

## Validation

- focused packet tests: `7 passed`
- complete fast tier: passed
- complete pytest suite, split into four non-overlapping shards: `1835 passed`
- all eleven required artifact-tier commands: passed
- exact-head GitHub tests and artifact audit: passed

## Claim scope

This is a finite fixed-pattern, history-blocked exact-clause diagnostic. It does not claim an all-order C25 obstruction, geometric counterexample, general proof of Erdos Problem #97, counterexample to the problem, or official/global status change.
