### PR TITLE
Research: strengthen radius-level forest with fan-in and export bounds

### DIFF
--- a/docs/minimum-radius-component-injectivity.md
+++ b/docs/minimum-radius-component-injectivity.md
@@ -1,0 +1,406 @@
+# Minimum-radius component injectivity
+
+Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING`.
+
+This note closes the three short return motifs left by
+`docs/radius-level-return-locality.md`, but only at the minimum radius level in
+the alternating boundary-neighbour branch. It is not a proof or disproof of
+Erdős Problem #97 and not a source-of-truth status update.
+
+## 1. Setup
+
+Let a strictly convex polygon have cyclic order
+
+\[
+E_0,Q_0,E_1,Q_1,\ldots,E_{m-1},Q_{m-1}.
+\]
+
+Assume the complete rich class at every `E_i` contains both boundary neighbours
+at radius `rho_i`:
+
+\[
+|E_iQ_{i-1}|=|E_iQ_i|=\rho_i.
+\]
+
+Put
+
+\[
+R=\min_i\rho_i,
+\qquad
+X=\{E_i:\rho_i=R\}.
+\]
+
+Every polygon side has length at least `R`. By
+`docs/radius-level-linear-forest.md`, the full distance-`R` graph on `X` is a
+disjoint union of paths.
+
+Call `W` an extra witness of `U in X` when
+
+\[
+|WU|=R
+\]
+
+and `W` is not one of the two boundary neighbours of `U`.
+
+## 2. Boundary-edge triangle-rhombus obstruction
+
+We first isolate the only algebraic local configuration needed below.
+
+> **Lemma.** Let `W,X` be consecutive vertices of a strictly convex polygon
+> with `|WX|=1`. There do not exist three further distinct polygon vertices
+> `U,Y,V`, all on the interior side of the boundary line `WX`, satisfying
+>
+> \[
+> |WU|=|UX|=|XY|=|YV|=|VW|=1.
+> \]
+
+### Proof
+
+Normalize
+
+\[
+W=0,\qquad X=1
+\]
+
+in the complex plane, with every other polygon vertex in the open upper
+half-plane. The unit triangle on the boundary edge has only one upper apex, so
+
+\[
+U=u:=e^{i\pi/3}.
+\]
+
+Write
+
+\[
+Y=1+e^{i\theta},\qquad V=e^{i\phi},
+\qquad 0<\theta,\phi<\pi.
+\]
+
+The remaining equality `|Y-V|=1` gives
+
+\[
+1+\cos\theta
+ =\cos\phi+\cos(\theta-\phi).
+\]
+
+Using sum-to-product,
+
+\[
+2\cos^2(\theta/2)
+ =2\cos(\theta/2)\cos(\phi-\theta/2).
+\]
+
+Since `0<theta<pi`, division by the positive factor
+`2*cos(theta/2)` is valid. With `0<phi<pi`, the only possibilities are
+
+\[
+\phi=\theta
+\]
+
+or `phi=0`; the latter would give `V=X`. Hence
+
+\[
+V=v:=e^{i\theta},\qquad Y=1+v,
+\]
+
+so `W,X,Y,V` form a rhombus.
+
+It remains to compare the direction `v` with the fixed direction
+`u=e^{i*pi/3}`.
+
+### Case 1: `0<theta<pi/3`
+
+Define
+
+\[
+a=\frac{\sin(\pi/3-\theta)}{\sin(\pi/3)},
+\qquad
+b=\frac{\sin\theta}{\sin(\pi/3)}.
+\]
+
+Then `a,b>0`, `b<1`, and the sine-resolution identity gives
+
+\[
+v=a+bu.
+\]
+
+Consequently
+
+\[
+V=\frac{1-b}{1+a}W
+  +\frac{b}{1+a}U
+  +\frac{a}{1+a}Y.
+\]
+
+All three coefficients are positive and sum to one, so `V` is strictly inside
+triangle `WUY`.
+
+### Case 2: `theta=pi/3`
+
+Then `V=U`, contrary to distinctness.
+
+### Case 3: `pi/3<theta<2pi/3`
+
+Set
+
+\[
+a=\frac{\sin(\theta-\pi/3)}{\sin\theta},
+\qquad
+b=\frac{\sin(\pi/3)}{\sin\theta}.
+\]
+
+Both `a,b` lie strictly between zero and one, and
+
+\[
+u=a+bv.
+\]
+
+Thus `U` has parallelogram coordinates `(a,b)` strictly inside the rhombus
+with vertices `W,X,V,Y`. Explicitly,
+
+\[
+U=(1-a)(1-b)W+a(1-b)X+(1-a)bV+abY,
+\]
+
+with all four coefficients positive.
+
+### Case 4: `theta=2pi/3`
+
+Then `Y=U`, again contrary to distinctness.
+
+### Case 5: `2pi/3<theta<pi`
+
+Put
+
+\[
+d=\sin(\theta-\pi/3),
+\quad
+a=\frac{\sin\theta}{d},
+\quad
+b=1-\frac{\sin(\pi/3)}{d}.
+\]
+
+Here `a,b>0`, while
+
+\[
+a+b
+ =1+\frac{\sin\theta-\sin(\pi/3)}{d}<1.
+\]
+
+A direct sine resolution gives
+
+\[
+Y=aU+bV+(1-a-b)W.
+\]
+
+Hence `Y` lies strictly inside triangle `WUV`.
+
+Every possible value of `theta` either identifies two vertices or makes one of
+the five points non-extreme, contradicting strict convexity. `QED`
+
+The statement scales from unit length to any positive radius.
+
+## 3. No target can return to one minimum-level component
+
+> **Minimum-radius component-injectivity theorem.** Let `W` be a polygon
+> vertex outside `X`. Then `W` cannot be an extra radius-`R` witness for two
+> vertices in the same path component of the distance-`R` graph on `X`.
+
+### Proof
+
+Suppose `W` is an extra witness for distinct path vertices `U,V`. Let
+
+\[
+U=X_0,X_1,\ldots,X_\ell=V
+\]
+
+be the unique path between them. Every path edge and both edges `WU,WV` have
+length `R`.
+
+The return-locality theorem already rules out `ell>=4`. It remains to treat
+`ell=1,2,3`.
+
+### Path length one
+
+The three vertices `W,U,V` are pairwise at distance `R`. The two `E`-vertices
+`U,V` are never adjacent on the polygon boundary, and `W` is an extra witness
+of both, so the three-vertex set is boundary-independent. Since every polygon
+side has length at least `R`, the minimum-side distance-forest lemma forbids
+this distance-`R` triangle.
+
+### Path length two
+
+Write the path as
+
+\[
+U-X_1-V.
+\]
+
+If `W` is not adjacent to `X_1` on the polygon boundary, then
+`{W,U,X_1,V}` is boundary-independent. Its distance-`R` graph contains the
+four-cycle
+
+\[
+W-U-X_1-V-W,
+\]
+
+contradicting the distance-forest lemma.
+
+If `W` is adjacent to `X_1`, then `|WX_1|=R` because `X_1 in X` has both
+boundary neighbours in its radius-`R` class. Both `U` and `V` are intersections
+of the two radius-`R` circles centered at `W,X_1`. The two distinct
+intersections lie on opposite sides of the boundary line `WX_1`, whereas all
+other polygon vertices lie in one open half-plane. Contradiction.
+
+### Path length three
+
+Write
+
+\[
+U-X_1-X_2-V.
+\]
+
+If `W` is adjacent to neither internal vertex, then the five vertices are
+boundary-independent and their distance-`R` graph contains
+
+\[
+W-U-X_1-X_2-V-W,
+\]
+
+contradicting the distance-forest lemma.
+
+If `W` is adjacent to both internal vertices, then `W` is at distance `R` from
+all four members
+
+\[
+U,X_1,X_2,V
+\]
+
+of `X`. This contradicts the radius-level common-target fan-in cap of three.
+
+Finally suppose `W` is adjacent to exactly one internal vertex, say `X_1`.
+After scaling by `R`, the boundary edge `WX_1`, the triangle
+
+\[
+W-U-X_1,
+\]
+
+and the four-cycle
+
+\[
+W-X_1-X_2-V-W
+\]
+
+satisfy the boundary-edge triangle-rhombus lemma. Contradiction. The case in
+which `W` is adjacent only to `X_2` is symmetric.
+
+All path lengths are excluded. `QED`
+
+## 4. Consequences for the minimum-level export graph
+
+Create a bipartite graph with
+
+- one left vertex for each path component of the distance-`R` graph on `X`;
+- one right vertex for each outside polygon vertex used as an extra
+  radius-`R` witness; and
+- one edge for each component-target incidence.
+
+The preceding results imply:
+
+1. the graph is simple: one target has at most one incidence with each path
+   component;
+2. every path component has degree at least two, because its two endpoints
+   each require an outside witness, while an isolated centre requires two
+   distinct outside witnesses;
+3. every target has degree at most two, by the minimum-level extra-target cap
+   from `docs/radius-level-linear-forest.md`.
+
+Thus the entire minimum-radius branch has been reduced to a simple bipartite
+component-target graph with left minimum degree two and right maximum degree
+two.
+
+## 5. Cycles in the component-target graph are locally concentrated
+
+Suppose the bipartite export graph has a simple cycle containing `k` path
+components and `k` outside targets. In each path component, join the two
+attachment centres used by the cycle with their unique radius-level path. Let
+`ell_i>=0` be its number of path edges and put
+
+\[
+L=\sum_{i=1}^k\ell_i.
+\]
+
+Lifting the bipartite cycle gives a simple distance-`R` cycle with
+
+\[
+g=2k+L
+\]
+
+vertices and edges.
+
+Every polygon side has length at least `R`. A boundary gap between consecutive
+vertices of the lifted set has detour length at least `2R` unless those two
+vertices are adjacent on the original polygon boundary. No two `X`-vertices
+are adjacent, so every one-edge gap is incident to at least one of the `k`
+outside targets. Each target has only two boundary neighbours. Hence the number
+`h` of possible one-edge gaps satisfies
+
+\[
+h\le2k.
+\]
+
+The weak-arc detour-cycle lemma rules out the lifted cycle whenever
+
+\[
+g\ge h+4.
+\]
+
+Since `g=2k+L` and `h<=2k`, every export-graph cycle must satisfy
+
+\[
+L\le3.                                                 \tag{1}
+\]
+
+> **Component-cycle locality corollary.** Along any cycle of the minimum-level
+> export graph, the sum of the path distances between its paired attachment
+> centres is at most three.
+
+Thus an unbounded graph-theoretic cycle has only four possible path-length
+profiles up to distributing zeroes:
+
+```text
+L=0,
+L=1,
+L=2,
+L=3.
+```
+
+The number of zero-distance component passages can still be arbitrarily large,
+so (1) is a finite *metric-defect* reduction rather than a finite cardinality
+classification.
+
+## 6. Remaining gap
+
+At the minimum radius level, target reuse inside one path component is now
+completely excluded. Any target of degree two must connect two different
+components. Any cycle among components and targets must concentrate all of its
+within-component travel into at most three radius-`R` path edges.
+
+This does not yet force a contradiction. The export graph may be a tree with
+leaves on the target side, and cycles with total path length zero through three
+remain possible at the present level of abstraction. Closing those profiles
+requires additional cyclic-order information, the rich rows of the outside
+targets, or a minimal-counterexample/deletion argument.
+
+## 7. Replay boundary
+
+The exact arithmetic replay records
+
+```text
+(2*g-6)-g=g-6
+```
+
+for the one-target return theorem and the more general weak-arc coefficient
+comparison. The trigonometric convex-combination proof in Section 2 and the
+short-motif case split are paper arguments and are not formalized by that
+replay.

--- a/docs/radius-level-linear-forest.md
+++ b/docs/radius-level-linear-forest.md
@@ -1,0 +1,292 @@
+# Radius-level linear forests and endpoint exports
+
+Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING`.
+
+This note strengthens `docs/sparse-minimum-distance-forest.md`. It is a
+restricted geometric result, not a proof or disproof of Erdős Problem #97 and
+not a source-of-truth status update.
+
+## 1. The detour-controlled distance graph has degree at most two
+
+Use the hypotheses of the boundary-detour distance forest lemma. Thus `X` is a
+boundary-independent set of vertices of a strictly convex polygon, `r>0`, and
+every boundary arc between consecutive members of `X` has total length at
+least `2r`. Let `H_r(X)` join the pairs in `X` at distance exactly `r`.
+
+> **Linear-forest strengthening.** Every vertex of `H_r(X)` has degree at most
+> two. Since the earlier lemma proves that `H_r(X)` is a forest, every component
+> is a path or an isolated vertex.
+
+There is also a quantitative local conclusion:
+
+> If `x` has two neighbours `y,z` in `H_r(X)`, then
+>
+> \[
+> \angle yxz>\pi/3.
+> \]
+
+### Two-neighbour angle bound
+
+List the three vertices in inherited cyclic order as `x,y,z`, reversing the
+polygon order if necessary. Let `sigma_0,sigma_1,sigma_2` be the internal
+exterior-turn sums on the boundary arcs
+
+\[
+x\longrightarrow y,\qquad y\longrightarrow z,\qquad z\longrightarrow x.
+\]
+
+Each arc is a union of one or more consecutive `X`-arcs and therefore has
+length at least `2r`.
+
+The first and third chords have length `r`. The projection estimate used in
+the forest proof gives
+
+\[
+\sigma_0\ge2\pi/3,
+\qquad
+\sigma_2\ge2\pi/3.                                    \tag{1}
+\]
+
+Put `alpha=angle yxz`. Since `x` is a strictly convex polygon vertex,
+`0<alpha<pi`. The two points `y,z` lie on the circle of radius `r` centered at
+`x`, so
+
+\[
+|yz|=2r\sin(\alpha/2).
+\]
+
+Projection along the middle boundary arc gives
+
+\[
+2r\sin(\alpha/2)\ge2r\cos(\sigma_1/2)
+\]
+
+when `sigma_1<pi`; the resulting inequality is automatic when
+`sigma_1>=pi`. Hence
+
+\[
+\sigma_1\ge\pi-\alpha.                                 \tag{2}
+\]
+
+The three open-arc turn sums omit the positive exterior turns at `x,y,z`, so
+
+\[
+\sigma_0+\sigma_1+\sigma_2<2\pi.
+\]
+
+Combining this with (1)--(2) gives
+
+\[
+\frac{4\pi}{3}+\pi-\alpha<2\pi,
+\]
+
+and therefore `alpha>pi/3`.
+
+### Three neighbours are impossible
+
+Suppose `x` has three distance-`r` neighbours `y_1,y_2,y_3`, listed in their
+boundary and angular order away from `x`. Put
+
+\[
+\alpha_1=\angle y_1xy_2,
+\qquad
+\alpha_2=\angle y_2xy_3.
+\]
+
+All three rays lie in the open interior-angle cone at `x`, hence
+
+\[
+\alpha_1+\alpha_2<\pi.                                 \tag{3}
+\]
+
+For the four boundary arcs cut out by
+
+\[
+x,y_1,y_2,y_3,
+\]
+
+the two end chords have length `r`, so their internal turn sums are at least
+`2pi/3`. The two middle arcs have internal turn sums at least
+`pi-alpha_1` and `pi-alpha_2`. Their total is therefore greater than
+
+\[
+\frac{4\pi}{3}+2\pi-(\alpha_1+\alpha_2)
+>\frac{7\pi}{3},
+\]
+
+by (3). But the four open-arc turn sums total less than `2pi`, a
+contradiction. Thus the degree is at most two.
+
+## 2. Radius-level components are paths
+
+Use the alternating boundary-neighbour setup
+
+\[
+E_0,Q_0,E_1,Q_1,\ldots,E_{m-1},Q_{m-1},
+\]
+
+where the complete rich class at each `E_i` contains both boundary neighbours
+at radius `rho_i`. For a fixed value `R`, put
+
+\[
+X_R=\{E_i:\rho_i=R\}.
+\]
+
+Every boundary detour between consecutive members of `X_R` has length at least
+`2R`. Consequently the full distance-`R` graph on `X_R` is a disjoint union of
+paths and isolated vertices, and every angle made by two consecutive edges of
+one such path is greater than `60` degrees.
+
+This improves the export bookkeeping from the companion note. At the Erdős
+threshold, each centre has at least two non-boundary radius-`R` witnesses.
+Therefore:
+
+- every endpoint of a nontrivial radius-level path has at least one witness
+  outside `X_R`;
+- every isolated vertex has at least two distinct witnesses outside `X_R`;
+- internal path vertices may use their two path neighbours as both required
+  non-boundary witnesses, but cannot have a third same-level neighbour.
+
+The aggregate bound
+
+\[
+B_R\ge2c_R
+\]
+
+still holds, where `c_R` is the number of path components, but the incidences
+are now localized at component endpoints rather than arising from an arbitrary
+forest deficit.
+
+## 3. Strong fan-in at the minimum `E`-radius
+
+Let
+
+\[
+R_*=\min_i\rho_i.
+\]
+
+Every polygon side has length at least `R_*`, because each side is incident to
+exactly one `E_i` and has length `rho_i`.
+
+Fix a polygon vertex `W`, and consider the centres in `X_{R_*}` for which `W`
+is a **non-boundary** witness. None of those centres is adjacent to `W` on the
+polygon boundary. The set consisting of `W` and all of those source centres is
+therefore boundary-independent. Since every polygon side has length at least
+`R_*`, the minimum-side corollary and the degree-two strengthening apply to
+that set.
+
+> **Minimum-level extra-target cap.** A single vertex can be a non-boundary
+> radius-`R_*` witness for at most two centres in `X_{R_*}`.
+
+Hence the `2c_{R_*}` mandatory external incidences require at least
+`c_{R_*}` distinct extra targets. Moreover, by the return-locality lemma in
+`docs/radius-level-return-locality.md`, the two endpoint exports of a path with
+at least five vertices cannot share one target.
+
+This conclusion uses minimum radius only among the `E`-centres in the chosen
+alternating branch. It does not assert that `R_*` is the globally shortest
+pairwise distance or the selected radius of an opposite-parity target.
+
+## 4. A consecutive same-level edge cannot have a second common apex
+
+There is a further local obstruction when one path edge joins consecutive
+alternate centres.
+
+> **Consecutive-edge common-witness obstruction.** Let consecutive alternate
+> centres `U,V` have the same rich radius `R`, let `A` be the boundary vertex
+> between them, and assume `|UV|=R`. Then there is no non-boundary polygon
+> vertex `W` such that
+>
+> \[
+> |WU|=|WV|=R.
+> \]
+
+### Proof
+
+Let `B` be the other boundary neighbour of `U` and `C` the other boundary
+neighbour of `V`. Normalize `R=1` and choose coordinates
+
+\[
+U=(0,0),\quad V=(1,0),\quad
+A=(1/2,\sqrt3/2).
+\]
+
+Because `A` is at unit distance from both `U,V`, any distinct common unit
+witness is the other intersection of the two unit circles:
+
+\[
+W=(1/2,-\sqrt3/2).
+\]
+
+The boundary-neighbour hypothesis gives `|UB|=|VC|=1`. In the polygon order,
+`B,U,A,V,C` are consecutive, while `W` lies on the complementary boundary
+chain from `C` to `B`.
+
+Ray order at the strictly convex vertex `U` places the direction of `UB`
+strictly between angles `-2pi/3` and `-pi/3`; otherwise the open interior cone
+at `U` could not contain both the rays to `V` and `W` while having angular
+width less than `pi`. Consequently
+
+\[
+x(B)<1/2,\qquad y(B)<-\sqrt3/2.
+\]
+
+The symmetric ray-order statement at `V` gives
+
+\[
+x(C)>1/2,\qquad y(C)<-\sqrt3/2.
+\]
+
+Thus the vertical line `x=1/2` meets the segment `BC` at a point strictly below
+`W`, while it meets the vertex `A` strictly above `W`. Therefore `W` lies in
+the interior of the triangle `ABC`, contradicting that every polygon vertex
+is extreme. `QED`
+
+This removes the shortest return motif when its radius-level tree edge is also
+an edge between consecutive alternate centres. A distance-`R` path edge whose
+endpoints are separated by other alternate centres remains outside this local
+argument.
+
+## 5. Remaining gap
+
+Within the alternating boundary-neighbour branch, a surviving radius level now
+has the following form:
+
+1. its same-level graph is a union of paths;
+2. path angles exceed `60` degrees;
+3. every path endpoint exports at least one non-boundary witness;
+4. a general outside target has fan-in at most three;
+5. at the minimum `E`-radius, an extra target has fan-in at most two;
+6. one target cannot reconnect tree vertices at distance four or more; and
+7. it cannot form the consecutive-edge double-apex motif above.
+
+The unresolved local returns have tree distance one with nonconsecutive
+centres, or tree distance two or three. Globally, the larger extraction gap
+also remains: an arbitrary hypothetical counterexample has not been shown to
+contain an alternating set whose rich classes all contain both boundary
+neighbours.
+
+## 6. Arithmetic replay
+
+The exact replay in `src/erdos97/sparse_minimum_distance_forest.py` records the
+coefficient facts used here:
+
+```text
+2*(1/3) + (1/2-alpha/(2*pi)) < 1
+    implies alpha/(2*pi) > 1/6,
+2*(1/3) + 2*(1/2) - (alpha_1+alpha_2)/(2*pi) > 1
+    when alpha_1+alpha_2 < pi.
+```
+
+Run:
+
+```bash
+python scripts/check_sparse_minimum_distance_forest.py \
+  --max-cycle-length 512 \
+  --assert-expected \
+  --summary-json
+```
+
+The replay checks only this arithmetic spine. The ray-order, projection, and
+strict-convexity arguments remain paper-proof steps requiring independent
+review.

