### PR TITLE
Document corrected three-defect deletion frontier

### DIFF
--- a/docs/conversation-three-defect-deletion-frontier-2026-08-10.md
+++ b/docs/conversation-three-defect-deletion-frontier-2026-08-10.md
@@ -1,0 +1,330 @@
+# Corrected three-defect deletion frontier from the conversation
+
+Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING / OPEN_BRIDGE`
+
+Date: 2026-08-10.
+
+This note is a correction and continuation of the conversation research ledger
+merged in PR #921. It records one assignment-independent theorem that survived
+the later proof search, identifies the exact overreach in the preceding
+blocker-potential argument, and gives a narrower successor target.
+
+It does **not** claim a proof or counterexample to Erdős Problem 97. It does not
+change `STATE.md`, `RESULTS.md`, `docs/claims.md`, or any machine-readable claim
+metadata.
+
+## 1. Correction to the maximal-blocker-assignment route
+
+A later conversation round chose, for every source `q`, one unique-four blocker
+`beta(q)` and maximized the sum of squared blocker-fiber sizes. The resulting
+exchange inequality is useful for the **chosen** assignment:
+
+```text
+q belongs to the exact row at c,
+beta(q) = d != c
+  => load(d) >= load(c) + 1.
+```
+
+That inequality can rule out certain mutual cross-memberships between two
+chosen blocker fibers.
+
+The overreach was the subsequent inference that deleting `q` can fail only at
+`beta(q)`. A point can belong to several complete exact-four rows. In
+particular, it can belong to a row centered at a unique-four center that receives
+no source under the chosen assignment. Deleting `q` destroys every unique-four
+row containing `q`, not merely the selected one.
+
+Therefore the following implication is **withdrawn**:
+
+```text
+chosen blocker beta(q)
+  => beta(q) is the only center made non-4-rich by deleting q.
+```
+
+Any downstream universal claim requiring that implication, including the
+unqualified canonical-candidate/equilateral fork, is not promoted here.
+
+The corrected route must count **all** unique-four rows containing a source.
+
+## 2. Setup
+
+Let `A` be a finite strictly convex carrier satisfying the four-equidistant
+property at every vertex, and assume `A` is vertex-minimal among such carriers.
+
+Write `K4(X,p)` for the assertion that `p` has at least four points of `X` at
+one positive distance.
+
+Call a center `c in A` fully deletion-robust when
+
+```text
+K4(A \ {q}, c)
+```
+
+holds for every `q in A`.
+
+Let
+
+```text
+U = { c in A : c is not fully deletion-robust }.
+```
+
+Minimality gives the standard unique-four structure.
+
+### Unique-four center lemma
+
+For every `c in U`, there is a unique positive radius whose complete distance
+class `K_c` has at least four points, and in fact
+
+```text
+|K_c| = 4.
+```
+
+Moreover, for every `q in A`,
+
+```text
+not K4(A \ {q}, c)  <=>  q in K_c.
+```
+
+#### Proof
+
+Choose `q` whose deletion destroys four-richness at `c`.
+
+Every rich radius class at `c` must contain `q`; otherwise it would remain
+after deleting `q`. Distinct radius classes are disjoint, so there is at most
+one rich radius. Its class cannot have at least five members, because deleting
+one point would leave four. Hence the complete class has exactly four members.
+
+Deleting a member of this class leaves only three points at the unique rich
+radius and therefore destroys `K4`. Deleting a point outside the class leaves
+the four-point class intact. This proves the equivalence.
+
+### Unique-four cover lemma
+
+Every `q in A` lies in `K_c` for at least one `c in U`.
+
+#### Proof
+
+Otherwise deleting `q` would preserve `K4` at every surviving center, producing
+a smaller strictly convex carrier with the same property and contradicting
+minimality.
+
+## 3. The assignment-independent incidence count
+
+For `q in A`, define
+
+```text
+d(q) = |{ c in U : q in K_c }|.
+```
+
+Count incidences `(c,q)` with `c in U` and `q in K_c` in two ways:
+
+```text
+sum_{q in A} d(q)
+  = sum_{c in U} |K_c|
+  = 4 |U|.
+```
+
+If `A` contains at least one fully deletion-robust center, then
+
+```text
+|U| <= |A| - 1,
+```
+
+and therefore
+
+```text
+sum_{q in A} d(q) <= 4|A| - 4 < 4|A|.
+```
+
+Hence some `q` satisfies `d(q) <= 3`. The cover lemma gives `d(q) >= 1`.
+
+The all-large tri-apex residual supplies three distinct fully deletion-robust
+MEC apices, so the hypothesis is available there with room to spare.
+
+## 4. Three-defect deletion theorem
+
+> **Theorem.**
+> In a vertex-minimal counterexample with at least one fully
+> deletion-robust center, there exists `q in A` such that deleting `q` leaves
+> between one and three non-4-rich centers. More exactly, if
+>
+> ```text
+> F(q) = { c in U : q in K_c },
+> ```
+>
+> then
+>
+> ```text
+> 1 <= |F(q)| <= 3
+> ```
+>
+> and
+>
+> ```text
+> { c in A \ {q} : not K4(A \ {q}, c) } = F(q).
+> ```
+
+### Proof
+
+Choose `q` with `1 <= d(q) <= 3` from the incidence count.
+
+For `c in F(q)`, the unique-four center lemma says that deleting `q` destroys
+`K4` at `c`.
+
+For `c in U \ F(q)`, the exact class `K_c` avoids `q` and survives intact.
+
+Every center outside `U` is fully deletion-robust and also survives.
+
+The deleted point `q` is not a member of its own positive-radius class, so it is
+not accidentally counted as a failed center. The displayed equality follows.
+
+## 5. Immediate dangerous-triple consequences
+
+Fix the source `q` from the theorem. For each `p in F(q)`, write
+
+```text
+K_p = {q} disjoint_union T_p.
+```
+
+Then:
+
+```text
+|T_p| = 3,
+```
+
+all members of `T_p` are at distance `|pq|` from `p`, and `T_p` is
+noncollinear. A line meets a positive-radius circle in at most two points.
+
+Thus `(q,p,T_p)` has exactly the theorem-facing shape called a U5 dangerous
+triple in the separate Lean formalization.
+
+For distinct `p,r in F(q)`, the circles centered at `p` and `r` both contain
+`q`. Distinct circles have at most two common points, so
+
+```text
+|T_p intersect T_r| <= 1.
+```
+
+Consequently:
+
+```text
+|F(q)| = 1  =>  one three-point dangerous triple;
+|F(q)| = 2  =>  the union of the two triples has at least 5 points;
+|F(q)| = 3  =>  the union of the three triples has at least 6 points.
+```
+
+For the last line, add the triples in sequence: the second loses at most one
+new point to the first, and the third loses at most two new points to the first
+two.
+
+Every center outside `F(q) union {q}` has some q-free four-point witness after
+deleting `q`.
+
+## 6. What the theorem does not supply
+
+The three-defect theorem does not by itself finish the current U5 route.
+
+Global q-free `K4` at a center only gives the existence of a four-point witness
+somewhere in `A \ {q}`. The current bounded U5 terminal needs a stronger
+payload, such as:
+
+1. a selected candidate on the dangerous `p`-circle;
+2. q-free selected classes confined to a named eight-point support;
+3. the positive row memberships of a proved q-critical/exact/q-critical or
+   equilateral-bridge incompatibility; or
+4. a small ordered set of exact rows matching one of the established
+   Kalmanson schemas.
+
+Deletion survival alone does not choose a canonical surviving radius at a
+robust center and does not confine the witness class to a bounded support.
+
+The theorem also does not ensure that the selected `q` lies in the designated
+surplus cap required by a particular on-spine U-lane ingress. It produces the
+native dangerous-triple geometry, not the entire cap-specific residual packet.
+
+## 7. Corrected remaining bridge
+
+The next theorem should be stated from the assignment-independent packet.
+
+> **Three-defect closure target.**
+> Let `q` be a source whose deletion has defect set `F(q)` of cardinality at
+> most three, and let `T_p` be the q-critical triple at each `p in F(q)`.
+> Prove that at least one of the following occurs:
+>
+> 1. a q-free witness lies on one dangerous `p`-circle;
+> 2. the q-free classes needed by a U5 audit are confined to a bounded support;
+> 3. four exact rows materialize a proved Kalmanson schema;
+> 4. deleting `q` together with a blocker-closed subset of `F(q)` leaves a
+>    proper nonempty `K4` subcarrier.
+
+Each output is already terminal or feeds an existing terminal. The missing work
+is the disjunction itself.
+
+A useful way to organize the proof is by the exact value of `|F(q)|`:
+
+```text
+1 defect: one q-critical circle plus q-free K4 everywhere else;
+2 defects: two q-critical circles through q, with at most one shared triple point;
+3 defects: three q-critical circles through q, with pairwise triple overlap <= 1.
+```
+
+This is a finite number of **critical centers**, but not yet a finite number of
+ambient witness vertices.
+
+## 8. Formalization crosswalk
+
+The separate Lean project already contains interfaces close to the required
+pieces:
+
+```text
+IsUniqueFourCenter / uniqueFourClass
+notRobustCenters
+U5DangerousTriple
+U5QCriticalTripleClass
+U5QDeletedK4Class
+U5BoundedEightPointSupport
+U5BoundedAuditSupport
+```
+
+The recommended first formal theorem is the pure double-counting statement:
+
+```text
+exists q in A,
+  1 <= card {c in notRobustCenters D | q in uniqueFourClass c}
+  and
+  card {c in notRobustCenters D | q in uniqueFourClass c} <= 3.
+```
+
+Its dependencies should be limited to:
+
+- the minimal unique-four cover;
+- exact cardinality four of every nonrobust center's unique class;
+- existence of one robust center;
+- finite incidence double counting.
+
+No cap order, Kalmanson inequality, solver certificate, or selected-blocker map
+is needed for this theorem.
+
+The second theorem should identify this incidence fiber with the exact set of
+centers that fail after deleting `q`.
+
+## 9. Status boundary
+
+The rigorous candidate advancement recorded here is:
+
+```text
+minimal counterexample
+  + at least one fully deletion-robust center
+  => a deletion with exactly 1, 2, or 3 bad centers
+  => at most three q-critical dangerous triples.
+```
+
+The still-open step is:
+
+```text
+at most three q-critical dangerous triples
+  + q-free K4 at every other center
+  => a bounded U5, Kalmanson, or smaller-subcarrier terminal.
+```
+
+No general proof is claimed.

--- a/docs/conversation-three-defect-deletion-frontier-2026-08-10.md
+++ b/docs/conversation-three-defect-deletion-frontier-2026-08-10.md
@@ -4,10 +4,11 @@ Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING / OPEN_BRIDGE`
 
 Date: 2026-08-10.
 
