### PR TITLE
CI: rebalance artifact pytest shards

### DIFF
--- a/.github/workflows/artifact-audit.yml
+++ b/.github/workflows/artifact-audit.yml
@@ -74,6 +74,7 @@ jobs:
           -n auto --dist worksteal
           --durations 20 --durations-min 1.0
           --shard-count 8 --shard-index ${{ matrix.shard }}
+          --shard-namespace artifact-pr-balanced-v1-1118
       - name: Run full artifact pytest shard
         if: github.event_name != 'pull_request'
         run: >-

--- a/src/erdos97/ci_sharding.py
+++ b/src/erdos97/ci_sharding.py
@@ -9,6 +9,10 @@ from typing import TypeVar
 
 T = TypeVar("T")
 SHARD_ALGORITHM = "sha256(key) modulo shard_count"
+NAMESPACED_SHARD_ALGORITHM = "sha256(namespace + NUL + key) modulo shard_count"
+# Selected from PR #926 duration telemetry so the eight slowest PR artifact
+# tests occupy eight distinct shards. The focused regression test pins that split.
+ARTIFACT_PR_SHARD_NAMESPACE = "artifact-pr-balanced-v1-1118"
 
 
 def validate_shard(shard_index: int, shard_count: int) -> None:
@@ -21,15 +25,18 @@ def validate_shard(shard_index: int, shard_count: int) -> None:
         )
 
 
-def stable_shard(key: str, shard_count: int) -> int:
+def stable_shard(key: str, shard_count: int, *, namespace: str = "") -> int:
     """Return the stable shard for ``key``.
 
     SHA-256 avoids Python's process-randomized ``hash`` and keeps assignment
-    independent of collection order and platform path separators.
+    independent of collection order and platform path separators. An optional
+    namespace permits a measured workload to use a different stable partition
+    without changing the default assignment used by existing consumers.
     """
     validate_shard(0, shard_count)
     normalized = key.replace("\\", "/")
-    digest = hashlib.sha256(normalized.encode("utf-8")).digest()
+    digest_input = normalized if not namespace else f"{namespace}\0{normalized}"
+    digest = hashlib.sha256(digest_input.encode("utf-8")).digest()
     return int.from_bytes(digest[:8], "big") % shard_count
 
 
@@ -39,7 +46,12 @@ def select_shard(
     key: Callable[[T], str],
     shard_index: int,
     shard_count: int,
+    namespace: str = "",
 ) -> list[T]:
     """Return exactly the items assigned to one deterministic shard."""
     validate_shard(shard_index, shard_count)
-    return [item for item in items if stable_shard(key(item), shard_count) == shard_index]
+    return [
+        item
+        for item in items
+        if stable_shard(key(item), shard_count, namespace=namespace) == shard_index
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from erdos97.ci_sharding import (  # noqa: E402
+    NAMESPACED_SHARD_ALGORITHM,
     SHARD_ALGORITHM,
     stable_shard,
     validate_shard,
@@ -35,25 +36,38 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=0,
         help="zero-based deterministic pytest shard to run",
     )
+    group.addoption(
+        "--shard-namespace",
+        action="store",
+        default="",
+        help="optional namespace selecting an alternate deterministic partition",
+    )
 
 
-def _pytest_shard(config: pytest.Config) -> tuple[int, int]:
+def _pytest_shard(config: pytest.Config) -> tuple[int, int, str]:
     shard_count = config.getoption("--shard-count")
     shard_index = config.getoption("--shard-index")
+    shard_namespace = config.getoption("--shard-namespace")
     try:
         validate_shard(shard_index, shard_count)
     except ValueError as exc:
         raise pytest.UsageError(str(exc)) from exc
-    return shard_index, shard_count
+    return shard_index, shard_count, shard_namespace
 
 
 def pytest_report_header(config: pytest.Config) -> str | None:
-    shard_index, shard_count = _pytest_shard(config)
+    shard_index, shard_count, shard_namespace = _pytest_shard(config)
     if shard_count == 1:
         return None
+    if shard_namespace:
+        algorithm = NAMESPACED_SHARD_ALGORITHM
+        namespace_suffix = f"; namespace={shard_namespace}"
+    else:
+        algorithm = SHARD_ALGORITHM
+        namespace_suffix = ""
     return (
         f"erdos97 shard {shard_index + 1}/{shard_count} "
-        f"({SHARD_ALGORITHM})"
+        f"({algorithm}{namespace_suffix})"
     )
 
 
@@ -62,13 +76,17 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    shard_index, shard_count = _pytest_shard(config)
+    shard_index, shard_count, shard_namespace = _pytest_shard(config)
     if shard_count == 1:
         return
     selected: list[pytest.Item] = []
     deselected: list[pytest.Item] = []
     for item in items:
-        destination = stable_shard(item.nodeid, shard_count)
+        destination = stable_shard(
+            item.nodeid,
+            shard_count,
+            namespace=shard_namespace,
+        )
         (selected if destination == shard_index else deselected).append(item)
     items[:] = selected
     if deselected:

--- a/tests/test_ci_environment.py
+++ b/tests/test_ci_environment.py
@@ -39,6 +39,7 @@ def test_python_312_ci_uses_the_checked_dependency_snapshot() -> None:
     )[1].split("- name: Run full artifact pytest shard", maxsplit=1)[0]
     assert "-n auto --dist worksteal" in pr_artifact_step
     assert "--durations 20 --durations-min 1.0" in pr_artifact_step
