### PR TITLE
Add quotient-stable n=9 template dual certificates

### DIFF
--- a/data/certificates/n9_vertex_circle_template_duals.json
+++ b/data/certificates/n9_vertex_circle_template_duals.json
@@ -1,0 +1,2103 @@
+{
+  "active_pair_count_counts": {
+    "4": 9,
+    "5": 3,
+    "6": 2,
+    "7": 2
+  },
+  "all_active_pair_quotients_preserve_zero_balance": true,
+  "all_equality_multipliers_signed_unit": true,
+  "all_identity_balances_zero": true,
+  "all_strict_coefficients_positive_unit": true,
+  "assignment_coverage": {
+    "all_label_maps_verified_dihedral": true,
+    "all_transformed_identities_verified_zero": true,
+    "all_transformed_terms_supported_by_assignment_cores": true,
+    "assignment_count": 184,
+    "family_assignment_counts": {
+      "F01": 18,
+      "F02": 18,
+      "F03": 18,
+      "F04": 18,
+      "F05": 18,
+      "F06": 18,
+      "F07": 6,
+      "F08": 2,
+      "F09": 6,
+      "F10": 18,
+      "F11": 18,
+      "F12": 18,
+      "F13": 2,
+      "F14": 2,
+      "F15": 2,
+      "F16": 2
+    },
+    "family_count": 16,
+    "template_assignment_counts": {
+      "T01": 6,
+      "T02": 40,
+      "T03": 20,
+      "T04": 2,
+      "T05": 18,
+      "T06": 18,
+      "T07": 18,
+      "T08": 18,
+      "T09": 18,
+      "T10": 18,
+      "T11": 6,
+      "T12": 2
+    },
+    "template_count": 12,
+    "transformed_certificate_sha256": "c60ce8833bd4b2fa7ad32e2e034091966369a77553614fffc2226dc4a0edf3eb",
+    "unique_assignment_count": 184
+  },
+  "certificates": [
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 6,
+        "assignment_ids": [
+          "A014",
+          "A024",
+          "A031",
+          "A140",
+          "A166",
+          "A175"
+        ],
+        "orbit_size_sum": 6
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            8
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            0,
+            2
+          ],
+          "supporting_rows": [
+            0
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            2
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            2
+          ]
+        }
+      ],
+      "family_id": "F09",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T01-F09-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            4,
+            8
+          ]
+        }
+      ],
+      "template_id": "T01"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            8
+          ],
+          "right_pair": [
+            0,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            8
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            0
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            1
+          ]
+        }
+      ],
+      "family_id": "F01",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T02-F01-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ]
+        }
+      ],
+      "template_id": "T02"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            2,
+            3
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            2
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            0
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            2
+          ],
+          "right_pair": [
+            2,
+            3
+          ],
+          "supporting_rows": [
+            2
+          ]
+        }
+      ],
+      "family_id": "F04",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T02-F04-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            2,
+            3
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            0,
+            2
+          ],
+          "outer_span": 3,
+          "row": 1,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            2,
+            3,
+            5,
+            0
+          ]
+        }
+      ],
+      "template_id": "T02"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [],
+        "orbit_size_sum": 2
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            8
+          ],
+          "right_pair": [
+            0,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            8
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            0
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            1
+          ]
+        }
+      ],
+      "family_id": "F08",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T02-F08-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            4,
+            8
+          ]
+        }
+      ],
+      "template_id": "T02"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [],
+        "orbit_size_sum": 2
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            8
+          ],
+          "right_pair": [
+            0,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            8
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            0
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            1
+          ]
+        }
+      ],
+      "family_id": "F14",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T02-F14-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            6,
+            8
+          ]
+        }
+      ],
+      "template_id": "T02"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            7
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            7
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            3,
+            7
+          ],
+          "right_pair": [
+            2,
+            3
+          ],
+          "supporting_rows": [
+            3
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            2,
+            3
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            2
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            2
+          ],
+          "right_pair": [
+            1,
+            7
+          ],
+          "supporting_rows": [
+            1
+          ]
+        }
+      ],
+      "family_id": "F05",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T03-F05-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            7
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            3,
+            7
+          ],
+          "outer_span": 2,
+          "row": 6,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            7,
+            1,
+            3,
+            5
+          ]
+        }
+      ],
+      "template_id": "T03"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [],
+        "orbit_size_sum": 2
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            4
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            2
+          ],
+          "right_pair": [
+            2,
+            3
+          ],
+          "supporting_rows": [
+            2
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            2,
+            3
+          ],
+          "right_pair": [
+            3,
+            4
+          ],
+          "supporting_rows": [
+            3
+          ]
+        }
+      ],
+      "family_id": "F15",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T03-F15-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            3,
+            4
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            4
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            3,
+            4,
+            8
+          ]
+        }
+      ],
+      "template_id": "T03"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            3,
+            5
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [],
+        "orbit_size_sum": 2
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            5
+          ],
+          "right_pair": [
+            3,
+            5
+          ],
+          "supporting_rows": [
+            5
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            3,
+            5
+          ],
+          "right_pair": [
+            1,
+            3
+          ],
+          "supporting_rows": [
+            3
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            3
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            1
+          ]
+        }
+      ],
+      "family_id": "F13",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T04-F13-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            5
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            5,
+            7
+          ]
+        }
+      ],
+      "template_id": "T04"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 4,
+        "active_pairs": [
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            8
+          ],
+          [
+            2,
+            7
+          ],
+          [
+            7,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 15
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            8
+          ],
+          "right_pair": [
+            7,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            7,
+            8
+          ],
+          "right_pair": [
+            2,
+            7
+          ],
+          "supporting_rows": [
+            7
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            2,
+            7
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            2
+          ]
+        }
+      ],
+      "family_id": "F10",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T05-F10-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            8
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            4,
+            8
+          ]
+        }
+      ],
+      "template_id": "T05"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 5,
+        "active_pairs": [
+          [
+            3,
+            5
+          ],
+          [
+            3,
+            8
+          ],
+          [
+            5,
+            7
+          ],
+          [
+            6,
+            7
+          ],
+          [
+            6,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 52
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 4,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            3,
+            8
+          ],
+          "right_pair": [
+            6,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            6,
+            8
+          ],
+          "right_pair": [
+            6,
+            7
+          ],
+          "supporting_rows": [
+            6
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            6,
+            7
+          ],
+          "right_pair": [
+            5,
+            7
+          ],
+          "supporting_rows": [
+            7
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            5,
+            7
+          ],
+          "right_pair": [
+            3,
+            5
+          ],
+          "supporting_rows": [
+            5
+          ]
+        }
+      ],
+      "family_id": "F11",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T06-F11-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            3,
+            5
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            3,
+            8
+          ],
+          "outer_span": 2,
+          "row": 1,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ]
+        }
+      ],
+      "template_id": "T06"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 5,
+        "active_pairs": [
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            6
+          ],
+          [
+            4,
+            5
+          ],
+          [
+            5,
+            6
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 52
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 4,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            4
+          ],
+          "right_pair": [
+            4,
+            5
+          ],
+          "supporting_rows": [
+            4
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            4,
+            5
+          ],
+          "right_pair": [
+            5,
+            6
+          ],
+          "supporting_rows": [
+            5
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            5,
+            6
+          ],
+          "right_pair": [
+            2,
+            6
+          ],
+          "supporting_rows": [
+            6
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            2,
+            6
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            2
+          ]
+        }
+      ],
+      "family_id": "F06",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T07-F06-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            4
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            4,
+            7
+          ]
+        }
+      ],
+      "template_id": "T07"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 6,
+        "active_pairs": [
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            1,
+            7
+          ],
+          [
+            2,
+            5
+          ],
+          [
+            5,
+            6
+          ],
+          [
+            6,
+            7
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 203
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 5,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            3
+          ],
+          "right_pair": [
+            1,
+            7
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            7
+          ],
+          "right_pair": [
+            6,
+            7
+          ],
+          "supporting_rows": [
+            7
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            6,
+            7
+          ],
+          "right_pair": [
+            5,
+            6
+          ],
+          "supporting_rows": [
+            6
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            5,
+            6
+          ],
+          "right_pair": [
+            2,
+            5
+          ],
+          "supporting_rows": [
+            5
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            2,
+            5
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            2
+          ]
+        }
+      ],
+      "family_id": "F02",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T08-F02-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            3
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ]
+        }
+      ],
+      "template_id": "T08"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 7,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            4,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 877
+      },
+      "contradiction_type": "strict_self_edge",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 6,
+      "equality_terms": [
+        {
+          "coefficient": -1,
+          "left_pair": [
+            1,
+            3
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            0,
+            8
+          ],
+          "supporting_rows": [
+            0
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            0,
+            8
+          ],
+          "right_pair": [
+            4,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            4,
+            8
+          ],
+          "right_pair": [
+            3,
+            4
+          ],
+          "supporting_rows": [
+            4
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            3,
+            4
+          ],
+          "right_pair": [
+            2,
+            3
+          ],
+          "supporting_rows": [
+            3
+          ]
+        },
+        {
+          "coefficient": -1,
+          "left_pair": [
+            2,
+            3
+          ],
+          "right_pair": [
+            1,
+            2
+          ],
+          "supporting_rows": [
+            2
+          ]
+        }
+      ],
+      "family_id": "F03",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T09-F03-strict-self-edge",
+      "strict_coefficient_sum": 1,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            2
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            3
+          ],
+          "outer_span": 2,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            2,
+            3,
+            8
+          ]
+        }
+      ],
+      "template_id": "T09"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 5,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            0,
+            6
+          ],
+          [
+            1,
+            6
+          ],
+          [
+            3,
+            6
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 52
+      },
+      "contradiction_type": "strict_directed_cycle",
+      "coverage": {
+        "assignment_count": 18,
+        "assignment_ids": [
+          "A020",
+          "A040",
+          "A047",
+          "A071",
+          "A080",
+          "A081",
+          "A083",
+          "A093",
+          "A095",
+          "A111",
+          "A126",
+          "A147",
+          "A151",
+          "A153",
+          "A154",
+          "A157",
+          "A164",
+          "A180"
+        ],
+        "orbit_size_sum": 18
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": 1,
+          "left_pair": [
+            0,
+            3
+          ],
+          "right_pair": [
+            3,
+            6
+          ],
+          "supporting_rows": [
+            3
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            3,
+            6
+          ],
+          "right_pair": [
+            1,
+            6
+          ],
+          "supporting_rows": [
+            6
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            0,
+            6
+          ],
+          "supporting_rows": [
+            0
+          ]
+        }
+      ],
+      "family_id": "F12",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T10-F12-strict-directed-cycle",
+      "strict_coefficient_sum": 2,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            0,
+            3
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            0,
+            6
+          ],
+          "outer_span": 2,
+          "row": 8,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            0,
+            3,
+            6,
+            7
+          ]
+        },
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            0,
+            1
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            6
+          ],
+          "outer_span": 2,
+          "row": 3,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            4,
+            6,
+            0,
+            1
+          ]
+        }
+      ],
+      "template_id": "T10"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 6,
+        "active_pairs": [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            0,
+            3
+          ],
+          [
+            0,
+            5
+          ],
+          [
+            1,
+            5
+          ],
+          [
+            5,
+            7
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 203
+      },
+      "contradiction_type": "strict_directed_cycle",
+      "coverage": {
+        "assignment_count": 6,
+        "assignment_ids": [],
+        "orbit_size_sum": 6
+      },
+      "equality_multiplier_l1": 3,
+      "equality_terms": [
+        {
+          "coefficient": 1,
+          "left_pair": [
+            0,
+            5
+          ],
+          "right_pair": [
+            5,
+            7
+          ],
+          "supporting_rows": [
+            5
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            1,
+            5
+          ],
+          "right_pair": [
+            0,
+            1
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            0,
+            1
+          ],
+          "right_pair": [
+            0,
+            2
+          ],
+          "supporting_rows": [
+            0
+          ]
+        }
+      ],
+      "family_id": "F07",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T11-F07-strict-directed-cycle",
+      "strict_coefficient_sum": 3,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            0,
+            3
+          ],
+          "inner_span": 2,
+          "outer_pair": [
+            0,
+            2
+          ],
+          "outer_span": 3,
+          "row": 1,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            2,
+            3,
+            5,
+            0
+          ]
+        },
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            0,
+            5
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            0,
+            3
+          ],
+          "outer_span": 2,
+          "row": 1,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            2,
+            3,
+            5,
+            0
+          ]
+        },
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            5
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            5,
+            7
+          ],
+          "outer_span": 3,
+          "row": 6,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            7,
+            8,
+            1,
+            5
+          ]
+        }
+      ],
+      "template_id": "T11"
+    },
+    {
+      "active_pair_quotient_check": {
+        "active_pair_count": 7,
+        "active_pairs": [
+          [
+            0,
+            3
+          ],
+          [
+            0,
+            8
+          ],
+          [
+            1,
+            3
+          ],
+          [
+            1,
+            4
+          ],
+          [
+            1,
+            7
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            2,
+            8
+          ]
+        ],
+        "all_quotient_balances_zero": true,
+        "set_partition_count": 877
+      },
+      "contradiction_type": "strict_directed_cycle",
+      "coverage": {
+        "assignment_count": 2,
+        "assignment_ids": [],
+        "orbit_size_sum": 2
+      },
+      "equality_multiplier_l1": 4,
+      "equality_terms": [
+        {
+          "coefficient": 1,
+          "left_pair": [
+            0,
+            8
+          ],
+          "right_pair": [
+            2,
+            8
+          ],
+          "supporting_rows": [
+            8
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            2,
+            4
+          ],
+          "right_pair": [
+            1,
+            4
+          ],
+          "supporting_rows": [
+            4
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            1,
+            4
+          ],
+          "right_pair": [
+            1,
+            7
+          ],
+          "supporting_rows": [
+            1
+          ]
+        },
+        {
+          "coefficient": 1,
+          "left_pair": [
+            1,
+            3
+          ],
+          "right_pair": [
+            0,
+            3
+          ],
+          "supporting_rows": [
+            3
+          ]
+        }
+      ],
+      "family_id": "F16",
+      "identity_balance": [],
+      "identity_verified_zero": true,
+      "positive_circuit_interpretation": "Each strict term is d(outer)-d(inner)>0; equality terms vanish; the displayed exact coefficient identity equals zero.",
+      "skeleton_id": "VC-T12-F16-strict-directed-cycle",
+      "strict_coefficient_sum": 3,
+      "strict_terms": [
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            0,
+            8
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            0,
+            3
+          ],
+          "outer_span": 3,
+          "row": 2,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            3,
+            5,
+            8,
+            0
+          ]
+        },
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            2,
+            4
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            2,
+            8
+          ],
+          "outer_span": 3,
+          "row": 1,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            2,
+            4,
+            7,
+            8
+          ]
+        },
+        {
+          "coefficient": 1,
+          "inner_pair": [
+            1,
+            3
+          ],
+          "inner_span": 1,
+          "outer_pair": [
+            1,
+            7
+          ],
+          "outer_span": 3,
+          "row": 0,
+          "source": "vertex_circle_chord_monotonicity",
+          "witness_order": [
+            1,
+            3,
+            6,
+            7
+          ]
+        }
+      ],
+      "template_id": "T12"
+    }
+  ],
+  "claim_scope": "Exact unit-positive dual identities for the 16 stored n=9 vertex-circle relation skeletons, with transformed-certificate coverage of the 184 review-pending frontier assignments and exhaustive active-variable quotient-coarsening checks; not local-template forcing, not a proof of n=9, not a bridge proof, not a proof of Erdos Problem #97, not a counterexample, and not independent review of the source packets.",
+  "contradiction_type_counts": {
+    "strict_directed_cycle": 3,
+    "strict_self_edge": 13
+  },
+  "covered_assignment_count": 184,
+  "equality_term_count_counts": {
+    "3": 11,
+    "4": 3,
+    "5": 1,
+    "6": 1
+  },
+  "family_count": 16,
+  "interpretation": [
+    "The 16 family certificates use one unit coefficient on every displayed strict edge and signed unit selected-row equality transfers.",
+    "The exact coefficient balance is zero in ordinary pair-distance coordinates, so each record is a positive-circuit contradiction rather than only a quotient-graph picture.",
+    "Every transformed certificate is checked against the compact core of each of the 184 source frontier assignments.",
+    "All set partitions of the active pair variables are enumerated as a defensive check of quotient stability; the general algebraic lemma supplies the proof.",
+    "The packet does not prove that arbitrary or minimal counterexamples contain one of the 16 source skeletons.",
+    "No proof of n=9 or Erdos Problem #97 is claimed."
+  ],
+  "maximum_active_pair_count": 7,
+  "maximum_equality_term_count": 6,
+  "n": 9,
+  "provenance": {
+    "command": "python scripts/check_n9_vertex_circle_template_duals.py --assert-expected --write",
+    "generator": "scripts/check_n9_vertex_circle_template_duals.py"
+  },
+  "quotient_stability_lemma": {
+    "admissible_scope": "coarsenings of ordinary pair-distance variables only; vertices, cyclic-order hypotheses, and strict-edge validity are not quotiented",
+    "proof": "The equality contribution vanishes and the strict contribution is positive, contradicting the zero identity. Applying any variable-identification map to the identity keeps its balance zero; a collapsed strict edge is already 0 > 0.",
+    "statement": "If a finite strict/equality system has an identity sum_i a_i L_i + sum_j b_j E_j = 0 with every a_i > 0, every L_i > 0, and every E_j = 0, then the system is infeasible. Adding equalities or inequalities, or identifying additional ordinary distance variables while retaining the strict constraints, preserves the same certificate."
+  },
+  "schema": "erdos97.n9_vertex_circle_template_duals.v1",
+  "skeleton_count": 16,
+  "source_artifacts": [
+    {
+      "path": "data/certificates/relation_skeleton_catalog.json",
+      "role": "16 canonical relation skeletons and local equality/strict paths",
+      "schema": "erdos97.relation_skeleton_catalog.v1"
+    },
+    {
+      "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+      "role": "184 assignment-to-family maps and compact transformed cores",
+      "schema": "erdos97.n9_vertex_circle_frontier_motif_classification.v1"
+    }
+  ],
+  "status": "REVIEW_PENDING_DIAGNOSTIC_ONLY",
+  "strict_term_count_counts": {
+    "1": 13,
+    "2": 1,
+    "3": 2
+  },
+  "template_count": 12,
+  "total_active_pair_quotient_partitions_checked": 2451,
+  "trust": "REVIEW_PENDING_DIAGNOSTIC"
+}

