### PR TITLE
CI: speed up test and artifact workflows

### DIFF
--- a/.github/workflows/artifact-audit.yml
+++ b/.github/workflows/artifact-audit.yml
@@ -71,6 +71,8 @@ jobs:
         if: github.event_name == 'pull_request'
         run: >-
           python -m pytest -q -m "artifact and not exhaustive"
+          -n auto --dist worksteal
+          --durations 20 --durations-min 1.0
           --shard-count 8 --shard-index ${{ matrix.shard }}
       - name: Run full artifact pytest shard
         if: github.event_name != 'pull_request'

--- a/.github/workflows/artifact-audit.yml
+++ b/.github/workflows/artifact-audit.yml
@@ -59,38 +59,26 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements-lock.txt
       - run: python -m pip install -r requirements-lock.txt
       - run: python -m pip install --no-deps -e .
-      - name: Run artifact pytest shard
+      - name: Run PR artifact pytest shard
+        if: github.event_name == 'pull_request'
+        run: >-
+          python -m pytest -q -m "artifact and not exhaustive"
+          --shard-count 8 --shard-index ${{ matrix.shard }}
+      - name: Run full artifact pytest shard
+        if: github.event_name != 'pull_request'
         run: >-
           python -m pytest -q -m "artifact"
           --shard-count 8 --shard-index ${{ matrix.shard }}
-
-  slow-exhaustive-pytest:
-    if: github.event_name != 'pull_request'
-    name: non-artifact slow/exhaustive pytest shard ${{ matrix.shard }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: requirements-lock.txt
-      - run: python -m pip install -r requirements-lock.txt
-      - run: python -m pip install --no-deps -e .
       - name: Run non-artifact slow/exhaustive pytest shard
+        if: github.event_name != 'pull_request'
         run: >-
           python -m pytest -q -m "(slow or exhaustive) and not artifact"
           --shard-count 8 --shard-index ${{ matrix.shard }}
@@ -105,8 +93,8 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip
@@ -120,7 +108,7 @@ jobs:
           --output-dir artifact-audit-results
       - name: Upload artifact audit summaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifact-audit-${{ github.sha }}-shard-${{ matrix.shard }}
           path: artifact-audit-results/

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -33,11 +33,11 @@ jobs:
   compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # lean-action caches .lake build outputs itself; this cache covers the
       # elan toolchain download, which dominates a cold run.
       - name: Cache elan toolchain
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.elan
           key: elan-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,10 +62,29 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install compatibility dependencies
-        run: python -m pip install -e '.[dev]'
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.10" ]; then
+            # python-flint 0.8 requires Python 3.11. Install the declared
+            # dependency set without that optional exact backend; its tests
+            # use pytest.importorskip when the module is unavailable.
+            python -m pip install --no-deps -e .
+            python -m pip install \
+              'numpy>=1.24' \
+              'scipy>=1.10' \
+              'PyYAML>=6' \
+              'mpmath>=1.3,<1.4' \
+              'pytest>=7' \
+              'pytest-xdist>=3.5' \
+              'reportlab>=4.4' \
+              'ruff>=0.15' \
+              'sympy>=1.12' \
+              'z3-solver>=4.12'
+          else
+            python -m pip install -e '.[dev]'
+          fi
       # Lint and reproducibility tooling use the pinned 3.12 snapshot above.
-      # These lanes exercise runtime compatibility without resolving a second
-      # floating copy of Ruff.
+      # These lanes exercise runtime compatibility without treating a floating
+      # Ruff version as the repository's lint authority.
       - name: Run compatibility tests
         run: python -m pytest -q
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,36 +12,61 @@ concurrency:
   group: tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
+    name: pytest (3.12)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON((github.event_name == 'push' || github.event_name == 'pull_request') && '["3.12"]' || '["3.10", "3.11", "3.12"]') }}
+    timeout-minutes: 60
     steps:
       # Full history so the release-packet provenance tests can resolve the
       # recorded source commit and take their strict verification path.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: |
             pyproject.toml
             requirements-lock.txt
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.python-version }}" = "3.12" ]; then
-            python -m pip install -r requirements-lock.txt
-            python -m pip install --no-deps -e .
-          else
-            python -m pip install -e '.[dev]'
-          fi
+          python -m pip install -r requirements-lock.txt
+          python -m pip install --no-deps -e .
       - run: make verify-fast
         env:
           # Parallelize the fast pytest tier across all runner cores; the
           # lint scripts ahead of it are unaffected.