-This note is a correction and continuation of the conversation research ledger
-merged in PR #921. It records one assignment-independent theorem that survived
-the later proof search, identifies the exact overreach in the preceding
-blocker-potential argument, and gives a narrower successor target.
+This note continues the conversation research ledger merged in PR #921. It
+records one assignment-independent theorem that survived the later proof
+search, identifies an overreach from an **unmerged** post-#921 conversation
+round, and gives a narrower successor target. No claim in merged PR #921 is
+being retracted.
 
 It does **not** claim a proof or counterexample to Erdős Problem 97. It does not
 change `STATE.md`, `RESULTS.md`, `docs/claims.md`, or any machine-readable claim
@@ -15,9 +16,10 @@ metadata.
 
 ## 1. Correction to the maximal-blocker-assignment route
 
-A later conversation round chose, for every source `q`, one unique-four blocker
-`beta(q)` and maximized the sum of squared blocker-fiber sizes. The resulting
-exchange inequality is useful for the **chosen** assignment:
+A later, unmerged conversation round chose, for every source `q`, one
+unique-four blocker `beta(q)` and maximized the sum of squared blocker-fiber
+sizes. The resulting exchange inequality is useful for the **chosen**
+assignment:
 
 ```text
 q belongs to the exact row at c,
@@ -34,7 +36,8 @@ particular, it can belong to a row centered at a unique-four center that receive
 no source under the chosen assignment. Deleting `q` destroys every unique-four
 row containing `q`, not merely the selected one.
 
-Therefore the following implication is **withdrawn**:
+Therefore the following implication is **withdrawn from that unmerged
+continuation**:
 
 ```text
 chosen blocker beta(q)