--- a/docs/radius-level-return-locality.md
+++ b/docs/radius-level-return-locality.md
@@ -1,0 +1,180 @@
+# Radius-level return locality
+
+Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING`.
+
+This note extends the boundary-detour machinery in
+`docs/sparse-minimum-distance-forest.md`. It is a restricted local theorem, not
+a proof or disproof of Erdős Problem #97 and not a source-of-truth status
+update.
+
+## 1. A detour-cycle lemma with weak arcs
+
+Let `Y` be `g` vertices of a strictly convex polygon, listed in inherited
+cyclic order, and fix `r>0`. Suppose every boundary arc between consecutive
+members of `Y` has length at least `r`, while all but `h` of those arcs have
+length at least `2r`.
+
+Assume there is a closed polygonal cycle through the vertices of `Y`, in any
+order, all of whose `g` edges have length exactly `r`.
+
+> **Weak-arc detour-cycle lemma.** If `g>=h+4`, this is impossible.
+
+The graph cycle need not follow the polygon's boundary order.
+
+### Proof
+
+For the boundary arc from `y_i` to `y_{i+1}`, let
+
+- `a_i=1` for one of the `h` weak arcs and `a_i=2` otherwise; and
+- `sigma_i` be the sum of the exterior turns strictly inside that arc.
+
+Thus its boundary length is at least `a_i r`. If `sigma_i<pi`, projection onto
+the bisector of the arc's edge-direction interval gives
+
+\[
+|y_i y_{i+1}|\ge a_i r\cos(\sigma_i/2)
+              \ge a_i r\left(1-\frac{\sigma_i}{\pi}\right).
+\]
+
+For `0<sigma_i<pi` the second inequality is strict. If `sigma_i>=pi`, the
+right-hand side is nonpositive and the same displayed weak inequality remains
+valid.
+
+Summing over the boundary-order chords gives
+
+\[
+\begin{aligned}
+\operatorname{per}(Y)
+&\ge r\sum_i a_i
+   -\frac r\pi\sum_i a_i\sigma_i\\
+&>r(2g-h)-4r\\
+&=r(2g-h-4).
+\end{aligned}
+\]
+
+Indeed,
+
+\[
+\sum_i a_i=2g-h,
+\qquad
+\sum_i a_i\sigma_i\le2\sum_i\sigma_i<4\pi,
+\]
+
+because the open-arc turn sums omit the positive exterior turns at the
+vertices of `Y`.
+
+The convex-hull perimeter of `Y` is no greater than the length of any closed
+tour visiting `Y`. The assumed `r`-edge cycle has length `gr`, so
+
+\[
+\operatorname{per}(Y)\le gr.
+\]
+
+When `g>=h+4`, however,
+
+\[
+2g-h-4\ge g,
+\]
+
+and the strict perimeter lower bound contradicts the cycle tour. `QED`
+
+### Boundary cases
+
+- `h=0` recovers the long-cycle part of the boundary-detour forest lemma for
+  every `g>=4`. The equilateral triangle case still needs the separate
+  `2pi/3` turn argument recorded there.
+- `h=2` rules out every such `r`-edge cycle of length at least six.
+- The inequality deliberately leaves the `h=2` cycle lengths three, four, and
+  five unresolved.
+
+## 2. One outside target can return only locally
+
+Use the alternating setup
+
+\[
+E_0,Q_0,E_1,Q_1,\ldots,E_{m-1},Q_{m-1}
+\]
+
+from `docs/sparse-minimum-distance-forest.md`. Fix a selected-radius value `R`
+and let
+
+\[
+X_R=\{E_i:\rho_i=R\}.
+\]
+
+The distance-`R` graph `H_R(X_R)` is a forest.
+
+Let `W` be any polygon vertex outside `X_R`, and suppose `W` is at distance
+`R` from two vertices `U,V` in the same component of `H_R(X_R)`. Let
+
+\[
+U=X_0,X_1,\ldots,X_\ell=V
+\]
+
+be their unique path in that tree. Every path edge and both edges `WU,WV` have
+length `R`, so these vertices support an `R`-edge cycle of length
+
+\[
+g=\ell+2.
+\]
+
+Consider them in inherited boundary order. The two boundary arcs incident to
+`W` each have length at least `R`: their other endpoint lies in `X_R`, and the
+last boundary edge entering that endpoint has length `R`. Every other arc has
+both endpoints in `X_R` and has length at least `2R` by the radius-level detour
+property.
+
+The weak-arc lemma applies with `h=2`. Hence `g<=5`, or equivalently
+
+\[
+\ell\le3.
+\]
+
+> **Same-component return-locality corollary.** One outside radius-`R` target
+> cannot attach to two vertices of the same radius-level tree at tree distance
+> four or more.
+
+This supplements the global fan-in cap of three. If one target absorbs several
+exports from one same-radius component, all of its attachment vertices must
+lie in a tree neighbourhood of diameter at most three.
+
+## 3. Why this is useful
+
+The forest/export bound alone permits a large tree component to send its two
+mandatory external incidences to one common target. The return-locality
+corollary shows that such reuse cannot join remote parts of the component.
+Consequently any high-reuse export pattern must be concentrated around a
+bounded local tree motif.
+
+This is a genuine strengthening, but it does not close the alternating branch:
+
+- two attachments at tree distance one, two, or three remain possible;
+- attachments to different same-radius components create no return cycle; and
+- opposite-parity targets need not change selected radius.
+
+The next finite proof-mining target is therefore the collection of short return
+motifs: a target attached across a tree edge, a length-two path, or a
+length-three path. The consecutive-three common-witness lemma already removes
+one subcase when three equal-radius centres occur consecutively on the polygon
+boundary.
+
+## 4. Arithmetic replay
+
+The existing replay now includes the exact `h=2` coefficient identity
+
+```text
+(2*g-6)-g = g-6.
+```
+
+Run:
+
+```bash
+python scripts/check_sparse_minimum_distance_forest.py \
+  --max-cycle-length 512 \
+  --assert-expected \
+  --summary-json
+```
+
+The replay records the first excluded one-defect cycle length as six. It does
+not formalize the geometric projection step or settle the three shorter return
+motifs.

--- a/docs/sparse-minimum-distance-forest.md
+++ b/docs/sparse-minimum-distance-forest.md
@@ -1,13 +1,13 @@
-# Boundary-detour distance forest lemma
+# Boundary-detour distance forest and fan-in lemmas
 
 Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING`.
 