-          PYTEST_ADDOPTS: -n auto
+          PYTEST_ADDOPTS: -n auto --dist worksteal
+
+  compatibility:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: compatibility pytest (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install compatibility dependencies
+        run: python -m pip install -e '.[dev]'
+      # Lint and reproducibility tooling use the pinned 3.12 snapshot above.
+      # These lanes exercise runtime compatibility without resolving a second
+      # floating copy of Ruff.
+      - name: Run compatibility tests
+        run: python -m pytest -q
+        env:
+          PYTEST_ADDOPTS: -n auto --dist worksteal

--- a/README.md
+++ b/README.md
@@ -359,7 +359,9 @@ pip install -e . --no-deps
 ```
 
 The snapshot pins direct dependencies only. Python 3.10 and 3.11 compatibility
-CI instead resolves the supported ranges in `pyproject.toml`.
+CI instead resolves the supported ranges in `pyproject.toml` and runs pytest
+without a second floating lint toolchain. The optional `python-flint` exact
+backend requires Python 3.11 or newer; its tests skip on Python 3.10.
 
 ## Artifact checks
 
@@ -402,12 +404,12 @@ For sharded metadata audits, the two global status/provenance preflights belong
 to shard `0` and therefore run exactly once across the complete shard set.
 
 Pull requests run the fast tier and, when artifact-sensitive files change, the
-artifact-marked pytest shards. The direct artifact-command audit and the
-non-artifact slow/exhaustive pytest shards run after merge to `main`, on the
-weekly schedule, or by manual dispatch. Documentation-only and Lean-only pull
-requests use their dedicated fast/status and Lean workflows instead of
-starting the artifact pytest matrix. Superseded runs on the same branch are
-cancelled automatically.
+non-exhaustive artifact-marked pytest shards. Exhaustive artifact replays, the
+direct artifact-command audit, and the non-artifact slow/exhaustive pytest
+shards run after merge to `main`, on the weekly schedule, or by manual
+dispatch. Documentation-only and Lean-only pull requests use their dedicated
+fast/status and Lean workflows instead of starting the artifact pytest matrix.
+Superseded runs on the same branch are cancelled automatically.
 
 Useful exploratory commands:
 

--- a/README.md
+++ b/README.md
@@ -359,9 +359,7 @@ pip install -e . --no-deps
 ```
 
 The snapshot pins direct dependencies only. Python 3.10 and 3.11 compatibility
-CI instead resolves the supported ranges in `pyproject.toml` and runs pytest
-without a second floating lint toolchain. The optional `python-flint` exact
-backend requires Python 3.11 or newer; its tests skip on Python 3.10.
+CI instead resolves the supported ranges in `pyproject.toml`.
 
 ## Artifact checks
 
@@ -404,12 +402,12 @@ For sharded metadata audits, the two global status/provenance preflights belong
 to shard `0` and therefore run exactly once across the complete shard set.
 
 Pull requests run the fast tier and, when artifact-sensitive files change, the
-non-exhaustive artifact-marked pytest shards. Exhaustive artifact replays, the
-direct artifact-command audit, and the non-artifact slow/exhaustive pytest
-shards run after merge to `main`, on the weekly schedule, or by manual
-dispatch. Documentation-only and Lean-only pull requests use their dedicated
-fast/status and Lean workflows instead of starting the artifact pytest matrix.
-Superseded runs on the same branch are cancelled automatically.
+artifact-marked pytest shards. The direct artifact-command audit and the
+non-artifact slow/exhaustive pytest shards run after merge to `main`, on the
+weekly schedule, or by manual dispatch. Documentation-only and Lean-only pull
+requests use their dedicated fast/status and Lean workflows instead of
+starting the artifact pytest matrix. Superseded runs on the same branch are
+cancelled automatically.
 
 Useful exploratory commands:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
   "mpmath>=1.3,<1.4",
   "pytest>=7",
   "pytest-xdist>=3.5",
-  "python-flint>=0.8,<0.9; python_version >= '3.11'",
+  "python-flint>=0.8,<0.9",
   "reportlab>=4.4",
   "ruff>=0.15",
   "sympy>=1.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
   "mpmath>=1.3,<1.4",
   "pytest>=7",
   "pytest-xdist>=3.5",
-  "python-flint>=0.8,<0.9",
+  "python-flint>=0.8,<0.9; python_version >= '3.11'",
   "reportlab>=4.4",
   "ruff>=0.15",
   "sympy>=1.12",

--- a/tests/test_c13_kalmanson_third_pair_refinement.py
+++ b/tests/test_c13_kalmanson_third_pair_refinement.py
@@ -86,6 +86,7 @@ def test_c13_third_pair_refinement_small_replay() -> None:
 
 @pytest.mark.artifact
 @pytest.mark.slow
+@pytest.mark.exhaustive
 def test_c13_third_pair_refinement_full_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_catalog_prefilter_sweep.py
@@ -117,6 +117,7 @@ def strip_platform_variant_histograms(payload: dict) -> dict:
 
 @pytest.mark.artifact
 @pytest.mark.slow
+@pytest.mark.exhaustive
 def test_c19_catalog_prefilter_window_sweep_full_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_prefix_window_prefilter_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_prefilter_sweep.py
@@ -99,6 +99,7 @@ def test_c19_prefilter_window_sweep_small_replay() -> None:
 
 @pytest.mark.artifact
 @pytest.mark.slow
+@pytest.mark.exhaustive
 def test_c19_prefilter_window_sweep_full_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_prefix_window_sweep.py
+++ b/tests/test_c19_kalmanson_prefix_window_sweep.py
@@ -98,6 +98,7 @@ def test_c19_prefix_window_sweep_small_replay() -> None:
 
 @pytest.mark.artifact
 @pytest.mark.slow
+@pytest.mark.exhaustive
 def test_c19_prefix_window_sweep_full_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_sampled_fifth_pair_refinement.py
+++ b/tests/test_c19_kalmanson_sampled_fifth_pair_refinement.py
@@ -116,6 +116,7 @@ def test_c19_sampled_fifth_pair_refinement_small_replay() -> None:
 
 @pytest.mark.artifact
 @pytest.mark.slow
+@pytest.mark.exhaustive
 def test_c19_sampled_fifth_pair_refinement_full_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_c19_kalmanson_sampled_fourth_pair_refinement.py
+++ b/tests/test_c19_kalmanson_sampled_fourth_pair_refinement.py
@@ -128,6 +128,7 @@ def test_c19_sampled_fourth_pair_refinement_small_replay() -> None:
 
 @pytest.mark.artifact
 @pytest.mark.slow
+@pytest.mark.exhaustive
 def test_c19_sampled_fourth_pair_refinement_full_replay_matches_artifact() -> None:
     payload = run_script("--assert-expected", "--json")
     artifact = json.loads(ARTIFACT.read_text(encoding="utf-8"))

--- a/tests/test_ci_environment.py
+++ b/tests/test_ci_environment.py
@@ -22,5 +22,16 @@ def test_python_312_ci_uses_the_checked_dependency_snapshot() -> None:
     )
     assert "python -m pip install -r requirements-lock.txt" in tests_workflow
     assert "python -m pip install --no-deps -e ." in tests_workflow
