### PR TITLE
Add fragile-cycle quotient hierarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ verify-bridge-frontier:
 	$(PYTHON) scripts/check_rigid_n15_shortest_side_grid.py --artifact data/certificates/rigid_n15_shortest_side_grid.json --check --assert-expected --json
 	$(PYTHON) scripts/check_n9_fragile_turn_pivot_crosswalk.py --check --assert-expected --summary-json
 	$(PYTHON) scripts/check_fragile_turn_pivot_guardrail.py --check --assert-expected --summary-json
+	$(PYTHON) scripts/check_fragile_cycle_quotient_hierarchy.py --check --assert-expected --summary-json
 	$(PYTHON) scripts/check_adjacent_closest_pair_nonagon_barrier.py --check --summary-json
 	$(PYTHON) scripts/check_brp_boundary_probe.py --check --assert-expected --json
 	$(PYTHON) scripts/check_four_c3_generic_orbit_obstruction.py --assert-expected --json

--- a/data/certificates/fragile_cycle_quotient_hierarchy.json
+++ b/data/certificates/fragile_cycle_quotient_hierarchy.json
@@ -1,0 +1,1138 @@
+{
+  "claim_scope": "Exact admissible-role-quotient classification for three stored convex certificate templates: the n=9 equilateral hinge, the fixed-order Z/16 marked-three-cycle inverse pair, and the scalable-family k=8 four-row circuit. The classification proves only certificate pushforward for these local templates. It does not force a template in an arbitrary counterexample, does not close a fragile-cycle bridge, does not prove n=9 or any arbitrary-size case, does not claim a Euclidean realization or counterexample, and does not update the official/global status of Erdos Problem #97.",
+  "conclusion": "The retained one-, two-, and four-inequality certificate templates are stable under every enumerated admissible role quotient. The hinge and Z/16 inverse templates are role-rigid under the stated marked-order rules. The scalable k=8 four-row template has exactly two nontrivial seven-role quotients, obtained by identifying roles 18 with 23 or roles 23 with 27. This is quotient-closed proof-mining evidence only; the missing bridge must still force one of the certificate templates or a separate geometric alternative.",
+  "hierarchy_definition": {
+    "admissibility": [
+      "each strict Kalmanson quadrilateral remains injective",
+      "each retained equal-distance pair remains a nonloop",
+      "all marked quadrilateral orders fit one target cyclic order"
+    ],
+    "coordinates": [
+      "strict_inequality_support",
+      "selected_center_support",
+      "admissible_role_quotient_vertex_count"
+    ],
+    "levels": [
+      1,
+      2,
+      4
+    ],
+    "pushforward_principle": "Merging role and distance classes sums source quotient coefficients. A nonnegative combination that is coordinatewise nonpositive remains so after every admissible quotient."
+  },
+  "limitations": [
+    "The three templates are benchmarks, not a complete fragile-cycle catalogue.",
+    "Unused halo roles are forgotten; the artifact classifies quotients only of the retained certificate support.",
+    "Admissibility preserves marked strict-quadrilateral order but does not assert Euclidean realizability.",
+    "The scalable k=8 minimality statement depends on the separately checked all-k inverse/three-row controls.",
+    "No arbitrary counterexample is proved to contain any template in this hierarchy.",
+    "No proof, counterexample, n=9 promotion, or official/global status update is claimed."
+  ],
+  "provenance": {
+    "command": "python scripts/check_fragile_cycle_quotient_hierarchy.py --write --assert-expected",
+    "generator": "scripts/check_fragile_cycle_quotient_hierarchy.py"
+  },
+  "schema": "erdos97.fragile_cycle_quotient_hierarchy.v1",
+  "status": "EXACT_BRIDGE_TEMPLATE_DIAGNOSTIC",
+  "summary": {
+    "admissible_ordered_quotient_count": 7,
+    "admissible_partition_count": 5,
+    "all_quotient_certificates_zero_sum": true,
+    "nontrivial_admissible_partition_count": 2,
+    "quotient_catalog_sha256": "58ad9b77ab1b71d2e9178a3b4faa572e46c2b253ed5f9b68eca6f5b18e8218b6",
+    "strict_support_levels": [
+      1,
+      2,
+      4
+    ],
+    "template_count": 3
+  },
+  "templates": [
+    {
+      "admissible_vertex_count_histogram": {
+        "4": 1
+      },
+      "context": "The arbitrary-size local hinge extracted from all 184 review-pending n=9 frontier assignments.",
+      "equality_groups": [
+        [
+          [
+            0,
+            1
+          ],
+          [
+            0,
+            2
+          ],
+          [
+            1,
+            2
+          ]
+        ],
+        [
+          [
+            0,
+            3
+          ],
+          [
+            1,
+            3
+          ]
+        ]
+      ],
+      "formal_labels": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "identity_certificate": {
+        "combined_nonzero_coefficient_count": 0,
+        "combined_positive_coefficient_count": 0,
+        "cyclic_order_verified": true,
+        "mapped_equality_groups": [
+          [
+            [
+              0,
+              1
+            ],
+            [
+              0,
+              2
+            ],
+            [
+              1,
+              2
+            ]
+          ],
+          [
+            [
+              0,
+              3
+            ],
+            [
+              1,
+              3
+            ]
+          ]
+        ],
+        "nonpositive_sum_verified": true,
+        "strict_rows": [
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "weight": 1
+          }
+        ],
+        "zero_sum_verified": true
+      },
+      "name": "n9_equilateral_hinge",
+      "partition_accounting": {
+        "admissible_ordered_quotients": 1,
+        "admissible_partitions": 1,
+        "nontrivial_admissible_partitions": 0,
+        "partitions_considered": 15,
+        "rejected_cyclic_order_incompatibility": 0,
+        "rejected_equality_pair_loop": 0,
+        "rejected_strict_quad_collision": 14
+      },
+      "quotients": [
+        {
+          "canonical_cyclic_order": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "certificate": {
+            "combined_nonzero_coefficient_count": 0,
+            "combined_positive_coefficient_count": 0,
+            "cyclic_order_verified": true,
+            "mapped_equality_groups": [
+              [
+                [
+                  0,
+                  1
+                ],
+                [
+                  0,
+                  2
+                ],
+                [
+                  1,
+                  2
+                ]
+              ],
+              [
+                [
+                  0,
+                  3
+                ],
+                [
+                  1,
+                  3
+                ]
+              ]
+            ],
+            "nonpositive_sum_verified": true,
+            "strict_rows": [
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "weight": 1
+              }
+            ],
+            "zero_sum_verified": true
+          },
+          "compatible_cyclic_order_count": 1,
+          "partition": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "role_blocks": [
+            [
+              0
+            ],
+            [
+              1
+            ],
+            [
+              2
+            ],
+            [
+              3
+            ]
+          ],
+          "vertex_count": 4
+        }
+      ],
+      "selected_center_support": 3,
+      "selected_centers": [
+        0,
+        1,
+        3
+      ],
+      "strict_inequality_support": 1,
+      "strict_rows": [
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "weight": 1
+        }
+      ],
+      "support_minimality": {
+        "evidence": "One strict Kalmanson row reduces to zero after the three retained rich-pair equalities.",
+        "status": "tautologically_minimal_positive_support",
+        "strict_inequality_count": 1
+      }
+    },
+    {
+      "admissible_vertex_count_histogram": {
+        "5": 1
+      },
+      "context": "The exact fixed-order Kalmanson inverse pair rejecting the Z/16 fragile/turn/pivot marked-three-cycle guardrail.",
+      "equality_groups": [
+        [
+          [
+            0,
+            7
+          ],
+          [
+            7,
+            9
+          ]
+        ],
+        [
+          [
+            0,
+            9
+          ],
+          [
+            0,
+            13
+          ]
+        ],
+        [
+          [
+            3,
+            13
+          ],
+          [
+            0,
+            3
+          ]
+        ]
+      ],
+      "formal_labels": [
+        0,
+        3,
+        7,
+        9,
+        13
+      ],
+      "identity_certificate": {
+        "combined_nonzero_coefficient_count": 0,
+        "combined_positive_coefficient_count": 0,
+        "cyclic_order_verified": true,
+        "mapped_equality_groups": [
+          [
+            [
+              0,
+              2
+            ],
+            [
+              2,
+              3
+            ]
+          ],
+          [
+            [
+              0,
+              3
+            ],
+            [
+              0,
+              4
+            ]
+          ],
+          [
+            [
+              1,
+              4
+            ],
+            [
+              0,
+              1
+            ]
+          ]
+        ],
+        "nonpositive_sum_verified": true,
+        "strict_rows": [
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              1,
+              3,
+              4
+            ],
+            "weight": 1
+          }
+        ],
+        "zero_sum_verified": true
+      },
+      "name": "z16_marked_three_cycle_inverse",
+      "one_row_fixed_order_scan": {
+        "nonpositive_row_count": 0,
+        "one_row_certificate_absent": true,
+        "strict_rows_checked": 3640,
+        "zero_sum_row_count": 0
+      },
+      "partition_accounting": {
+        "admissible_ordered_quotients": 1,
+        "admissible_partitions": 1,
+        "nontrivial_admissible_partitions": 0,
+        "partitions_considered": 52,
+        "rejected_cyclic_order_incompatibility": 1,
+        "rejected_equality_pair_loop": 0,
+        "rejected_strict_quad_collision": 50
+      },
+      "quotients": [
+        {
+          "canonical_cyclic_order": [
+            0,
+            1,
+            2,
+            3,
+            4
+          ],
+          "certificate": {
+            "combined_nonzero_coefficient_count": 0,
+            "combined_positive_coefficient_count": 0,
+            "cyclic_order_verified": true,
+            "mapped_equality_groups": [
+              [
+                [
+                  0,
+                  2
+                ],
+                [
+                  2,
+                  3
+                ]
+              ],
+              [
+                [
+                  0,
+                  3
+                ],
+                [
+                  0,
+                  4
+                ]
+              ],
+              [
+                [
+                  1,
+                  4
+                ],
+                [
+                  0,
+                  1
+                ]
+              ]
+            ],
+            "nonpositive_sum_verified": true,
+            "strict_rows": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  1,
+                  3,
+                  4
+                ],
+                "weight": 1
+              }
+            ],
+            "zero_sum_verified": true
+          },
+          "compatible_cyclic_order_count": 1,
+          "partition": [
+            0,
+            1,
+            2,
+            3,
+            4
+          ],
+          "role_blocks": [
+            [
+              0
+            ],
+            [
+              3
+            ],
+            [
+              7
+            ],
+            [
+              9
+            ],
+            [
+              13
+            ]
+          ],
+          "vertex_count": 5
+        }
+      ],
+      "selected_center_support": 3,
+      "selected_centers": [
+        0,
+        3,
+        7
+      ],
+      "strict_inequality_support": 2,
+      "strict_rows": [
+        {
+          "kind": "K1_diag_gt_sides",
+          "quad": [
+            0,
+            3,
+            7,
+            9
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            0,
+            3,
+            9,
+            13
+          ],
+          "weight": 1
+        }
+      ],
+      "support_minimality": {
+        "evidence": "An exhaustive scan of all 2*binom(16,4)=3640 strict Kalmanson rows finds no one-row nonpositive quotient certificate; the displayed inverse pair sums to zero.",
+        "status": "fixed_order_minimal",
+        "strict_inequality_count": 2
+      }
+    },
+    {
+      "admissible_vertex_count_histogram": {
+        "7": 2,
+        "8": 1
+      },
+      "context": "The support-minimal four-inequality circuit in the k=8 member of the scalable strict-cycle bridge control.",
+      "equality_groups": [
+        [
+          [
+            8,
+            27
+          ],
+          [
+            1,
+            8
+          ]
+        ],
+        [
+          [
+            18,
+            37
+          ],
+          [
+            18,
+            27
+          ]
+        ],
+        [
+          [
+            1,
+            23
+          ],
+          [
+            16,
+            23
+          ]
+        ],
+        [
+          [
+            16,
+            44
+          ],
+          [
+            37,
+            44
+          ]
+        ]
+      ],
+      "formal_labels": [
+        1,
+        8,
+        16,
+        18,
+        23,
+        27,
+        37,
+        44
+      ],
+      "identity_certificate": {
+        "combined_nonzero_coefficient_count": 0,
+        "combined_positive_coefficient_count": 0,
+        "cyclic_order_verified": true,
+        "mapped_equality_groups": [
+          [
+            [
+              1,
+              5
+            ],
+            [
+              0,
+              1
+            ]
+          ],
+          [
+            [
+              3,
+              6
+            ],
+            [
+              3,
+              5
+            ]
+          ],
+          [
+            [
+              0,
+              4
+            ],
+            [
+              2,
+              4
+            ]
+          ],
+          [
+            [
+              2,
+              7
+            ],
+            [
+              6,
+              7
+            ]
+          ]
+        ],
+        "nonpositive_sum_verified": true,
+        "strict_rows": [
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              1,
+              2,
+              5
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              2,
+              3,
+              5,
+              6
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K2_diag_gt_other",
+            "quad": [
+              0,
+              2,
+              4,
+              6
+            ],
+            "weight": 1
+          },
+          {
+            "kind": "K1_diag_gt_sides",
+            "quad": [
+              0,
+              2,
+              6,
+              7
+            ],
+            "weight": 1
+          }
+        ],
+        "zero_sum_verified": true
+      },
+      "name": "scalable_k8_four_circuit",
+      "partition_accounting": {
+        "admissible_ordered_quotients": 5,
+        "admissible_partitions": 3,
+        "nontrivial_admissible_partitions": 2,
+        "partitions_considered": 4140,
+        "rejected_cyclic_order_incompatibility": 49,
+        "rejected_equality_pair_loop": 0,
+        "rejected_strict_quad_collision": 4088
+      },
+      "quotients": [
+        {
+          "canonical_cyclic_order": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "certificate": {
+            "combined_nonzero_coefficient_count": 0,
+            "combined_positive_coefficient_count": 0,
+            "cyclic_order_verified": true,
+            "mapped_equality_groups": [
+              [
+                [
+                  1,
+                  4
+                ],
+                [
+                  0,
+                  1
+                ]
+              ],
+              [
+                [
+                  3,
+                  5
+                ],
+                [
+                  3,
+                  4
+                ]
+              ],
+              [
+                [
+                  0,
+                  3
+                ],
+                [
+                  2,
+                  3
+                ]
+              ],
+              [
+                [
+                  2,
+                  6
+                ],
+                [
+                  5,
+                  6
+                ]
+              ]
+            ],
+            "nonpositive_sum_verified": true,
+            "strict_rows": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  4
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  3,
+                  5
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  5,
+                  6
+                ],
+                "weight": 1
+              }
+            ],
+            "zero_sum_verified": true
+          },
+          "compatible_cyclic_order_count": 1,
+          "partition": [
+            0,
+            1,
+            2,
+            3,
+            3,
+            4,
+            5,
+            6
+          ],
+          "role_blocks": [
+            [
+              1
+            ],
+            [
+              8
+            ],
+            [
+              16
+            ],
+            [
+              18,
+              23
+            ],
+            [
+              27
+            ],
+            [
+              37
+            ],
+            [
+              44
+            ]
+          ],
+          "vertex_count": 7
+        },
+        {
+          "canonical_cyclic_order": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "certificate": {
+            "combined_nonzero_coefficient_count": 0,
+            "combined_positive_coefficient_count": 0,
+            "cyclic_order_verified": true,
+            "mapped_equality_groups": [
+              [
+                [
+                  1,
+                  4
+                ],
+                [
+                  0,
+                  1
+                ]
+              ],
+              [
+                [
+                  3,
+                  5
+                ],
+                [
+                  3,
+                  4
+                ]
+              ],
+              [
+                [
+                  0,
+                  4
+                ],
+                [
+                  2,
+                  4
+                ]
+              ],
+              [
+                [
+                  2,
+                  6
+                ],
+                [
+                  5,
+                  6
+                ]
+              ]
+            ],
+            "nonpositive_sum_verified": true,
+            "strict_rows": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  4
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  4,
+                  5
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  5,
+                  6
+                ],
+                "weight": 1
+              }
+            ],
+            "zero_sum_verified": true
+          },
+          "compatible_cyclic_order_count": 1,
+          "partition": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            4,
+            5,
+            6
+          ],
+          "role_blocks": [
+            [
+              1
+            ],
+            [
+              8
+            ],
+            [
+              16
+            ],
+            [
+              18
+            ],
+            [
+              23,
+              27
+            ],
+            [
+              37
+            ],
+            [
+              44
+            ]
+          ],
+          "vertex_count": 7
+        },
+        {
+          "canonical_cyclic_order": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "certificate": {
+            "combined_nonzero_coefficient_count": 0,
+            "combined_positive_coefficient_count": 0,
+            "cyclic_order_verified": true,
+            "mapped_equality_groups": [
+              [
+                [
+                  1,
+                  5
+                ],
+                [
+                  0,
+                  1
+                ]
+              ],
+              [
+                [
+                  3,
+                  6
+                ],
+                [
+                  3,
+                  5
+                ]
+              ],
+              [
+                [
+                  0,
+                  4
+                ],
+                [
+                  2,
+                  4
+                ]
+              ],
+              [
+                [
+                  2,
+                  7
+                ],
+                [
+                  6,
+                  7
+                ]
+              ]
+            ],
+            "nonpositive_sum_verified": true,
+            "strict_rows": [
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  1,
+                  2,
+                  5
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  2,
+                  3,
+                  5,
+                  6
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K2_diag_gt_other",
+                "quad": [
+                  0,
+                  2,
+                  4,
+                  6
+                ],
+                "weight": 1
+              },
+              {
+                "kind": "K1_diag_gt_sides",
+                "quad": [
+                  0,
+                  2,
+                  6,
+                  7
+                ],
+                "weight": 1
+              }
+            ],
+            "zero_sum_verified": true
+          },
+          "compatible_cyclic_order_count": 3,
+          "partition": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "role_blocks": [
+            [
+              1
+            ],
+            [
+              8
+            ],
+            [
+              16
+            ],
+            [
+              18
+            ],
+            [
+              23
+            ],
+            [
+              27
+            ],
+            [
+              37
+            ],
+            [
+              44
+            ]
+          ],
+          "vertex_count": 8
+        }
+      ],
+      "selected_center_support": 4,
+      "selected_centers": [
+        8,
+        18,
+        23,
+        44
+      ],
+      "strict_inequality_support": 4,
+      "strict_rows": [
+        {
+          "kind": "K1_diag_gt_sides",
+          "quad": [
+            1,
+            8,
+            16,
+            27
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            16,
+            18,
+            27,
+            37
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K2_diag_gt_other",
+          "quad": [
+            1,
+            16,
+            23,
+            37
+          ],
+          "weight": 1
+        },
+        {
+          "kind": "K1_diag_gt_sides",
+          "quad": [
+            1,
+            16,
+            37,
+            44
+          ],
+          "weight": 1
+        }
+      ],
+      "support_minimality": {
+        "dependency_commands": [
+          "python scripts/check_scalable_kalmanson_inverse_control.py --assert-expected --json",
+          "python scripts/check_scalable_kalmanson_three_control.py --assert-expected --json"
+        ],
+        "evidence": "The existing all-k Presburger replay excludes positive Kalmanson circuits with at most three inequalities for every k>=8, while these four rows sum to zero at k=8.",
+        "status": "family_specific_minimal_by_existing_exact_control",
+        "strict_inequality_count": 4
+      }
+    }
+  ],
+  "trust": "EXACT_CERTIFICATE_DIAGNOSTIC"
+}