-This note records a geometric strengthening of the alternate-vertex perimeter
-obstruction in `docs/alternate-vertex-perimeter-obstruction.md`. It is a
-restricted lemma, not a proof or disproof of Erdős Problem #97 and not a
+This note records geometric strengthenings of the alternate-vertex perimeter
+obstruction in `docs/alternate-vertex-perimeter-obstruction.md`. They are
+restricted lemmas, not a proof or disproof of Erdős Problem #97 and not a
 source-of-truth status update.
 
-## Statement
+## 1. Boundary-detour distance forest
 
 Let
 
@@ -28,10 +28,9 @@ Euclidean distance exactly `r`.
 > **Boundary-detour distance forest lemma.** `H_r(X)` is a forest.
 
 The hypothesis concerns the length of each boundary detour, not the individual
-side lengths. In particular, sides elsewhere in the polygon may be shorter
-than `r`.
+side lengths. Sides elsewhere in the polygon may be shorter than `r`.
 
-## Step 1: a sparse-subpolygon perimeter bound
+### Step 1: a sparse-subpolygon perimeter bound
 
 Write
 
@@ -93,19 +92,18 @@ because every exterior turn `tau_x` at a member of `X` is positive. Summing
 Here `per(X)` is the perimeter of the convex polygon on `X` in inherited
 order.
 
-### Boundary-detour perimeter lemma
+Equation (2) is a reusable intermediate statement:
 
-Equation (2) proves the reusable intermediate statement:
-
-> If each boundary detour between consecutive members of a
-> boundary-independent `s`-vertex set has length at least `2r`, then the
-> convex-hull perimeter of that set is greater than `2r(s-2)`.
+> **Boundary-detour perimeter lemma.** If each boundary detour between
+> consecutive members of a boundary-independent `s`-vertex set has length at
+> least `2r`, then the convex-hull perimeter of that set is greater than
+> `2r(s-2)`.
 
 The same hypothesis remains true after passing from `X` to a subset `Y`: a
 boundary arc between consecutive members of `Y` is a union of one or more of
-the original arcs and therefore still has length at least `2r`.
+the original arcs.
 
-## Step 2: triangles of `r`-edges are impossible
+### Step 2: triangles of `r`-edges are impossible
 
 Suppose three members `A,B,C` of `X` are pairwise at distance `r`. Pass to the
 subset `Y={A,B,C}`. Each of its three boundary arcs has length at least `2r`.
@@ -127,10 +125,10 @@ If `sigma\ge pi`, the same lower bound is automatic. Thus all three arc-turn
 sums are at least `2pi/3`, so their sum is at least `2pi`.
 
 But those three sums omit the positive exterior turns at `A,B,C`; their total
-is therefore strictly less than `2pi`. This contradiction rules out a
-triangle in `H_r(X)`.
+is strictly less than `2pi`. This contradiction rules out a triangle in
+`H_r(X)`.
 
-## Step 3: longer cycles are impossible
+### Step 3: longer cycles are impossible
 
 Assume `H_r(X)` has a simple cycle of length `g>=4`, and let `Y` be its vertex
 set. The boundary-detour hypothesis survives passage to `Y`, so (2) gives
@@ -163,19 +161,79 @@ with equality only at `g=4`. Hence
 contradicting the cycle tour. Together with Step 2, this proves that `H_r(X)`
 has no cycle and is a forest.
 
-## Useful minimum-side corollary
+### Minimum-side corollary
 
 If every side of `P` has length at least `r`, then any boundary-independent
 set automatically satisfies the detour hypothesis: each arc contains at least
 two boundary edges and therefore has length at least `2r`.
 
-Thus the earlier formulation remains valid as a direct corollary:
+Thus:
 
 > In a strictly convex polygon whose sides all have length at least `r`, the
 > graph of distance-`r` edges on any boundary-independent vertex set is a
 > forest.
 
-## Erdős-97 corollary: every radius level is a forest
+## 2. A common target has fan-in at most three
+
+The detour hypothesis also bounds how many vertices of `X` can lie on one
+circle centered at another polygon vertex.
+
+> **Boundary-detour fan-in lemma.** Under the hypotheses above, fix a polygon
+> vertex `z` outside `X`. At most three vertices `x` in `X` can satisfy
+> `|zx|=r`.
+
+### Proof
+
+Suppose `y_1,...,y_k` are the members of `X` at distance `r` from `z`, listed
+along the boundary chain that does not pass through `z`.
+
+A fan triangulation from the strictly convex vertex `z` shows that the rays
+`zy_i` occur in the same order and lie in the open interior-angle cone at `z`.
+Let
+
+\[
+\alpha_i=\angle y_i z y_{i+1}\qquad(1\le i<k).
+\]
+
+Then every `alpha_i>0` and
+
+\[
+\sum_{i=1}^{k-1}\alpha_i<\pi.                            \tag{3}
+\]
+
+The boundary arc from `y_i` to `y_{i+1}` avoiding `z` is a union of one or
+more consecutive `X`-arcs, so its length is at least `2r`. Let its internal
+turn be `sigma_i`. If `sigma_i<pi`, projection along that arc and the chord
+formula on the circle centered at `z` give
+
+\[
+2r\sin(\alpha_i/2)
+ =|y_i y_{i+1}|
+ \ge2r\cos(\sigma_i/2).
+\]
+
+Both half-angles lie in `[0,pi/2]`, hence
+
+\[
+\sigma_i\ge\pi-\alpha_i.
+\]
+
+The same conclusion is automatic when `sigma_i\ge pi`. Summing and using (3),
+
+\[
+\sum_{i=1}^{k-1}\sigma_i
+ \ge(k-1)\pi-\sum_{i=1}^{k-1}\alpha_i
+ >(k-2)\pi.                                             \tag{4}
+\]
+
+The arcs in (4) are disjoint portions of the polygon boundary, so their
+internal turns sum to less than `2pi`. If `k>=4`, (4) is already greater than
+or equal to `2pi`, a contradiction. Therefore `k<=3`. `QED`
+
+The value three is only an upper bound from this argument; no sharpness claim
+is made.
+
+## 3. Erdős-97 radius-level consequences
 
 Consider a strictly convex polygon in alternating notation
 
@@ -183,8 +241,8 @@ Consider a strictly convex polygon in alternating notation
 E_0,Q_0,E_1,Q_1,\ldots,E_{m-1},Q_{m-1}.
 \]
 
-Suppose each `E_i` has a selected radius `rho_i` whose distance class contains
-both boundary neighbours:
+Suppose each `E_i` has a rich radius `rho_i` whose complete distance class
+contains both boundary neighbours:
 
 \[
 |E_iQ_{i-1}|=|E_iQ_i|=\rho_i.
@@ -196,90 +254,187 @@ Fix an arbitrary radius value `R` and put
 X_R=\{E_i:\rho_i=R\}.
 \]
 
-The set `X_R` is boundary-independent. More importantly, every boundary arc
-between consecutive members of `X_R` begins with an edge of length `R` leaving
-its first centre and ends with an edge of length `R` entering its second
-centre. Its total length is therefore at least `2R`, regardless of the side
-lengths or selected radii at the intermediate vertices.
+The set `X_R` is boundary-independent. Every boundary arc between consecutive
+members of `X_R` begins with an edge of length `R` leaving its first centre and
+ends with an edge of length `R` entering its second centre. Its total length is
+therefore at least `2R`, regardless of intermediate side lengths or radii.
 
-Applying the lemma with `r=R` gives:
+Applying the two lemmas with `r=R` gives:
 
-> **Radius-level reciprocal-forest corollary.** For every `R`, the graph on
-> `X_R` joining pairs at distance `R` is a forest.
+1. **Radius-level reciprocal forest.** The graph on `X_R` joining pairs at
+   distance `R` is a forest.
+2. **Radius-level fan-in cap.** Any polygon vertex outside `X_R` is at distance
+   `R` from at most three members of `X_R`.
 
-This is the full same-radius distance graph, not merely a chosen selected-edge
-subgraph. If two centres in `X_R` are distance `R` apart, each belongs to the
-other centre's complete radius-`R` class. Any selected reciprocal graph at
-that radius is therefore a subgraph of this forest.
+The first graph is the full same-radius distance graph, not merely a chosen
+selected-edge subgraph. If two centres in `X_R` are distance `R` apart, each
+belongs to the other centre's complete radius-`R` class.
 
 Consequently every nontrivial same-radius component has a centre with at most