-    assert artifact_workflow.count("python -m pip install -r requirements-lock.txt") == 3
-    assert artifact_workflow.count("python -m pip install --no-deps -e .") == 3
+    assert artifact_workflow.count("python -m pip install -r requirements-lock.txt") == 2
+    assert artifact_workflow.count("python -m pip install --no-deps -e .") == 2
+    assert "slow-exhaustive-pytest:" not in artifact_workflow
+    assert '-m "artifact and not exhaustive"' in artifact_workflow
+
+
+def test_compatibility_lanes_do_not_run_floating_lint() -> None:
+    workflow = (ROOT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
+    compatibility = workflow.split("  compatibility:\n", maxsplit=1)[1]
+
+    assert "python-version: ['3.10', '3.11']" in compatibility
+    assert "python -m pytest -q" in compatibility
+    assert "make verify-fast" not in compatibility

--- a/tests/test_ci_environment.py
+++ b/tests/test_ci_environment.py
@@ -33,5 +33,7 @@ def test_compatibility_lanes_do_not_run_floating_lint() -> None:
     compatibility = workflow.split("  compatibility:\n", maxsplit=1)[1]
 
     assert "python-version: ['3.10', '3.11']" in compatibility
+    assert 'if [ "${{ matrix.python-version }}" = "3.10" ]; then' in compatibility
+    assert "python -m pip install --no-deps -e ." in compatibility
     assert "python -m pytest -q" in compatibility
     assert "make verify-fast" not in compatibility

--- a/tests/test_ci_environment.py
+++ b/tests/test_ci_environment.py
@@ -26,6 +26,11 @@ def test_python_312_ci_uses_the_checked_dependency_snapshot() -> None:
     assert artifact_workflow.count("python -m pip install --no-deps -e .") == 2
     assert "slow-exhaustive-pytest:" not in artifact_workflow
     assert '-m "artifact and not exhaustive"' in artifact_workflow
+    pr_artifact_step = artifact_workflow.split(
+        "- name: Run PR artifact pytest shard", maxsplit=1
+    )[1].split("- name: Run full artifact pytest shard", maxsplit=1)[0]
+    assert "-n auto --dist worksteal" in pr_artifact_step
+    assert "--durations 20 --durations-min 1.0" in pr_artifact_step
 
 
 def test_compatibility_lanes_do_not_run_floating_lint() -> None:

--- a/tests/test_sparse_full_cone_c25_persistent_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_persistent_augmented_cegar.py
@@ -144,6 +144,8 @@ def test_augmented_cegar_learns_eight_new_exact_wide_certificates() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_persistent_augmented_cegar_replays_exactly() -> None:
     assert CEGAR.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_persistent_augmented_residual_compression.py
+++ b/tests/test_sparse_full_cone_c25_persistent_augmented_residual_compression.py
@@ -155,6 +155,8 @@ def test_width_three_residual_two_orbit_is_exact_minimum_new_cover() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_persistent_residual_compression_replays_exactly() -> None:
     assert COMPRESSION.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_persistent_escape_compression.py
+++ b/tests/test_sparse_full_cone_c25_persistent_escape_compression.py
@@ -139,6 +139,8 @@ def test_minimum_marginal_cover_selects_only_the_width_four_source() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_persistent_escape_compression_replays_exactly() -> None:
     assert COMPRESSION.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_persistent_escape_screen.py
+++ b/tests/test_sparse_full_cone_c25_persistent_escape_screen.py
@@ -85,6 +85,8 @@ def test_stored_targets_have_two_exact_positive_circuits() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_persistent_escape_screen_replays_exactly() -> None:
     assert SCREEN.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_replacement_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_replacement_augmented_cegar.py
@@ -153,6 +153,8 @@ def test_replacement_cegar_learns_eight_new_exact_wide_certificates() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_replacement_augmented_cegar_replays_exactly() -> None:
     assert CEGAR.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_residual_seed_augmentation.py
+++ b/tests/test_sparse_full_cone_c25_residual_seed_augmentation.py
@@ -148,6 +148,8 @@ def test_stored_probe_has_no_residual_seed_coverage_marginal() -> None:
     }
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_c25_residual_seed_probe_replays_exactly() -> None:
     assert PROBE.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_selected_residual_augmented_cegar.py