@@ -138,8 +141,13 @@ sum_{q in A} d(q) <= 4|A| - 4 < 4|A|.
 
 Hence some `q` satisfies `d(q) <= 3`. The cover lemma gives `d(q) >= 1`.
 
-The all-large tri-apex residual supplies three distinct fully deletion-robust
-MEC apices, so the hypothesis is available there with room to spare.
+In the intended all-large tri-apex residual, each of the three distinct
+physical MEC apices carries the established `ApexRichClassStructure`: either
+one radius class has at least six points or two distinct radii each have at
+least four. Either alternative makes the center fully deletion-robust, as
+recorded by the pinned Lean theorem
+[`fullyDeletionRobustAt_of_apexRichClassStructure`](https://github.com/mysticflounder/erdos-97-96-formalization/blob/3ee15db22b02f4923da535a7f7a19c4a75fb3030/lean/Erdos9796Proof/P97/ATail/ApexRichClassStructure.lean#L70-L83).
+Thus the hypothesis is available there with room to spare.
 
 ## 4. Three-defect deletion theorem
 
@@ -273,8 +281,15 @@ ambient witness vertices.
 
 ## 8. Formalization crosswalk
 
-The separate Lean project already contains interfaces close to the required
-pieces:
+This crosswalk is pinned to upstream formalization commit
+[`3ee15db`](https://github.com/mysticflounder/erdos-97-96-formalization/commit/3ee15db22b02f4923da535a7f7a19c4a75fb3030),
+the `main` revision at 2026-08-10 10:43 UTC immediately before this note was
+committed. The unique-four interfaces are in
+[`MinimalUniqueFourCover.lean`](https://github.com/mysticflounder/erdos-97-96-formalization/blob/3ee15db22b02f4923da535a7f7a19c4a75fb3030/lean/Erdos9796Proof/P97/ATail/MinimalUniqueFourCover.lean),
+and the U5 interfaces are in
+[`U5GlobalIncidenceBasic.lean`](https://github.com/mysticflounder/erdos-97-96-formalization/blob/3ee15db22b02f4923da535a7f7a19c4a75fb3030/lean/Erdos9796Proof/P97/U5GlobalIncidenceBasic.lean).
+At that revision the separate Lean project contains interfaces close to the
+required pieces:
 
 ```text
 IsUniqueFourCenter / uniqueFourClass

--- a/docs/conversation-three-defect-formalization-contract-2026-08-10.md
+++ b/docs/conversation-three-defect-formalization-contract-2026-08-10.md
@@ -1,0 +1,275 @@
+# Formalization contract for the three-defect deletion theorem
+
+Status: `FORMALIZATION_TARGET / REVIEW_PENDING / NO_STATUS_PROMOTION`
+
+Date: 2026-08-10.
+
+This document turns the corrected conversation result into a small,
+independently checkable theorem contract. It is intentionally separated from
+the larger cap, U5, and Kalmanson machinery.
+
+## 1. Pure finite-cover core
+
+The geometric content needed for the first theorem is only the existence of a
+proper family of four-element blocks that covers the carrier.
+
+Let:
+
+```text
+V = finite nonempty set of vertices,
+C = finite set of critical centers,
+K(c) subset V for c in C,
+|K(c)| = 4 for every c,
+union_{c in C} K(c) = V,
+|C| < |V|.
+```
+
+Define the block degree
+
+```text
+d(v) = |{c in C : v in K(c)}|.
+```
+
+Then:
+
+> **Low-degree four-cover lemma.**
+> There exists `v in V` with
+>
+> ```text
+> 1 <= d(v) <= 3.
+> ```
+
+### Proof
+
+Coverage gives `d(v) >= 1` for every `v`.
+
+Double counting gives
+
+```text
+sum_{v in V} d(v) = sum_{c in C} |K(c)| = 4|C| < 4|V|.
+```
+
+If every degree were at least four, the left side would be at least `4|V|`, a
+contradiction.
+
+This lemma should be formalized first, with no Euclidean imports.
+
+## 2. Suggested abstract Lean surface
+
+One possible theorem shape is:
+
+```lean
+theorem exists_mem_degree_between_one_and_three
+    {V C : Type*}
+    [Fintype V] [Fintype C]
+    [DecidableEq V] [DecidableEq C]
+    (K : C → Finset V)
+    (hcard : ∀ c, (K c).card = 4)
+    (hcover : ∀ v, ∃ c, v ∈ K c)
+    (hproper : Fintype.card C < Fintype.card V) :
+    ∃ v : V,
+      1 ≤ ((Finset.univ : Finset C).filter fun c => v ∈ K c).card ∧
+      ((Finset.univ : Finset C).filter fun c => v ∈ K c).card ≤ 3
+```
+
+The proof should use a finite incidence set or a sum-swap identity rather than
+any solver-backed arithmetic.
+
+A convenient incidence set is:
+
+```lean
+I = (Finset.univ.product Finset.univ).filter fun pair => pair.1 ∈ K pair.2
+```
+
+Count `I` by centers and by vertices.
+
+## 3. Geometric adapter
+
+For a vertex-minimal four-rich convex carrier `D.A`, instantiate:
+
+```text
+V = carrier vertices,
+C = notRobustCenters D,
+K(c) = the complete unique-four class at c.
+```
+
+The adapter needs four established facts.
+
+### A. Exact four
+
+For every `c in notRobustCenters D`, the unique rich class at `c` has
+cardinality exactly four.
+
+### B. Cover
+
+Every carrier vertex belongs to the unique-four class of at least one
+nonrobust center.
+
+### C. Proper center set
+
+At least one carrier center is fully deletion-robust. In the intended
+all-large tri-apex application, all three physical MEC apices are robust, so
+
+```text
+(notRobustCenters D).card <= D.A.card - 3.
+```
+
+Only strict inequality is needed by the abstract lemma.
+
+### D. Failure equivalence
+
+For `c` nonrobust and `q` a carrier vertex:
+
+```text
+not K4(D.A.erase q, c)
+  <=>
+q belongs to the complete unique-four class at c.
+```
+
+The forward direction follows because every rich class must meet the deleted
+point. The reverse direction follows from uniqueness and exact cardinality
+four.
+
+## 4. Suggested geometric declarations
+
+The first declaration should expose only the incidence fiber:
+
+```lean
+noncomputable def deletionDefectFiber
+    (D : CounterexampleData) (q : ℝ²) : Finset ℝ² :=
+  (notRobustCenters D).filter fun c =>
+    q ∈ uniqueFourClass D.A c
+```
+
+The exact argument list of `uniqueFourClass` should follow the live source
+rather than this schematic notation.
+
+Then prove:
+
+```lean
+theorem exists_deletionDefectFiber_card_between_one_and_three
+    (D : CounterexampleData)
+    (hmin : D.Minimal)
+    (hrobust : ∃ a ∈ D.A, FullyDeletionRobustAt D a) :
+    ∃ q ∈ D.A,
+      1 ≤ (deletionDefectFiber D q).card ∧
+      (deletionDefectFiber D q).card ≤ 3
+```
+
+The second declaration should identify the fiber semantically:
+
+```lean
+theorem deletionDefectFiber_eq_failedCenters
+    (D : CounterexampleData)
+    (hmin : D.Minimal)
+    {q : ℝ²} (hq : q ∈ D.A) :
+    deletionDefectFiber D q =
+      (D.A.erase q).filter fun c =>
+        ¬ HasNEquidistantPointsAt 4 (D.A.erase q) c
+```
+
+Depending on the live definition of robustness, it may be cleaner to filter
+all of `D.A`; `q` itself should not enter the failure set because deleting the
+center does not remove any positive-radius witness.
+
+The combined theorem is:
+
+```lean
+theorem exists_threeDefectDeletion
+    (D : CounterexampleData)
+    (hmin : D.Minimal)
+    (hrobust : ∃ a ∈ D.A, FullyDeletionRobustAt D a) :
+    ∃ q ∈ D.A,
+      1 ≤ ((D.A.erase q).filter fun c =>
+        ¬ HasNEquidistantPointsAt 4 (D.A.erase q) c).card ∧
+      ((D.A.erase q).filter fun c =>
+        ¬ HasNEquidistantPointsAt 4 (D.A.erase q) c).card ≤ 3
+```
+
+## 5. Dangerous-triple adapter
+
+For each `p` in the defect fiber, the ambient complete class through `q` is a
+critical four-shell. Erasing `q` gives a three-point class.
+
+The adapter should prove:
+
+```lean
+theorem exists_u5DangerousTriple_of_mem_deletionDefectFiber
+    (D : CounterexampleData)
+    (hmin : D.Minimal)
+    {q p : ℝ²}
+    (hq : q ∈ D.A)
+    (hp : p ∈ deletionDefectFiber D q) :
+    ∃ T : Finset ℝ²,
+      U5DangerousTriple D q p T
+```
+
+The support can be defined canonically as the unique-four class at `p` erased
+at `q`.
+
+For distinct defect centers, prove the overlap bound:
+
+```lean
+theorem dangerousTriples_inter_card_le_one
+    ...
+    (hp_ne_hr : p ≠ r) :
+    (T_p ∩ T_r).card ≤ 1
+```
+
+This is the ordinary two-circle intersection bound after accounting for their
+already shared point `q`.
+
+Optional useful corollaries are:
+
+```text
+2 defect centers => union of triples has cardinality at least 5;
+3 defect centers => union of triples has cardinality at least 6.
+```
+
+## 6. Explicit non-goals
+
+This formalization must not claim any of the following:
+
+- the selected source lies in a designated Moser cap;
+- only one center fails after deletion;
+- a robust center's surviving class is its previously selected class;
+- all needed U5 classes lie in eight points;
+- the three-defect packet already contradicts convexity;
+- a proof of Erdős 97 has been completed.
+
+The theorem is assignment-independent. It should not depend on a maximized
+blocker selector, blocker-fiber loads, or a chosen critical-shell map except as
+an adapter for an already canonical unique-four class.
+
+## 7. Validation plan
+
+Before connecting the theorem to the live spine:
+
+1. Prove the pure finite-cover lemma in an isolated file.
+2. Print its axioms and require only the ordinary Lean core axioms used by the
+   surrounding noncomputational geometry.
+3. Instantiate it with a small synthetic four-cover where the minimum degree is
+   exactly three, to guard against accidentally proving a stronger false bound.
+4. Add a negative control with `|C| = |V|` and every degree exactly four; this
+   should demonstrate why the existence of a robust center, hence `|C| < |V|`,
+   is load-bearing.
+5. Prove the failure-fiber equality separately from the counting theorem.
+6. Only then construct the U5 dangerous triples.
+
+## 8. Successor theorem contract
+
+The next genuinely geometric statement is not part of the first PR-sized
+formalization task.
+
+> **Three-defect bounded-closure target.**
+> From one to three q-critical dangerous triples and q-free K4 at every other
+> center, produce at least one of:
+>
+> - a U5 same-circle export;
+> - bounded support for the U5 finite audit;
+> - a proved positive-incidence U5 or Kalmanson pattern;
+> - a proper blocker-closed K4 subcarrier.
+
+The three-defect theorem narrows the number of exceptional centers. It does not
+bound the ambient witnesses used by surviving classes. That support-confinement
+step remains the open bridge.

--- a/docs/conversation-three-defect-formalization-contract-2026-08-10.md
+++ b/docs/conversation-three-defect-formalization-contract-2026-08-10.md
@@ -8,6 +8,12 @@ This document turns the corrected conversation result into a small,
 independently checkable theorem contract. It is intentionally separated from
 the larger cap, U5, and Kalmanson machinery.
 
+The schematic Lean vocabulary below is pinned to upstream formalization commit
+[`3ee15db`](https://github.com/mysticflounder/erdos-97-96-formalization/commit/3ee15db22b02f4923da535a7f7a19c4a75fb3030),
+the `main` revision at 2026-08-10 10:43 UTC immediately before this document
+was committed. Later implementations should either use that revision or
+explicitly recheck the names and theorem surfaces against a newer source.
+
 ## 1. Pure finite-cover core
 
 The geometric content needed for the first theorem is only the existence of a
@@ -108,7 +114,11 @@ nonrobust center.
 ### C. Proper center set
 
 At least one carrier center is fully deletion-robust. In the intended
-all-large tri-apex application, all three physical MEC apices are robust, so
+all-large tri-apex application, each of the three physical MEC apices carries
+`ApexRichClassStructure`: either one radius class has at least six points or
+two distinct radii each have at least four. The pinned theorem
+[`fullyDeletionRobustAt_of_apexRichClassStructure`](https://github.com/mysticflounder/erdos-97-96-formalization/blob/3ee15db22b02f4923da535a7f7a19c4a75fb3030/lean/Erdos9796Proof/P97/ATail/ApexRichClassStructure.lean#L70-L83)
+makes either alternative fully deletion-robust. Hence
 
 ```text
 (notRobustCenters D).card <= D.A.card - 3.
@@ -141,7 +151,8 @@ noncomputable def deletionDefectFiber
     q ∈ uniqueFourClass D.A c
 ```
 
-The exact argument list of `uniqueFourClass` should follow the live source
+The exact argument list of `uniqueFourClass` should follow the pinned source,
+or a later source revision whose interface has been explicitly rechecked,
 rather than this schematic notation.
 
 Then prove:

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,12 @@ put detailed reconciliation in the canonical synthesis.
 - [`conversation-frontier-and-failed-routes-2026-08-06.md`](conversation-frontier-and-failed-routes-2026-08-06.md):
   failed-route record, verified upstream crosswalk, and open paired frontier;
   `DIAGNOSTIC_ONLY` / `OPEN_BRIDGE`, with no closure claim.
+- [`conversation-three-defect-deletion-frontier-2026-08-10.md`](conversation-three-defect-deletion-frontier-2026-08-10.md):
+  corrected assignment-independent three-defect deletion theorem candidate;
+  `PAPER_PROOF_CANDIDATE` / `REVIEW_PENDING` / `OPEN_BRIDGE`.
+- [`conversation-three-defect-formalization-contract-2026-08-10.md`](conversation-three-defect-formalization-contract-2026-08-10.md):
+  pinned finite-cover and Lean-adapter contract for the same candidate;
+  `FORMALIZATION_TARGET` / `REVIEW_PENDING` / `NO_STATUS_PROMOTION`.
 - [`canonical-synthesis.md`](canonical-synthesis.md): long-form canonical
   synthesis, claim taxonomy, failed-route reconciliation, and source/hash
   inventory.


### PR DESCRIPTION
## Summary

This follow-up to merged PR #921 records the strongest defensible result from the later conversation rounds and corrects an overstrong blocker-assignment inference.

It adds and indexes two research documents:

- `docs/conversation-three-defect-deletion-frontier-2026-08-10.md`
  - explains why a maximized chosen-blocker assignment does **not** identify every center destroyed by deleting a source;
  - withdraws downstream claims that relied on a unique bad center from the unmerged continuation, without retracting any claim merged in PR #921;
  - proves, at paper level, an assignment-independent double-counting theorem: in a minimal counterexample with at least one fully deletion-robust center, some deletion leaves exactly 1–3 non-4-rich centers;
  - derives the corresponding family of at most three q-critical dangerous triples and their pairwise overlap bound;
  - isolates the remaining bounded-closure/U5/Kalmanson bridge.

- `docs/conversation-three-defect-formalization-contract-2026-08-10.md`
  - separates the pure finite four-cover lemma from its geometric adapter;
  - gives schematic Lean theorem surfaces for the defect fiber, failed-center equality, and dangerous-triple construction;
  - lists explicit non-goals, negative controls, and a staged validation plan.

## Why this is worth preserving

The correction prevents future work from silently treating one selected blocker as the complete deletion-failure set. The replacement theorem counts all unique-four rows containing a source, is independent of blocker-selector choices, and narrows the post-deletion exception set to at most three centers in the robust-apex residual.

The proof uses only:

- the minimal unique-four cover;
- exact cardinality four of every nonrobust center's unique rich class;
- existence of at least one fully deletion-robust center;
- finite incidence double counting.

No cap order, solver output, selected blocker map, or Kalmanson inequality is needed for the three-defect theorem itself.

## Trust boundary

This is a documentation/research PR, not a theorem-status update.

- No proof or counterexample to Erdős 97 is claimed.
- Both documents are labeled `REVIEW_PENDING` / `OPEN_BRIDGE`.
- `STATE.md`, `RESULTS.md`, `docs/claims.md`, and machine-readable claim metadata are unchanged.
- The later bounded-support/U5 closure remains explicitly open.

## Validation

- Compared the branch against `main`: 3 commits, 3 changed Markdown files, 637 additions, no deletions.
- Manually rechecked the incidence identity, exact failure-set equivalence, dangerous-triple overlap argument, and the negative control showing why `|critical centers| < |vertices|` is load-bearing.
- Pinned and verified the Lean crosswalk at upstream formalization commit `3ee15db22b02f4923da535a7f7a19c4a75fb3030`, including the all-large tri-apex robustness implication.
- Local text-cleanliness, status-consistency, provenance, generated-Makefile, diff, and Ruff checks passed.
- GitHub Actions installed the package in editable mode and passed the complete `make verify-fast` job on commit `0ef10d6742c9f5a45394f5506031a11f2c57a17f`.
- No artifact-tier command was required because this PR changes review-pending documentation only; it adds no finite-case certificate and promotes no public theorem-style claim.

## Review focus

The highest-value checks are:

1. the unique-four failure equivalence under deletion;
2. the double-counting identity `sum_q d(q) = 4|U|`;
3. the use of one robust center to force a degree at most three;
4. the conversion of each failed center into a q-critical three-point dangerous triple;
5. the proposed Lean interfaces and whether they match the pinned formalization vocabulary without strengthening it.