-one same-radius reciprocal neighbour. In particular:
+one same-radius reciprocal neighbour. The coprime step-`k` Hamiltonian pattern
+from `docs/alternate-vertex-perimeter-obstruction.md` is a special case, since
+its same-radius graph is already a cycle.
 
-1. if every `E_i` has one common selected radius and at least two additional
-   `E`-witnesses at that radius, the resulting graph has minimum degree at
-   least two, contradicting the forest lemma;
-2. if a connected reciprocal selected graph on the `E_i` has minimum degree
-   at least two, reciprocal edges propagate one common radius through the
-   component and the same contradiction follows; and
-3. the coprime step-`k` Hamiltonian pattern from
-   `docs/alternate-vertex-perimeter-obstruction.md` is a special case, since
-   its reciprocal graph is already a cycle.
+### Exact export accounting
 
-## Cross-radius escape forced by the lemma
+Let `n_R=|X_R|`, and let the radius-`R` forest have `c_R` connected components.
+Assume each centre has at least `d>=2` non-boundary witnesses at distance `R`.
+This is automatic with `d=2` when its rich class has size at least four and its
+two boundary neighbours are already in that class.
 
-The corollary also identifies the exact escape from the common-radius route.
-Suppose every centre `E_i` has at least two additional witnesses among the
-other `E`-vertices. At a leaf or isolated vertex of each same-radius forest,
-at least one of those witnesses must have a *different selected radius* from
-the centre. Thus any surviving configuration must export witness incidences
-between distinct radius levels.
+The forest has at most `n_R-c_R` internal edges. Internal edges account for at
+most `2(n_R-c_R)` centre-to-witness incidences. Therefore the number `B_R` of
+incidences from centres in `X_R` to vertices outside `X_R` obeys
 
-This is genuine variable-radius information: a proof can no longer close the
-alternating-boundary-neighbour branch by analysing one radius level in
-isolation. It must control the directed cross-radius dependency graph.
+\[
+B_R\ge d n_R-2(n_R-c_R)
+     =(d-2)n_R+2c_R.                                   \tag{5}
+\]
 
-## What this advances—and what remains open
+For the Erdős threshold `d=2`, every same-radius forest component exports at
+least two incidences in aggregate:
+
+\[
+B_R\ge2c_R.                                             \tag{6}
+\]
+
+By the fan-in cap, one outside target absorbs at most three of those incidences.
+Thus at least
+
+\[
+\left\lceil\frac{(d-2)n_R+2c_R}{3}\right\rceil          \tag{7}
+\]
+
+distinct outside targets are required.
+
+This accounting is deliberately careful about what “outside” means. A target
+outside `X_R` may be
+
+- another `E`-vertex with a different selected radius; or
+- a `Q`-vertex, possibly with the same selected radius.
+
+Thus (5)--(7) force export from the same-radius `E`-forest, but they do **not**
+unconditionally force a change of radius. If the non-boundary witnesses are
+known separately to lie among the `E`-vertices, then every exported target does
+have a different selected radius and the bounds become genuine cross-radius
+bounds.
+
+## 4. Three consecutive centres cannot share one extra witness
+
+There is a further local restriction in the alternating setting.
+
+> **Consecutive-three common-witness lemma.** Let three consecutive alternate
+> centres `U,V,Z` have the same selected radius `R`. Let `A` be the boundary
+> vertex between `U,V`, and `B` the boundary vertex between `V,Z`. There is no
+> polygon vertex `W`, distinct from `A,B`, such that
+>
+> \[
+> |WU|=|WV|=|WZ|=R.
+> \]
+
+### Proof
+
+Translate `W` to the origin, scale `R` to one, and rotate so that
+`V=(1,0)`. Since `W` is a strictly convex polygon vertex, the rays from `W` to
+`U,V,Z` occur in their boundary order inside an angle strictly smaller than
+`pi`. Hence for some `a,b>0` with `a+b<pi`,
+
+\[
+U=(\cos a,-\sin a),\qquad Z=(\cos b,\sin b).
+\]
+
+The points `W` and `A` are the two intersections of the unit circles centered
+at `U,V`. Therefore
+
+\[
+A=U+V-W=U+V.
+\]
+
+Likewise
+
+\[
+B=V+Z.
+\]
+
+Put
+
+\[
+D=\sin a+\sin b+\sin(a+b)>0,
+\]
+
+and
+
+\[
+\lambda=\frac{\sin b}{D},\qquad
+\mu=\frac{\sin a}{D}.
+\]
+
+A direct coordinate calculation gives
+
+\[
+\lambda A+\mu B=V.
+\]
+
+Moreover `lambda,mu>0` and
+
+\[
+\lambda+\mu
+ =\frac{\sin a+\sin b}{D}<1
+\]
+
+because `sin(a+b)>0`. Thus
+
+\[
+V=\lambda A+\mu B+(1-\lambda-\mu)W
+\]
+
+is a strict convex combination of the three other polygon vertices `A,B,W`.
+This contradicts strict convexity. `QED`
+
+In particular, one outside target cannot absorb three *extra* radius-`R`
+witness incidences from three consecutive `R`-centres: being extra at all
+three centres ensures it is distinct from the intervening boundary vertices.
+
+## 5. What this advances—and what remains open
 
 The earlier terminal required a specified Hamiltonian reciprocal cycle and a
-common radius propagated along it. The new lemma removes Hamiltonicity,
+common radius propagated along it. The forest lemma removes Hamiltonicity,
 fixed-step symmetry, global side-length lower bounds, and the common-radius
-assumption. It applies independently at every selected-radius level.
+assumption. It applies independently at every selected-radius level. The
+fan-in and export lemmas additionally prevent unlimited concentration at one
+outside witness.
 
 The remaining extraction problem is still substantial. In an arbitrary
 hypothetical counterexample:
 
 - a rich distance class need not contain both boundary neighbours;
-- the two non-boundary witnesses need not lie in one boundary-independent
-  centre set; and
-- cross-radius witness dependencies can be one-way, so the forest conclusion
-  alone does not create a cycle at one fixed radius.
+- its non-boundary witnesses need not lie in one parity class; and
+- same-radius forest exports can move to the opposite parity without changing
+  radius, or can form one-way dependencies between different radii.
 
-The next proof target is therefore a geometric restriction on those
-cross-radius exports—for example, a fan-in bound, an ordered dependency-cycle
-obstruction, or a forced return to one radius level. None of those statements
-is claimed here.
+The next proof target is a geometric restriction on those exports—for example,
+a stronger target-capacity theorem, an ordered dependency-cycle obstruction,
+or a minimal-counterexample argument forcing enough rows into the
+boundary-neighbour branch. None of those statements is claimed here.
 
-## Arithmetic replay
+## 6. Arithmetic replay
 
-The companion command checks the exact coefficient spine used after the two
-geometric projection steps:
+The companion command checks the exact coefficient spine used after the
+geometric projection steps and the export-count formula:
 
 ```bash
 python scripts/check_sparse_minimum_distance_forest.py \
   --assert-expected --summary-json
 ```
 
-It verifies symbolically that the long-cycle margin is
+It verifies symbolically that
 
 ```text
 2*(g-2)-g = g-4 >= 0  for every g >= 4,
-```
-
-and records the normalized triangle turn budget
-
-```text
 3*(1/3) = 1,
+d*n - 2*(n-c) = (d-2)*n + 2*c,
 ```
 
-against the strict total-turn upper bound. This replay is not a formal proof
-of the projection lemma; the complete paper proof is the argument above.
+and records the fan-in threshold `4 -> contradiction`. This replay is not a
+formal proof of the projection or angular-order lemmas; the complete paper
+proofs are the arguments above.

--- a/docs/triple-fanin-radius-descent.md
+++ b/docs/triple-fanin-radius-descent.md
@@ -63,7 +63,7 @@ vertex `T`, in boundary order. Hence
 
 \[
 \alpha_1>0,\quad \alpha_2>0,\quad
-\alpha_1+\alpha_2<\pi.                                 \tag{3)
+\alpha_1+\alpha_2<\pi.                                 \tag{3}
 \]
 
 Let `sigma_0,sigma_1,sigma_2,sigma_3` be the sums of the exterior turns at the
@@ -245,6 +245,15 @@ The companion arithmetic replay records the equivalent threshold identities
 ```text
 acos(x)+acos(y)<pi/2  iff  x^2+y^2>1,
 2/(1+s)^2>1          iff  s<sqrt(2)-1.
+```
+
+Run:
+
+```bash
+python scripts/check_radius_level_advanced_arithmetic.py \
+  --max-cycle-length 512 \
+  --assert-expected \
+  --summary-json
 ```
 
 The trigonometric projection and boundary-order argument above remain