--- a/docs/n9-vertex-circle-template-duals.md
+++ b/docs/n9-vertex-circle-template-duals.md
@@ -1,0 +1,176 @@
+# n=9 Vertex-Circle Template Dual Certificates
+
+Status: `REVIEW_PENDING_DIAGNOSTIC_ONLY`.
+
+This note consolidates the sixteen stored `n=9` vertex-circle relation
+skeletons into exact positive-circuit identities. It is a proof-mining and
+review artifact. It does not force any skeleton in an arbitrary polygon, does
+not prove `n=9`, does not prove Erdos Problem #97, and does not claim a
+counterexample. The official/global status remains falsifiable/open.
+
+## Result
+
+For every one of the sixteen stored relation skeletons, the checker constructs
+an exact identity
+
+```text
+sum(strict distance differences)
+  + sum(signed selected-row equality differences)
+  = 0.
+```
+
+Every strict term has coefficient `1`. Every equality multiplier is `+1` or
+`-1`. Since each strict term is positive and every selected-row equality term
+vanishes, the identity is an exact `0 > 0` contradiction.
+
+Checked counts:
+
+```text
+relation skeletons:                    16
+local templates:                       12
+dihedral families:                     16
+covered frontier assignments:         184
+
+strict-term counts per certificate:
+  1 term:                              13
+  2 terms:                              1
+  3 terms:                              2
+
+equality-term counts per certificate:
+  3 terms:                             11
+  4 terms:                              3
+  5 terms:                              1
+  6 terms:                              1
+
+maximum active ordinary pair distances: 7
+active-variable quotient partitions:   2451
+```
+
+The checked artifact is
+`data/certificates/n9_vertex_circle_template_duals.json`.
+
+## The dual identity
+
+Write `d_ab` for the ordinary distance between labels `a` and `b`. A stored
+vertex-circle strict edge contributes
+
+```text
+d_outer - d_inner > 0.
+```
+
+A selected row centered at `c` identifies the four distances from `c` to its
+witnesses. An oriented equality-path step therefore contributes
+
+```text
+d_left - d_right = 0.
+```
+
+For a self-edge skeleton, the equality path joins the outer pair to the inner
+pair. Subtracting that path from the one strict inequality gives the zero
+coefficient vector.
+
+For a directed-cycle skeleton, each equality path joins the inner pair of one
+strict edge to the outer pair of the next. Adding the strict edges and the
+oriented connector paths telescopes around the cycle. The result is again the
+zero coefficient vector.
+
+This is the linear-dual form of the quotient self-edge or directed-cycle
+argument. It records the contradiction in the original ordinary pair-distance
+coordinates rather than only displaying the quotient graph.
+
+## Quotient-stability lemma
+
+The packet uses the following elementary lemma.
+
+> If a finite system has an identity
+> `sum_i a_i L_i + sum_j b_j E_j = 0`, where every `a_i > 0`, every
+> `L_i > 0`, and every `E_j = 0`, then the system is infeasible. Adding more
+> constraints or identifying additional variables preserves the certificate,
+> provided the strict constraints remain valid.
+
+The proof is immediate: the equality contribution is zero and the strict
+contribution is positive, contradicting the displayed identity. Applying any
+variable-identification map to the coefficient identity preserves zero
+balance. If a strict edge collapses to one variable, it becomes the immediate
+contradiction `0 > 0`.
+
+Here “quotient” has a deliberately narrow meaning: additional identifications
+among ordinary pair-distance variables. The result does not identify polygon
+vertices, discard cyclic-order hypotheses, or establish new strict edges.
+
+As a defensive computation, the checker enumerates all set partitions of the
+active pair-distance variables in every certificate. There are `2451` such
+partitions in total, and every coarsened coefficient balance remains zero. The
+general algebraic argument above is the proof; the enumeration checks the
+implementation and stored paths.
+
+## Assignment-level replay
+
+The frontier classification maps each of the `184` labelled assignments to
+one canonical dihedral family. The checker inverts each dihedral label map,
+transforms the corresponding family certificate back to the assignment, and
+checks that:
+
+- every transformed strict term is supported by a row in the stored compact
+  assignment core;
+- every transformed equality step is supplied by a stored selected row;
+- the transformed ordinary-distance coefficient vector is exactly zero; and
+- the family/template coverage is disjoint and totals `184` assignments.
+
+The deterministic digest of the complete transformed-certificate replay is:
+
+```text
+c60ce8833bd4b2fa7ad32e2e034091966369a77553614fffc2226dc4a0edf3eb
+```
+
+This is a crosswalk over review-pending source artifacts. It does not
+independently prove frontier coverage or the geometric vertex-circle lemma.
+
+## What this changes
+
+The local obstruction layer is now expressed in the form needed by a
+duality-first or potential-search program:
+
+```text
+local hypotheses -> exact positive circuit -> quotient-stable contradiction.
+```
+
+In particular, a richer equality class cannot repair one of the sixteen
+stored local obstructions. The unresolved bridge is not certificate stability;
+it is proving that minimal-counterexample geometry supplies one of the local
+hypothesis systems, or supplies a different global accumulating potential.
+
+The scalable strict-cycle negative control remains decisive. It shows that the
+current abstract bridge axioms do not force a universally bounded
+vertex-circle certificate or a Kalmanson circuit using at most three
+inequalities. This packet does not evade that control: it consolidates the
+finite `n=9` terminal certificates but does not force them in the scalable
+family.
+
+## Reproduction
+
+Generate and check the artifact:
+
+```bash
+python scripts/check_n9_vertex_circle_template_duals.py \
+  --assert-expected \
+  --write
+
+python scripts/check_n9_vertex_circle_template_duals.py \
+  --check \
+  --assert-expected \
+  --json
+```
+
+Run the focused tests:
+
+```bash
+python -m pytest tests/test_n9_vertex_circle_template_duals.py -q
+```
+
+## Source artifacts
+
+- `data/certificates/relation_skeleton_catalog.json`
+- `data/certificates/n9_vertex_circle_frontier_motif_classification.json`
+- `docs/relation-skeleton-catalog.md`
+- `docs/scalable-strict-cycle-bridge-control.md`