--- a/docs/codex-backlog.md
+++ b/docs/codex-backlog.md
@@ -37,6 +37,15 @@ ordinary-distance/Kalmanson lemma extracted from a fragile matching cycle and
 its halos. It must reject the `Z/16` control by its exact Kalmanson mechanism
 and must not assume that the finite `n=9` pivot census generalizes.
 
+The exact quotient hierarchy
+`python scripts/check_fragile_cycle_quotient_hierarchy.py --check --assert-expected --summary-json`
+now supplies smaller regression targets for that work. It classifies the
+stored certificate supports under all admissible role partitions and finds
+two proper seven-role forms of the scalable four-row circuit. The next bridge
+PR should try to force one of those forms, the role-rigid hinge or inverse
+template, or an explicit geometric alternative; the quotient classification
+alone is not a bridge proof.
+
 1. Use the vertex-circle route decision preflight
    `python scripts/check_n9_vertex_circle_route_decision_preflight.py --check --summary-json`
    to hand the 2026-06-09 internal A6/A7, A8, and A10 review notes into an

--- a/docs/fragile-cycle-quotient-hierarchy.md
+++ b/docs/fragile-cycle-quotient-hierarchy.md
@@ -1,0 +1,104 @@
+# Fragile-cycle quotient hierarchy
+
+Status: exact certificate diagnostic and proof-mining aid. This note does not
+claim a fragile-cycle bridge, a proof of `n=9`, a general proof, a Euclidean
+realization, or a counterexample.
+
+## Why this pilot exists
+
+The [OpenAI reasoning walkthroughs](https://cdn.openai.com/pdf/reasoning-walkthroughs.pdf)
+suggest a useful research habit: extract small, independently checkable
+intermediate objects from a successful reasoning trace, then test which parts
+survive simplification. The PDF is methodological context, not mathematical
+evidence for this repository.
+
+Here the intermediate objects are three existing strict Kalmanson
+certificates:
+
+1. the one-row `n=9` equilateral hinge;
+2. the two-row fixed-order `Z/16` marked-three-cycle inverse pair; and
+3. the four-row `k=8` member of the scalable bridge-control family.
+
+The new question is exact and finite: after forgetting unused halo roles,
+which identifications of the remaining formal roles preserve the certificate?
+
+## Admissible role quotients
+
+For a template with formal role set (R), retained equal-distance classes,
+and marked strict Kalmanson quadrilaterals, a set partition of (R) is
+admissible when:
+
+- no marked strict quadrilateral loses a vertex;
+- no retained distance pair becomes a loop; and
+- all mapped quadrilaterals fit one cyclic order of the quotient roles.
+
+The checker exhausts every set partition, not a sampled subset. It then
+rebuilds every mapped strict row and retained equality class with exact integer
+arithmetic.
+
+The reusable algebraic point is conditional but elementary. If a nonnegative
+combination of strict rows has coordinate coefficients (c_Cleq 0) in one
+distance quotient, merging quotient classes replaces a target coefficient by
+(sum_{Cmapsto D}c_C). It therefore remains nonpositive. In the three
+stored templates the checked combinations are stronger: every mapped sum is
+identically zero.
+
+This pushforward statement certifies an admissible quotient of a known
+template. It does not prove that a hypothetical minimal counterexample
+contains the template.
+
+## Exact classification
+
+| Template | Formal roles | Partitions checked | Strict rows | Admissible partitions | Compatible ordered quotients | Nontrivial partitions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `n9_equilateral_hinge` | 4 | 15 | 1 | 1 | 1 | 0 |
+| `z16_marked_three_cycle_inverse` | 5 | 52 | 2 | 1 | 1 | 0 |
+| `scalable_k8_four_circuit` | 8 | 4,140 | 4 | 3 | 5 | 2 |
+
+The first two templates are role-rigid under these admissibility rules. The
+scalable four-row template has exactly two proper quotients, both on seven
+roles:
+
+- identify roles (18) and (23); or
+- identify roles (23) and (27).
+
+Each proper quotient has one compatible cyclic order. The unmerged
+eight-role template has three compatible cyclic orders, giving five ordered
+quotients at that level and seven across the full hierarchy.
+
+For the `Z/16` equality quotient, an independent fixed-order scan also checks
+all (2inom{16}{4}=3,640) individual strict Kalmanson rows. None is
+coordinatewise nonpositive, while the stored two-row inverse pair sums to
+zero. This records fixed-order support minimality only.
+
+## What this teaches us
+
+- The one-, two-, and four-row certificates are closed under every admissible
+  role identification in this finite catalogue.
+- Quotienting exposes two smaller seven-role forms of the scalable
+  certificate. They are better local targets than the original eight-role
+  labelling when looking for a forcing lemma.
+- The hinge and `Z/16` inverse pair cannot be simplified by role
+  identification without destroying a marked strict quadrilateral or its
+  cyclic-order compatibility.
+- The unresolved step is geometric and structural: force one of these
+  certificate templates, or a separately stated rich-class/deletion
+  alternative, from a genuine fragile matching cycle and its halos.
+
+The catalogue is deliberately incomplete. It forgets unused halo roles,
+preserves only marked quadrilateral orders, and does not check Euclidean
+realizability. It is a proof-mining hierarchy, not a bridge theorem.
+
+## Replay
+
+```bash
+python scripts/check_fragile_cycle_quotient_hierarchy.py \
+  --check --assert-expected --summary-json
+
+python scripts/check_fragile_turn_pivot_guardrail.py \
+  --check --assert-expected --summary-json
+
+python scripts/check_scalable_kalmanson_inverse_control.py \
+  --assert-expected --json
+
+python scripts/check_scalable_kalmanson_three_control.py \

--- a/docs/fragile-cycle-quotient-hierarchy.md
+++ b/docs/fragile-cycle-quotient-hierarchy.md
@@ -24,8 +24,8 @@ which identifications of the remaining formal roles preserve the certificate?
 
 ## Admissible role quotients
 
-For a template with formal role set (R), retained equal-distance classes,
-and marked strict Kalmanson quadrilaterals, a set partition of (R) is
+For a template with formal role set `R`, retained equal-distance classes,
+and marked strict Kalmanson quadrilaterals, a set partition of `R` is
 admissible when:
 
 - no marked strict quadrilateral loses a vertex;
@@ -37,9 +37,10 @@ rebuilds every mapped strict row and retained equality class with exact integer
 arithmetic.
 
 The reusable algebraic point is conditional but elementary. If a nonnegative
-combination of strict rows has coordinate coefficients (c_Cleq 0) in one
+combination of strict rows has coordinate coefficients `c_C <= 0` in one
 distance quotient, merging quotient classes replaces a target coefficient by
-(sum_{Cmapsto D}c_C). It therefore remains nonpositive. In the three
+the sum of `c_C` over source classes `C` mapped to the target class. It
+therefore remains nonpositive. In the three
 stored templates the checked combinations are stronger: every mapped sum is
 identically zero.
 
@@ -59,15 +60,15 @@ The first two templates are role-rigid under these admissibility rules. The
 scalable four-row template has exactly two proper quotients, both on seven
 roles:
 
-- identify roles (18) and (23); or
-- identify roles (23) and (27).
+- identify roles `18` and `23`; or
+- identify roles `23` and `27`.
 
 Each proper quotient has one compatible cyclic order. The unmerged
 eight-role template has three compatible cyclic orders, giving five ordered
 quotients at that level and seven across the full hierarchy.
 
 For the `Z/16` equality quotient, an independent fixed-order scan also checks
-all (2inom{16}{4}=3,640) individual strict Kalmanson rows. None is
+all `2 * binom(16, 4) = 3,640` individual strict Kalmanson rows. None is
 coordinatewise nonpositive, while the stored two-row inverse pair sums to
 zero. This records fixed-order support minimality only.
 

--- a/docs/fragile-turn-pivot-bridge-audit.md
+++ b/docs/fragile-turn-pivot-bridge-audit.md
@@ -179,6 +179,15 @@ cycle and its halos. Such a lemma must:
 - reject the abstract `n=16` control for the right metric reason; and
 - remain compatible with the exact `n=9` two-pivot/`F15` split.
 
+The exact quotient-hierarchy pilot in
+`docs/fragile-cycle-quotient-hierarchy.md` now packages the known one-, two-,
+and four-row certificates as role templates and exhausts all admissible role
+partitions. The hinge and `Z/16` inverse templates are role-rigid; the
+scalable four-row template has exactly two proper seven-role quotients. This
+narrows the proof-mining target, but it is not the missing bridge: a geometric
+lemma must still force one of those templates or a separately stated
+rich-class/deletion alternative.
+
 The existing `n=16` certificate suggests a concrete first template: search
 for two cyclic quadruples whose strict Kalmanson coefficient rows cancel
 after quotienting by three matched fragile rows. The negative control provides
@@ -191,6 +200,9 @@ python scripts/check_n9_fragile_turn_pivot_crosswalk.py \
   --check --assert-expected --summary-json
 
 python scripts/check_fragile_turn_pivot_guardrail.py \
+  --check --assert-expected --summary-json
+
+python scripts/check_fragile_cycle_quotient_hierarchy.py \
   --check --assert-expected --summary-json
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -295,6 +295,11 @@ put detailed reconciliation in the canonical synthesis.
   exact `n=9` witness-matching/inversion-pivot crosswalk together with the
   abstract `n=16` guardrail showing why the same marked-three-cycle argument
   does not generalize without stronger convex metric information.
+- [`fragile-cycle-quotient-hierarchy.md`](fragile-cycle-quotient-hierarchy.md):
+  exact role-quotient classification of the stored one-, two-, and four-row
+  fragile-cycle certificate templates, including two proper seven-role
+  quotients of the scalable template; proof-mining evidence only, not a
+  bridge theorem.
 - [`minimal-two-deletion-profile.md`](minimal-two-deletion-profile.md): exact
   `T4`/`T5`/`T44` classification for centers made good by deleting two
   vertices, with pair capacities and the exclusive-mutual-pair corollary.

--- a/docs/lemma-driven-bridge-targets.md
+++ b/docs/lemma-driven-bridge-targets.md
@@ -293,8 +293,10 @@ or a specified additional rich-class/deletion alternative is forced.
 Useful evidence:
 
 - `docs/fragile-turn-pivot-bridge-audit.md`
+- `docs/fragile-cycle-quotient-hierarchy.md`
 - `data/certificates/n9_fragile_turn_pivot_crosswalk.json`
 - `data/certificates/fragile_turn_pivot_guardrail.json`
+- `data/certificates/fragile_cycle_quotient_hierarchy.json`
 - `docs/turn-packing-bridge.md`
 - `docs/n9-kalmanson-three-row-core-compression.md`
 
@@ -311,6 +313,12 @@ Required guardrails:
   merely repeat selected-distance quotient nesting.
 - Any Kalmanson statement must quantify over the cyclic order genuinely
   supplied by the polygon, not only one convenient labelling.
+
+The exact quotient hierarchy reduces the smallest currently stored
+four-inequality target to two proper seven-role templates, merging roles
+`18=23` or `23=27`. A successful Contract F lemma must force one of these
+or another checked certificate from genuine geometry; quotient closure by
+itself is not a forcing argument.
 
 ## Low-leverage moves to avoid
 
@@ -355,4 +363,5 @@ python scripts/check_block6_fragile_sixth_row_survivors.py --assert-expected --j
 python scripts/check_block6_reversed_block_clean_kalmanson.py --check --assert-expected --json
 python scripts/check_n9_fragile_turn_pivot_crosswalk.py --check --assert-expected --summary-json
 python scripts/check_fragile_turn_pivot_guardrail.py --check --assert-expected --summary-json
+python scripts/check_fragile_cycle_quotient_hierarchy.py --check --assert-expected --summary-json
 ```

--- a/metadata/generated_artifacts.yaml
+++ b/metadata/generated_artifacts.yaml
@@ -1545,6 +1545,47 @@ artifacts:
       - official/global status update
       - general proof of Erdos Problem #97
 
+  - id: fragile_cycle_quotient_hierarchy
+    path: data/certificates/fragile_cycle_quotient_hierarchy.json
+    sha256: 307c77bd44fc417e7f1c8d59db7a2a1c4d992682f1e04c40f8f95359b06d64b9
+    size_bytes: 25624
+    kind: exact_quotient_hierarchy_artifact
+    generator: scripts/check_fragile_cycle_quotient_hierarchy.py
+    command: python scripts/check_fragile_cycle_quotient_hierarchy.py --write --assert-expected
+    checker: scripts/check_fragile_cycle_quotient_hierarchy.py
+    check_command: python scripts/check_fragile_cycle_quotient_hierarchy.py --check --assert-expected --summary-json
+    direct_edit_allowed: false
+    provenance_mode: embedded
+    trust_class: EXACT_CERTIFICATE_DIAGNOSTIC
+    claim_scope: >
+      Exact admissible-role-quotient classification for the stored n=9
+      equilateral hinge, fixed-order Z/16 inverse pair, and scalable k=8
+      four-row Kalmanson circuit. It proves certificate pushforward only for
+      these local templates; not Euclidean realizability, a fragile-cycle
+      bridge, n=9, a general proof, a counterexample, or an official/global
+      status update.
+    json_top_level_type: object
+    expected_json:
+      schema: erdos97.fragile_cycle_quotient_hierarchy.v1
+      status: EXACT_BRIDGE_TEMPLATE_DIAGNOSTIC
+      trust: EXACT_CERTIFICATE_DIAGNOSTIC
+      summary.template_count: 3
+      summary.strict_support_levels: [1, 2, 4]
+      summary.admissible_partition_count: 5
+      summary.admissible_ordered_quotient_count: 7
+      summary.nontrivial_admissible_partition_count: 2
+      summary.all_quotient_certificates_zero_sum: true
+      summary.quotient_catalog_sha256: 58ad9b77ab1b71d2e9178a3b4faa572e46c2b253ed5f9b68eca6f5b18e8218b6
+      provenance.command: python scripts/check_fragile_cycle_quotient_hierarchy.py --write --assert-expected
+    forbidden_claims:
+      - Euclidean realization
+      - a fragile-cycle bridge is proved
+      - n=9 is proved
+      - general proof of Erdos Problem #97
+      - counterexample to Erdos Problem #97
+      - source-of-truth strongest result
+      - official/global status update
+
   - id: n9_vertex_circle_local_core_packet
     path: data/certificates/n9_vertex_circle_local_core_packet.json
     sha256: d6eff2556d93338d15da665a7670ebb6bac2145238fe55789eb5dbbf84404d30

--- a/scripts/audit_commands.json
+++ b/scripts/audit_commands.json
@@ -542,6 +542,17 @@
       "claim_scope": "Exact abstract n=16 negative control for the proposed fragile-matching/three-pivot bridge; the fixed order is Kalmanson-obstructed, so this is not a Euclidean realization, counterexample, proof, or official/global status update."
     },
     {
+      "id": "fragile_cycle_quotient_hierarchy",
+      "command": [
+        "python",
+        "scripts/check_fragile_cycle_quotient_hierarchy.py",
+        "--check",
+        "--assert-expected",
+        "--summary-json"
+      ],
+      "claim_scope": "Exact admissible-role-quotient classification for three stored Kalmanson certificate templates; proves only certificate pushforward for those templates, not Euclidean realizability, a fragile-cycle bridge, n=9, a general proof, a counterexample, or an official/global status update."
+    },
+    {
       "id": "n9_vertex_circle_input_audit",
       "command": [
         "python",
@@ -3343,6 +3354,7 @@
       "rigid_n15_shortest_side_grid",
       "n9_fragile_turn_pivot_crosswalk",
       "fragile_turn_pivot_guardrail",
+      "fragile_cycle_quotient_hierarchy",
       "adjacent_closest_pair_nonagon_barrier",
       "brp_boundary_vertexization_probe",
       "four_c3_generic_orbit_obstruction",

--- a/scripts/check_fragile_cycle_quotient_hierarchy.py
+++ b/scripts/check_fragile_cycle_quotient_hierarchy.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Generate or check the exact fragile-cycle quotient hierarchy pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from erdos97.fragile_cycle_quotient_hierarchy import (
+    assert_expected_payload,
+    hierarchy_payload,
+    validate_payload,
+)
+from erdos97.json_io import load_json, write_json
+from erdos97.path_display import display_path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT = (
+    ROOT / "data" / "certificates" / "fragile_cycle_quotient_hierarchy.json"
+)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected object payload in {display_path(path, ROOT)}")
+    return payload
+
+
+def summary_json_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing hierarchy summary."""
+
+    return {
+        "schema": payload["schema"],
+        "status": payload["status"],
+        "trust": payload["trust"],
+        "claim_scope": payload["claim_scope"],
+        "hierarchy_definition": payload["hierarchy_definition"],
+        "templates": [
+            {
+                "name": template["name"],
+                "strict_inequality_support": template[
+                    "strict_inequality_support"
+                ],
+                "selected_center_support": template["selected_center_support"],
+                "support_minimality": template["support_minimality"],
+                "partition_accounting": template["partition_accounting"],
+                "admissible_vertex_count_histogram": template[
+                    "admissible_vertex_count_histogram"
+                ],
+                "nontrivial_role_blocks": [
+                    record["role_blocks"]
+                    for record in template["quotients"]
+                    if record["vertex_count"] < len(template["formal_labels"])
+                ],
+            }
+            for template in payload["templates"]
+        ],
+        "summary": payload["summary"],
+        "limitations": payload["limitations"],
+        "conclusion": payload["conclusion"],
+        "provenance": payload["provenance"],
+    }
+
+
+def _print_summary(payload: dict[str, Any], elapsed: float) -> None:
+    print("exact fragile-cycle quotient hierarchy pilot")
+    for template in payload["templates"]:
+        accounting = template["partition_accounting"]
+        print(
+            f"{template['name']}: strict={template['strict_inequality_support']} "
+            f"admissible={accounting['admissible_partitions']} "
+            f"nontrivial={accounting['nontrivial_admissible_partitions']}"
+        )
+    print(
+        "all quotient certificates zero-sum: "
+        f"{payload['summary']['all_quotient_certificates_zero_sum']}"
+    )
+    print(f"quotient catalog sha256: {payload['summary']['quotient_catalog_sha256']}")
+    print(f"elapsed_seconds: {elapsed:.6f}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--json", action="store_true", help="print full JSON")
+    output_group.add_argument(
+        "--summary-json",
+        action="store_true",
+        help="print compact hierarchy JSON",
+    )
+    parser.add_argument("--write", action="store_true", help="write stable JSON artifact")
+    parser.add_argument("--check", action="store_true", help="check a stored artifact")
+    parser.add_argument("--assert-expected", action="store_true")
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact_path = _resolve(args.artifact)
+    out_path = _resolve(args.out)
+    if args.write and args.check and artifact_path != out_path:
+        raise SystemExit("--write --check requires --artifact and --out to match")
+
+    start = perf_counter()
+    payload = _load_object(artifact_path) if args.check else hierarchy_payload()
+    errors = validate_payload(payload) if args.check else []
+    if errors:
+        raise SystemExit("; ".join(errors[:5]))
+    if args.assert_expected:
+        assert_expected_payload(payload)
+    if args.write:
+        write_json(payload, out_path)
+    elapsed = perf_counter() - start
+
+    if args.summary_json:
+        print(json.dumps(summary_json_payload(payload), indent=2, sort_keys=True))
+    elif args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_summary(payload, elapsed)
+        if args.assert_expected:
+            print("OK: fragile-cycle quotient hierarchy matches expected data")
+        if args.check:
+            print(f"checked {display_path(artifact_path, ROOT)}")
+        if args.write:
+            print(f"wrote {display_path(out_path, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_kalmanson_equilateral_hinge_crosswalk.py
+++ b/scripts/check_kalmanson_equilateral_hinge_crosswalk.py
@@ -21,6 +21,7 @@ from erdos97.kalmanson_equilateral_hinge import (
     find_core_hinge_instances,
     find_hinge_instances,
 )
+from erdos97.path_display import display_path
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -269,7 +270,7 @@ def build_payload(source_path: Path = DEFAULT_SOURCE) -> dict[str, Any]:
             "contradiction": "the three spoke equalities make both sides equal",
         },
         "source_artifact": {
-            "path": str(source_path.relative_to(ROOT)),
+            "path": display_path(source_path, ROOT),
             "sha256": source_digest,
             "schema": source.get("schema"),
             "status": source.get("status"),

--- a/scripts/check_text_clean.py
+++ b/scripts/check_text_clean.py
@@ -124,6 +124,11 @@ def display_path(path: Path) -> str:
 def hidden_char_description(char: str) -> str | None:
     if char in HIDDEN_CHARS:
         return HIDDEN_CHARS[char]
+    # Tabs and line feeds are the only C0 controls allowed in tracked text.
+    # Other ASCII controls can silently corrupt rendered prose (for example,
+    # a backspace produced by an accidentally escaped \binom string).
+    if unicodedata.category(char) == "Cc" and char not in {"\t", "\n"}:
+        return unicodedata.name(char, "CONTROL CHARACTER")
     # Policy: tracked text files should contain no Unicode format controls.
     # They are invisible in review and too easy to mistake for ordinary text.
     if unicodedata.category(char) == "Cf" or unicodedata.bidirectional(char) in BIDI_CONTROL_CLASSES:

--- a/src/erdos97/fragile_cycle_quotient_hierarchy.py
+++ b/src/erdos97/fragile_cycle_quotient_hierarchy.py
@@ -1,0 +1,706 @@
+"""Exact admissible-role quotients of small convex certificate templates.
+
+The templates in this module are proof-mining objects.  They retain only the
+distance equalities used by a strict Kalmanson certificate and forget all
+unused witnesses.  A role quotient may identify formal labels except when an
+identification would:
+
+* collapse a distance pair used by a retained equality;
+* collapse two vertices of one strict Kalmanson quadrilateral; or
+* make the marked quadrilateral orders incompatible with one cyclic order.
+
+The certificate then pushes forward to the role quotient.  Coordinatewise
+nonpositive quotient coefficients remain nonpositive after quotient classes
+are merged, so every enumerated quotient is checked with exact integer
+arithmetic.  This is a local certificate diagnostic, not a bridge proving
+that an arbitrary counterexample contains one of the templates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from itertools import combinations, permutations
+from typing import Iterator, Mapping, Sequence
+
+from erdos97.fragile_turn_pivot_guardrail import selected_rows as z16_rows
+from erdos97.quotient_cone import (
+    KALMANSON_KINDS,
+    UnionFind,
+    kalmanson_row,
+    kalmanson_terms,
+    pair,
+    selected_distance_quotient,
+)
+
+Pair = tuple[int, int]
+EqualityGroup = tuple[Pair, ...]
+
+SCHEMA = "erdos97.fragile_cycle_quotient_hierarchy.v1"
+STATUS = "EXACT_BRIDGE_TEMPLATE_DIAGNOSTIC"
+TRUST = "EXACT_CERTIFICATE_DIAGNOSTIC"
+CLAIM_SCOPE = (
+    "Exact admissible-role-quotient classification for three stored convex "
+    "certificate templates: the n=9 equilateral hinge, the fixed-order Z/16 "
+    "marked-three-cycle inverse pair, and the scalable-family k=8 four-row "
+    "circuit. The classification proves only certificate pushforward for "
+    "these local templates. It does not force a template in an arbitrary "
+    "counterexample, does not close a fragile-cycle bridge, does not prove "
+    "n=9 or any arbitrary-size case, does not claim a Euclidean realization "
+    "or counterexample, and does not update the official/global status of "
+    "Erdos Problem #97."
+)
+CONCLUSION = (
+    "The retained one-, two-, and four-inequality certificate templates are "
+    "stable under every enumerated admissible role quotient. The hinge and "
+    "Z/16 inverse templates are role-rigid under the stated marked-order "
+    "rules. The scalable k=8 four-row template has exactly two nontrivial "
+    "seven-role quotients, obtained by identifying roles 18 with 23 or roles "
+    "23 with 27. This is quotient-closed proof-mining evidence only; the "
+    "missing bridge must still force one of the certificate templates or a "
+    "separate geometric alternative."
+)
+PROVENANCE = {
+    "generator": "scripts/check_fragile_cycle_quotient_hierarchy.py",
+    "command": (
+        "python scripts/check_fragile_cycle_quotient_hierarchy.py "
+        "--write --assert-expected"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class TemplateStrictRow:
+    """One weighted strict Kalmanson row on formal roles."""
+
+    kind: str
+    quad: tuple[int, int, int, int]
+    weight: int = 1
+
+
+@dataclass(frozen=True)
+class CertificateTemplate:
+    """A local equality quotient and its strict certificate."""
+
+    name: str
+    context: str
+    labels: tuple[int, ...]
+    equality_groups: tuple[EqualityGroup, ...]
+    strict_rows: tuple[TemplateStrictRow, ...]
+    selected_centers: tuple[int, ...]
+    support_minimality: Mapping[str, object]
+
+
+def certificate_templates() -> tuple[CertificateTemplate, ...]:
+    """Return the three deterministic hierarchy benchmarks."""
+
+    return (
+        CertificateTemplate(
+            name="n9_equilateral_hinge",
+            context=(
+                "The arbitrary-size local hinge extracted from all 184 "
+                "review-pending n=9 frontier assignments."
+            ),
+            labels=(0, 1, 2, 3),
+            equality_groups=(
+                ((0, 1), (0, 2), (1, 2)),
+                ((0, 3), (1, 3)),
+            ),
+            strict_rows=(
+                TemplateStrictRow("K2_diag_gt_other", (0, 1, 2, 3)),
+            ),
+            selected_centers=(0, 1, 3),
+            support_minimality={
+                "strict_inequality_count": 1,
+                "status": "tautologically_minimal_positive_support",
+                "evidence": (
+                    "One strict Kalmanson row reduces to zero after the three "
+                    "retained rich-pair equalities."
+                ),
+            },
+        ),
+        CertificateTemplate(
+            name="z16_marked_three_cycle_inverse",
+            context=(
+                "The exact fixed-order Kalmanson inverse pair rejecting the "
+                "Z/16 fragile/turn/pivot marked-three-cycle guardrail."
+            ),
+            labels=(0, 3, 7, 9, 13),
+            equality_groups=(
+                ((0, 7), (7, 9)),
+                ((0, 9), (0, 13)),
+                ((3, 13), (0, 3)),
+            ),
+            strict_rows=(
+                TemplateStrictRow("K1_diag_gt_sides", (0, 3, 7, 9)),
+                TemplateStrictRow("K2_diag_gt_other", (0, 3, 9, 13)),
+            ),
+            selected_centers=(0, 3, 7),
+            support_minimality={
+                "strict_inequality_count": 2,
+                "status": "fixed_order_minimal",
+                "evidence": (
+                    "An exhaustive scan of all 2*binom(16,4)=3640 strict "
+                    "Kalmanson rows finds no one-row nonpositive quotient "
+                    "certificate; the displayed inverse pair sums to zero."
+                ),
+            },
+        ),
+        CertificateTemplate(
+            name="scalable_k8_four_circuit",
+            context=(
+                "The support-minimal four-inequality circuit in the k=8 "
+                "member of the scalable strict-cycle bridge control."
+            ),
+            labels=(1, 8, 16, 18, 23, 27, 37, 44),
+            equality_groups=(
+                ((8, 27), (1, 8)),
+                ((18, 37), (18, 27)),
+                ((1, 23), (16, 23)),
+                ((16, 44), (37, 44)),
+            ),
+            strict_rows=(
+                TemplateStrictRow("K1_diag_gt_sides", (1, 8, 16, 27)),
+                TemplateStrictRow("K2_diag_gt_other", (16, 18, 27, 37)),
+                TemplateStrictRow("K2_diag_gt_other", (1, 16, 23, 37)),
+                TemplateStrictRow("K1_diag_gt_sides", (1, 16, 37, 44)),
+            ),
+            selected_centers=(8, 18, 23, 44),
+            support_minimality={
+                "strict_inequality_count": 4,
+                "status": "family_specific_minimal_by_existing_exact_control",
+                "evidence": (
+                    "The existing all-k Presburger replay excludes positive "
+                    "Kalmanson circuits with at most three inequalities for "
+                    "every k>=8, while these four rows sum to zero at k=8."
+                ),
+                "dependency_commands": [
+                    (
+                        "python scripts/check_scalable_kalmanson_inverse_control.py "
+                        "--assert-expected --json"
+                    ),
+                    (
+                        "python scripts/check_scalable_kalmanson_three_control.py "
+                        "--assert-expected --json"
+                    ),
+                ],
+            },
+        ),
+    )
+
+
+def restricted_growth_partitions(size: int) -> Iterator[tuple[int, ...]]:
+    """Yield every set partition as a restricted-growth string."""
+
+    if size <= 0:
+        raise ValueError("partition size must be positive")
+    values = [0] * size
+
+    def visit(index: int, maximum: int) -> Iterator[tuple[int, ...]]:
+        if index == size:
+            yield tuple(values)
+            return
+        for value in range(maximum + 2):
+            values[index] = value
+            yield from visit(index + 1, max(maximum, value))
+
+    yield from visit(1, 0)
+
+
+def _mapped_pair(role_index: Mapping[int, int], partition: Sequence[int], raw: Pair) -> Pair:
+    return pair(partition[role_index[raw[0]]], partition[role_index[raw[1]]])
+
+
+def _cyclically_ordered(quad: Sequence[int], positions: Mapping[int, int]) -> bool:
+    size = len(positions)
+    base = positions[int(quad[0])]
+    offsets = [(positions[int(label)] - base) % size for label in quad]
+    return offsets[0] == 0 and offsets[1] < offsets[2] < offsets[3]
+
+
+def feasible_cyclic_orders(
+    mapped_quads: Sequence[Sequence[int]],
+    block_count: int,
+) -> tuple[tuple[int, ...], ...]:
+    """Return all rotation-normalized cyclic orders satisfying marked quads."""
+
+    if block_count <= 0:
+        raise ValueError("block_count must be positive")
+    orders: list[tuple[int, ...]] = []
+    for tail in permutations(range(1, block_count)):
+        order = (0, *tail)
+        positions = {label: index for index, label in enumerate(order)}
+        if all(_cyclically_ordered(quad, positions) for quad in mapped_quads):
+            orders.append(order)
+    return tuple(orders)
+
+
+def verify_mapped_certificate(
+    template: CertificateTemplate,
+    partition: Sequence[int],
+    cyclic_order: Sequence[int],
+) -> dict[str, object]:
+    """Verify one role quotient by exact pushforward arithmetic."""
+
+    role_index = {label: index for index, label in enumerate(template.labels)}
+    block_count = max(partition) + 1
+    all_pairs = [pair(left, right) for left, right in combinations(range(block_count), 2)]
+    quotient = UnionFind(all_pairs)
+
+    mapped_equality_groups: list[list[list[int]]] = []
+    for equality_group in template.equality_groups:
+        mapped = [_mapped_pair(role_index, partition, raw) for raw in equality_group]
+        base = mapped[0]
+        for other in mapped[1:]:
+            quotient.union(base, other)
+        mapped_equality_groups.append([[left, right] for left, right in mapped])
+
+    combined: Counter[Pair] = Counter()
+    mapped_rows: list[dict[str, object]] = []
+    mapped_quads: list[tuple[int, int, int, int]] = []
+    for strict_row in template.strict_rows:
+        mapped_quad = tuple(
+            partition[role_index[label]] for label in strict_row.quad
+        )
+        if len(set(mapped_quad)) != 4:
+            raise ValueError("strict quadrilateral collapsed in role quotient")
+        mapped_quads.append(mapped_quad)  # type: ignore[arg-type]
+        for raw_pair, coefficient in kalmanson_terms(strict_row.kind, mapped_quad):
+            combined[quotient.find(raw_pair)] += strict_row.weight * coefficient
+        mapped_rows.append(
+            {
+                "kind": strict_row.kind,
+                "quad": list(mapped_quad),
+                "weight": strict_row.weight,
+            }
+        )
+
+    positions = {label: index for index, label in enumerate(cyclic_order)}
+    order_verified = all(
+        _cyclically_ordered(mapped_quad, positions) for mapped_quad in mapped_quads
+    )
+    coefficients = [value for value in combined.values() if value]
+    return {
+        "mapped_equality_groups": mapped_equality_groups,
+        "strict_rows": mapped_rows,
+        "cyclic_order_verified": order_verified,
+        "combined_nonzero_coefficient_count": len(coefficients),
+        "combined_positive_coefficient_count": sum(value > 0 for value in coefficients),
+        "zero_sum_verified": not coefficients,
+        "nonpositive_sum_verified": all(value <= 0 for value in coefficients),
+    }
+
+
+def enumerate_admissible_quotients(template: CertificateTemplate) -> dict[str, object]:
+    """Enumerate every admissible role partition and compatible cyclic order."""
+
+    _validate_template(template)
+    role_index = {label: index for index, label in enumerate(template.labels)}
+    counters: Counter[str] = Counter()
+    records: list[dict[str, object]] = []
+
+    for partition in restricted_growth_partitions(len(template.labels)):
+        counters["partitions_considered"] += 1
+        mapped_quads = [
+            tuple(partition[role_index[label]] for label in strict_row.quad)
+            for strict_row in template.strict_rows
+        ]
+        if any(len(set(quad)) != 4 for quad in mapped_quads):
+            counters["rejected_strict_quad_collision"] += 1
+            continue
+        if any(
+            partition[role_index[left]] == partition[role_index[right]]
+            for equality_group in template.equality_groups
+            for left, right in equality_group
+        ):
+            counters["rejected_equality_pair_loop"] += 1
+            continue
+
+        block_count = max(partition) + 1
+        orders = feasible_cyclic_orders(mapped_quads, block_count)
+        if not orders:
+            counters["rejected_cyclic_order_incompatibility"] += 1
+            continue
+
+        counters["admissible_partitions"] += 1
+        counters["admissible_ordered_quotients"] += len(orders)
+        counters[f"admissible_vertex_count_{block_count}"] += 1
+        if block_count < len(template.labels):
+            counters["nontrivial_admissible_partitions"] += 1
+
+        role_blocks = [
+            [
+                label
+                for label, block in zip(template.labels, partition)
+                if block == block_index
+            ]
+            for block_index in range(block_count)
+        ]
+        certificate = verify_mapped_certificate(template, partition, orders[0])
+        if not certificate["zero_sum_verified"]:
+            raise AssertionError(
+                f"{template.name} quotient certificate did not push forward"
+            )
+        records.append(
+            {
+                "partition": list(partition),
+                "role_blocks": role_blocks,
+                "vertex_count": block_count,
+                "compatible_cyclic_order_count": len(orders),
+                "canonical_cyclic_order": list(orders[0]),
+                "certificate": certificate,
+            }
+        )
+
+    records.sort(
+        key=lambda record: (
+            int(record["vertex_count"]),
+            record["partition"],
+            record["canonical_cyclic_order"],
+        )
+    )
+    return {
+        "partition_accounting": {
+            key: counters[key]
+            for key in (
+                "partitions_considered",
+                "rejected_strict_quad_collision",
+                "rejected_equality_pair_loop",
+                "rejected_cyclic_order_incompatibility",
+                "admissible_partitions",
+                "admissible_ordered_quotients",
+                "nontrivial_admissible_partitions",
+            )
+        },
+        "admissible_vertex_count_histogram": {
+            key.removeprefix("admissible_vertex_count_"): value
+            for key, value in sorted(counters.items())
+            if key.startswith("admissible_vertex_count_")
+        },
+        "quotients": records,
+    }
+
+
+def _validate_template(template: CertificateTemplate) -> None:
+    labels = set(template.labels)
+    if len(labels) != len(template.labels):
+        raise ValueError(f"{template.name}: duplicate formal labels")
+    if not template.strict_rows:
+        raise ValueError(f"{template.name}: no strict rows")
+    for strict_row in template.strict_rows:
+        if strict_row.kind not in KALMANSON_KINDS:
+            raise ValueError(f"{template.name}: unknown kind {strict_row.kind}")
+        if strict_row.weight <= 0:
+            raise ValueError(f"{template.name}: nonpositive strict-row weight")
+        if len(set(strict_row.quad)) != 4 or not set(strict_row.quad) <= labels:
+            raise ValueError(f"{template.name}: invalid strict quadrilateral")
+    for equality_group in template.equality_groups:
+        if len(equality_group) < 2:
+            raise ValueError(f"{template.name}: singleton equality group")
+        for left, right in equality_group:
+            if left == right or left not in labels or right not in labels:
+                raise ValueError(f"{template.name}: invalid equality pair")
+
+
+def _z16_one_row_scan() -> dict[str, object]:
+    rows = z16_rows()
+    quotient = selected_distance_quotient(rows)
+    zero_rows = 0
+    nonpositive_rows = 0
+    strict_rows_checked = 0
+    for quad in combinations(range(16), 4):
+        for kind in KALMANSON_KINDS:
+            strict_rows_checked += 1
+            vector = kalmanson_row(quotient, kind, quad).vector
+            zero_rows += all(value == 0 for value in vector)
+            nonpositive_rows += all(value <= 0 for value in vector)
+    return {
+        "strict_rows_checked": strict_rows_checked,
+        "zero_sum_row_count": zero_rows,
+        "nonpositive_row_count": nonpositive_rows,
+        "one_row_certificate_absent": nonpositive_rows == 0,
+    }
+
+
+def _template_payload(template: CertificateTemplate) -> dict[str, object]:
+    enumeration = enumerate_admissible_quotients(template)
+    role_index = {label: index for index, label in enumerate(template.labels)}
+    identity_partition = tuple(range(len(template.labels)))
+    identity_orders = feasible_cyclic_orders(
+        [
+            tuple(role_index[label] for label in strict_row.quad)
+            for strict_row in template.strict_rows
+        ],
+        len(template.labels),
+    )
+    if not identity_orders:
+        raise AssertionError(f"{template.name}: identity order is infeasible")
+    identity_check = verify_mapped_certificate(
+        template,
+        identity_partition,
+        identity_orders[0],
+    )
+    payload: dict[str, object] = {
+        "name": template.name,
+        "context": template.context,
+        "formal_labels": list(template.labels),
+        "selected_centers": list(template.selected_centers),
+        "equality_groups": [
+            [[left, right] for left, right in equality_group]
+            for equality_group in template.equality_groups
+        ],
+        "strict_rows": [
+            {
+                "kind": strict_row.kind,
+                "quad": list(strict_row.quad),
+                "weight": strict_row.weight,
+            }
+            for strict_row in template.strict_rows
+        ],
+        "strict_inequality_support": len(template.strict_rows),
+        "selected_center_support": len(template.selected_centers),
+        "identity_certificate": identity_check,
+        "support_minimality": dict(template.support_minimality),
+        **enumeration,
+    }
+    if template.name == "z16_marked_three_cycle_inverse":
+        payload["one_row_fixed_order_scan"] = _z16_one_row_scan()
+    return payload
+
+
+def hierarchy_payload() -> dict[str, object]:
+    """Return the stable exact quotient-hierarchy artifact payload."""
+
+    templates = [_template_payload(template) for template in certificate_templates()]
+    quotient_records = [
+        {
+            "name": template["name"],
+            "quotients": template["quotients"],
+        }
+        for template in templates
+    ]
+    digest = hashlib.sha256(
+        json.dumps(
+            quotient_records,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "hierarchy_definition": {
+            "levels": [1, 2, 4],
+            "coordinates": [
+                "strict_inequality_support",
+                "selected_center_support",
+                "admissible_role_quotient_vertex_count",
+            ],
+            "admissibility": [
+                "each strict Kalmanson quadrilateral remains injective",
+                "each retained equal-distance pair remains a nonloop",
+                "all marked quadrilateral orders fit one target cyclic order",
+            ],
+            "pushforward_principle": (
+                "Merging role and distance classes sums source quotient "
+                "coefficients. A nonnegative combination that is "
+                "coordinatewise nonpositive remains so after every "
+                "admissible quotient."
+            ),
+        },
+        "templates": templates,
+        "summary": {
+            "template_count": len(templates),
+            "strict_support_levels": [
+                int(template["strict_inequality_support"])
+                for template in templates
+            ],
+            "admissible_partition_count": sum(
+                int(template["partition_accounting"]["admissible_partitions"])
+                for template in templates
+            ),
+            "admissible_ordered_quotient_count": sum(
+                int(
+                    template["partition_accounting"][
+                        "admissible_ordered_quotients"
+                    ]
+                )
+                for template in templates
+            ),
+            "nontrivial_admissible_partition_count": sum(
+                int(
+                    template["partition_accounting"][
+                        "nontrivial_admissible_partitions"
+                    ]
+                )
+                for template in templates
+            ),
+            "all_quotient_certificates_zero_sum": all(
+                quotient["certificate"]["zero_sum_verified"]
+                for template in templates
+                for quotient in template["quotients"]
+            ),
+            "quotient_catalog_sha256": digest,
+        },
+        "limitations": [
+            "The three templates are benchmarks, not a complete fragile-cycle catalogue.",
+            "Unused halo roles are forgotten; the artifact classifies quotients only of the retained certificate support.",
+            "Admissibility preserves marked strict-quadrilateral order but does not assert Euclidean realizability.",
+            "The scalable k=8 minimality statement depends on the separately checked all-k inverse/three-row controls.",
+            "No arbitrary counterexample is proved to contain any template in this hierarchy.",
+            "No proof, counterexample, n=9 promotion, or official/global status update is claimed.",
+        ],
+        "conclusion": CONCLUSION,
+        "provenance": dict(PROVENANCE),
+    }
+
+
+EXPECTED_TEMPLATE_ACCOUNTING = {
+    "n9_equilateral_hinge": {
+        "partitions_considered": 15,
+        "rejected_strict_quad_collision": 14,
+        "rejected_equality_pair_loop": 0,
+        "rejected_cyclic_order_incompatibility": 0,
+        "admissible_partitions": 1,
+        "admissible_ordered_quotients": 1,
+        "nontrivial_admissible_partitions": 0,
+    },
+    "z16_marked_three_cycle_inverse": {
+        "partitions_considered": 52,
+        "rejected_strict_quad_collision": 50,
+        "rejected_equality_pair_loop": 0,
+        "rejected_cyclic_order_incompatibility": 1,
+        "admissible_partitions": 1,
+        "admissible_ordered_quotients": 1,
+        "nontrivial_admissible_partitions": 0,
+    },
+    "scalable_k8_four_circuit": {
+        "partitions_considered": 4140,
+        "rejected_strict_quad_collision": 4088,
+        "rejected_equality_pair_loop": 0,
+        "rejected_cyclic_order_incompatibility": 49,
+        "admissible_partitions": 3,
+        "admissible_ordered_quotients": 5,
+        "nontrivial_admissible_partitions": 2,
+    },
+}
+
+
+def assert_expected_payload(payload: Mapping[str, object]) -> None:
+    """Assert the stable pilot counts and claim boundaries."""
+
+    for key, expected in (
+        ("schema", SCHEMA),
+        ("status", STATUS),
+        ("trust", TRUST),
+        ("claim_scope", CLAIM_SCOPE),
+        ("conclusion", CONCLUSION),
+        ("provenance", PROVENANCE),
+    ):
+        if payload.get(key) != expected:
+            raise AssertionError(
+                f"{key}: expected {expected!r}, got {payload.get(key)!r}"
+            )
+
+    templates = payload.get("templates")
+    if not isinstance(templates, list) or len(templates) != 3:
+        raise AssertionError("expected exactly three hierarchy templates")
+    observed_names = [template.get("name") for template in templates]
+    if observed_names != list(EXPECTED_TEMPLATE_ACCOUNTING):
+        raise AssertionError(f"unexpected template order: {observed_names!r}")
+
+    for template in templates:
+        name = str(template["name"])
+        if template.get("partition_accounting") != EXPECTED_TEMPLATE_ACCOUNTING[name]:
+            raise AssertionError(f"{name}: partition accounting changed")
+        identity = template.get("identity_certificate")
+        if not isinstance(identity, Mapping) or identity.get("zero_sum_verified") is not True:
+            raise AssertionError(f"{name}: identity certificate is not zero-sum")
+        quotients = template.get("quotients")
+        if not isinstance(quotients, list):
+            raise AssertionError(f"{name}: quotient records must be a list")
+        if not all(
+            isinstance(record, Mapping)
+            and isinstance(record.get("certificate"), Mapping)
+            and record["certificate"].get("zero_sum_verified") is True
+            for record in quotients
+        ):
+            raise AssertionError(f"{name}: quotient pushforward failed")
+
+    z16 = templates[1]
+    if z16.get("one_row_fixed_order_scan") != {
+        "strict_rows_checked": 3640,
+        "zero_sum_row_count": 0,
+        "nonpositive_row_count": 0,
+        "one_row_certificate_absent": True,
+    }:
+        raise AssertionError("Z/16 one-row scan changed")
+
+    scalable = templates[2]
+    nontrivial_blocks = [
+        record["role_blocks"]
+        for record in scalable["quotients"]
+        if record["vertex_count"] == 7
+    ]
+    if nontrivial_blocks != [
+        [[1], [8], [16], [18, 23], [27], [37], [44]],
+        [[1], [8], [16], [18], [23, 27], [37], [44]],
+    ]:
+        raise AssertionError(f"unexpected scalable quotient blocks: {nontrivial_blocks!r}")
+
+    summary = payload.get("summary")
+    if not isinstance(summary, Mapping):
+        raise AssertionError("summary must be an object")
+    for key, expected in (
+        ("template_count", 3),
+        ("strict_support_levels", [1, 2, 4]),
+        ("admissible_partition_count", 5),
+        ("admissible_ordered_quotient_count", 7),
+        ("nontrivial_admissible_partition_count", 2),
+        ("all_quotient_certificates_zero_sum", True),
+    ):
+        if summary.get(key) != expected:
+            raise AssertionError(
+                f"summary.{key}: expected {expected!r}, got {summary.get(key)!r}"
+            )
+    digest = summary.get("quotient_catalog_sha256")
+    if not isinstance(digest, str) or len(digest) != 64:
+        raise AssertionError("summary quotient catalog digest is malformed")
+
+
+def validate_payload(payload: Mapping[str, object]) -> list[str]:
+    """Compare a stored payload with deterministic regeneration."""
+
+    errors: list[str] = []
+    try:
+        assert_expected_payload(payload)
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        errors.append(str(exc))
+        return errors
+    if payload != hierarchy_payload():
+        errors.append("stored payload differs from complete regenerated hierarchy")
+    return errors
+
+
+__all__ = [
+    "CLAIM_SCOPE",
+    "CONCLUSION",
+    "PROVENANCE",
+    "SCHEMA",
+    "STATUS",
+    "TRUST",
+    "CertificateTemplate",
+    "TemplateStrictRow",
+    "assert_expected_payload",
+    "certificate_templates",
+    "enumerate_admissible_quotients",
+    "feasible_cyclic_orders",
+    "hierarchy_payload",
+    "restricted_growth_partitions",
+    "validate_payload",
+    "verify_mapped_certificate",
+]

--- a/tests/test_check_fragile_cycle_quotient_hierarchy.py
+++ b/tests/test_check_fragile_cycle_quotient_hierarchy.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_fragile_cycle_quotient_hierarchy.py"
+
+
+def test_cli_write_then_check(tmp_path: Path) -> None:
+    artifact = tmp_path / "hierarchy.json"
+    write = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--write",
+            "--assert-expected",
+            "--out",
+            str(artifact),
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    written = json.loads(write.stdout)
+    assert written["summary"]["strict_support_levels"] == [1, 2, 4]
+
+    checked = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--check",
+            "--assert-expected",
+            "--artifact",
+            str(artifact),
+            "--summary-json",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(checked.stdout)
+    assert payload["summary"]["all_quotient_certificates_zero_sum"] is True
+
+
+def test_cli_rejects_modified_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "hierarchy.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--write", "--out", str(artifact)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    payload["summary"]["admissible_partition_count"] = 6
+    artifact.write_text(json.dumps(payload), encoding="utf-8")
+
+    checked = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check", "--artifact", str(artifact)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert checked.returncode != 0
+    assert "admissible_partition_count" in checked.stderr

--- a/tests/test_check_text_clean.py
+++ b/tests/test_check_text_clean.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.check_text_clean import is_text_target
+from scripts.check_text_clean import hidden_char_description, is_text_target
 
 
 def test_repository_text_formats_are_covered() -> None:
@@ -23,3 +23,9 @@ def test_repository_text_formats_are_covered() -> None:
 def test_binary_artifacts_are_not_decoded_as_text() -> None:
     for name in ("paper.pdf", "bundle.zip", "figure.png"):
         assert not is_text_target(Path(name)), name
+
+
+def test_ascii_controls_are_rejected_except_tab_and_line_feed() -> None:
+    assert hidden_char_description("\x08") == "CONTROL CHARACTER"
+    assert hidden_char_description("\t") is None
+    assert hidden_char_description("\n") is None

--- a/tests/test_fragile_cycle_quotient_hierarchy.py
+++ b/tests/test_fragile_cycle_quotient_hierarchy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from erdos97.fragile_cycle_quotient_hierarchy import (
+    EXPECTED_TEMPLATE_ACCOUNTING,
+    assert_expected_payload,
+    certificate_templates,
+    enumerate_admissible_quotients,
+    hierarchy_payload,
+    restricted_growth_partitions,
+)
+
+
+def test_restricted_growth_partition_counts() -> None:
+    assert len(list(restricted_growth_partitions(4))) == 15
+    assert len(list(restricted_growth_partitions(5))) == 52
+    assert len(list(restricted_growth_partitions(8))) == 4140
+
+
+def test_template_partition_accounting() -> None:
+    for template in certificate_templates():
+        result = enumerate_admissible_quotients(template)
+        assert (
+            result["partition_accounting"]
+            == EXPECTED_TEMPLATE_ACCOUNTING[template.name]
+        )
+        assert all(
+            record["certificate"]["zero_sum_verified"]
+            for record in result["quotients"]
+        )
+
+
+def test_scalable_template_has_two_nontrivial_quotients() -> None:
+    scalable = certificate_templates()[2]
+    result = enumerate_admissible_quotients(scalable)
+    nontrivial = [
+        record
+        for record in result["quotients"]
+        if record["vertex_count"] < len(scalable.labels)
+    ]
+    assert [record["role_blocks"] for record in nontrivial] == [
+        [[1], [8], [16], [18, 23], [27], [37], [44]],
+        [[1], [8], [16], [18], [23, 27], [37], [44]],
+    ]
+    assert all(record["compatible_cyclic_order_count"] == 1 for record in nontrivial)
+
+
+def test_hierarchy_payload_expected() -> None:
+    payload = hierarchy_payload()
+    assert_expected_payload(payload)
+    assert payload["summary"]["strict_support_levels"] == [1, 2, 4]
+    assert payload["summary"]["admissible_partition_count"] == 5
+    assert payload["summary"]["nontrivial_admissible_partition_count"] == 2


### PR DESCRIPTION
## Summary

- add an exact admissible-role-quotient enumerator for the stored n=9 hinge, fixed-order Z/16 inverse pair, and scalable k=8 four-row Kalmanson templates
- generate and register a provenance-checked JSON artifact; link it into the bridge audit, Contract F target ledger, documentation index, backlog, and generated Makefile target
- isolate exactly two proper seven-role quotients of the scalable template while preserving the repository's no-proof/no-counterexample claim boundary
- normalize the hinge crosswalk's source path with the repository path helper so its stored artifact replays on Windows

## Review fixes

- repair mangled mathematical notation and remove an embedded U+0008 backspace from the new documentation
- extend the fast text-clean check to reject unexpected ASCII control characters
- add a focused regression test for the control-character policy
- update the branch onto post-#915 `main` and verify the combined tree

## Verification

Passed on combined head `0258c3e2c290567751e32127819cb86709e0def8`:

- text cleanliness, status consistency, artifact provenance, generated Makefile check, HEAD-relative whitespace check, and full Ruff
- both exact PR artifact checkers and 12 focused tests
- all-k scalable inverse and three-row minimality controls
- all 11 finite-artifact commands required by AGENTS.md
- hosted full test job and all eight hosted artifact pytest shards
- local fast suite: 1,844 tests passed; the sole Windows-sandbox ProcessPool test was blocked by named-pipe permissions and passed when rerun with named-pipe access

No source-of-truth strongest-result or official/global status field is changed. The artifact remains a local certificate diagnostic, not a bridge proof, proof of n=9, general proof, Euclidean realization, or counterexample.