--- a/docs/triple-fanin-radius-descent.md
+++ b/docs/triple-fanin-radius-descent.md
@@ -1,0 +1,251 @@
+# Triple-fan-in radius descent
+
+Status: `PAPER_PROOF_CANDIDATE / REVIEW_PENDING`.
+
+This note strengthens the fan-in analysis in
+`docs/sparse-minimum-distance-forest.md`. It proves a quantitative radius
+ordering whenever three equal-radius centres share one non-boundary witness.
+It is not a proof or disproof of Erdős Problem #97 and not a source-of-truth
+status update.
+
+## 1. General asymmetric statement
+
+Let a strictly convex polygon contain four distinct vertices
+
+\[
+T,Y_1,Y_2,Y_3
+\]
+
+in that cyclic order, after reversing orientation if necessary. Fix `R>0` and
+assume
+
+\[
+|TY_1|=|TY_2|=|TY_3|=R.                                \tag{1}
+\]
+
+Assume also that:
+
+1. `T` is not adjacent on the polygon boundary to any `Y_i`;
+2. the boundary side at `T` entering the arc from `Y_3` to `T` has length
+   `a>0`, while the boundary side at `T` leaving toward `Y_1` has length
+   `b>0`;
+3. the boundary side incident to either side of every `Y_i` has length `R`.
+
+Then:
+
+> **Asymmetric triple-fan-in inequality.**
+>
+> \[
+> \left(\frac{R}{R+a}\right)^2
+> +\left(\frac{R}{R+b}\right)^2>1.                     \tag{2}
+> \]
+
+In particular, with
+
+\[
+c=\sqrt2-1,
+\]
+
+at least one of `a,b` is strictly smaller than `cR`.
+
+### Proof
+
+Let
+
+\[
+\alpha_1=\angle Y_1TY_2,
+\qquad
+\alpha_2=\angle Y_2TY_3.
+\]
+
+All three rays lie in the open interior-angle cone at the strictly convex
+vertex `T`, in boundary order. Hence
+
+\[
+\alpha_1>0,\quad \alpha_2>0,\quad
+\alpha_1+\alpha_2<\pi.                                 \tag{3)
+\]
+
+Let `sigma_0,sigma_1,sigma_2,sigma_3` be the sums of the exterior turns at the
+vertices strictly inside the four boundary arcs
+
+\[
+T\to Y_1,\quad Y_1\to Y_2,\quad
+Y_2\to Y_3,\quad Y_3\to T.
+\]
+
+The two middle arcs begin and end with boundary sides of length `R`, so each
+has total length at least `2R`. Since the chord `Y_iY_{i+1}` has length
+
+\[
+2R\sin(\alpha_i/2),
+\]
+
+the standard projection estimate gives
+
+\[
+\sigma_i\ge\pi-\alpha_i
+\qquad(i=1,2).                                         \tag{4}
+\]
+
+The first arc contains one side of length `b` at `T` and one side of length
+`R` at `Y_1`; these are distinct because the endpoints are not adjacent.
+Thus its total length is at least `R+b`. From the chord equality
+`|TY_1|=R`, projection gives
+
+\[
+\sigma_0\ge
+2\arccos\left(\frac{R}{R+b}\right).                    \tag{5}
+\]
+
+Likewise,
+
+\[
+\sigma_3\ge
+2\arccos\left(\frac{R}{R+a}\right).                    \tag{6}
+\]
+
+Equations (4) and (3) imply
+
+\[
+\sigma_1+\sigma_2
+\ge2\pi-(\alpha_1+\alpha_2)>\pi.                       \tag{7}
+\]
+
+The four open-arc turn sums omit the positive exterior turns at
+`T,Y_1,Y_2,Y_3`, so their total is strictly less than `2pi`. Combining this
+with (5)--(7) yields
+
+\[
+\arccos\left(\frac{R}{R+a}\right)
++
+\arccos\left(\frac{R}{R+b}\right)
+<\frac\pi2.                                            \tag{8}
+\]
+
+Put
+
+\[
+x=\frac{R}{R+a},\qquad y=\frac{R}{R+b}.
+\]
+
+Both numbers lie in `(0,1)`. For such `x,y`, inequality (8) is equivalent to
+
+\[
+x^2+y^2>1.
+\]
+
+Indeed, the two arccosines lie in `(0,pi/2)`, and positivity of the cosine of
+their sum is equivalent to
+
+\[
+xy>\sqrt{1-x^2}\sqrt{1-y^2};
+\]
+
+squaring gives `x^2+y^2>1`. This proves (2).
+
+If both `a,b` were at least `(sqrt(2)-1)R`, then both `x,y` would be at most
+`1/sqrt(2)`, contradicting their strict squared-sum inequality. `QED`
+
+## 2. Alternating radius-level corollary
+
+Use the alternating boundary-neighbour setup
+
+\[
+E_0,Q_0,E_1,Q_1,\ldots,E_{m-1},Q_{m-1},
+\]
+
+where the complete rich class at each `E_i` contains its two boundary
+neighbours at radius `rho_i`.
+
+Fix a radius value `R`, and suppose one polygon vertex `T` is an extra
+radius-`R` witness for three centres in
+
+\[
+X_R=\{E_i:\rho_i=R\}.
+\]
+
+The three source centres all have their two incident sides of length `R`, so
+the hypotheses above hold.
+
+- If `T=E_j`, both incident sides at `T` have length `rho_j`. Therefore
+
+  \[
+  \rho_j<(\sqrt2-1)R.                                  \tag{9}
+  \]
+
+- If `T=Q_j`, its incident boundary sides have lengths `rho_j` and
+  `rho_{j+1}`. Therefore
+
+  \[
+  \min(\rho_j,\rho_{j+1})<(\sqrt2-1)R.                 \tag{10}
+  \]
+
+Thus every triple-fan-in target identifies an adjacent `E`-centre whose
+selected boundary radius drops by the uniform factor `sqrt(2)-1`.
+
+## 3. Consequences
+
+### Minimum-level cap two
+
+If `R` is the minimum selected radius among all `E_i`, equations (9)--(10) are
+impossible. Hence no vertex can be an extra radius-`R` witness for three
+minimum-level centres. This independently recovers the minimum-level
+extra-target cap of two from `docs/radius-level-linear-forest.md`.
+
+### No triple-fan-in radius cycle
+
+Create a directed dependency from a radius level `R` to a radius level `S`
+whenever a triple-fan-in target at level `R` selects an adjacent centre of
+radius `S` as supplied by (9) or (10). Every such edge obeys
+
+\[
+S<(\sqrt2-1)R.
+\]
+
+Therefore the triple-fan-in dependency graph is acyclic. Along a directed path
+of length `k`, the radii satisfy
+
+\[
+R_k<(\sqrt2-1)^kR_0.
+\]
+
+This is a genuine metric descent rather than an incidence-only ordering.
+
+### Capacity interpretation
+
+At a fixed level `R`, the general fan-in lemma permits at most three source
+centres per target. The present result divides the targets into two classes:
+
+- targets not adjacent to a centre of radius below `(sqrt(2)-1)R` have
+  capacity at most two;
+- capacity three is possible only by paying for a uniformly smaller adjacent
+  radius.
+
+This supplies a natural charging rule for future global counting arguments.
+
+## 4. Boundary of the result
+
+The argument requires all three source incidences to be non-boundary
+incidences. If `T` is a boundary neighbour of one source, one end detour may
+contain only one side and the coefficient in (2) changes.
+
+The result also says nothing directly about targets receiving only one or two
+incidences. A global proof still needs to control those low-fan-in exports or
+to force enough triple-fan-in targets for the descent to iterate.
+
+Finally, the larger extraction gap remains: an arbitrary hypothetical
+counterexample has not been shown to supply an alternating family whose rich
+classes all contain both boundary neighbours.
+
+## 5. Exact replay target
+
+The companion arithmetic replay records the equivalent threshold identities
+
+```text
+acos(x)+acos(y)<pi/2  iff  x^2+y^2>1,
+2/(1+s)^2>1          iff  s<sqrt(2)-1.
+```
+
+The trigonometric projection and boundary-order argument above remain
+review-pending paper mathematics rather than a formal proof object.