+++ b/tests/test_sparse_full_cone_c25_selected_residual_augmented_cegar.py
@@ -134,6 +134,8 @@ def test_five_seed_cegar_learns_eight_new_exact_wide_certificates() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_selected_residual_augmented_cegar_replays_exactly() -> None:
     assert CEGAR.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_selected_residual_augmented_escape_compression.py
+++ b/tests/test_sparse_full_cone_c25_selected_residual_augmented_escape_compression.py
@@ -151,6 +151,8 @@ def test_width_four_residual_two_replaces_nonmarginal_old_width_three() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_selected_residual_escape_compression_replays_exactly() -> None:
     assert COMPRESSION.check_payload(artifact_payload()) == {
         "status": "OK",

--- a/tests/test_sparse_full_cone_c25_transfer_cegar.py
+++ b/tests/test_sparse_full_cone_c25_transfer_cegar.py
@@ -88,6 +88,8 @@ def test_history_identity_omits_full_orders_but_pins_hashes() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_c25_transfer_cegar_replays_exactly() -> None:
     if not ARTIFACT.exists():
         return

--- a/tests/test_sparse_full_cone_c25_transfer_residual_compression.py
+++ b/tests/test_sparse_full_cone_c25_transfer_residual_compression.py
@@ -119,6 +119,8 @@ def test_width_three_orbit_is_exact_minimum_residual_cover() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_c25_residual_compression_replays_exactly() -> None:
     result = COMPRESSION.check_payload(artifact_payload())
 

--- a/tests/test_sparse_full_cone_fresh_certificate_compression.py
+++ b/tests/test_sparse_full_cone_fresh_certificate_compression.py
@@ -117,6 +117,8 @@ def test_stopping_rule_continues_for_new_small_or_affine_reuse() -> None:
     assert assessment["decision"] == "CONTINUE_CLUSTER_MINING"
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_fresh_compression_packet_replays_exactly() -> None:
     if not ARTIFACT.exists():
         return

--- a/tests/test_sparse_full_cone_fresh_order_screen.py
+++ b/tests/test_sparse_full_cone_fresh_order_screen.py
@@ -4,6 +4,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "exploration" / "screen_sparse_full_cone_fresh_orders.py"
 SOURCE = (
@@ -78,6 +80,8 @@ def test_run_summary_keeps_conclusive_outcomes_separate() -> None:
     assert summary["unresolved_numerical_screen_count"] == 1
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_fresh_order_screen_replays_exactly() -> None:
     module = load_module()
     if not ARTIFACT.exists():

--- a/tests/test_sparse_full_cone_fresh_template_transfer.py
+++ b/tests/test_sparse_full_cone_fresh_template_transfer.py
@@ -129,6 +129,8 @@ def test_transfer_decision_stops_only_after_two_zero_hit_packets() -> None:
     )
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_transfer_packet_replays_exactly() -> None:
     if not ARTIFACT.exists():
         return

--- a/tests/test_sparse_full_cone_seeded_cegar.py
+++ b/tests/test_sparse_full_cone_seeded_cegar.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "exploration" / "run_sparse_full_cone_seeded_cegar.py"
@@ -94,6 +96,8 @@ def test_probe_summary_counts_seed_source_overlap() -> None:
     assert summary["seed_source_overlap_histogram"] == {"0": 1, "1": 1}
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_seeded_cegar_packet_replays_exactly() -> None:
     payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
 

--- a/tests/test_sparse_full_cone_seeded_certificate_compression.py
+++ b/tests/test_sparse_full_cone_seeded_certificate_compression.py
@@ -119,6 +119,8 @@ def test_quotient_vector_reuse_records_pairwise_overlap() -> None:
     ]
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_seeded_compression_packet_replays_exactly() -> None:
     payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
 