--- a/docs/relation-skeleton-catalog.md
+++ b/docs/relation-skeleton-catalog.md
@@ -247,6 +247,16 @@ strict directed-cycle skeletons map to multi-class descent regions, with the
 same `184` assignment/orbit total. It is packet bookkeeping only, not
 local-lemma completeness, a bridge proof, or an `n=9` proof.
 
+## Exact Dual Follow-up
+
+`docs/n9-vertex-circle-template-duals.md` converts every skeleton into an
+exact positive-circuit identity in ordinary pair-distance coordinates. The
+follow-up checks unit positive strict coefficients, signed unit equality
+transfers, all active-variable quotient coarsenings, and transformed replay
+across the `184` source assignments. It proves certificate stability under
+additional distance equalities only; it does not force a skeleton or promote
+the review-pending `n=9` result.
+
 ## Review Standard
 
 A reviewer should be able to restate each skeleton as a local lemma without

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1697,6 +1697,69 @@ artifacts:
       - motif classification is an independent proof
       - general proof of Erdos Problem #97
 
+  - id: n9_vertex_circle_template_duals
+    path: data/certificates/n9_vertex_circle_template_duals.json
+    sha256: 3223b82598b49214f331167093f259d66c53f88d600c9fc00fbe66faa25f9da0
+    size_bytes: 45024
+    kind: certificate_diagnostic_artifact
+    generator: scripts/check_n9_vertex_circle_template_duals.py
+    command: python scripts/check_n9_vertex_circle_template_duals.py --assert-expected --write
+    checker: scripts/check_n9_vertex_circle_template_duals.py
+    check_command: python scripts/check_n9_vertex_circle_template_duals.py --check --assert-expected --json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust_class: REVIEW_PENDING_DIAGNOSTIC
+    claim_scope: 'Exact unit-positive dual identities for the 16 stored n=9 vertex-circle relation skeletons, with transformed-certificate coverage of the 184 review-pending frontier assignments and exhaustive active-variable quotient-coarsening checks; not local-template forcing, not a proof of n=9, not a bridge proof, not a proof of Erdos Problem #97, not a counterexample, and not independent review of the source packets.'
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.n9_vertex_circle_template_duals.v1
+      status: REVIEW_PENDING_DIAGNOSTIC_ONLY
+      trust: REVIEW_PENDING_DIAGNOSTIC
+      claim_scope: 'Exact unit-positive dual identities for the 16 stored n=9 vertex-circle relation skeletons, with transformed-certificate coverage of the 184 review-pending frontier assignments and exhaustive active-variable quotient-coarsening checks; not local-template forcing, not a proof of n=9, not a bridge proof, not a proof of Erdos Problem #97, not a counterexample, and not independent review of the source packets.'
+      n: 9
+      skeleton_count: 16
+      template_count: 12
+      family_count: 16
+      covered_assignment_count: 184
+      contradiction_type_counts.strict_directed_cycle: 3
+      contradiction_type_counts.strict_self_edge: 13
+      strict_term_count_counts.1: 13
+      strict_term_count_counts.2: 1
+      strict_term_count_counts.3: 2
+      equality_term_count_counts.3: 11
+      equality_term_count_counts.4: 3
+      equality_term_count_counts.5: 1
+      equality_term_count_counts.6: 1
+      active_pair_count_counts.4: 9
+      active_pair_count_counts.5: 3
+      active_pair_count_counts.6: 2
+      active_pair_count_counts.7: 2
+      maximum_equality_term_count: 6
+      maximum_active_pair_count: 7
+      total_active_pair_quotient_partitions_checked: 2451
+      all_strict_coefficients_positive_unit: true
+      all_equality_multipliers_signed_unit: true
+      all_identity_balances_zero: true
+      all_active_pair_quotients_preserve_zero_balance: true
+      assignment_coverage.assignment_count: 184
+      assignment_coverage.unique_assignment_count: 184
+      assignment_coverage.family_count: 16
+      assignment_coverage.template_count: 12
+      assignment_coverage.transformed_certificate_sha256: c60ce8833bd4b2fa7ad32e2e034091966369a77553614fffc2226dc4a0edf3eb
+      assignment_coverage.all_transformed_identities_verified_zero: true
+      assignment_coverage.all_transformed_terms_supported_by_assignment_cores: true
+      assignment_coverage.all_label_maps_verified_dihedral: true
+      provenance.command: python scripts/check_n9_vertex_circle_template_duals.py --assert-expected --write
+    forbidden_claims:
+      - local-template forcing is proved
+      - n=9 is proved
+      - 'bridge proof of Erdos Problem #97'
+      - 'counterexample to Erdos Problem #97'
+      - independent review of the source packets is complete
+      - source-of-truth strongest result
+      - official/global status update
+      - 'general proof of Erdos Problem #97'
+
   - id: n9_vertex_circle_frontier_comparison
     path: data/certificates/n9_vertex_circle_frontier_comparison.json
     sha256: 76074a8001a36600d528db767a0bd643a47becead762e985debfca6e0688ed4c

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -1124,6 +1124,17 @@
       "claim_scope": "Sixteen-entry relation-skeleton catalog for focused n=9 vertex-circle quotient motifs; proof-mining scaffolding only, not a proof of n=9, counterexample, or independent review completion."
     },
     {
+      "id": "n9_vertex_circle_template_duals",
+      "command": [
+        "python",
+        "scripts/check_n9_vertex_circle_template_duals.py",
+        "--check",
+        "--assert-expected",
+        "--json"
+      ],
+      "claim_scope": "Exact unit-positive dual identities for the 16 stored n=9 vertex-circle relation skeletons, transformed replay over 184 review-pending frontier assignments, and quotient-coarsening checks; not local-template forcing, proof of n=9, bridge proof, counterexample, independent review, or official/global status update."
+    },
+    {
       "id": "n9_relation_skeleton_closed_descent_crosswalk",
       "command": [
         "python",

--- a/scripts/check_n9_vertex_circle_template_duals.py
+++ b/scripts/check_n9_vertex_circle_template_duals.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Generate or check exact dual identities for n=9 relation skeletons."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+from erdos97.json_io import write_json  # noqa: E402
+from erdos97.n9_vertex_circle_template_duals import (  # noqa: E402
+    SCHEMA,
+    assert_expected_template_dual_counts,
+    template_dual_payload,
+)
+from erdos97.path_display import display_path  # noqa: E402
+
+
+DEFAULT_RELATION_SKELETONS = (
+    ROOT / "data" / "certificates" / "relation_skeleton_catalog.json"
+)
+DEFAULT_FRONTIER_CLASSIFICATION = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_vertex_circle_frontier_motif_classification.json"
+)
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_template_duals.json"
+)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _summary(path: Path, payload: Any, errors: Sequence[str]) -> dict[str, Any]:
+    record = payload if isinstance(payload, dict) else {}
+    coverage = record.get("assignment_coverage")
+    coverage = coverage if isinstance(coverage, dict) else {}
+    return {
+        "ok": not errors,
+        "artifact": display_path(path, ROOT),
+        "schema": record.get("schema"),
+        "status": record.get("status"),
+        "trust": record.get("trust"),
+        "skeleton_count": record.get("skeleton_count"),
+        "template_count": record.get("template_count"),
+        "family_count": record.get("family_count"),
+        "covered_assignment_count": record.get("covered_assignment_count"),
+        "strict_term_count_counts": record.get("strict_term_count_counts"),
+        "equality_term_count_counts": record.get("equality_term_count_counts"),
+        "maximum_active_pair_count": record.get("maximum_active_pair_count"),
+        "total_active_pair_quotient_partitions_checked": record.get(
+            "total_active_pair_quotient_partitions_checked"
+        ),
+        "transformed_certificate_sha256": coverage.get(
+            "transformed_certificate_sha256"
+        ),
+        "validation_errors": list(errors),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--relation-skeletons",
+        type=Path,
+        default=DEFAULT_RELATION_SKELETONS,
+    )
+    parser.add_argument(
+        "--frontier-classification",
+        type=Path,
+        default=DEFAULT_FRONTIER_CLASSIFICATION,
+    )
+    parser.add_argument("--artifact", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    out = _resolve(args.out)
+    artifact = _resolve(args.artifact) if args.artifact is not None else DEFAULT_ARTIFACT
+    if args.write and args.check:
+        if args.artifact is not None and artifact != out:
+            print(
+                "--write --check requires matching --artifact/--out or omitted --artifact",
+                file=sys.stderr,
+            )
+            return 2
+        artifact = out
+
+    try:
+        relation_skeletons = _load(_resolve(args.relation_skeletons))
+        frontier_classification = _load(_resolve(args.frontier_classification))
+        generated = template_dual_payload(
+            relation_skeletons,
+            frontier_classification,
+        )
+        if args.assert_expected:
+            assert_expected_template_dual_counts(generated)
+    except (AssertionError, KeyError, OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        summary = _summary(artifact, {}, [str(exc)])
+        if args.json:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            print(f"FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        write_json(generated, out)
+        if not args.check:
+            summary = _summary(out, generated, [])
+            if args.json:
+                print(json.dumps(summary, indent=2, sort_keys=True))
+            else:
+                print(f"wrote {display_path(out, ROOT)}")
+            return 0
+
+    payload = generated
+    errors: list[str] = []
+    if args.check:
+        try:
+            payload = _load(artifact)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(str(exc))
+            payload = {}
+        if isinstance(payload, dict):
+            if payload.get("schema") != SCHEMA:
+                errors.append(
+                    f"schema mismatch: expected {SCHEMA!r}, got {payload.get('schema')!r}"
+                )
+            if payload != generated:
+                errors.append("artifact does not match regenerated exact dual payload")
+            if args.assert_expected:
+                try:
+                    assert_expected_template_dual_counts(payload)
+                except (AssertionError, KeyError, TypeError, ValueError) as exc:
+                    errors.append(f"stored expected-count check failed: {exc}")
+        else:
+            errors.append("artifact top level must be an object")
+
+    summary = _summary(artifact if args.check else out, payload, errors)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif errors:
+        for error in errors:
+            print(f"FAILED: {error}", file=sys.stderr)
+    else:
+        print(
+            "OK: exact template duals verified "
+            f"({summary['skeleton_count']} skeletons, "
+            f"{summary['covered_assignment_count']} transformed assignments)"
+        )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/erdos97/n9_vertex_circle_template_duals.py
+++ b/src/erdos97/n9_vertex_circle_template_duals.py
@@ -1,0 +1,753 @@
+"""Exact dual identities for the n=9 vertex-circle relation skeletons.
+
+The source relation-skeleton catalog records strict inequalities between
+ordinary pair distances together with selected-row equality paths.  This
+module turns each stored obstruction into one explicit positive-circuit
+identity
+
+    sum(strict distance differences) + sum(equality differences) = 0.
+
+Every strict coefficient is one.  The equality multipliers are signed unit
+coefficients obtained by orienting the stored equality paths.  The resulting
+identity is an exact Farkas-style contradiction and is preserved when more
+ordinary distance variables are identified.
+
+This is proof-mining support for review-pending local packets.  It does not
+prove that an arbitrary counterexample contains one of the source skeletons.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from hashlib import sha256
+import json
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+
+SCHEMA = "erdos97.n9_vertex_circle_template_duals.v1"
+STATUS = "REVIEW_PENDING_DIAGNOSTIC_ONLY"
+TRUST = "REVIEW_PENDING_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Exact unit-positive dual identities for the 16 stored n=9 vertex-circle "
+    "relation skeletons, with transformed-certificate coverage of the 184 "
+    "review-pending frontier assignments and exhaustive active-variable "
+    "quotient-coarsening checks; not local-template forcing, not a proof of "
+    "n=9, not a bridge proof, not a proof of Erdos Problem #97, not a "
+    "counterexample, and not independent review of the source packets."
+)
+PROVENANCE = {
+    "generator": "scripts/check_n9_vertex_circle_template_duals.py",
+    "command": (
+        "python scripts/check_n9_vertex_circle_template_duals.py "
+        "--assert-expected --write"
+    ),
+}
+
+RELATION_SKELETON_SCHEMA = "erdos97.relation_skeleton_catalog.v1"
+FRONTIER_CLASSIFICATION_SCHEMA = (
+    "erdos97.n9_vertex_circle_frontier_motif_classification.v1"
+)
+
+EXPECTED_N = 9
+EXPECTED_SKELETON_COUNT = 16
+EXPECTED_TEMPLATE_COUNT = 12
+EXPECTED_FAMILY_COUNT = 16
+EXPECTED_ASSIGNMENT_COUNT = 184
+EXPECTED_CONTRADICTION_TYPE_COUNTS = {
+    "strict_directed_cycle": 3,
+    "strict_self_edge": 13,
+}
+EXPECTED_STRICT_TERM_COUNT_COUNTS = {"1": 13, "2": 1, "3": 2}
+EXPECTED_EQUALITY_TERM_COUNT_COUNTS = {"3": 11, "4": 3, "5": 1, "6": 1}
+EXPECTED_ACTIVE_PAIR_COUNT_COUNTS = {"4": 9, "5": 3, "6": 2, "7": 2}
+EXPECTED_MAXIMUM_EQUALITY_TERM_COUNT = 6
+EXPECTED_MAXIMUM_ACTIVE_PAIR_COUNT = 7
+EXPECTED_TOTAL_QUOTIENT_PARTITIONS = 2451
+EXPECTED_TRANSFORMED_CERTIFICATE_SHA256 = (
+    "c60ce8833bd4b2fa7ad32e2e034091966369a77553614fffc2226dc4a0edf3eb"
+)
+
+Pair = tuple[int, int]
+Vector = dict[Pair, int]
+
+
+def _pair(value: Sequence[int]) -> Pair:
+    if len(value) != 2:
+        raise ValueError(f"pair must contain two labels: {value!r}")
+    left, right = (int(value[0]), int(value[1]))
+    if left == right:
+        raise ValueError(f"pair labels must be distinct: {value!r}")
+    if not (0 <= left < EXPECTED_N and 0 <= right < EXPECTED_N):
+        raise ValueError(f"pair label outside 0..{EXPECTED_N - 1}: {value!r}")
+    return (left, right) if left < right else (right, left)
+
+
+def _pair_json(pair: Pair) -> list[int]:
+    return [pair[0], pair[1]]
+
+
+def _selected_rows(skeleton: Mapping[str, Any]) -> tuple[tuple[int, ...], ...]:
+    hypotheses = skeleton.get("hypotheses")
+    if not isinstance(hypotheses, Mapping):
+        raise ValueError("skeleton hypotheses must be an object")
+    raw_rows = hypotheses.get("selected_rows")
+    if not isinstance(raw_rows, list):
+        raise ValueError("skeleton selected_rows must be a list")
+    rows = []
+    for raw_row in raw_rows:
+        if not isinstance(raw_row, list) or len(raw_row) != 5:
+            raise ValueError(f"selected row must contain a center and four witnesses: {raw_row!r}")
+        row = tuple(int(label) for label in raw_row)
+        if len(set(row)) != 5:
+            raise ValueError(f"selected row labels must be distinct: {raw_row!r}")
+        rows.append(row)
+    if len({row[0] for row in rows}) != len(rows):
+        raise ValueError("local skeleton selected-row centers must be distinct")
+    return tuple(rows)
+
+
+def _row_key(row: Sequence[int]) -> tuple[int, tuple[int, ...]]:
+    return int(row[0]), tuple(sorted(int(label) for label in row[1:]))
+
+
+def _row_distance_pairs(row: Sequence[int]) -> set[Pair]:
+    center = int(row[0])
+    return {_pair((center, int(witness))) for witness in row[1:]}
+
+
+def _supporting_rows(
+    rows: Sequence[Sequence[int]],
+    left_pair: Pair,
+    right_pair: Pair,
+) -> tuple[int, ...]:
+    centers = []
+    for row in rows:
+        distances = _row_distance_pairs(row)
+        if left_pair in distances and right_pair in distances:
+            centers.append(int(row[0]))
+    return tuple(sorted(centers))
+
+
+def _add_pair_difference(
+    vector: Vector,
+    left_pair: Pair,
+    right_pair: Pair,
+    coefficient: int,
+) -> None:
+    vector[left_pair] = vector.get(left_pair, 0) + coefficient
+    vector[right_pair] = vector.get(right_pair, 0) - coefficient
+    if vector[left_pair] == 0:
+        del vector[left_pair]
+    if vector.get(right_pair) == 0:
+        vector.pop(right_pair, None)
+
+
+def _strict_edge_index(skeleton: Mapping[str, Any]) -> dict[tuple[Pair, Pair], dict[str, Any]]:
+    relation = skeleton.get("relation_quotient")
+    if not isinstance(relation, Mapping):
+        raise ValueError("skeleton relation_quotient must be an object")
+    raw_edges = relation.get("strict_edges")
+    if not isinstance(raw_edges, list):
+        raise ValueError("skeleton strict_edges must be a list")
+    rows = _selected_rows(skeleton)
+    row_keys = {_row_key(row) for row in rows}
+    index: dict[tuple[Pair, Pair], dict[str, Any]] = {}
+    for raw_edge in raw_edges:
+        if not isinstance(raw_edge, Mapping):
+            raise ValueError("strict edge must be an object")
+        outer_pair = _pair(raw_edge["outer_pair"])
+        inner_pair = _pair(raw_edge["inner_pair"])
+        key = (outer_pair, inner_pair)
+        if key in index:
+            raise ValueError(f"duplicate displayed strict edge: {key!r}")
+        row = int(raw_edge["row"])
+        witness_order = tuple(int(label) for label in raw_edge["witness_order"])
+        if len(witness_order) != 4 or len(set(witness_order)) != 4:
+            raise ValueError("strict-edge witness_order must contain four distinct labels")
+        if (row, tuple(sorted(witness_order))) not in row_keys:
+            raise ValueError("strict edge is not supported by a listed selected row")
+        if not set(outer_pair).issubset(witness_order):
+            raise ValueError("strict outer pair is not contained in witness_order")
+        if not set(inner_pair).issubset(witness_order):
+            raise ValueError("strict inner pair is not contained in witness_order")
+        outer_span = int(raw_edge["outer_span"])
+        inner_span = int(raw_edge["inner_span"])
+        if not (outer_span > inner_span >= 1):
+            raise ValueError("strict edge must have a strictly larger outer span")
+        index[key] = {
+            "row": row,
+            "witness_order": list(witness_order),
+            "outer_span": outer_span,
+            "inner_span": inner_span,
+            "source": str(raw_edge["source"]),
+        }
+    return index
+
+
+def _oriented_chain(
+    raw_chain: Sequence[Sequence[int]],
+    start_pair: Pair,
+    end_pair: Pair,
+) -> tuple[list[Pair], int]:
+    chain = [_pair(raw_pair) for raw_pair in raw_chain]
+    if len(chain) == 1:
+        if chain[0] == start_pair == end_pair:
+            return chain, 1
+        raise ValueError("singleton equality chain must already join identical endpoint pairs")
+    if chain[0] == start_pair and chain[-1] == end_pair:
+        return chain, 1
+    if chain[0] == end_pair and chain[-1] == start_pair:
+        return list(reversed(chain)), -1
+    raise ValueError(
+        f"equality chain endpoints {chain[0]!r}, {chain[-1]!r} do not match "
+        f"{start_pair!r}, {end_pair!r}"
+    )
+
+
+def _strict_term(
+    outer_pair: Pair,
+    inner_pair: Pair,
+    edge_index: Mapping[tuple[Pair, Pair], Mapping[str, Any]],
+) -> dict[str, Any]:
+    metadata = edge_index.get((outer_pair, inner_pair))
+    if metadata is None:
+        raise ValueError(
+            f"displayed strict edge missing for {outer_pair!r} > {inner_pair!r}"
+        )
+    return {
+        "coefficient": 1,
+        "outer_pair": _pair_json(outer_pair),
+        "inner_pair": _pair_json(inner_pair),
+        "row": int(metadata["row"]),
+        "witness_order": list(metadata["witness_order"]),
+        "outer_span": int(metadata["outer_span"]),
+        "inner_span": int(metadata["inner_span"]),
+        "source": str(metadata["source"]),
+    }
+
+
+def _equality_terms_for_chain(
+    chain: Sequence[Pair],
+    coefficient: int,
+    rows: Sequence[Sequence[int]],
+) -> list[dict[str, Any]]:
+    terms = []
+    for left_pair, right_pair in zip(chain, chain[1:]):
+        supporting_rows = _supporting_rows(rows, left_pair, right_pair)
+        if not supporting_rows:
+            raise ValueError(
+                f"equality {left_pair!r} = {right_pair!r} is unsupported by the local rows"
+            )
+        terms.append(
+            {
+                "coefficient": coefficient,
+                "left_pair": _pair_json(left_pair),
+                "right_pair": _pair_json(right_pair),
+                "supporting_rows": list(supporting_rows),
+            }
+        )
+    return terms
+
+
+def _identity_balance(
+    strict_terms: Sequence[Mapping[str, Any]],
+    equality_terms: Sequence[Mapping[str, Any]],
+) -> Vector:
+    vector: Vector = {}
+    for term in strict_terms:
+        _add_pair_difference(
+            vector,
+            _pair(term["outer_pair"]),
+            _pair(term["inner_pair"]),
+            int(term["coefficient"]),
+        )
+    for term in equality_terms:
+        _add_pair_difference(
+            vector,
+            _pair(term["left_pair"]),
+            _pair(term["right_pair"]),
+            int(term["coefficient"]),
+        )
+    return vector
+
+
+def _balance_json(vector: Mapping[Pair, int]) -> list[dict[str, Any]]:
+    return [
+        {"pair": _pair_json(pair), "coefficient": int(vector[pair])}
+        for pair in sorted(vector)
+        if vector[pair]
+    ]
+
+
+def _restricted_growth_partitions(size: int) -> Iterator[tuple[int, ...]]:
+    """Yield every set partition as a restricted-growth block-label tuple."""
+
+    if size < 0:
+        raise ValueError("partition size must be nonnegative")
+    if size == 0:
+        yield ()
+        return
+    labels = [0] * size
+
+    def visit(index: int, maximum: int) -> Iterator[tuple[int, ...]]:
+        if index == size:
+            yield tuple(labels)
+            return
+        for label in range(maximum + 2):
+            labels[index] = label
+            yield from visit(index + 1, max(maximum, label))
+
+    yield from visit(1, 0)
+
+
+def _quotient_partition_check(
+    strict_terms: Sequence[Mapping[str, Any]],
+    equality_terms: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    active_pairs = sorted(
+        {
+            _pair(raw_pair)
+            for term in (*strict_terms, *equality_terms)
+            for raw_pair in (
+                (term["outer_pair"], term["inner_pair"])
+                if "outer_pair" in term
+                else (term["left_pair"], term["right_pair"])
+            )
+        }
+    )
+    pair_index = {pair: index for index, pair in enumerate(active_pairs)}
+    checked = 0
+    for partition in _restricted_growth_partitions(len(active_pairs)):
+        quotient_balance: dict[int, int] = {}
+
+        def add(left: Pair, right: Pair, coefficient: int) -> None:
+            left_block = partition[pair_index[left]]
+            right_block = partition[pair_index[right]]
+            quotient_balance[left_block] = quotient_balance.get(left_block, 0) + coefficient
+            quotient_balance[right_block] = quotient_balance.get(right_block, 0) - coefficient
+
+        for term in strict_terms:
+            add(
+                _pair(term["outer_pair"]),
+                _pair(term["inner_pair"]),
+                int(term["coefficient"]),
+            )
+        for term in equality_terms:
+            add(
+                _pair(term["left_pair"]),
+                _pair(term["right_pair"]),
+                int(term["coefficient"]),
+            )
+        if any(quotient_balance.values()):
+            raise AssertionError("dual identity failed after an active-pair quotient")
+        checked += 1
+    return {
+        "active_pair_count": len(active_pairs),
+        "active_pairs": [_pair_json(pair) for pair in active_pairs],
+        "set_partition_count": checked,
+        "all_quotient_balances_zero": True,
+    }
+
+
+def _self_edge_certificate(skeleton: Mapping[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    conclusion = skeleton.get("conclusion")
+    relation = skeleton.get("relation_quotient")
+    if not isinstance(conclusion, Mapping) or not isinstance(relation, Mapping):
+        raise ValueError("self-edge skeleton conclusion/relation must be objects")
+    outer_pair = _pair(conclusion["strict_from_pair"])
+    inner_pair = _pair(conclusion["strict_to_pair"])
+    raw_chains = relation.get("equality_chains")
+    if not isinstance(raw_chains, list) or len(raw_chains) != 1:
+        raise ValueError("self-edge skeleton must contain one equality chain")
+    chain, orientation = _oriented_chain(raw_chains[0], outer_pair, inner_pair)
+    rows = _selected_rows(skeleton)
+    strict_terms = [_strict_term(outer_pair, inner_pair, _strict_edge_index(skeleton))]
+    equality_terms = _equality_terms_for_chain(chain, -orientation, rows)
+    return strict_terms, equality_terms
+
+
+def _strict_cycle_certificate(skeleton: Mapping[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    conclusion = skeleton.get("conclusion")
+    if not isinstance(conclusion, Mapping):
+        raise ValueError("strict-cycle skeleton conclusion must be an object")
+    raw_steps = conclusion.get("quotient_cycle")
+    if not isinstance(raw_steps, list) or len(raw_steps) < 2:
+        raise ValueError("strict-cycle skeleton must contain at least two cycle steps")
+    edge_index = _strict_edge_index(skeleton)
+    rows = _selected_rows(skeleton)
+    strict_terms: list[dict[str, Any]] = []
+    equality_terms: list[dict[str, Any]] = []
+    strict_from_pairs = [_pair(step["strict_from_pair"]) for step in raw_steps]
+    for index, raw_step in enumerate(raw_steps):
+        if not isinstance(raw_step, Mapping):
+            raise ValueError("strict-cycle step must be an object")
+        outer_pair = strict_from_pairs[index]
+        inner_pair = _pair(raw_step["strict_to_pair"])
+        next_outer_pair = _pair(raw_step["next_outer_pair"])
+        if next_outer_pair != strict_from_pairs[(index + 1) % len(raw_steps)]:
+            raise ValueError("strict-cycle next_outer_pair does not match the next strict edge")
+        chain, orientation = _oriented_chain(
+            raw_step["equality_chain_to_next_outer_pair"],
+            inner_pair,
+            next_outer_pair,
+        )
+        strict_terms.append(_strict_term(outer_pair, inner_pair, edge_index))
+        equality_terms.extend(_equality_terms_for_chain(chain, orientation, rows))
+    return strict_terms, equality_terms
+
+
+def _certificate_record(skeleton: Mapping[str, Any]) -> dict[str, Any]:
+    contradiction_type = str(skeleton["contradiction_type"])
+    if contradiction_type == "strict_self_edge":
+        strict_terms, equality_terms = _self_edge_certificate(skeleton)
+    elif contradiction_type == "strict_directed_cycle":
+        strict_terms, equality_terms = _strict_cycle_certificate(skeleton)
+    else:
+        raise ValueError(f"unsupported contradiction type: {contradiction_type!r}")
+    balance = _identity_balance(strict_terms, equality_terms)
+    if balance:
+        raise AssertionError(
+            f"{skeleton['skeleton_id']} dual identity does not cancel: {balance!r}"
+        )
+    if any(int(term["coefficient"]) <= 0 for term in strict_terms):
+        raise AssertionError("every strict dual coefficient must be positive")
+    if any(abs(int(term["coefficient"])) != 1 for term in equality_terms):
+        raise AssertionError("every equality multiplier must be signed unit")
+    quotient_check = _quotient_partition_check(strict_terms, equality_terms)
+    coverage = skeleton.get("coverage")
+    if not isinstance(coverage, Mapping):
+        raise ValueError("skeleton coverage must be an object")
+    return {
+        "skeleton_id": str(skeleton["skeleton_id"]),
+        "template_id": str(skeleton["source_template_id"]),
+        "family_id": str(skeleton["source_family_id"]),
+        "contradiction_type": contradiction_type,
+        "coverage": {
+            "assignment_count": int(coverage["assignment_count"]),
+            "assignment_ids": [str(item) for item in coverage.get("assignment_ids", [])],
+            "orbit_size_sum": int(coverage["orbit_size_sum"]),
+        },
+        "strict_terms": strict_terms,
+        "equality_terms": equality_terms,
+        "identity_balance": _balance_json(balance),
+        "identity_verified_zero": True,
+        "strict_coefficient_sum": sum(int(term["coefficient"]) for term in strict_terms),
+        "equality_multiplier_l1": sum(abs(int(term["coefficient"])) for term in equality_terms),
+        "positive_circuit_interpretation": (
+            "Each strict term is d(outer)-d(inner)>0; equality terms vanish; "
+            "the displayed exact coefficient identity equals zero."
+        ),
+        "active_pair_quotient_check": quotient_check,
+    }
+
+
+def _is_dihedral_label_map(label_map: Sequence[int]) -> bool:
+    if sorted(int(label) for label in label_map) != list(range(EXPECTED_N)):
+        return False
+    step = (int(label_map[1]) - int(label_map[0])) % EXPECTED_N
+    if step not in {1, EXPECTED_N - 1}:
+        return False
+    return all(
+        int(label_map[index]) % EXPECTED_N
+        == (int(label_map[0]) + step * index) % EXPECTED_N
+        for index in range(EXPECTED_N)
+    )
+
+
+def _inverse_label_map(to_canonical: Sequence[int]) -> tuple[int, ...]:
+    if not _is_dihedral_label_map(to_canonical):
+        raise ValueError("assignment-to-canonical label map must be dihedral")
+    inverse = [0] * EXPECTED_N
+    for assignment_label, canonical_label in enumerate(to_canonical):
+        inverse[int(canonical_label)] = assignment_label
+    return tuple(inverse)
+
+
+def _map_pair(pair: Pair, label_map: Sequence[int]) -> Pair:
+    return _pair((int(label_map[pair[0]]), int(label_map[pair[1]])))
+
+
+def _mapped_certificate_digest_record(
+    assignment: Mapping[str, Any],
+    certificate: Mapping[str, Any],
+) -> dict[str, Any]:
+    inverse = _inverse_label_map(assignment["to_canonical_label_map"])
+    raw_core_rows = assignment.get("core_selected_rows")
+    if not isinstance(raw_core_rows, list):
+        raise ValueError("assignment core_selected_rows must be a list")
+    core_row_keys = {_row_key(row) for row in raw_core_rows}
+    transformed_strict_terms = []
+    for term in certificate["strict_terms"]:
+        row = inverse[int(term["row"])]
+        witness_order = [inverse[int(label)] for label in term["witness_order"]]
+        if (row, tuple(sorted(witness_order))) not in core_row_keys:
+            raise ValueError("transformed strict term is not supported by the assignment core")
+        transformed_strict_terms.append(
+            {
+                "coefficient": int(term["coefficient"]),
+                "outer_pair": _pair_json(_map_pair(_pair(term["outer_pair"]), inverse)),
+                "inner_pair": _pair_json(_map_pair(_pair(term["inner_pair"]), inverse)),
+                "row": row,
+            }
+        )
+    transformed_equality_terms = []
+    core_rows = [tuple(int(label) for label in row) for row in raw_core_rows]
+    for term in certificate["equality_terms"]:
+        left_pair = _map_pair(_pair(term["left_pair"]), inverse)
+        right_pair = _map_pair(_pair(term["right_pair"]), inverse)
+        supporting_rows = _supporting_rows(core_rows, left_pair, right_pair)
+        if not supporting_rows:
+            raise ValueError("transformed equality term is not supported by the assignment core")
+        transformed_equality_terms.append(
+            {
+                "coefficient": int(term["coefficient"]),
+                "left_pair": _pair_json(left_pair),
+                "right_pair": _pair_json(right_pair),
+                "supporting_rows": list(supporting_rows),
+            }
+        )
+    if _identity_balance(transformed_strict_terms, transformed_equality_terms):
+        raise AssertionError("transformed assignment dual identity does not cancel")
+    return {
+        "assignment_id": str(assignment["assignment_id"]),
+        "family_id": str(assignment["family_id"]),
+        "template_id": str(assignment["template_id"]),
+        "skeleton_id": str(certificate["skeleton_id"]),
+        "strict_terms": transformed_strict_terms,
+        "equality_terms": transformed_equality_terms,
+    }
+
+
+def _assignment_coverage(
+    classification_payload: Mapping[str, Any],
+    certificates: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    raw_assignments = classification_payload.get("assignments")
+    if not isinstance(raw_assignments, list):
+        raise ValueError("frontier classification assignments must be a list")
+    by_family = {str(certificate["family_id"]): certificate for certificate in certificates}
+    if len(by_family) != len(certificates):
+        raise ValueError("template-dual certificates must have unique family ids")
+    records = []
+    family_counts: Counter[str] = Counter()
+    template_counts: Counter[str] = Counter()
+    seen_ids: set[str] = set()
+    for raw_assignment in raw_assignments:
+        if not isinstance(raw_assignment, Mapping):
+            raise ValueError("frontier classification assignment must be an object")
+        assignment_id = str(raw_assignment["assignment_id"])
+        if assignment_id in seen_ids:
+            raise ValueError(f"duplicate assignment id: {assignment_id}")
+        seen_ids.add(assignment_id)
+        family_id = str(raw_assignment["family_id"])
+        certificate = by_family.get(family_id)
+        if certificate is None:
+            raise ValueError(f"no dual certificate for assignment family {family_id}")
+        if str(raw_assignment["template_id"]) != str(certificate["template_id"]):
+            raise ValueError(f"{assignment_id} template/family dual mismatch")
+        source_assignment_ids = certificate["coverage"]["assignment_ids"]
+        if source_assignment_ids and assignment_id not in source_assignment_ids:
+            raise ValueError(f"{assignment_id} absent from source skeleton coverage")
+        records.append(_mapped_certificate_digest_record(raw_assignment, certificate))
+        family_counts[family_id] += 1
+        template_counts[str(raw_assignment["template_id"])] += 1
+    for family_id, certificate in by_family.items():
+        expected_count = int(certificate["coverage"]["assignment_count"])
+        if family_counts[family_id] != expected_count:
+            raise ValueError(
+                f"{family_id} assignment coverage mismatch: "
+                f"expected {expected_count}, got {family_counts[family_id]}"
+            )
+    records.sort(key=lambda record: record["assignment_id"])
+    encoded = json.dumps(records, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return {
+        "assignment_count": len(records),
+        "unique_assignment_count": len(seen_ids),
+        "family_count": len(family_counts),
+        "template_count": len(template_counts),
+        "family_assignment_counts": dict(sorted(family_counts.items())),
+        "template_assignment_counts": dict(sorted(template_counts.items())),
+        "transformed_certificate_sha256": sha256(encoded).hexdigest(),
+        "all_transformed_identities_verified_zero": True,
+        "all_transformed_terms_supported_by_assignment_cores": True,
+        "all_label_maps_verified_dihedral": True,
+    }
+
+
+def _json_counter(values: Iterable[int | str]) -> dict[str, int]:
+    counts = Counter(str(value) for value in values)
+    return {key: int(counts[key]) for key in sorted(counts, key=lambda item: (len(item), item))}
+
+
+def template_dual_payload(
+    relation_skeleton_payload: Mapping[str, Any],
+    frontier_classification_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the exact template-dual certificate packet."""
+
+    if relation_skeleton_payload.get("schema") != RELATION_SKELETON_SCHEMA:
+        raise ValueError("unexpected relation-skeleton catalog schema")
+    if frontier_classification_payload.get("schema") != FRONTIER_CLASSIFICATION_SCHEMA:
+        raise ValueError("unexpected frontier-classification schema")
+    raw_skeletons = relation_skeleton_payload.get("skeletons")
+    if not isinstance(raw_skeletons, list):
+        raise ValueError("relation-skeleton catalog must contain skeletons")
+    certificates = sorted(
+        (_certificate_record(skeleton) for skeleton in raw_skeletons),
+        key=lambda record: str(record["skeleton_id"]),
+    )
+    assignment_coverage = _assignment_coverage(
+        frontier_classification_payload,
+        certificates,
+    )
+    contradiction_type_counts = _json_counter(
+        str(certificate["contradiction_type"]) for certificate in certificates
+    )
+    strict_term_count_counts = _json_counter(
+        len(certificate["strict_terms"]) for certificate in certificates
+    )
+    equality_term_count_counts = _json_counter(
+        len(certificate["equality_terms"]) for certificate in certificates
+    )
+    active_pair_count_counts = _json_counter(
+        int(certificate["active_pair_quotient_check"]["active_pair_count"])
+        for certificate in certificates
+    )
+    payload = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": EXPECTED_N,
+        "skeleton_count": len(certificates),
+        "template_count": len({str(record["template_id"]) for record in certificates}),
+        "family_count": len({str(record["family_id"]) for record in certificates}),
+        "covered_assignment_count": int(assignment_coverage["assignment_count"]),
+        "contradiction_type_counts": contradiction_type_counts,
+        "strict_term_count_counts": strict_term_count_counts,
+        "equality_term_count_counts": equality_term_count_counts,
+        "active_pair_count_counts": active_pair_count_counts,
+        "maximum_equality_term_count": max(
+            len(certificate["equality_terms"]) for certificate in certificates
+        ),
+        "maximum_active_pair_count": max(
+            int(certificate["active_pair_quotient_check"]["active_pair_count"])
+            for certificate in certificates
+        ),
+        "total_active_pair_quotient_partitions_checked": sum(
+            int(certificate["active_pair_quotient_check"]["set_partition_count"])
+            for certificate in certificates
+        ),
+        "all_strict_coefficients_positive_unit": all(
+            int(term["coefficient"]) == 1
+            for certificate in certificates
+            for term in certificate["strict_terms"]
+        ),
+        "all_equality_multipliers_signed_unit": all(
+            abs(int(term["coefficient"])) == 1
+            for certificate in certificates
+            for term in certificate["equality_terms"]
+        ),
+        "all_identity_balances_zero": all(
+            certificate["identity_verified_zero"] for certificate in certificates
+        ),
+        "all_active_pair_quotients_preserve_zero_balance": all(
+            certificate["active_pair_quotient_check"]["all_quotient_balances_zero"]
+            for certificate in certificates
+        ),
+        "quotient_stability_lemma": {
+            "statement": (
+                "If a finite strict/equality system has an identity sum_i "
+                "a_i L_i + sum_j b_j E_j = 0 with every a_i > 0, every "
+                "L_i > 0, and every E_j = 0, then the system is infeasible. "
+                "Adding equalities or inequalities, or identifying additional "
+                "ordinary distance variables while retaining the strict "
+                "constraints, preserves the same certificate."
+            ),
+            "proof": (
+                "The equality contribution vanishes and the strict contribution "
+                "is positive, contradicting the zero identity. Applying any "
+                "variable-identification map to the identity keeps its balance "
+                "zero; a collapsed strict edge is already 0 > 0."
+            ),
+            "admissible_scope": (
+                "coarsenings of ordinary pair-distance variables only; vertices, "
+                "cyclic-order hypotheses, and strict-edge validity are not quotiented"
+            ),
+        },
+        "certificates": certificates,
+        "assignment_coverage": assignment_coverage,
+        "interpretation": [
+            "The 16 family certificates use one unit coefficient on every displayed strict edge and signed unit selected-row equality transfers.",
+            "The exact coefficient balance is zero in ordinary pair-distance coordinates, so each record is a positive-circuit contradiction rather than only a quotient-graph picture.",
+            "Every transformed certificate is checked against the compact core of each of the 184 source frontier assignments.",
+            "All set partitions of the active pair variables are enumerated as a defensive check of quotient stability; the general algebraic lemma supplies the proof.",
+            "The packet does not prove that arbitrary or minimal counterexamples contain one of the 16 source skeletons.",
+            "No proof of n=9 or Erdos Problem #97 is claimed.",
+        ],
+        "source_artifacts": [
+            {
+                "path": "data/certificates/relation_skeleton_catalog.json",
+                "schema": relation_skeleton_payload.get("schema"),
+                "role": "16 canonical relation skeletons and local equality/strict paths",
+            },
+            {
+                "path": "data/certificates/n9_vertex_circle_frontier_motif_classification.json",
+                "schema": frontier_classification_payload.get("schema"),
+                "role": "184 assignment-to-family maps and compact transformed cores",
+            },
+        ],
+        "provenance": PROVENANCE,
+    }
+    assert_expected_template_dual_counts(payload)
+    return payload
+
+
+def assert_expected_template_dual_counts(payload: Mapping[str, Any]) -> None:
+    """Assert stable headline and exact-certificate invariants."""
+
+    expected_scalars = {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "n": EXPECTED_N,
+        "skeleton_count": EXPECTED_SKELETON_COUNT,
+        "template_count": EXPECTED_TEMPLATE_COUNT,
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "covered_assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "contradiction_type_counts": EXPECTED_CONTRADICTION_TYPE_COUNTS,
+        "strict_term_count_counts": EXPECTED_STRICT_TERM_COUNT_COUNTS,
+        "equality_term_count_counts": EXPECTED_EQUALITY_TERM_COUNT_COUNTS,
+        "active_pair_count_counts": EXPECTED_ACTIVE_PAIR_COUNT_COUNTS,
+        "maximum_equality_term_count": EXPECTED_MAXIMUM_EQUALITY_TERM_COUNT,
+        "maximum_active_pair_count": EXPECTED_MAXIMUM_ACTIVE_PAIR_COUNT,
+        "total_active_pair_quotient_partitions_checked": EXPECTED_TOTAL_QUOTIENT_PARTITIONS,
+        "all_strict_coefficients_positive_unit": True,
+        "all_equality_multipliers_signed_unit": True,
+        "all_identity_balances_zero": True,
+        "all_active_pair_quotients_preserve_zero_balance": True,
+    }
+    for key, expected in expected_scalars.items():
+        if payload.get(key) != expected:
+            raise AssertionError(
+                f"unexpected {key}: expected {expected!r}, got {payload.get(key)!r}"
+            )
+    coverage = payload.get("assignment_coverage")
+    if not isinstance(coverage, Mapping):
+        raise AssertionError("assignment_coverage must be an object")
+    for key, expected in {
+        "assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "unique_assignment_count": EXPECTED_ASSIGNMENT_COUNT,
+        "family_count": EXPECTED_FAMILY_COUNT,
+        "template_count": EXPECTED_TEMPLATE_COUNT,
+        "all_transformed_identities_verified_zero": True,
+        "all_transformed_terms_supported_by_assignment_cores": True,
+        "all_label_maps_verified_dihedral": True,
+        "transformed_certificate_sha256": EXPECTED_TRANSFORMED_CERTIFICATE_SHA256,
+    }.items():
+        if coverage.get(key) != expected:
+            raise AssertionError(
+                f"unexpected assignment_coverage.{key}: "
+                f"expected {expected!r}, got {coverage.get(key)!r}"
+            )

--- a/tests/test_n9_vertex_circle_template_duals.py
+++ b/tests/test_n9_vertex_circle_template_duals.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from erdos97.n9_vertex_circle_template_duals import (
+    EXPECTED_ASSIGNMENT_COUNT,
+    EXPECTED_FAMILY_COUNT,
+    EXPECTED_SKELETON_COUNT,
+    EXPECTED_TEMPLATE_COUNT,
+    assert_expected_template_dual_counts,
+    template_dual_payload,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RELATION_SKELETONS = (
+    ROOT / "data" / "certificates" / "relation_skeleton_catalog.json"
+)
+FRONTIER_CLASSIFICATION = (
+    ROOT
+    / "data"
+    / "certificates"
+    / "n9_vertex_circle_frontier_motif_classification.json"
+)
+ARTIFACT = (
+    ROOT / "data" / "certificates" / "n9_vertex_circle_template_duals.json"
+)
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _generated() -> dict[str, object]:
+    return template_dual_payload(
+        _load(RELATION_SKELETONS),
+        _load(FRONTIER_CLASSIFICATION),
+    )
+
+
+def test_stored_template_duals_match_regeneration() -> None:
+    generated = _generated()
+    assert_expected_template_dual_counts(generated)
+    assert _load(ARTIFACT) == generated
+
+
+def test_all_dual_identities_are_positive_and_quotient_stable() -> None:
+    payload = _generated()
+    assert payload["skeleton_count"] == EXPECTED_SKELETON_COUNT
+    assert payload["template_count"] == EXPECTED_TEMPLATE_COUNT
+    assert payload["family_count"] == EXPECTED_FAMILY_COUNT
+    assert payload["covered_assignment_count"] == EXPECTED_ASSIGNMENT_COUNT
+    assert payload["all_strict_coefficients_positive_unit"] is True
+    assert payload["all_equality_multipliers_signed_unit"] is True
+    assert payload["all_identity_balances_zero"] is True
+    assert payload["all_active_pair_quotients_preserve_zero_balance"] is True
+    assert payload["total_active_pair_quotient_partitions_checked"] == 2451
+
+    certificates = payload["certificates"]
+    assert isinstance(certificates, list)
+    assert all(certificate["identity_balance"] == [] for certificate in certificates)
+    assert all(
+        certificate["active_pair_quotient_check"]["all_quotient_balances_zero"]
+        for certificate in certificates
+    )
+
+
+def test_all_transformed_frontier_certificates_replay() -> None:
+    coverage = _generated()["assignment_coverage"]
+    assert coverage["assignment_count"] == EXPECTED_ASSIGNMENT_COUNT
+    assert coverage["unique_assignment_count"] == EXPECTED_ASSIGNMENT_COUNT
+    assert coverage["all_transformed_identities_verified_zero"] is True
+    assert coverage["all_transformed_terms_supported_by_assignment_cores"] is True
+    assert coverage["all_label_maps_verified_dihedral"] is True
+    assert coverage["transformed_certificate_sha256"] == (
+        "c60ce8833bd4b2fa7ad32e2e034091966369a77553614fffc2226dc4a0edf3eb"
+    )


### PR DESCRIPTION
## What

- add exact unit-positive dual identities for the 16 stored n=9 vertex-circle relation skeletons
- replay all 184 review-pending frontier assignments through the transformed certificates
- check 2,451 active-variable quotient partitions
- add a committed JSON certificate, checker, focused tests, documentation, and audit-registry entry

## Why

This turns the article-inspired idea—machine-checkable proof objects plus independent replay—into a concrete repo-local diagnostic for the existing relation-skeleton packet.

## Scope and impact

The artifact is explicitly `REVIEW_PENDING_DIAGNOSTIC_ONLY`. It establishes stability of these stored positive-circuit identities under additional distance equalities. It does **not** force any skeleton, prove the n=9 case, prove Erdős Problem #97, provide a counterexample, complete independent review, or update the official/global status.

Certificate digest: `c60ce8833bd4b2fa7ad32e2e034091966369a77553614fffc2226dc4a0edf3eb`.

## Verification

- `python scripts/check_n9_vertex_circle_template_duals.py --check --assert-expected --json`
- `python -m pytest -q tests/test_n9_vertex_circle_template_duals.py` (3 passed)
- `python scripts/check_text_clean.py`
- `python scripts/check_status_consistency.py`
- `python scripts/check_artifact_provenance.py`
- `python scripts/generate_makefile_verify_targets.py --check`
- `python -m ruff check .`
- `git diff --check`

The broader artifact tier and adjusted default test suite were also run before isolating the publish branch; all functional checks passed.