--- a/scripts/check_radius_level_advanced_arithmetic.py
+++ b/scripts/check_radius_level_advanced_arithmetic.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Replay exact arithmetic for advanced radius-level proof candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from erdos97.radius_level_advanced_arithmetic import (
+    assert_expected_payload,
+    payload,
+)
+
+
+def summary_payload(candidate: dict[str, Any]) -> dict[str, Any]:
+    """Return the compact reviewer-facing fields."""
+
+    compact = dict(candidate)
+    compact.pop("weak_arc_cases", None)
+    compact.pop("component_cycle_cases", None)
+    return compact
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-cycle-length", type=int, default=128)
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--json", action="store_true")
+    output.add_argument("--summary-json", action="store_true")
+    parser.add_argument("--assert-expected", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    candidate = payload(args.max_cycle_length)
+    if args.assert_expected:
+        assert_expected_payload(candidate)
+
+    if args.summary_json:
+        print(json.dumps(summary_payload(candidate), indent=2, sort_keys=True))
+    elif args.json:
+        print(json.dumps(candidate, indent=2, sort_keys=True))
+    else:
+        print("advanced radius-level arithmetic replay")
+        print(f"weak-arc identity: {candidate['weak_arc_identity']}")
+        print(
+            "component-cycle first forbidden total path length: "
+            f"{candidate['component_cycle_first_forbidden_total_path_length']}"
+        )
+        print(
+            "forced internal path angle: "
+            f"{candidate['linear_forest_angle']['forced_angle_radians']}"
+        )
+        print(
+            "triple-fan-in descent factor: "
+            f"{candidate['triple_fanin_radius_descent']['positive_threshold']}"
+        )
+        if args.assert_expected:
+            print("OK: advanced radius-level arithmetic matches expected data")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_sparse_minimum_distance_forest.py
+++ b/scripts/check_sparse_minimum_distance_forest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Replay the exact arithmetic spine of the sparse forest lemma."""
+"""Replay exact arithmetic for the boundary-detour forest and fan-in lemmas."""
 
 from __future__ import annotations
 
@@ -18,6 +18,8 @@ def summary_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
     compact = dict(payload)
     compact.pop("long_cycle_cases", None)
+    compact.pop("fan_in_cases", None)
+    compact.pop("export_cases", None)
     return compact
 
 
@@ -42,7 +44,7 @@ def main(argv: list[str] | None = None) -> int:
     elif args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print("sparse minimum-distance forest arithmetic replay")
+        print("boundary-detour forest and fan-in arithmetic replay")
         print(
             "triangle normalized lower sum: "
             f"{payload['triangle_case']['normalized_internal_turn_lower_sum']}"
@@ -53,9 +55,11 @@ def main(argv: list[str] | None = None) -> int:
             "all checked long cycles close: "
             f"{payload['all_checked_long_cycles_close']}"
         )
-        print(f"identity: {payload['long_cycle_identity']}")
+        print(f"long-cycle identity: {payload['long_cycle_identity']}")
+        print(f"common-target fan-in cap: {payload['fan_in_cap']}")
+        print(f"export identity: {payload['export_identity']}")
         if args.assert_expected:
-            print("OK: sparse forest arithmetic matches expected data")
+            print("OK: forest, fan-in, and export arithmetic matches expected data")
     return 0
 
 

--- a/scripts/check_sparse_minimum_distance_forest.py
+++ b/scripts/check_sparse_minimum_distance_forest.py
@@ -18,6 +18,7 @@ def summary_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
     compact = dict(payload)
     compact.pop("long_cycle_cases", None)
+    compact.pop("one_defect_cycle_cases", None)
     compact.pop("fan_in_cases", None)
     compact.pop("export_cases", None)
     return compact
@@ -56,10 +57,18 @@ def main(argv: list[str] | None = None) -> int:
             f"{payload['all_checked_long_cycles_close']}"
         )
         print(f"long-cycle identity: {payload['long_cycle_identity']}")
+        print(
+            "one-defect first forbidden cycle length: "
+            f"{payload['one_defect_first_forbidden_cycle_length']}"
+        )
+        print(
+            "one-defect identity: "
+            f"{payload['one_defect_cycle_identity']}"
+        )
         print(f"common-target fan-in cap: {payload['fan_in_cap']}")
         print(f"export identity: {payload['export_identity']}")
         if args.assert_expected:
-            print("OK: forest, fan-in, and export arithmetic matches expected data")
+            print("OK: forest, return, fan-in, and export arithmetic matches expected data")
     return 0
 
 

--- a/src/erdos97/radius_level_advanced_arithmetic.py
+++ b/src/erdos97/radius_level_advanced_arithmetic.py
@@ -1,0 +1,208 @@
+"""Exact arithmetic for advanced radius-level proof candidates.
+
+This module checks only coefficient and algebraic identities used by the paper
+arguments in ``docs/radius-level-linear-forest.md``,
+``docs/radius-level-return-locality.md``, and
+``docs/triple-fanin-radius-descent.md``. It does not formalize their geometric
+projection, ray-order, or strict-convexity steps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from fractions import Fraction
+from typing import Any
+
+SCHEMA = "erdos97.radius_level_advanced_arithmetic.v1"
+STATUS = "REVIEW_PENDING_PAPER_LEMMA_ARITHMETIC_REPLAY"
+TRUST = "PAPER_PROOF_CANDIDATE"
+CLAIM_SCOPE = (
+    "Exact arithmetic replay for review-pending radius-level linear-forest, "
+    "weak-arc return, component-cycle locality, and triple-fan-in radius "
+    "descent lemmas. It is not a formal proof of the geometric steps, not a "
+    "proof or disproof of Erdős Problem #97, and not a source-of-truth update."
+)
+
+
+@dataclass(frozen=True)
+class WeakArcCycleArithmetic:
+    """Coefficient comparison for a cycle with ``h`` weak detour gaps."""
+
+    cycle_length: int
+    weak_arc_count: int
+    cycle_tour_coefficient: int
+    perimeter_lower_coefficient: int
+    margin: int
+    contradiction: bool
+
+
+@dataclass(frozen=True)
+class ComponentCycleArithmetic:
+    """Worst-case margin for a lifted component-target cycle."""
+
+    component_count: int
+    total_path_length: int
+    lifted_cycle_length: int
+    weak_arc_upper_bound: int
+    worst_case_margin: int
+    contradiction: bool
+
+
+def weak_arc_cycle_arithmetic(
+    cycle_length: int,
+    weak_arc_count: int,
+) -> WeakArcCycleArithmetic:
+    """Return the exact identity ``(2g-h-4)-g=g-h-4``."""
+
+    if cycle_length < 3:
+        raise ValueError("cycle_length must be at least 3")
+    if weak_arc_count < 0 or weak_arc_count > cycle_length:
+        raise ValueError("weak_arc_count must lie in 0..cycle_length")
+    perimeter = 2 * cycle_length - weak_arc_count - 4
+    margin = perimeter - cycle_length
+    return WeakArcCycleArithmetic(
+        cycle_length=cycle_length,
+        weak_arc_count=weak_arc_count,
+        cycle_tour_coefficient=cycle_length,
+        perimeter_lower_coefficient=perimeter,
+        margin=margin,
+        contradiction=margin >= 0,
+    )
+
+
+def component_cycle_arithmetic(
+    component_count: int,
+    total_path_length: int,
+) -> ComponentCycleArithmetic:
+    """Return the worst-case lifted-cycle margin ``L-4``."""
+
+    if component_count < 2:
+        raise ValueError("component_count must be at least 2")
+    if total_path_length < 0:
+        raise ValueError("total_path_length must be nonnegative")
+    cycle_length = 2 * component_count + total_path_length
+    weak_upper = 2 * component_count
+    margin = cycle_length - weak_upper - 4
+    return ComponentCycleArithmetic(
+        component_count=component_count,
+        total_path_length=total_path_length,
+        lifted_cycle_length=cycle_length,
+        weak_arc_upper_bound=weak_upper,
+        worst_case_margin=margin,
+        contradiction=margin >= 0,
+    )
+
+
+def linear_forest_angle_arithmetic() -> dict[str, Any]:
+    """Return normalized turn arithmetic for degree at most two."""
+
+    end_total = 2 * Fraction(1, 3)
+    middle_constant = Fraction(1, 2)
+    angle_threshold = end_total + middle_constant - 1
+    degree_three_lower = end_total + 2 * middle_constant - Fraction(1, 2)
+    return {
+        "two_neighbor_end_arc_total": str(end_total),
+        "middle_arc_lower_form": "1/2-alpha/(2*pi)",
+        "forced_angle_normalized_lower_bound": str(angle_threshold),
+        "forced_angle_radians": ">pi/3",
+        "degree_three_normalized_strict_lower_bound": f">{degree_three_lower}",
+        "normalized_total_turn_upper_bound": "<1",
+        "degree_three_contradiction": degree_three_lower > 1,
+    }
+
+
+def _quadratic_pair_multiply(
+    left: tuple[int, int],
+    right: tuple[int, int],
+) -> tuple[int, int]:
+    """Multiply exact pairs representing ``a+b*sqrt(2)``."""
+
+    a, b = left
+    c, d = right
+    return (a * c + 2 * b * d, a * d + b * c)
+
+
+def triple_fanin_radius_arithmetic() -> dict[str, Any]:
+    """Return exact algebra for the ``sqrt(2)-1`` descent threshold."""
+
+    root = (-1, 1)
+    square = _quadratic_pair_multiply(root, root)
+    polynomial = (square[0] + 2 * root[0] - 1, square[1] + 2 * root[1])
+    return {
+        "angular_condition": "acos(x)+acos(y)<pi/2",
+        "equivalent_asymmetric_condition": "x^2+y^2>1",
+        "substitution": "x=R/(R+a), y=R/(R+b)",
+        "symmetric_condition": "2/(1+s)^2>1",
+        "equivalent_quadratic": "s^2+2*s-1<0",
+        "positive_threshold": "sqrt(2)-1",
+        "threshold_quadratic_value": [polynomial[0], polynomial[1]],
+        "threshold_identity_verified": polynomial == (0, 0),
+        "descent_conclusion": "min(a,b)<(sqrt(2)-1)*R",
+    }
+
+
+def payload(max_cycle_length: int = 128) -> dict[str, Any]:
+    """Return a deterministic reviewer-facing arithmetic payload."""
+
+    if max_cycle_length < 6:
+        raise ValueError("max_cycle_length must be at least 6")
+    weak_cases = [
+        asdict(weak_arc_cycle_arithmetic(length, weak))
+        for length in range(3, max_cycle_length + 1)
+        for weak in range(0, min(length, 12) + 1)
+    ]
+    component_cases = [
+        asdict(component_cycle_arithmetic(components, path_length))
+        for components in range(2, 17)
+        for path_length in range(0, 13)
+    ]
+    return {
+        "schema": SCHEMA,
+        "status": STATUS,
+        "trust": TRUST,
+        "claim_scope": CLAIM_SCOPE,
+        "linear_forest_angle": linear_forest_angle_arithmetic(),
+        "weak_arc_identity": "(2*g-h-4)-g=g-h-4",
+        "checked_cycle_length_range": [3, max_cycle_length],
+        "weak_arc_cases": weak_cases,
+        "all_weak_arc_cases_match_threshold": all(
+            bool(case["contradiction"])
+            == (
+                int(case["cycle_length"])
+                >= int(case["weak_arc_count"]) + 4
+            )
+            for case in weak_cases
+        ),
+        "component_cycle_identity": "g-h-4 >= L-4",
+        "component_cycle_cases": component_cases,
+        "component_cycle_first_forbidden_total_path_length": 4,
+        "all_component_cycle_cases_match_threshold": all(
+            bool(case["contradiction"])
+            == (int(case["total_path_length"]) >= 4)
+            for case in component_cases
+        ),
+        "triple_fanin_radius_descent": triple_fanin_radius_arithmetic(),
+        "limitations": [
+            "Projection, angular-order, and convexity steps remain paper mathematics.",
+            "The bounded tables replay unbounded integer identities only.",
+            "Component cycles with total path length at most three remain open.",
+            "No proof, disproof, or counterexample for Erdős #97 is claimed.",
+        ],
+    }
+
+
+def assert_expected_payload(candidate: dict[str, Any]) -> None:
+    """Assert exact fields and complete deterministic regeneration."""
+
+    raw_range = candidate.get("checked_cycle_length_range")
+    if not (
+        isinstance(raw_range, list)
+        and len(raw_range) == 2
+        and raw_range[0] == 3
+        and isinstance(raw_range[1], int)
+        and raw_range[1] >= 6
+    ):
+        raise AssertionError("invalid checked cycle-length range")
+    expected = payload(raw_range[1])
+    if candidate != expected:
+        raise AssertionError("advanced arithmetic payload differs from regeneration")

--- a/src/erdos97/sparse_minimum_distance_forest.py
+++ b/src/erdos97/sparse_minimum_distance_forest.py
@@ -1,8 +1,9 @@
-"""Exact arithmetic spine for the boundary-detour distance forest lemma.
+"""Exact arithmetic spine for the boundary-detour forest and fan-in lemmas.
 
-The geometric proof lives in ``docs/sparse-minimum-distance-forest.md``.
-This module checks only the final normalized turn and cycle-length arithmetic;
-it does not formalize the projection argument and does not prove Erdős #97.
+The geometric proofs live in ``docs/sparse-minimum-distance-forest.md``.
+This module checks only their normalized turn, cycle-length, and incidence
+accounting arithmetic; it does not formalize the projection or angular-order
+arguments and does not prove Erdős #97.
 """
 
 from __future__ import annotations
@@ -11,15 +12,17 @@ from dataclasses import asdict, dataclass
 from fractions import Fraction
 from typing import Any
 
-SCHEMA = "erdos97.sparse_minimum_distance_forest.v1"
+SCHEMA = "erdos97.sparse_minimum_distance_forest.v2"
 STATUS = "REVIEW_PENDING_PAPER_LEMMA_ARITHMETIC_REPLAY"
 TRUST = "PAPER_PROOF_CANDIDATE"
 CLAIM_SCOPE = (
     "Exact arithmetic replay for the review-pending boundary-detour distance "
-    "forest lemma. It checks the normalized triangle turn budget and the "
-    "long-cycle coefficient margin after the geometric projection steps. "
-    "It is not a formal proof of those projection steps, not a proof or "
-    "disproof of Erdős Problem #97, and not a source-of-truth status update."
+    "forest, common-target fan-in, and radius-level export lemmas. It checks "
+    "the normalized triangle and fan-in turn budgets, the long-cycle "
+    "coefficient margin, and the forest-incidence accounting identity after "
+    "the geometric projection and angular-order steps. It is not a formal "
+    "proof of those geometric steps, not a proof or disproof of Erdős Problem "
+    "#97, and not a source-of-truth status update."
 )
 
 
@@ -32,6 +35,30 @@ class LongCycleArithmetic:
     perimeter_lower_coefficient: int
     margin: int
     contradiction: bool
+
+
+@dataclass(frozen=True)
+class FanInArithmetic:
+    """Normalized turn threshold for one common-target fan-in size."""
+
+    source_count: int
+    normalized_strict_lower_bound: str
+    normalized_total_turn_upper_bound: str
+    contradiction: bool
+
+
+@dataclass(frozen=True)
+class ExportArithmetic:
+    """Forest-incidence export bound for one radius level."""
+
+    vertex_count: int
+    component_count: int
+    minimum_additional_witnesses_per_center: int
+    maximum_forest_edges: int
+    maximum_internal_incidences: int
+    minimum_external_incidences: int
+    fan_in_cap: int
+    minimum_distinct_external_targets: int
 
 
 def long_cycle_arithmetic(cycle_length: int) -> LongCycleArithmetic:
@@ -72,14 +99,81 @@ def triangle_turn_arithmetic() -> dict[str, Any]:
     }
 
 
+def fan_in_arithmetic(source_count: int) -> FanInArithmetic:
+    """Return the exact common-target turn threshold for ``source_count``."""
+
+    if source_count < 1:
+        raise ValueError("source_count must be positive")
+    # The paper argument gives a strict lower bound
+    #   sum(sigma_i)/(2*pi) > (source_count - 2)/2.
+    lower = Fraction(source_count - 2, 2)
+    return FanInArithmetic(
+        source_count=source_count,
+        normalized_strict_lower_bound=f">{lower}",
+        normalized_total_turn_upper_bound="<1",
+        contradiction=lower >= 1,
+    )
+
+
+def export_arithmetic(
+    vertex_count: int,
+    component_count: int,
+    minimum_additional_witnesses_per_center: int = 2,
+    fan_in_cap: int = 3,
+) -> ExportArithmetic:
+    """Return the exact forest export and distinct-target lower bounds."""
+
+    if vertex_count < 1:
+        raise ValueError("vertex_count must be positive")
+    if component_count < 1 or component_count > vertex_count:
+        raise ValueError("component_count must lie in 1..vertex_count")
+    if minimum_additional_witnesses_per_center < 2:
+        raise ValueError("minimum additional witness count must be at least 2")
+    if fan_in_cap < 1:
+        raise ValueError("fan_in_cap must be positive")
+
+    maximum_edges = vertex_count - component_count
+    maximum_internal = 2 * maximum_edges
+    minimum_external = (
+        minimum_additional_witnesses_per_center * vertex_count
+        - maximum_internal
+    )
+    identity_value = (
+        (minimum_additional_witnesses_per_center - 2) * vertex_count
+        + 2 * component_count
+    )
+    if minimum_external != identity_value:
+        raise AssertionError("forest export identity failed")
+    minimum_targets = (minimum_external + fan_in_cap - 1) // fan_in_cap
+    return ExportArithmetic(
+        vertex_count=vertex_count,
+        component_count=component_count,
+        minimum_additional_witnesses_per_center=(
+            minimum_additional_witnesses_per_center
+        ),
+        maximum_forest_edges=maximum_edges,
+        maximum_internal_incidences=maximum_internal,
+        minimum_external_incidences=minimum_external,
+        fan_in_cap=fan_in_cap,
+        minimum_distinct_external_targets=minimum_targets,
+    )
+
+
 def arithmetic_payload(max_cycle_length: int = 128) -> dict[str, Any]:
     """Return a deterministic reviewer-facing replay payload."""
 
     if max_cycle_length < 4:
         raise ValueError("max_cycle_length must be at least 4")
-    cases = [
+    cycle_cases = [
         asdict(long_cycle_arithmetic(length))
         for length in range(4, max_cycle_length + 1)
+    ]
+    fan_in_cases = [asdict(fan_in_arithmetic(count)) for count in range(1, 9)]
+    export_cases = [
+        asdict(export_arithmetic(vertices, components, witnesses))
+        for vertices in range(1, 17)
+        for components in range(1, vertices + 1)
+        for witnesses in range(2, 6)
     ]
     return {
         "schema": SCHEMA,
@@ -89,17 +183,40 @@ def arithmetic_payload(max_cycle_length: int = 128) -> dict[str, Any]:
         "triangle_case": triangle_turn_arithmetic(),
         "long_cycle_identity": "2*(g-2)-g=g-4",
         "checked_cycle_length_range": [4, max_cycle_length],
-        "long_cycle_cases": cases,
+        "long_cycle_cases": cycle_cases,
         "all_checked_long_cycles_close": all(
-            bool(case["contradiction"]) for case in cases
+            bool(case["contradiction"]) for case in cycle_cases
+        ),
+        "fan_in_identity": (
+            "sum(sigma_i)/(2*pi) > (k-2)/2; k>=4 contradicts total <1"
+        ),
+        "fan_in_cap": 3,
+        "fan_in_cases": fan_in_cases,
+        "all_checked_fan_in_cases_match_cap": all(
+            bool(case["contradiction"]) == (int(case["source_count"]) >= 4)
+            for case in fan_in_cases
+        ),
+        "export_identity": "d*n-2*(n-c)=(d-2)*n+2*c",
+        "export_cases": export_cases,
+        "all_checked_export_cases_nonnegative": all(
+            int(case["minimum_external_incidences"]) >= 0
+            for case in export_cases
+        ),
+        "erdos_threshold_component_export": (
+            "For d=2, every forest component contributes at least two "
+            "external incidences in aggregate."
         ),
         "general_integer_argument": (
             "For every integer g>=4, g-4>=0; the strict geometric perimeter "
-            "bound therefore exceeds the length g*r of an r-edge cycle."
+            "bound exceeds the length g*r of an r-edge cycle. For k>=4 "
+            "common-target sources, the strict normalized turn lower bound is "
+            "at least 1. Forest edge counting gives the export identity for "
+            "all n>=c>=1 and d>=2."
         ),
         "limitations": [
-            "The projection and convex-hull-perimeter lemmas remain paper proof steps.",
-            "The bounded replay table illustrates an unbounded integer identity.",
+            "The projection, angular-order, and convex-hull-perimeter lemmas remain paper proof steps.",
+            "The bounded replay tables illustrate unbounded integer identities.",
+            "Outside a fixed E-radius level, a target may have opposite parity without changing radius.",
             "No general proof, disproof, or counterexample for Erdős #97 is claimed.",
         ],
     }
@@ -115,6 +232,10 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
         "claim_scope": CLAIM_SCOPE,
         "long_cycle_identity": "2*(g-2)-g=g-4",
         "all_checked_long_cycles_close": True,
+        "fan_in_cap": 3,
+        "all_checked_fan_in_cases_match_cap": True,
+        "export_identity": "d*n-2*(n-c)=(d-2)*n+2*c",
+        "all_checked_export_cases_nonnegative": True,
     }
     for key, value in expected.items():
         if payload.get(key) != value:
@@ -142,16 +263,34 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
     ):
         raise AssertionError("invalid checked cycle-length range")
 
-    cases = payload.get("long_cycle_cases")
-    if not isinstance(cases, list):
+    cycle_cases = payload.get("long_cycle_cases")
+    if not isinstance(cycle_cases, list):
         raise AssertionError("long_cycle_cases must be a list")
     expected_lengths = list(range(4, raw_range[1] + 1))
-    actual_lengths = [case.get("cycle_length") for case in cases]
+    actual_lengths = [case.get("cycle_length") for case in cycle_cases]
     if actual_lengths != expected_lengths:
         raise AssertionError("long-cycle replay range is incomplete")
-
-    for case in cases:
+    for case in cycle_cases:
         length = int(case["cycle_length"])
-        expected_case = asdict(long_cycle_arithmetic(length))
-        if case != expected_case:
+        if case != asdict(long_cycle_arithmetic(length)):
             raise AssertionError(f"incorrect long-cycle case at g={length}")
+
+    fan_in_cases = payload.get("fan_in_cases")
+    if not isinstance(fan_in_cases, list):
+        raise AssertionError("fan_in_cases must be a list")
+    if fan_in_cases != [
+        asdict(fan_in_arithmetic(count)) for count in range(1, 9)
+    ]:
+        raise AssertionError("fan-in replay cases differ from regeneration")
+
+    export_cases = payload.get("export_cases")
+    if not isinstance(export_cases, list):
+        raise AssertionError("export_cases must be a list")
+    expected_exports = [
+        asdict(export_arithmetic(vertices, components, witnesses))
+        for vertices in range(1, 17)
+        for components in range(1, vertices + 1)
+        for witnesses in range(2, 6)
+    ]
+    if export_cases != expected_exports:
+        raise AssertionError("export replay cases differ from regeneration")

--- a/src/erdos97/sparse_minimum_distance_forest.py
+++ b/src/erdos97/sparse_minimum_distance_forest.py
@@ -12,23 +12,34 @@ from dataclasses import asdict, dataclass
 from fractions import Fraction
 from typing import Any
 
-SCHEMA = "erdos97.sparse_minimum_distance_forest.v2"
+SCHEMA = "erdos97.sparse_minimum_distance_forest.v3"
 STATUS = "REVIEW_PENDING_PAPER_LEMMA_ARITHMETIC_REPLAY"
 TRUST = "PAPER_PROOF_CANDIDATE"
 CLAIM_SCOPE = (
     "Exact arithmetic replay for the review-pending boundary-detour distance "
-    "forest, common-target fan-in, and radius-level export lemmas. It checks "
-    "the normalized triangle and fan-in turn budgets, the long-cycle "
-    "coefficient margin, and the forest-incidence accounting identity after "
-    "the geometric projection and angular-order steps. It is not a formal "
-    "proof of those geometric steps, not a proof or disproof of Erdős Problem "
-    "#97, and not a source-of-truth status update."
+    "forest, common-target fan-in, one-defect return-cycle, and radius-level "
+    "export lemmas. It checks the normalized turn budgets, cycle coefficient "
+    "margins, and forest-incidence accounting identity after the geometric "
+    "projection and angular-order steps. It is not a formal proof of those "
+    "geometric steps, not a proof or disproof of Erdős Problem #97, and not a "
+    "source-of-truth status update."
 )
 
 
 @dataclass(frozen=True)
 class LongCycleArithmetic:
-    """Integer coefficient comparison for one cycle length."""
+    """Integer coefficient comparison for one detour-controlled cycle."""
+
+    cycle_length: int
+    cycle_tour_coefficient: int
+    perimeter_lower_coefficient: int
+    margin: int
+    contradiction: bool
+
+
+@dataclass(frozen=True)
+class OneDefectCycleArithmetic:
+    """Integer comparison for a cycle with two one-radius detour arcs."""
 
     cycle_length: int
     cycle_tour_coefficient: int
@@ -70,6 +81,23 @@ def long_cycle_arithmetic(cycle_length: int) -> LongCycleArithmetic:
     perimeter = 2 * (cycle_length - 2)
     margin = perimeter - tour
     return LongCycleArithmetic(
+        cycle_length=cycle_length,
+        cycle_tour_coefficient=tour,
+        perimeter_lower_coefficient=perimeter,
+        margin=margin,
+        contradiction=margin >= 0,
+    )
+
+
+def one_defect_cycle_arithmetic(cycle_length: int) -> OneDefectCycleArithmetic:
+    """Return the exact two-weak-arc comparison for ``cycle_length >= 3``."""
+
+    if cycle_length < 3:
+        raise ValueError("one-defect cycle arithmetic requires cycle_length >= 3")
+    tour = cycle_length
+    perimeter = 2 * cycle_length - 6
+    margin = perimeter - tour
+    return OneDefectCycleArithmetic(
         cycle_length=cycle_length,
         cycle_tour_coefficient=tour,
         perimeter_lower_coefficient=perimeter,
@@ -162,11 +190,15 @@ def export_arithmetic(
 def arithmetic_payload(max_cycle_length: int = 128) -> dict[str, Any]:
     """Return a deterministic reviewer-facing replay payload."""
 
-    if max_cycle_length < 4:
-        raise ValueError("max_cycle_length must be at least 4")
+    if max_cycle_length < 6:
+        raise ValueError("max_cycle_length must be at least 6")
     cycle_cases = [
         asdict(long_cycle_arithmetic(length))
         for length in range(4, max_cycle_length + 1)
+    ]
+    one_defect_cases = [
+        asdict(one_defect_cycle_arithmetic(length))
+        for length in range(3, max_cycle_length + 1)
     ]
     fan_in_cases = [asdict(fan_in_arithmetic(count)) for count in range(1, 9)]
     export_cases = [
@@ -186,6 +218,14 @@ def arithmetic_payload(max_cycle_length: int = 128) -> dict[str, Any]:
         "long_cycle_cases": cycle_cases,
         "all_checked_long_cycles_close": all(
             bool(case["contradiction"]) for case in cycle_cases
+        ),
+        "one_defect_cycle_identity": "(2*g-6)-g=g-6",
+        "checked_one_defect_cycle_range": [3, max_cycle_length],
+        "one_defect_cycle_cases": one_defect_cases,
+        "one_defect_first_forbidden_cycle_length": 6,
+        "all_checked_one_defect_cases_match_threshold": all(
+            bool(case["contradiction"]) == (int(case["cycle_length"]) >= 6)
+            for case in one_defect_cases
         ),
         "fan_in_identity": (
             "sum(sigma_i)/(2*pi) > (k-2)/2; k>=4 contradicts total <1"
@@ -207,15 +247,17 @@ def arithmetic_payload(max_cycle_length: int = 128) -> dict[str, Any]:
             "external incidences in aggregate."
         ),
         "general_integer_argument": (
-            "For every integer g>=4, g-4>=0; the strict geometric perimeter "
-            "bound exceeds the length g*r of an r-edge cycle. For k>=4 "
-            "common-target sources, the strict normalized turn lower bound is "
-            "at least 1. Forest edge counting gives the export identity for "
-            "all n>=c>=1 and d>=2."
+            "For every integer g>=4, g-4>=0 closes a fully detour-controlled "
+            "r-edge cycle. With one defect and two one-radius boundary arcs, "
+            "g-6>=0 closes every r-edge cycle of length at least six. For "
+            "k>=4 common-target sources, the strict normalized turn lower "
+            "bound is at least 1. Forest edge counting gives the export "
+            "identity for all n>=c>=1 and d>=2."
         ),
         "limitations": [
             "The projection, angular-order, and convex-hull-perimeter lemmas remain paper proof steps.",
             "The bounded replay tables illustrate unbounded integer identities.",
+            "The one-defect argument leaves return cycles of lengths three, four, and five unresolved.",
             "Outside a fixed E-radius level, a target may have opposite parity without changing radius.",
             "No general proof, disproof, or counterexample for Erdős #97 is claimed.",
         ],
@@ -232,6 +274,9 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
         "claim_scope": CLAIM_SCOPE,
         "long_cycle_identity": "2*(g-2)-g=g-4",
         "all_checked_long_cycles_close": True,
+        "one_defect_cycle_identity": "(2*g-6)-g=g-6",
+        "one_defect_first_forbidden_cycle_length": 6,
+        "all_checked_one_defect_cases_match_threshold": True,
         "fan_in_cap": 3,
         "all_checked_fan_in_cases_match_cap": True,
         "export_identity": "d*n-2*(n-c)=(d-2)*n+2*c",
@@ -259,7 +304,7 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
         and len(raw_range) == 2
         and raw_range[0] == 4
         and isinstance(raw_range[1], int)
-        and raw_range[1] >= 4
+        and raw_range[1] >= 6
     ):
         raise AssertionError("invalid checked cycle-length range")
 
@@ -274,6 +319,19 @@ def assert_expected_payload(payload: dict[str, Any]) -> None:
         length = int(case["cycle_length"])
         if case != asdict(long_cycle_arithmetic(length)):
             raise AssertionError(f"incorrect long-cycle case at g={length}")
+
+    one_defect_range = payload.get("checked_one_defect_cycle_range")
+    if one_defect_range != [3, raw_range[1]]:
+        raise AssertionError("invalid one-defect cycle range")
+    one_defect_cases = payload.get("one_defect_cycle_cases")
+    if not isinstance(one_defect_cases, list):
+        raise AssertionError("one_defect_cycle_cases must be a list")
+    expected_one_defect = [
+        asdict(one_defect_cycle_arithmetic(length))
+        for length in range(3, raw_range[1] + 1)
+    ]
+    if one_defect_cases != expected_one_defect:
+        raise AssertionError("one-defect replay cases differ from regeneration")
 
     fan_in_cases = payload.get("fan_in_cases")
     if not isinstance(fan_in_cases, list):

--- a/tests/test_radius_level_advanced_arithmetic.py
+++ b/tests/test_radius_level_advanced_arithmetic.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from erdos97.radius_level_advanced_arithmetic import (
+    CLAIM_SCOPE,
+    assert_expected_payload,
+    component_cycle_arithmetic,
+    linear_forest_angle_arithmetic,
+    payload,
+    triple_fanin_radius_arithmetic,
+    weak_arc_cycle_arithmetic,
+)
+
+
+def test_weak_arc_threshold_is_g_at_least_h_plus_four() -> None:
+    for length in range(3, 20):
+        for weak in range(length + 1):
+            case = weak_arc_cycle_arithmetic(length, weak)
+            assert case.margin == length - weak - 4
+            assert case.contradiction is (length >= weak + 4)
+
+    with pytest.raises(ValueError, match="at least 3"):
+        weak_arc_cycle_arithmetic(2, 0)
+    with pytest.raises(ValueError, match="0..cycle_length"):
+        weak_arc_cycle_arithmetic(5, 6)
+
+
+def test_linear_forest_angle_and_degree_three_budgets() -> None:
+    arithmetic = linear_forest_angle_arithmetic()
+
+    assert arithmetic["two_neighbor_end_arc_total"] == "2/3"
+    assert arithmetic["forced_angle_normalized_lower_bound"] == "1/6"
+    assert arithmetic["forced_angle_radians"] == ">pi/3"
+    assert arithmetic["degree_three_normalized_strict_lower_bound"] == ">7/6"
+    assert arithmetic["degree_three_contradiction"] is True
+
+
+def test_component_cycle_threshold_depends_only_on_total_path_length() -> None:
+    for components in (2, 3, 10, 100):
+        for path_length in range(9):
+            case = component_cycle_arithmetic(components, path_length)
+            assert case.lifted_cycle_length == 2 * components + path_length
+            assert case.weak_arc_upper_bound == 2 * components
+            assert case.worst_case_margin == path_length - 4
+            assert case.contradiction is (path_length >= 4)
+
+
+def test_triple_fanin_threshold_is_exact_in_q_sqrt_2() -> None:
+    arithmetic = triple_fanin_radius_arithmetic()
+
+    assert arithmetic["equivalent_asymmetric_condition"] == "x^2+y^2>1"
+    assert arithmetic["positive_threshold"] == "sqrt(2)-1"
+    assert arithmetic["threshold_quadratic_value"] == [0, 0]
+    assert arithmetic["threshold_identity_verified"] is True
+    assert arithmetic["descent_conclusion"] == "min(a,b)<(sqrt(2)-1)*R"
+
+
+def test_payload_regenerates_exactly() -> None:
+    candidate = payload(256)
+
+    assert_expected_payload(candidate)
+    assert candidate["claim_scope"] == CLAIM_SCOPE
+    assert candidate["checked_cycle_length_range"] == [3, 256]
+    assert candidate["all_weak_arc_cases_match_threshold"] is True
+    assert candidate["all_component_cycle_cases_match_threshold"] is True
+
+
+def test_cli_summary_is_compact() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/check_radius_level_advanced_arithmetic.py",
+            "--max-cycle-length",
+            "512",
+            "--assert-expected",
+            "--summary-json",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    candidate = json.loads(result.stdout)
+    assert candidate["claim_scope"] == CLAIM_SCOPE
+    assert candidate["checked_cycle_length_range"] == [3, 512]
+    assert candidate["triple_fanin_radius_descent"][
+        "threshold_identity_verified"
+    ] is True
+    assert "weak_arc_cases" not in candidate
+    assert "component_cycle_cases" not in candidate

--- a/tests/test_sparse_minimum_distance_forest.py
+++ b/tests/test_sparse_minimum_distance_forest.py
@@ -10,6 +10,8 @@ from erdos97.sparse_minimum_distance_forest import (
     CLAIM_SCOPE,
     arithmetic_payload,
     assert_expected_payload,
+    export_arithmetic,
+    fan_in_arithmetic,
     long_cycle_arithmetic,
     triangle_turn_arithmetic,
 )
@@ -39,6 +41,37 @@ def test_triangle_turn_budget_is_exact() -> None:
     assert triangle["contradiction"] is True
 
 
+def test_common_target_fan_in_threshold_is_four() -> None:
+    assert fan_in_arithmetic(3).contradiction is False
+    assert fan_in_arithmetic(3).normalized_strict_lower_bound == ">1/2"
+    assert fan_in_arithmetic(4).contradiction is True
+    assert fan_in_arithmetic(4).normalized_strict_lower_bound == ">1"
+    assert fan_in_arithmetic(100).contradiction is True
+    with pytest.raises(ValueError, match="positive"):
+        fan_in_arithmetic(0)
+
+
+def test_forest_export_formula_and_target_rounding() -> None:
+    threshold = export_arithmetic(10, 3)
+    assert threshold.maximum_forest_edges == 7
+    assert threshold.maximum_internal_incidences == 14
+    assert threshold.minimum_external_incidences == 6
+    assert threshold.minimum_distinct_external_targets == 2
+
+    richer = export_arithmetic(10, 3, 4)
+    assert richer.minimum_external_incidences == 26
+    assert richer.minimum_distinct_external_targets == 9
+
+    rounded = export_arithmetic(5, 2, 3)
+    assert rounded.minimum_external_incidences == 9
+    assert rounded.minimum_distinct_external_targets == 3
+
+    with pytest.raises(ValueError, match="1..vertex_count"):
+        export_arithmetic(4, 5)
+    with pytest.raises(ValueError, match="at least 2"):
+        export_arithmetic(4, 1, 1)
+
+
 def test_payload_preserves_claim_scope_and_complete_range() -> None:
     payload = arithmetic_payload(256)
 
@@ -48,6 +81,9 @@ def test_payload_preserves_claim_scope_and_complete_range() -> None:
     assert len(payload["long_cycle_cases"]) == 253
     assert payload["long_cycle_cases"][0]["margin"] == 0
     assert payload["long_cycle_cases"][-1]["margin"] == 252
+    assert payload["fan_in_cap"] == 3
+    assert payload["all_checked_fan_in_cases_match_cap"] is True
+    assert payload["all_checked_export_cases_nonnegative"] is True
 
 
 def test_cli_summary_json_is_compact() -> None:
@@ -72,4 +108,8 @@ def test_cli_summary_json_is_compact() -> None:
     assert payload["checked_cycle_length_range"] == [4, 512]
     assert payload["all_checked_long_cycles_close"] is True
     assert payload["triangle_case"]["contradiction"] is True
+    assert payload["fan_in_cap"] == 3
+    assert payload["export_identity"] == "d*n-2*(n-c)=(d-2)*n+2*c"
     assert "long_cycle_cases" not in payload
+    assert "fan_in_cases" not in payload
+    assert "export_cases" not in payload

--- a/tests/test_sparse_minimum_distance_forest.py
+++ b/tests/test_sparse_minimum_distance_forest.py
@@ -13,6 +13,7 @@ from erdos97.sparse_minimum_distance_forest import (
     export_arithmetic,
     fan_in_arithmetic,
     long_cycle_arithmetic,
+    one_defect_cycle_arithmetic,
     triangle_turn_arithmetic,
 )
 
@@ -29,6 +30,20 @@ def test_long_cycle_margin_is_exact_for_unbounded_formula() -> None:
 def test_long_cycle_arithmetic_rejects_triangle_input() -> None:
     with pytest.raises(ValueError, match="cycle_length >= 4"):
         long_cycle_arithmetic(3)
+
+
+def test_one_defect_return_threshold_is_six() -> None:
+    for length in range(3, 6):
+        case = one_defect_cycle_arithmetic(length)
+        assert case.margin == length - 6
+        assert case.contradiction is False
+    for length in (6, 7, 20, 10_000):
+        case = one_defect_cycle_arithmetic(length)
+        assert case.perimeter_lower_coefficient == 2 * length - 6
+        assert case.margin == length - 6
+        assert case.contradiction is True
+    with pytest.raises(ValueError, match="cycle_length >= 3"):
+        one_defect_cycle_arithmetic(2)
 
 
 def test_triangle_turn_budget_is_exact() -> None:
@@ -81,6 +96,10 @@ def test_payload_preserves_claim_scope_and_complete_range() -> None:
     assert len(payload["long_cycle_cases"]) == 253
     assert payload["long_cycle_cases"][0]["margin"] == 0
     assert payload["long_cycle_cases"][-1]["margin"] == 252
+    assert payload["checked_one_defect_cycle_range"] == [3, 256]
+    assert len(payload["one_defect_cycle_cases"]) == 254
+    assert payload["one_defect_first_forbidden_cycle_length"] == 6
+    assert payload["all_checked_one_defect_cases_match_threshold"] is True
     assert payload["fan_in_cap"] == 3
     assert payload["all_checked_fan_in_cases_match_cap"] is True
     assert payload["all_checked_export_cases_nonnegative"] is True
@@ -107,9 +126,12 @@ def test_cli_summary_json_is_compact() -> None:
     assert payload["claim_scope"] == CLAIM_SCOPE
     assert payload["checked_cycle_length_range"] == [4, 512]
     assert payload["all_checked_long_cycles_close"] is True
+    assert payload["one_defect_first_forbidden_cycle_length"] == 6
+    assert payload["all_checked_one_defect_cases_match_threshold"] is True
     assert payload["triangle_case"]["contradiction"] is True
     assert payload["fan_in_cap"] == 3
     assert payload["export_identity"] == "d*n-2*(n-c)=(d-2)*n+2*c"
     assert "long_cycle_cases" not in payload
+    assert "one_defect_cycle_cases" not in payload
     assert "fan_in_cases" not in payload
     assert "export_cases" not in payload


### PR DESCRIPTION
## Summary

Strengthens the perimeter packet merged in #928 with several review-pending geometric consequences.

- upgrades the side-length version to a **boundary-detour distance forest lemma**: if every boundary arc between consecutive members of a boundary-independent set has length at least `2r`, then its distance-`r` graph is a forest;
- proves a **common-target fan-in cap of three** under the same detour hypotheses;
- applies both statements independently at every selected-radius level in the alternating boundary-neighbour branch;
- derives the exact export bound

  ```text
  B_R >= d*n_R - 2*(n_R-c_R)
      = (d-2)*n_R + 2*c_R,
  ```

  and the distinct-target lower bound obtained from fan-in at most three;
- proves a **weak-arc detour-cycle lemma**: an `r`-edge cycle of length `g` is impossible when at most `h` boundary gaps have only an `r` detour and `g >= h+4`;
- derives **same-component return locality**: one outside radius-`R` target can attach to two vertices of the same radius-level tree only when their tree distance is at most three;
- adds a local lemma excluding one extra witness shared by three consecutive equal-radius alternate centres;
- expands the deterministic arithmetic replay and regression tests.

## Claim scope

This PR does **not** claim a proof or disproof of Erdős Problem #97 and does not update the repository source-of-truth status. The projection, angular-order, barycentric, and perimeter arguments are labelled `PAPER_PROOF_CANDIDATE / REVIEW_PENDING`; the Python module checks only their exact arithmetic spine.

The results require the alternating branch in which each selected centre's rich class contains both boundary neighbours. In an arbitrary hypothetical counterexample that hypothesis is not yet forced. Also, an exported witness may move to the opposite parity without changing selected radius, so the export bound alone is not a global radius-descent theorem. Return cycles of lengths three, four, and five remain outside the weak-arc coefficient contradiction.

## Replay

```bash
python scripts/check_sparse_minimum_distance_forest.py \
  --max-cycle-length 512 \
  --assert-expected \
  --summary-json

python -m pytest tests/test_sparse_minimum_distance_forest.py -q
```

## New proof targets exposed

A surviving configuration in this branch must evade same-radius cycles, cannot concentrate four same-level incidences at one target, must supply at least two external incidences per same-radius forest component at the Erdős threshold, and cannot reuse one target across tree distance four or more. The remaining bounded return motifs have tree-path lengths one, two, or three; globally, the main bridge is still to force enough rows into the boundary-neighbour branch or constrain parity-changing/cross-radius exports.