--- a/tests/test_sparse_full_cone_small_template_fresh_stream.py
+++ b/tests/test_sparse_full_cone_small_template_fresh_stream.py
@@ -105,6 +105,8 @@ def test_template_coverage_summary_counts_hits() -> None:
     assert summary["by_template"][0]["matching_orbit_clause_occurrences"] == 2
 
 
+@pytest.mark.artifact
+@pytest.mark.exhaustive
 def test_stored_fresh_stream_artifact_replays_exactly() -> None:
     module = load_module()
     if not ARTIFACT.exists():


### PR DESCRIPTION
## Summary
- keep the pinned Python 3.12 fast tier on pushes and pull requests, using xdist work stealing, while moving Python 3.10/3.11 compatibility to scheduled/manual pytest-only lanes
- let Python 3.10 install the declared runtime/test dependencies without python-flint 0.8, which requires Python 3.11; flint-dependent tests retain their existing optional skip
- run the eight pull-request artifact shards with xdist work stealing; keep checked-in artifact summaries and bounded fresh replays on pull requests, while explicitly named full replays remain enforced after merge, on schedule, and by manual dispatch
- collapse post-merge slow/exhaustive pytest into the existing artifact shard jobs and update supported GitHub Action majors

## Live validation
- final clean pull-request Python 3.12 fast tier: pass in 8m33s, versus the recent 26-33 minute baseline
- final clean pull-request artifact matrix: all 8 shards pass in 1m12s-7m13s; wall time 7m13s, versus about 33 minutes previously (about 78% faster)
- final clean pull-request critical path: about 8m33s, roughly 74% faster than the original roughly 33-minute path
- pull-request Lean compile: pass in 28s
- manual compatibility run: Python 3.10 pass in 6m31s; Python 3.11 pass in 6m54s; pinned Python 3.12 pass in 8m55s
- local text/status/provenance/generator checks, Ruff, workflow YAML parsing, whitespace checks, artifact-summary tests, and marker-selection checks pass

The release-packet source snapshot is unchanged. No mathematical claim or artifact result is changed.