+    assert "--shard-namespace artifact-pr-balanced-v1-1118" in pr_artifact_step
 
 
 def test_compatibility_lanes_do_not_run_floating_lint() -> None:

--- a/tests/test_ci_sharding.py
+++ b/tests/test_ci_sharding.py
@@ -4,7 +4,24 @@ from __future__ import annotations
 
 import pytest
 
-from erdos97.ci_sharding import select_shard, stable_shard, validate_shard
+from erdos97.ci_sharding import (
+    ARTIFACT_PR_SHARD_NAMESPACE,
+    select_shard,
+    stable_shard,
+    validate_shard,
+)
+
+
+HEAVIEST_ARTIFACT_PR_TESTS = [
+    "tests/test_bootstrap_t12_151_6_label4_center8_target_sparse_three_row_repairs.py::test_target_sparse_three_row_repairs_cli_json",
+    "tests/test_bootstrap_t12_151_6_label4_center8_target_sparse_three_row_repairs.py::test_target_sparse_three_row_repairs_artifact_matches_generator",
+    "tests/test_c19_fifth_pair_two_row_prefilter.py::test_c19_fifth_pair_two_row_prefilter_replay_matches_artifact",
+    "tests/test_c19_kalmanson_prefix_window_prefilter.py::test_c19_prefilter_window_416_447_replay_matches_artifact",
+    "tests/test_fragile_cycle_halo_slot_budget.py::test_fast_motif_predicates_match_generic_two_halo_frontier",
+    "tests/test_c19_kalmanson_prefix_window_prefilter.py::test_c19_prefilter_window_448_479_replay_matches_artifact",
+    "tests/test_c19_kalmanson_prefix_window.py::test_c19_prefix_window_160_191_replay_matches_artifact",
+    "tests/test_c19_kalmanson_prefix_window_prefilter.py::test_c19_prefilter_window_384_415_replay_matches_artifact",
+]
 
 
 def test_stable_shards_partition_keys_exactly_once() -> None:
@@ -26,6 +43,19 @@ def test_stable_shard_normalizes_platform_path_separators() -> None:
         "tests\\test_a.py::test_x",
         8,
     )
+
+
+def test_artifact_pr_namespace_separates_measured_heavy_tests() -> None:
+    assignments = [
+        stable_shard(
+            nodeid,
+            8,
+            namespace=ARTIFACT_PR_SHARD_NAMESPACE,
+        )
+        for nodeid in HEAVIEST_ARTIFACT_PR_TESTS
+    ]
+
+    assert assignments == [3, 4, 5, 0, 2, 6, 7, 1]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add an optional namespace to deterministic pytest sharding while preserving the existing default partition for every current consumer
- apply a telemetry-selected namespace to the pull-request artifact lane so the eight slowest tests measured on PR #926 occupy eight different shards
- pin the measured heavyweight split and the workflow wiring with focused regression tests

## Validation
- all GitHub checks pass
- artifact-shard execution ranges from 3m26s to 5m16s; the critical shard is 33% shorter than the 7m50s baseline from PR #926
- the artifact workflow took 7m44s wall clock because two shards waited for hosted runners; execution time and queue delay are reported separately
- all text, status, provenance, generated-Makefile, Ruff, YAML, and whitespace checks pass
- focused CI environment and sharding tests pass: 9 passed
- the namespaced artifact collection covers all 466 selected tests exactly once with zero overlap; shard counts range from 49 to 70
- the full fast run passed 1,883 tests; its only two local failures were the expected clean-worktree guard before commit and a sandbox-denied Windows multiprocessing pipe, and both passed when rerun from the committed clean worktree with the required permission

No mathematical claim, certificate, or artifact result is changed.
