### PR TITLE
CI: shard the fast test tier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,33 @@ permissions:
   contents: read
 
 jobs:
-  pytest:
-    name: pytest (3.12)
+  lint:
+    name: lint (3.12)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-lock.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements-lock.txt
+          python -m pip install --no-deps -e .
+      - run: make verify-lint
+
+  pytest-shard:
+    name: pytest shard ${{ matrix.shard }} (3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
     steps:
       # Full history so the release-packet provenance tests can resolve the
       # recorded source commit and take their strict verification path.
@@ -37,11 +60,27 @@ jobs:
         run: |
           python -m pip install -r requirements-lock.txt
           python -m pip install --no-deps -e .
-      - run: make verify-fast
+      - name: Run fast pytest shard
+        run: >-
+          python -m pytest -q
+          --durations 20 --durations-min 1.0
+          --shard-count 2 --shard-index ${{ matrix.shard }}
         env:
-          # Parallelize the fast pytest tier across all runner cores; the
-          # lint scripts ahead of it are unaffected.
           PYTEST_ADDOPTS: -n auto --dist worksteal
+
+  pytest:
+    if: always()
+    name: pytest (3.12)
+    needs: [lint, pytest-shard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check fast tier results
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          PYTEST_RESULT: ${{ needs.pytest-shard.result }}
+        run: |
+          test "$LINT_RESULT" = success
+          test "$PYTEST_RESULT" = success
 
   compatibility:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,25 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    name: lint (3.12)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: |
-            pyproject.toml
-            requirements-lock.txt
-      - name: Install dependencies
-        run: |
-          python -m pip install -r requirements-lock.txt
-          python -m pip install --no-deps -e .
-      - run: make verify-lint
-
   pytest-shard:
     name: pytest shard ${{ matrix.shard }} (3.12)
     runs-on: ubuntu-latest
@@ -60,6 +41,9 @@ jobs:
         run: |
           python -m pip install -r requirements-lock.txt
           python -m pip install --no-deps -e .
+      - name: Run lint
+        if: matrix.shard == 0
+        run: make verify-lint
       - name: Run fast pytest shard
         run: >-
           python -m pytest -q
@@ -71,15 +55,13 @@ jobs:
   pytest:
     if: always()
     name: pytest (3.12)
-    needs: [lint, pytest-shard]
+    needs: pytest-shard
     runs-on: ubuntu-latest
     steps:
       - name: Check fast tier results
         env:
-          LINT_RESULT: ${{ needs.lint.result }}
           PYTEST_RESULT: ${{ needs.pytest-shard.result }}
         run: |
-          test "$LINT_RESULT" = success
           test "$PYTEST_RESULT" = success
 
   compatibility:

--- a/tests/test_ci_environment.py
+++ b/tests/test_ci_environment.py
@@ -22,14 +22,14 @@ def test_python_312_ci_uses_the_checked_dependency_snapshot() -> None:
     )
     assert "python -m pip install -r requirements-lock.txt" in tests_workflow
     assert "python -m pip install --no-deps -e ." in tests_workflow
-    assert "  lint:\n" in tests_workflow
     assert "  pytest-shard:\n" in tests_workflow
     assert "        shard: [0, 1]\n" in tests_workflow
     assert "make verify-lint" in tests_workflow
+    assert "if: matrix.shard == 0" in tests_workflow
     assert "--durations 20 --durations-min 1.0" in tests_workflow
     assert '--shard-count 2 --shard-index ${{ matrix.shard }}' in tests_workflow
     assert "    name: pytest (3.12)\n" in tests_workflow
-    assert "    needs: [lint, pytest-shard]\n" in tests_workflow
+    assert "    needs: pytest-shard\n" in tests_workflow
     assert artifact_workflow.count("python -m pip install -r requirements-lock.txt") == 2
     assert artifact_workflow.count("python -m pip install --no-deps -e .") == 2
     assert "slow-exhaustive-pytest:" not in artifact_workflow

--- a/tests/test_ci_environment.py
+++ b/tests/test_ci_environment.py
@@ -22,6 +22,14 @@ def test_python_312_ci_uses_the_checked_dependency_snapshot() -> None:
     )
     assert "python -m pip install -r requirements-lock.txt" in tests_workflow
     assert "python -m pip install --no-deps -e ." in tests_workflow
+    assert "  lint:\n" in tests_workflow
+    assert "  pytest-shard:\n" in tests_workflow
+    assert "        shard: [0, 1]\n" in tests_workflow
+    assert "make verify-lint" in tests_workflow
+    assert "--durations 20 --durations-min 1.0" in tests_workflow
+    assert '--shard-count 2 --shard-index ${{ matrix.shard }}' in tests_workflow
+    assert "    name: pytest (3.12)\n" in tests_workflow
+    assert "    needs: [lint, pytest-shard]\n" in tests_workflow
     assert artifact_workflow.count("python -m pip install -r requirements-lock.txt") == 2
     assert artifact_workflow.count("python -m pip install --no-deps -e .") == 2
     assert "slow-exhaustive-pytest:" not in artifact_workflow


### PR DESCRIPTION
## Summary
- split the pinned Python 3.12 fast pytest collection across two deterministic repository-native shards, with xdist work stealing inside each shard
- keep lint on shard 0 so the two test runners and eight artifact runners fit within the observed 10-runner capacity
- preserve the existing `pytest (3.12)` required-check name as an aggregate gate over both shards
- emit per-shard slow-test durations for the next hillclimb

## Validation
- all clean GitHub checks pass, including all eight artifact-audit shards
- a queue-free rerun completed end to end in 5m08s: shard 0 in 4m37s, shard 1 in 5m04s, and the aggregate gate in 2s
- compared with the 8m33s pre-sharding baseline, the fast-test critical path is 40% shorter; an earlier clean sample completed in 5m57s
- raw text/status/provenance/generator checks, Ruff, workflow YAML parsing, and whitespace checks pass
- CI environment and deterministic sharding tests pass
- the two shard selections collect 978 and 906 tests, covering the same 1,884-test fast set
- the local full run passed 1,878 tests; six subprocess-sensitive cases resolved the ambient editable install from the original checkout, and the affected files passed 8/8 when rerun against this isolated worktree; both clean GitHub samples passed the complete suite

No mathematical claim or artifact result is changed.
